### PR TITLE
[Aws] Add support for NCCL 2.6 and some improvements in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The plug-in currently supports the following distributions:
 
 It also requires
 [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.5.6](https://github.com/NVIDIA/nccl/releases/tag/v2.5.6-2).
+and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
+The plug-in also maintains backward compatibility with older NCCL versions
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
+[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -72,6 +75,13 @@ dependencies with the following flags:
   --with-cuda=PATH        Path to non-standard CUDA installation
   --with-nccl=PATH        Path to non-standard NCCL installation
   --with-mpi=PATH         Path to non-standard MPI installation
+```
+
+To enable trace messages for debugging (disabled by default), use the
+following config option:
+
+```
+   --enable-trace         Enable printing trace messages
 ```
 
 ### Running Unit Tests

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,29 @@
 * Ubuntu 16.04 LTS
 * CentOS 7
 
+# v1.0.1 release notes
+
+This release supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It also includes bug fixes and testing enhancements.
+
+New Features:
+* Support NCCL v2.6.4
+* Add validation of memory registration APIs and getProperties API in tests.
+
+Bug Fixes:
+* Use fid_mr for memory handle
+* Support disabling trace messages
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.0.0 release notes
 
 This release requires [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)

--- a/configure.ac
+++ b/configure.ac
@@ -55,6 +55,14 @@ AC_ARG_WITH([mpi],
              LDFLAGS="-L$withval/$mpi_libdir $LDFLAGS"],
             [])
 
+AC_ARG_ENABLE(trace, [AS_HELP_STRING([--enable-trace], [Enable printing trace messages])], [], [enable_trace=no])
+AC_MSG_CHECKING([whether to enable trace messages])
+AS_IF([test "x${enable_trace}" = "xyes" ],
+      [trace=1
+       AC_MSG_RESULT(yes)],
+       [trace=0
+       AC_MSG_RESULT(no)])
+AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-debug, 0 otherwise])
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h cuda_runtime.h], [],[

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -895,6 +895,81 @@ static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 	return ncclSuccess;
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
+					  ncclNetProperties_v3_t *props)
+{
+	ncclResult_t ret = ncclSuccess;
+
+	props->name = strdup(nic_prov->domain_attr->name);
+
+	/*
+	 * Currently, libfabric providers provide multiple `fi_info`
+	 * objects for devices with multiple ports. So, safely assume port number
+	 * to be always 1.
+	 */
+	props->port = 1;
+	props->maxComms = nic_prov->domain_attr->ep_cnt;
+	props->guid = dev;
+
+	ret = ofi_pciPath(dev, &props->pciPath);
+	if (ret != ncclSuccess)
+		props->pciPath = NULL;
+
+	ret = ofi_ptrSupport(dev, &props->ptrSupport);
+
+	/* Should be successful for ptrSupport invocation */
+	return ret;
+}
+
+static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_v3_t *props)
+{
+	ncclResult_t ret = ncclSuccess;
+	ncclNetProperties_v3_t dev_props = {0};
+	struct fi_info *nic_prov = NULL;
+	struct fid_nic *nic_info = NULL;
+
+	if (dev < 0 || dev >= ofi_ndevices) {
+		NCCL_OFI_WARN("Incorrect dev %d provided", dev);
+		ret = ncclSystemError;
+		goto error;
+	}
+
+	nic_prov = get_nic_info(dev, ofi_info_list);
+	if (nic_prov == NULL) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "Unable to find provider for dev %d", dev);
+		ret = ncclSystemError;
+		goto error;
+	}
+
+	ret = set_nic_props_default(dev, nic_prov, &dev_props);
+	if (ret != ncclSuccess)
+		goto error;
+
+	/* Change default values as set by NIC attributes */
+	nic_info = (struct fid_nic *)nic_prov->nic;
+	if (nic_info == NULL) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "No NIC info for dev %d. Supplying default values for NIC properties.",
+			      dev);
+		goto exit;
+	}
+
+	dev_props.name = strdup(nic_info->device_attr->name);
+	/* Speed reported in Mbps */
+	dev_props.speed = nic_info->link_attr->speed / (1e6);
+
+	goto exit;
+
+error:
+	props = NULL;
+exit:
+	*props = dev_props;
+	return ret;
+}
+#endif
+
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1605,8 +1680,12 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.name = "AWS Libfabric",
 	.init = ofi_init,
 	.devices = ofi_devices,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+	.getProperties = ofi_getProperties,
+#else /* Support NCCL version >= v2.4.x and < v2.6.x */
 	.pciPath = ofi_pciPath,
 	.ptrSupport = ofi_ptrSupport,
+#endif
 	.listen = ofi_listen,
 	.connect = ofi_connect,
 	.accept = ofi_accept,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -960,6 +960,26 @@ static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_v3_t *props)
 	/* Speed reported in Mbps */
 	dev_props.speed = nic_info->link_attr->speed / (1e6);
 
+        /*
+         * TODO: Current libfabric release doesn't report correct speed for
+         * EFA device which leads to slight performance drop. This is because
+         * NCCL reduces parallelism based on overall speed of topology.
+         *
+         * Fix it by explicitly setting the right speed and REMOVE this after
+         * libfabric release with the fix is available.
+         */
+#ifdef EFA_NIC_DUP
+        if (IS_EFA_PROVIDER(nic_prov->fabric_attr->prov_name)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Correcting speed for EFA provider");
+		dev_props.speed = 1e5; /* 100 Gb/s */
+		/* Make a unique device name for each EFA device */
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Correcting device names");
+		snprintf(dev_props.name, FI_NAME_MAX + 2, "%s%x", nic_info->device_attr->name, dev);
+        }
+        else
+                NCCL_OFI_WARN("Only EFA provider is supported");
+#endif
+
 	goto exit;
 
 error:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1287,10 +1287,7 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 	}
 
 exit:
-	if (mr_handle == NULL)
-		*mhandle = mr_handle;
-	else
-		*mhandle = fi_mr_desc(mr_handle);
+	*mhandle = (void *)mr_handle;
 	return ret;
 }
 
@@ -1330,6 +1327,7 @@ static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 	nccl_ofi_req_t *req = NULL;
 	sendComm_t *sComm = (sendComm_t *)sendComm;
 	nccl_ofi_t *nccl_ofi_comp = NULL;
+	void *desc = NULL;
 
 	/* Validate sendComm */
 	if (OFI_UNLIKELY(sComm == NULL)) {
@@ -1372,11 +1370,13 @@ static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 	if (OFI_UNLIKELY(ret != 0))
 		goto error;
 
+	if (mhandle != NULL)
+		desc = fi_mr_desc(mhandle);
 	/*
 	 * Try sending data to remote EP; Return NULL request
 	 * if not able to send.
 	 */
-	rc = fi_tsend(sComm->local_ep, data, size, mhandle,
+	rc = fi_tsend(sComm->local_ep, data, size, desc,
 		      sComm->remote_ep, sComm->tag, &req->ctx);
 	if (OFI_UNLIKELY(rc == -FI_EAGAIN)) {
 		/* Return NULL */
@@ -1411,6 +1411,7 @@ static ncclResult_t ofi_irecv(void* recvComm, void* data, int size,
 	ssize_t rc = 0;
 	nccl_ofi_req_t *req = NULL;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
+	void *desc = NULL;
 
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
@@ -1445,8 +1446,11 @@ static ncclResult_t ofi_irecv(void* recvComm, void* data, int size,
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
+	if (mhandle != NULL)
+		desc = fi_mr_desc(mhandle);
+
 	/* Try posting buffer to local EP */
-	rc = fi_trecv(rComm->local_ep, data, size, mhandle,
+	rc = fi_trecv(rComm->local_ep, data, size, desc,
 		      FI_ADDR_UNSPEC, rComm->tag, 0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/* Return NULL request */

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -33,20 +33,19 @@ int main(int argc, char* argv[])
 	if (extNet == NULL)
 		return -1;
 
-	/* TODO: Check return codes for transport layer APIs */
 	/* Init API */
-	extNet->init(logger);
+	OFINCCLCHECK(extNet->init(logger));
 	NCCL_OFI_INFO(NCCL_INIT, "Process rank %d started. NCCLNet device used on %s is %s.",
 		      rank, name, extNet->name);
 
 	/* Devices API */
-	extNet->devices(&ndev);
+	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
 	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev 0");
-	extNet->listen(0, (void *)&handle, (void **)&lComm);
+	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
@@ -58,11 +57,11 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		extNet->connect(0, (void *)src_handle, (void **)&sComm);
+		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		extNet->accept((void *)lComm, (void **)&rComm);
+		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank + 1);
 	}
@@ -76,18 +75,18 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		extNet->connect(0, (void *)src_handle, (void **)&sComm);
+		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		extNet->accept((void *)lComm, (void **)&rComm);
+		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank - 1);
 	}
 
-	extNet->closeListen((void *)lComm);
-	extNet->closeSend((void *)sComm);
-	extNet->closeRecv((void *)rComm);
+	OFINCCLCHECK(extNet->closeListen((void *)lComm));
+	OFINCCLCHECK(extNet->closeSend((void *)sComm));
+	OFINCCLCHECK(extNet->closeRecv((void *)rComm));
 
 	MPI_Barrier(MPI_COMM_WORLD);
 	MPI_Finalize();

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -14,14 +14,13 @@ int main(int argc, char* argv[])
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */
-	int ndev;
+	int ndev, dev;
 	sendComm_t *sComm = NULL;
 	listenComm_t *lComm = NULL;
 	recvComm_t *rComm = NULL;
 	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
 	ncclNet_t *extNet = NULL;
 
-	ncclDebugLogger_t ofi_log_function = NULL;
 	ofi_log_function = logger;
 
 	MPI_Init(&argc, &argv);
@@ -41,6 +40,24 @@ int main(int argc, char* argv[])
 	/* Devices API */
 	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
+
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+	/* Get Properties for the device */
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v3_t props = {0};
+		OFINCCLCHECK(extNet->getProperties(dev, &props));
+		print_dev_props(dev, &props);
+	}
+#else
+	/* Get PCIe path and plugin memory pointer support */
+	for (dev = 0; dev < ndev; dev++) {
+		char *path = NULL;
+		int supported_types = 0;
+		extNet->pciPath(dev, &path);
+		OFINCCLCHECK(extNet->ptrSupport(dev, &supported_types));
+		NCCL_OFI_TRACE(NCCL_INIT, "Dev %d has path %s and supports pointers of type %d", dev, path, supported_types);
+	}
+#endif
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -24,6 +24,14 @@
 #define SEND_SIZE	(5000)
 #define RECV_SIZE	(5200)
 
+#define OFINCCLCHECK(call) do { \
+  ncclResult_t res = call; \
+  if (res != ncclSuccess) { \
+    NCCL_OFI_WARN("OFI NCCL failure: %d", res);    \
+    return res; \
+  } \
+} while (false);
+
 void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	    int line, const char *fmt, ...)
 {

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -12,6 +12,7 @@
 #include <nccl_ofi.h>
 #include <nccl_ofi_log.h>
 #include "mpi.h"
+#include "config.h"
 #include <unistd.h>
 #include <nccl.h>
 #include <dlfcn.h>
@@ -45,8 +46,12 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 			printf("INFO: Function: %s Line: %d: ", filefunc, line);
 			break;
 		case NCCL_LOG_TRACE:
+#if OFI_NCCL_TRACE
 			printf("TRACE: Function: %s Line: %d: ", filefunc, line);
 			break;
+#else
+			return;
+#endif
 		default:
 			break;
 	};

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -62,6 +62,19 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	va_end(vargs);
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+{
+        NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Plugin Support: %d", props->name, props->ptrSupport);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %d", props->name, props->guid);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+}
+#endif
+
 ncclNet_t *get_extNet(void)
 {
 	void *netPluginLib = NULL;


### PR DESCRIPTION
This PR adds several commits which adds the following support:

* Add NCCL v2.6.x support
* Modify tests to validate NCCL v2.6.x support, memory registration/deregistration.
* Use fid_mr for memory handle.
* Check NCCL API return codes in tests.
* Enable/disable printing of trace message

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
