### PR TITLE
OFI-NCCL: Fix missing completion check for connect API

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -953,6 +953,11 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 
 	/* Send "connect" message to remote EP */
 	do {
+		/*
+		 * TODO: replace it with API of FI_INJECT type when most of
+		 * providers can support it, so that need for completion check
+		 * below can be lifted.
+		 */
 		rc = fi_tsend(sComm->local_ep, (void *)&local_ep_addr,
 			      MAX_EP_ADDR, NULL, sComm->remote_ep,
 			      sComm->tag | ~max_tag, &req->ctx);
@@ -975,6 +980,13 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		}
 	} while (true);
 
+	/* Ensure the message is sent. */
+	do {
+		ret = nccl_ofi_progress(nccl_ofi_component[dev]);
+		if (OFI_UNLIKELY(ret != 0))
+			goto error;
+	} while (req->state != NCCL_OFI_REQ_COMPLETED);
+
 	*sendComm = sComm;
 
 	goto exit;
@@ -984,9 +996,9 @@ unlock:
 error:
 	if (sComm)
 		free(sComm);
+exit:
 	if (req)
 		free_nccl_ofi_req(req, false);
-exit:
 	return ret;
 }
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -577,10 +577,6 @@ static inline ncclResult_t process_completions(
 				/* Mark listenComm to accepted state */
 				req->lComm->accepted = true;
 			}
-			else
-				free_nccl_ofi_req(req, false);
-
-			continue;
 		}
 	}
 


### PR DESCRIPTION
Three patches to merge.
```
1) OFI-NCCL: Fix missing completion check for connect API
2) OFI-NCCL: Remove unnecessary free in completion process
```
1) resolves issue #18 but 2) is also necessary for some providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
