### PR TITLE
OFI-NCCL: Change AWS provider to support latest EFA

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The plug-in currently supports the following distributions:
 * CentOS 7
 
 It also requires
-[Libfabric v1.7.x](https://github.com/ofiwg/libfabric/tree/v1.7.x)
-and supports [NCCL v2.4.2](https://github.com/NVIDIA/nccl/releases/tag/v2.4.2-1).
+[Libfabric v1.8.x](https://github.com/ofiwg/libfabric/tree/v1.8.x)
+and supports [NCCL v2.4.6](https://github.com/NVIDIA/nccl/releases/tag/v2.4.6-1).
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -13,7 +13,7 @@
 #include <unistd.h>
 #include <stack.h>
 #ifdef EFA_NIC_DUP
-#define EFA_PROVIDER_NAME "efa;ofi_rxr"
+#define EFA_PROVIDER_NAME "efa"
 #define IS_EFA_PROVIDER(NAME) (strcmp((NAME), EFA_PROVIDER_NAME)==0)
 #include <ctype.h>
 #include <cuda_runtime.h>


### PR DESCRIPTION
AWS squashed "efa" and "ofi_rxr" provider so support plugin to use the
squashed provider from latest releases.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
