### PR TITLE
 OFI-NCCL: Fix plug-in with psm2

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,11 +35,14 @@ support the following features as defined in the
 [libfabric API documentation](https://github.com/ofiwg/libfabric/tree/master/man/).
 
 * Tagged messaging (`FI_TAGGED`)
-* Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
 * Index-based addressing in address vectors (`FI_AV_TABLE`)
 * Automatic control and data progress model (`FI_PROGRESS_AUTO`)
+
+The plug-n supports the following modes:
+
+* Data transfer context structures (`FI_CONTEXT`)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -34,8 +34,7 @@ Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
 [libfabric API documentation](https://github.com/ofiwg/libfabric/tree/master/man/).
 
-* Tagged messaging (`FI_TAGGED`, `FI_MSG`)
-* Source address availability in completions (`FI_SOURCE`)
+* Tagged messaging (`FI_TAGGED`)
 * Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,6 +103,7 @@ typedef struct sendComm {
 	uint64_t num_inflight_reqs;
 	fi_addr_t remote_ep;
 	struct fid_ep *local_ep;
+	void *lcoal_ep_name;
 	free_list_t *nccl_ofi_reqs_fl;
 	free_list_t *pending_reqs_fl;
 	int dev;
@@ -118,9 +119,6 @@ typedef struct recvComm {
 } recvComm_t;
 
 typedef struct nccl_ofi_req {
-	/* Source address */
-	fi_addr_t src_addr;
-
 	/* Associated Comm object */
 	union {
 		listenComm_t *lComm;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,7 +103,7 @@ typedef struct sendComm {
 	uint64_t num_inflight_reqs;
 	fi_addr_t remote_ep;
 	struct fid_ep *local_ep;
-	void *lcoal_ep_name;
+	void *local_ep_name;
 	free_list_t *nccl_ofi_reqs_fl;
 	free_list_t *pending_reqs_fl;
 	int dev;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -291,7 +291,7 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	}
 
 	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG;
+	hints->caps = FI_TAGGED;
 	hints->mode = FI_CONTEXT;
 
 	hints->ep_attr->type = FI_EP_RDM;

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -10,7 +10,7 @@
 
 int main(int argc, char* argv[])
 {
-	int rank, len, proc_name;
+	int rank, proc_name;
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -11,7 +11,7 @@
 
 int main(int argc, char* argv[])
 {
-	int rank, len, proc_name;
+	int rank, proc_name;
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This first commit fixes OFI-NCCL plug-in over psm2 provider that hangs in case of >= 3 ranks. psm2 provider is unable to provide AV address (`src_addr` parameter in `fi_cq_read_rom()`) and fails completion, because the address of the peer doesn't exist in AV.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
