### PR TITLE
OFI-NCCL: Fix missing completion check for connect API

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -588,10 +588,6 @@ static inline ncclResult_t process_completions(
 				/* Mark listenComm to accepted state */
 				req->lComm->accepted = true;
 			}
-			else
-				free_nccl_ofi_req(req, false);
-
-			continue;
 		}
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -700,6 +700,9 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		// Make the list cyclic to emulate having multiple devices
 		ofi_info_list->next = ofi_info_list;
 		NCCL_OFI_INFO(NCCL_INIT, "Forcing AWS OFI ndev %d", ofi_ndevices);
+	} else {
+		NCCL_OFI_WARN("Only EFA provider is supported");
+		return ncclSystemError;
 	}
 #else
 	/*


### PR DESCRIPTION
Three patches to merge.
```
1) OFI-NCCL: Fix missing completion check for connect API
2) OFI-NCCL: Remove unnecessary free in completion process
3) OFI-NCCL: Fix EFA provider topology override
```
1) resolves issue #18 but 2) is also necessary for some providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
