### PR TITLE
OFI-NCCL: Plugin doesn't work with OFI providers that require FI_CONTEXT mode

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1217,7 +1217,7 @@ static ncclResult_t ofi_irecv(void* recvComm, void* data, int size, int type, vo
 
 	/* Try posting buffer to local EP */
 	rc = fi_trecv(rComm->local_ep, data, size, NULL,
-		      rComm->remote_ep, rComm->tag, 0, &req->ctx);
+		      FI_ADDR_UNSPEC, rComm->tag, 0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/* Return NULL request */
 		*request = NULL;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -674,15 +674,8 @@ exit:
 
 static inline ncclResult_t nccl_ofi_progress(nccl_ofi_t *nccl_ofi_comp)
 {
-	ncclResult_t ret = ncclSuccess;
-
 	/* Read completion queue entries */
-	ret = ofi_process_cq(nccl_ofi_comp);
-	if (OFI_UNLIKELY(ret != 0))
-		goto exit;
-
-exit:
-	return ret;
+	return ofi_process_cq(nccl_ofi_comp);
 }
 
 static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
@@ -1093,8 +1086,6 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	}
 
 	*recvComm = rComm;
-
-	goto exit;
 
 exit:
 	if (req)


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Fix the bug in the NCCL/OFI plugin. This bug doesn't allow us to work with OFI/psm2 provider and other providers that require `FI_CONTEXT` mode.
And + minor code cleanups (excessive `goto` operators has been removed)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
