### PR TITLE
OFI-NCCL: Remove FI_AV_TABLE requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ support the following features as defined in the
 * Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
-* Index-based addressing in address vectors (`FI_AV_TABLE`)
 * Automatic control and data progress model (`FI_PROGRESS_AUTO`)
 
 ## Getting Started

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -298,7 +298,6 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->av_type = FI_AV_TABLE;
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
 	/* Indicate that the application support local memory registration */
@@ -454,7 +453,6 @@ static ncclResult_t create_nccl_ofi_component(struct fi_info *prov,
 		goto error;
 	}
 
-	av_attr.type = FI_AV_TABLE;
 	ret = fi_av_open(nccl_ofi_comp->domain, &av_attr, &nccl_ofi_comp->av, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't open AV. RC: %d, ERROR: %s",


### PR DESCRIPTION
All calls to fi_av_insert() pass a non-NULL fi_addr_t and use that
returned address for subsequent libfabric calls. It's therefore safe to
use either AV type, so the av_type attr can be left zeroed (i.e.,
FI_AV_UNSPEC) to let the provider choose whichever it prefers.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
