### PR TITLE
Add support for NCCL 2.6 and some improvements in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ The plug-in currently supports the following distributions:
 
 It also requires
 [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.5.6](https://github.com/NVIDIA/nccl/releases/tag/v2.5.6-2).
+and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
+The plug-in also maintains backward compatibility with older NCCL versions
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
+[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -69,6 +72,13 @@ dependencies with the following flags:
   --with-cuda=PATH        Path to non-standard CUDA installation
   --with-nccl=PATH        Path to non-standard NCCL installation
   --with-mpi=PATH         Path to non-standard MPI installation
+```
+
+To enable trace messages for debugging (disabled by default), use the
+following config option:
+
+```
+   --enable-trace         Enable printing trace messages
 ```
 
 ### Running Unit Tests

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,29 @@
 * Ubuntu 16.04 LTS
 * CentOS 7
 
+# v1.0.1 release notes
+
+This release supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It also includes bug fixes and testing enhancements.
+
+New Features:
+* Support NCCL v2.6.4
+* Add validation of memory registration APIs and getProperties API in tests.
+
+Bug Fixes:
+* Use fid_mr for memory handle
+* Support disabling trace messages
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.0.0 release notes
 
 This release requires [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,14 @@ AC_ARG_WITH([mpi],
              LDFLAGS="-L$withval/$mpi_libdir $LDFLAGS"],
             [])
 
+AC_ARG_ENABLE(trace, [AS_HELP_STRING([--enable-trace], [Enable printing trace messages])], [], [enable_trace=no])
+AC_MSG_CHECKING([whether to enable trace messages])
+AS_IF([test "x${enable_trace}" = "xyes" ],
+      [trace=1
+       AC_MSG_RESULT(yes)],
+       [trace=0
+       AC_MSG_RESULT(no)])
+AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-debug, 0 otherwise])
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h cuda_runtime.h], [],[

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -33,20 +33,19 @@ int main(int argc, char* argv[])
 	if (extNet == NULL)
 		return -1;
 
-	/* TODO: Check return codes for transport layer APIs */
 	/* Init API */
-	extNet->init(logger);
+	OFINCCLCHECK(extNet->init(logger));
 	NCCL_OFI_INFO(NCCL_INIT, "Process rank %d started. NCCLNet device used on %s is %s.",
 		      rank, name, extNet->name);
 
 	/* Devices API */
-	extNet->devices(&ndev);
+	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
 	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev 0");
-	extNet->listen(0, (void *)&handle, (void **)&lComm);
+	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
@@ -58,11 +57,11 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		extNet->connect(0, (void *)src_handle, (void **)&sComm);
+		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		extNet->accept((void *)lComm, (void **)&rComm);
+		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank + 1);
 	}
@@ -76,18 +75,18 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		extNet->connect(0, (void *)src_handle, (void **)&sComm);
+		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		extNet->accept((void *)lComm, (void **)&rComm);
+		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank - 1);
 	}
 
-	extNet->closeListen((void *)lComm);
-	extNet->closeSend((void *)sComm);
-	extNet->closeRecv((void *)rComm);
+	OFINCCLCHECK(extNet->closeListen((void *)lComm));
+	OFINCCLCHECK(extNet->closeSend((void *)sComm));
+	OFINCCLCHECK(extNet->closeRecv((void *)rComm));
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	MPI_Finalize();

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -14,14 +14,13 @@ int main(int argc, char* argv[])
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */
-	int ndev;
+	int ndev, dev;
 	sendComm_t *sComm = NULL;
 	listenComm_t *lComm = NULL;
 	recvComm_t *rComm = NULL;
 	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
 	ncclNet_t *extNet = NULL;
 
-	ncclDebugLogger_t ofi_log_function = NULL;
 	ofi_log_function = logger;
 
 	MPI_Init(&argc, &argv);
@@ -41,6 +40,24 @@ int main(int argc, char* argv[])
 	/* Devices API */
 	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
+
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+	/* Get Properties for the device */
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v3_t props = {0};
+		OFINCCLCHECK(extNet->getProperties(dev, &props));
+		print_dev_props(dev, &props);
+	}
+#else
+	/* Get PCIe path and plugin memory pointer support */
+	for (dev = 0; dev < ndev; dev++) {
+		char *path = NULL;
+		int supported_types = 0;
+		extNet->pciPath(dev, &path);
+		OFINCCLCHECK(extNet->ptrSupport(dev, &supported_types));
+		NCCL_OFI_TRACE(NCCL_INIT, "Dev %d has path %s and supports pointers of type %d", dev, path, supported_types);
+	}
+#endif
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -24,6 +24,14 @@
 #define SEND_SIZE	(5000)
 #define RECV_SIZE	(5200)
 
+#define OFINCCLCHECK(call) do { \
+  ncclResult_t res = call; \
+  if (res != ncclSuccess) { \
+    NCCL_OFI_WARN("OFI NCCL failure: %d", res);    \
+    return res; \
+  } \
+} while (false);
+
 void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	    int line, const char *fmt, ...)
 {

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -12,6 +12,7 @@
 #include <nccl_ofi.h>
 #include <nccl_ofi_log.h>
 #include "mpi.h"
+#include "config.h"
 #include <unistd.h>
 #include <nccl.h>
 #include <dlfcn.h>
@@ -45,8 +46,12 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 			printf("INFO: Function: %s Line: %d: ", filefunc, line);
 			break;
 		case NCCL_LOG_TRACE:
+#if OFI_NCCL_TRACE
 			printf("TRACE: Function: %s Line: %d: ", filefunc, line);
 			break;
+#else
+			return;
+#endif
 		default:
 			break;
 	};

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -62,6 +62,19 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	va_end(vargs);
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+{
+        NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Plugin Support: %d", props->name, props->ptrSupport);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %d", props->name, props->guid);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+}
+#endif
+
 ncclNet_t *get_extNet(void)
 {
 	void *netPluginLib = NULL;


### PR DESCRIPTION
This PR adds several commits which adds the following support:

* Add NCCL v2.6.x support
* Modify tests to validate NCCL v2.6.x support, memory registration/deregistration.
* Use fid_mr for memory handle.
* Check NCCL API return codes in tests.
* Enable/disable printing of trace message


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
