### PR TITLE
[master] OFI-NCCL: fix resource leak

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ The plug-in currently supports the following distributions:
 * CentOS 7
 
 It also requires
-[Libfabric v1.7.x](https://github.com/ofiwg/libfabric/tree/v1.7.x)
-and supports [NCCL v2.4.2](https://github.com/NVIDIA/nccl/releases/tag/v2.4.2-1).
+[Libfabric v1.8.x](https://github.com/ofiwg/libfabric/tree/v1.8.x)
+and supports [NCCL v2.4.6](https://github.com/NVIDIA/nccl/releases/tag/v2.4.6-1).
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -178,7 +178,20 @@ typedef struct pending_reqs_q {
 	pending_reqs_q_elem_t *tail;
 } pending_reqs_q_t;
 
+/*
+ * Structure for an OFI network device.
+ *
+ * As this can be shared by multiple entities, it must be protected by
+ * nccl_ofi_lock. Also, for resource management, refcnt is maintained internally
+ * and get/put_nccl_ofi_comp() must be called in pair when an object is acquired
+ * to use and released. get_nccl_ofi_comp() allocates a new object when it is
+ * called for the first time and put_nccl_ofi_comp() releases the object if
+ * refcnt is decreased down to zero.
+ */
 typedef struct nccl_ofi {
+	/* Reference counter of the object */
+	int refcnt;
+
 	/* Current available tag ID */
 	uint64_t tag;
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -75,20 +75,29 @@ typedef enum nccl_ofi_req_direction {
 } nccl_ofi_req_direction_t;
 
 typedef struct stack {
-	int *array;
 	int top;
 	int size;
+
+	/*
+	 * Array of stack entries comes after stack structure. size field
+	 * indicates the size of the array.
+	 * NOTE: no more field is allowed beyond this point.
+	 */
+	int array[];
 } stack_t;
 
 typedef struct free_list {
-	/* Array of free buffers */
-	void *buffers;
-
 	/* Stack of free buffer indexes */
 	stack_t *free_index;
 
 	/* Size of buffers array */
 	uint64_t size;
+
+	/*
+	 * Array of free buffers comes after list head.
+	 * NOTE: no more field is allowed beyond this point.
+	 */
+	void *buffers[];
 } free_list_t;
 
 typedef struct listenComm {

--- a/include/stack.h
+++ b/include/stack.h
@@ -21,26 +21,15 @@ static stack_t *allocate_stack(size_t num_elems)
 {
 	stack_t *stack = NULL;
 
-	stack = (stack_t *)malloc(sizeof(stack_t));
+	stack = (stack_t *)malloc(sizeof(stack_t) + num_elems * sizeof(int));
 	if (stack == NULL) {
-		NCCL_OFI_WARN("Unable to allocate stack structure");
+		NCCL_OFI_WARN("Unable to allocate stack");
 		goto exit;
 	}
 
 	stack->size = num_elems;
 	stack->top = -1;
-	stack->array = (int *)malloc(stack->size * sizeof(int));
-	if (stack->array == NULL) {
-		NCCL_OFI_WARN("Could not allocate stack array");
-		goto error;
-	}
 
-	goto exit;
-
-error:
-	if (stack)
-		free(stack);
-	stack = NULL;
 exit:
 	return stack;
 }
@@ -51,12 +40,10 @@ exit:
 
 void free_stack(stack_t *stack)
 {
-	if (stack)
-	{
-		if(stack->array)
-			free(stack->array);
-		free(stack);
-	}
+	if (!stack)
+		return;
+
+	free(stack);
 }
 
 /*

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -953,6 +953,11 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 
 	/* Send "connect" message to remote EP */
 	do {
+		/*
+		 * TODO: replace it with API of FI_INJECT type when most of
+		 * providers can support it, so that need for completion check
+		 * below can be lifted.
+		 */
 		rc = fi_tsend(sComm->local_ep, (void *)&local_ep_addr,
 			      MAX_EP_ADDR, NULL, sComm->remote_ep,
 			      sComm->tag | ~max_tag, &req->ctx);
@@ -975,6 +980,13 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		}
 	} while (true);
 
+	/* Ensure the message is sent. */
+	do {
+		ret = nccl_ofi_progress(nccl_ofi_component[dev]);
+		if (OFI_UNLIKELY(ret != 0))
+			goto error;
+	} while (req->state != NCCL_OFI_REQ_COMPLETED);
+
 	*sendComm = sComm;
 
 	goto exit;
@@ -984,9 +996,9 @@ unlock:
 error:
 	if (sComm)
 		free(sComm);
+exit:
 	if (req)
 		free_nccl_ofi_req(req, false);
-exit:
 	return ret;
 }
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -577,10 +577,6 @@ static inline ncclResult_t process_completions(
 				/* Mark listenComm to accepted state */
 				req->lComm->accepted = true;
 			}
-			else
-				free_nccl_ofi_req(req, false);
-
-			continue;
 		}
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -720,7 +720,7 @@ static ncclResult_t ofi_pciPath(int dev, char** path)
 	struct fi_info* prov = NULL;
 	struct fid_nic *nic_info = NULL;
 	struct fi_pci_attr *pci = NULL;
-	char device_path[] = "/sys/class/pci_bus/0000:00/../../0000:00:00.0";
+	char device_path[] = "/sys/class/pci_bus/0000:00/../../0000:00:00.00";
 
 	prov = get_nic_info(dev, ofi_info_list);
 	if (prov == NULL) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -523,12 +523,69 @@ static ncclResult_t create_nccl_ofi_comp_for_dev(int dev, struct fi_info *nic_in
 	if (ret != 0)
 		goto exit;
 
+	NCCL_OFI_TRACE(NCCL_NET, "OFI component #%d is created", dev);
+
 	return ret;
 
 exit:
 	if (nccl_ofi_component[dev] != NULL)
 		free(nccl_ofi_component[dev]);
 	return ret;
+}
+
+/*
+ * @brief	Release various libfabric resources.
+ */
+void release_nccl_ofi_component(int dev)
+{
+	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[dev];
+
+	if (!nccl_ofi_comp)
+		return;
+
+	if (nccl_ofi_comp->ep)
+		fi_close((fid_t)nccl_ofi_comp->ep);
+	if (nccl_ofi_comp->av)
+		fi_close((fid_t)nccl_ofi_comp->av);
+	if (nccl_ofi_comp->cq)
+		fi_close((fid_t)nccl_ofi_comp->cq);
+	if (nccl_ofi_comp->domain)
+		fi_close((fid_t)nccl_ofi_comp->domain);
+	if (nccl_ofi_comp->fabric)
+		fi_close((fid_t)nccl_ofi_comp->fabric);
+
+	free(nccl_ofi_comp);
+	nccl_ofi_component[dev] = NULL;
+
+	NCCL_OFI_TRACE(NCCL_NET, "OFI component #%d is released", dev);
+}
+
+/*
+ * @brief	Get nccl_ofi_component for given device ID.
+ * 		Create if it does not exist. Increase refernce counter. Must be
+ * 		protected by nccl_ofi_lock.
+ */
+static ncclResult_t get_nccl_ofi_comp(int dev)
+{
+	ncclResult_t ret = ncclSuccess;
+
+	if (!nccl_ofi_component[dev])
+		ret = create_nccl_ofi_comp_for_dev(dev, ofi_info_list);
+
+	++nccl_ofi_component[dev]->refcnt;
+
+	return ret;
+}
+
+/*
+ * @brief	Release nccl_ofi_component for given device ID.
+ *		Decrease refernce counter. Release resources if reference
+ *		counter becomes zero. Must be protected by nccl_ofi_lock.
+ */
+static void put_nccl_ofi_comp(int dev)
+{
+	if (--nccl_ofi_component[dev]->refcnt == 0)
+		release_nccl_ofi_component(dev);
 }
 
 /*
@@ -784,11 +841,9 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	 * already created, else increase tag ID.
 	 */
 	pthread_mutex_lock(&nccl_ofi_lock);
-	if (OFI_UNLIKELY(nccl_ofi_component[dev] == NULL)) {
-		ret = create_nccl_ofi_comp_for_dev(dev, ofi_info_list);
-		if (ret != 0)
-			goto unlock;
-	}
+	ret = get_nccl_ofi_comp(dev);
+	if (ret)
+		goto unlock;
 
 	if (nccl_ofi_component[dev]->tag + 1 >=
 	    nccl_ofi_component[dev]->max_tag) {
@@ -866,11 +921,9 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	 * already created.
 	 */
 	pthread_mutex_lock(&nccl_ofi_lock);
-	if (OFI_UNLIKELY(nccl_ofi_component[dev] == NULL)) {
-		ret = create_nccl_ofi_comp_for_dev(dev, ofi_info_list);
-		if (ret != 0)
-			goto unlock;
-	}
+	ret = get_nccl_ofi_comp(dev);
+	if (ret)
+		goto unlock;
 	pthread_mutex_unlock(&nccl_ofi_lock);
 	max_tag = nccl_ofi_component[dev]->max_tag;
 
@@ -1001,15 +1054,23 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	nccl_ofi_req_t *req = NULL;
 	char remote_ep_addr[MAX_EP_ADDR] = {0};
 	fi_addr_t remote_ep;
-	uint64_t max_tag = nccl_ofi_comp->max_tag;
+	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
 
+	pthread_mutex_lock(&nccl_ofi_lock);
 	if (nccl_ofi_comp == NULL) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("NCCL OFI component for dev %d is uninitialised",
 			     dev);
-		goto exit;
+		goto unlock;
 	}
+
+	ret = get_nccl_ofi_comp(dev);
+	if (ret)
+		goto unlock;
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	max_tag = nccl_ofi_comp->max_tag;
 
 	if (lComm->accepted == true) {
 		ret = ncclSystemError;
@@ -1098,6 +1159,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 	*recvComm = rComm;
 
+unlock:
+	pthread_mutex_unlock(&nccl_ofi_lock);
 exit:
 	if (req)
 		free(req);
@@ -1386,6 +1449,7 @@ exit:
 static ncclResult_t ofi_closeSend(void *sendComm)
 {
 	sendComm_t *sComm = (sendComm_t *)sendComm;
+	int dev;
 	ncclResult_t ret = ncclSuccess;
 
 	if (OFI_UNLIKELY(sendComm == NULL)) {
@@ -1393,14 +1457,15 @@ static ncclResult_t ofi_closeSend(void *sendComm)
 		goto exit;
 	}
 
-	/*
-	 * We do not want to free EP associated with the comm
-	 * object as it my be used by other rings
-	 */
-	sComm->local_ep = NULL;
+	dev = sComm->dev;
 
 	free_ofi_fl(sComm->nccl_ofi_reqs_fl);
 	free(sendComm);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+	put_nccl_ofi_comp(dev);
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
 exit:
 	return ret;
 }
@@ -1408,6 +1473,7 @@ exit:
 static ncclResult_t ofi_closeRecv(void *recvComm)
 {
 	recvComm_t *rComm = (recvComm_t *)recvComm;
+	int dev;
 	ncclResult_t ret = ncclSuccess;
 
 	if (OFI_UNLIKELY(recvComm == NULL)) {
@@ -1415,20 +1481,23 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 		goto exit;
 	}
 
-	/*
-	 * We do not want to free EP associated with the comm
-	 * object as it may be used by other rings
-	 */
-	rComm->local_ep = NULL;
+	dev = rComm->dev;
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);
 	free(recvComm);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+	put_nccl_ofi_comp(dev);
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
 exit:
 	return ret;
 }
 
 static ncclResult_t ofi_closeListen(void *listenComm)
 {
+	listenComm_t *lComm = (listenComm_t *)listenComm;
+	int dev;
 	ncclResult_t ret = ncclSuccess;
 
 	if (OFI_UNLIKELY(listenComm == NULL)) {
@@ -1436,13 +1505,14 @@ static ncclResult_t ofi_closeListen(void *listenComm)
 		goto exit;
 	}
 
-	/*
-	 * We do not want to free EP associated with the comm
-	 * object as it may be used by other rings
-	 */
-	((listenComm_t *)listenComm)->local_ep = NULL;
+	dev = lComm->dev;
 
 	free(listenComm);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+	put_nccl_ofi_comp(dev);
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
 exit:
 	return ret;
 }


### PR DESCRIPTION
This PR introduces 4 new patches to the master branch
```
OFI-NCCL: fix resource leak
OFI-NCCL: fix tag value overflow
OFI-NCCL: fix memory leak
OFI-NCCL: fix compiler warning
```

The following patch is cherry-picked from aws branch in order to make master up to date.
```
Documentation: Modify README.md to support latest libfabric and NCCL versions
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
