### PR TITLE
[Aws] Add GPUDirect support

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,6 +103,7 @@ typedef struct free_list {
 typedef struct listenComm {
 	uint64_t tag;
 	struct fid_ep *local_ep;
+	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
 } listenComm_t;
@@ -122,6 +123,7 @@ typedef struct recvComm {
 	uint64_t tag;
 	uint64_t num_inflight_reqs;
 	fi_addr_t remote_ep;
+	fi_addr_t local_ep_addr;
 	struct fid_ep *local_ep;
 	free_list_t *nccl_ofi_reqs_fl;
 } recvComm_t;

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -83,6 +83,15 @@ OFI_NCCL_PARAM_INT(use_ipv6_tcp, "USE_IPV6_TCP", 0);
  */
 OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
 
+/*
+ * Disable flush operation when using GPUDirect. Flush commands
+ * are used to enforce data consistency at the receiving GPU. It should
+ * only be disabled when underlying libfabric provider or hardware
+ * ensures data consistency.
+ * By default, plugin issues flush commands.
+ */
+OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1250,8 +1250,10 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	ncclResult_t ret = ncclSuccess;
 	char ep_name[MAX_EP_ADDR] = {0};
 	size_t namelen = sizeof(ep_name);
+	fi_addr_t local_ep_addr;
 	listenComm_t *lComm = NULL;
 	uint64_t tag;
+	int num_addrs;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1299,12 +1301,25 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	memcpy(handle, ep_name, MAX_EP_ADDR);
 	memcpy(handle + MAX_EP_ADDR, &tag, sizeof(tag));
 
+	/* Insert local EP address to AV. This will be used to issue local read operations */
+	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
+				 &local_ep_addr, 0, NULL);
+	if (OFI_UNLIKELY(num_addrs != 1)) {	/* Only 1 address should be inserted into the AV */
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+			      dev, fi_strerror(-ret));
+		ret = ncclSystemError;
+		goto exit;
+	} else {
+		ret = ncclSuccess;
+	}
+
 	/* Build listenComm */
 	lComm = (listenComm_t *)calloc(1, sizeof(listenComm_t));
 	lComm->tag = tag;
 	lComm->local_ep = nccl_ofi_component[dev]->ep;
 	lComm->accepted = false;
 	lComm->dev = dev;
+	lComm->local_ep_addr = local_ep_addr;
 
 	*listenComm = lComm;
 
@@ -1575,6 +1590,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 	rComm->tag = lComm->tag;
 	rComm->local_ep = lComm->local_ep;
+	rComm->local_ep_addr = lComm->local_ep_addr;
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1905,6 +1905,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key;
 
+	if (ofi_nccl_gdr_flush_disable())
+		goto exit;
+
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		ret = ncclSystemError;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -28,6 +28,8 @@ int ofi_ndevices = -1;
 nccl_ofi_t **nccl_ofi_component = NULL;
 /* Indicates if memory registration of local buffers is required */
 bool local_mr = false;
+/* Indicates if memory registration of device buffers is required */
+bool hmem_mr = false;
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -364,6 +366,107 @@ static void filter_tcp_info_list()
 	}
 }
 
+/*
+ * @brief	Gets the CUDA device associated with the buffer
+ *
+ * @param	data
+ *		Pointer to CUDA buffer.
+ *
+ * @return	Valid CUDA device ID on success
+ *		-1 on error
+ * @return	0 on success
+ *		non-zero on error
+ */
+static ncclResult_t get_cuda_device(void *data, int *device)
+{
+	ncclResult_t ret = ncclSuccess;
+	int cuda_device = -1;
+	struct cudaPointerAttributes attr;
+	cudaError_t cuda_ret = cudaPointerGetAttributes(&attr, data);
+
+	if (cuda_ret != cudaSuccess) {
+		ret = ncclUnhandledCudaError;
+		NCCL_OFI_WARN("Invalid buffer pointer provided");
+		goto exit;
+	}
+
+	if (attr.type == cudaMemoryTypeDevice) {
+		cuda_device = attr.device;
+	}
+	else {
+		ret = ncclInvalidArgument;
+		NCCL_OFI_WARN("Invalid type of buffer provided. Only device memory is expected for NCCL_PTR_CUDA type");
+	}
+
+exit:
+	*device = cuda_device;
+	return ret;
+}
+
+/*
+ * @brief	Registers memory region (both HOST and CUDA)
+ *
+ *
+ * @return	OFI memory handle for data transfer operations
+ * @return	0 on success
+ *		non-zero on error
+ */
+static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
+					int size, int type,
+					struct fid_mr **mr_handle)
+{
+	ncclResult_t ret = ncclSuccess;
+	int rc;
+	struct fi_mr_attr mr_attr = {0};
+	struct iovec iov = {0};
+
+	/* Check if provider requires registration of local buffers */
+	if ((local_mr != true) && (type == NCCL_PTR_HOST)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			"Skip registering host buffer. local_mr: %d", local_mr);
+		goto exit;
+	}
+
+	/* Check if provider requires registration of cuda device buffers */
+	if ((hmem_mr != true) && (type == NCCL_PTR_CUDA)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			"Skip registering CUDA buffer. hmem_mr: %d", hmem_mr);
+		goto exit;
+	}
+
+	/* Populate IOV vector for memory registration */
+	iov.iov_base = data;
+	iov.iov_len = size;
+
+	/* Initialize MR attributes */
+	mr_attr.mr_iov = &iov;
+	mr_attr.iov_count = 1;
+	mr_attr.access = FI_SEND | FI_RECV;
+
+	if (type == NCCL_PTR_HOST) {
+		mr_attr.iface = FI_HMEM_SYSTEM;
+	} else {
+		mr_attr.iface = FI_HMEM_CUDA;
+
+		/* Get CUDA device ID */
+		ret = get_cuda_device(data, &mr_attr.device.cuda);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			goto exit;
+		}
+	}
+
+
+	rc = fi_mr_regattr(nccl_ofi_component[rComm->dev]->domain,
+			    &mr_attr, 0, mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
+		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
+			       type, rComm->dev, fi_strerror(-rc));
+		ret = ncclSystemError;
+	}
+
+exit:
+	return ret;
+}
 
 /*
  * @brief	Calls fi_getinfo() to find a list of usable providers for RDM
@@ -391,15 +494,16 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	}
 
 	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG;
+	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM;
 	hints->mode = FI_CONTEXT;
 
 	hints->ep_attr->type = FI_EP_RDM;
 
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	/* Indicate that the application support local memory registration */
-	hints->domain_attr->mr_mode = FI_MR_LOCAL;
+	/* Indicate that the application support both local
+	 * and device memory registration */
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM;
 
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->rx_attr->msg_order = FI_ORDER_SAS;
@@ -901,9 +1005,16 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 
 	/* Check if provider requires local memory registration */
 	if (ofi_info_list->domain_attr->mr_mode & FI_MR_LOCAL) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s required registration of local memory buffers",
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		local_mr = true;
+	}
+
+	/* Check if provider requires heterogeneous memory registration */
+	if (ofi_info_list->domain_attr->mr_mode & FI_MR_HMEM) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of device buffers",
+			       ofi_info_list->fabric_attr->prov_name);
+		hmem_mr = true;
 	}
 
 	/*
@@ -1034,7 +1145,8 @@ exit:
 
 static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 {
-	*supportedTypes = NCCL_PTR_HOST;
+	/* Supports message transfer from both CUDA and HOST buffers */
+	*supportedTypes = NCCL_PTR_HOST | NCCL_PTR_CUDA;
 	return ncclSuccess;
 }
 
@@ -1504,25 +1616,14 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	}
 
-	/* Validate type to be NCCL_PTR_HOST */
-	if (OFI_UNLIKELY(type != NCCL_PTR_HOST)) {
+	/* Validate type of buffer */
+	if ((type != NCCL_PTR_HOST) && (type != NCCL_PTR_CUDA)) {
 		ret = ncclSystemError;
-		NCCL_OFI_WARN("Plugin supports registration of host buffers only");
+		NCCL_OFI_WARN("Invalid buffer type provided: %d", type);
 		goto exit;
 	}
 
-	/* Check if we do registration of local buffers */
-	if (!local_mr) {
-		goto exit;
-	}
-
-	ret = fi_mr_reg(nccl_ofi_component[sComm->dev]->domain, data, size,
-			FI_SEND | FI_RECV, 0, 0, 0, &mr_handle, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to register memory for device %d. RC: %d, Error: %s",
-			      sComm->dev, fi_strerror(-ret));
-		ret = ncclSystemError;
-	}
+	ret = register_mr_buffers(sComm, data, size, type, &mr_handle);
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -1532,6 +1633,7 @@ exit:
 static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 {
 	ncclResult_t ret = ncclSuccess;
+	int rc;
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 
 	/* Validate Comm */
@@ -1541,16 +1643,16 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 		goto exit;
 	}
 
-	/* Check if we do registration of local buffers */
-	if (!local_mr) {
+	if (OFI_LIKELY(mr_handle == NULL)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Null MR handle provided. Skipping deregisteration.");
 		goto exit;
 	}
 
-	ret = fi_close((fid_t)mr_handle);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-			      fi_strerror(-ret));
+	rc = fi_close((fid_t)mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
 		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			      fi_strerror(-rc));
 	}
 
 exit:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -411,7 +411,7 @@ exit:
  * @return	0 on success
  *		non-zero on error
  */
-static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
+static ncclResult_t register_mr_buffers(ofiComm_t *comm, void *data,
 					int size, int type,
 					struct fid_mr **mr_handle)
 {
@@ -455,12 +455,11 @@ static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
 		}
 	}
 
-
-	rc = fi_mr_regattr(nccl_ofi_component[rComm->dev]->domain,
+	rc = fi_mr_regattr(nccl_ofi_component[comm->dev]->domain,
 			    &mr_attr, 0, mr_handle);
 	if (OFI_UNLIKELY(rc != 0)) {
 		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
-			       type, rComm->dev, fi_strerror(-rc));
+			       type, comm->dev, fi_strerror(-rc));
 		ret = ncclSystemError;
 	}
 
@@ -494,16 +493,18 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	}
 
 	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM;
+	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_RMA | FI_READ | FI_REMOTE_COMM;
 	hints->mode = FI_CONTEXT;
 
 	hints->ep_attr->type = FI_EP_RDM;
 
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	/* Indicate that the application support both local
-	 * and device memory registration */
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM;
+	/* Set MR mode bits to indicate FI_MR_BASIC registration */
+	hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
+	/* Set MR mode bits to indicate that application allows
+	 * registration of both local and device memory buffers */
+	hints->domain_attr->mr_mode |= FI_MR_LOCAL | FI_MR_HMEM;
 
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->rx_attr->msg_order = FI_ORDER_SAS;
@@ -1501,6 +1502,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	fi_addr_t remote_ep;
 	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
+	struct fid_mr *mr_handle = NULL;
 
 	pthread_mutex_lock(&nccl_ofi_lock);
 	if (nccl_ofi_comp == NULL) {
@@ -1530,11 +1532,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		ret = ncclSystemError;
 		goto exit;
 	}
+
 	req->state = NCCL_OFI_REQ_CREATED;
-
-	if (OFI_UNLIKELY(ret != 0))
-		goto exit;
-
 	req->lComm = lComm;
 	req->dev = dev;
 
@@ -1594,19 +1593,39 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
+	rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
+
+	/* Register flush dummy buffer for provider access */
+	ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
+				  rComm->flush_buff.size, NCCL_PTR_HOST,
+				  &mr_handle);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+			      dev);
+		goto error;
+	}
+	rComm->flush_buff.mr_handle = mr_handle;
+
 	/* Pre-allocated buffers for data path */
 	ret = allocate_ofi_fl(&rComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 			     dev);
-		goto exit;
+		goto error;
 	}
 
 	*recvComm = rComm;
 
+	goto exit;
+
 unlock:
 	pthread_mutex_unlock(&nccl_ofi_lock);
+error:
+	if (mr_handle)
+		fi_close((fid_t)mr_handle);
+	if (rComm)
+		free(rComm);
 exit:
 	if (req)
 		free(req);
@@ -1619,14 +1638,10 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 	struct fid_mr *mr_handle = NULL;
 	ncclResult_t ret = ncclSuccess;
 
-	/*
-	 * Let's assume the given Comm structure is for sendComm.
-	 * It doesn't matter as we will extract only dev from it
-	 */
-	sendComm_t *sComm = (sendComm_t *)comm;
+	ofiComm_t *ofi_comm = (ofiComm_t *)comm;
 
 	/* Validate Comm */
-	if (OFI_UNLIKELY(sComm == NULL)) {
+	if (OFI_UNLIKELY(ofi_comm == NULL)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Invalid Comm object provided");
 		goto exit;
@@ -1639,7 +1654,7 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	}
 
-	ret = register_mr_buffers(sComm, data, size, type, &mr_handle);
+	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle);
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -1834,13 +1849,6 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
-			      void *mhandle)
-{
-	/* NO-OP until we support NCCL_PTR_CUDA */
-	return ncclSuccess;
-}
-
 static ncclResult_t ofi_test(void* request, int* done, int* size)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1886,6 +1894,119 @@ exit:
 	return ret;
 }
 
+static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
+			      void *mhandle)
+{
+	ncclResult_t ret = ncclSuccess;
+	recvComm_t *rComm = (recvComm_t *)recvComm;
+	nccl_ofi_req_t *req = NULL;
+	ssize_t rc = 0;
+	int done = 0;
+	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
+	uint64_t cuda_key;
+
+	/* Validate recvComm */
+	if (OFI_UNLIKELY(rComm == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid recvComm provided");
+		goto exit;
+	}
+
+	if (OFI_UNLIKELY(mr_handle == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid memory registration handle provided");
+		goto exit;
+	}
+
+	if (size == 0) {
+		/*
+		 * Flush is an expensive operation. So, don't send fi_read for
+		 * 0-sized messages. Since, NCCL issues flush for every irecv(),
+		 * we guarantee to sync data to GPU even without it.
+		 */
+		goto exit;
+	}
+
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
+	if (OFI_UNLIKELY(rComm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Can not support more than %d inflight requests",
+			     NCCL_OFI_MAX_REQUESTS);
+		goto exit;
+	}
+
+	/* Allocate NCCL OFI request */
+	req = allocate_nccl_ofi_request(rComm->nccl_ofi_reqs_fl);
+	if (OFI_UNLIKELY(req == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			     rComm->dev);
+		goto exit;
+	}
+
+	req->rComm = rComm;
+	req->dev = rComm->dev;
+	req->direction = NCCL_OFI_RECV;
+
+	/* Extract remote key */
+	cuda_key = fi_mr_key(mr_handle);
+	if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Memory registration may not have completed.");
+		goto error;
+	}
+
+	/* Issue RDMA read */
+	do {
+		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
+			     rComm->flush_buff.size,
+			     fi_mr_desc(rComm->flush_buff.mr_handle),
+			     rComm->local_ep_addr, (uint64_t)data,
+			     cuda_key, &req->ctx);
+		if (rc == 0) {
+			break;
+		}
+		else if (rc == -FI_EAGAIN) {
+			/*
+			 * Process completions so that you have enough
+			 * resources for issuing fi_read
+			 */
+			ret = nccl_ofi_progress(nccl_ofi_component[rComm->dev]);
+			if (OFI_UNLIKELY(ret != ncclSuccess))
+				goto error;
+		}
+		else {
+			NCCL_OFI_WARN("Unable to issue read operation for dev %d. RC: %zd, ERROR: %s",
+				     rComm->dev, rc, fi_strerror(-rc));
+			ret = ncclSystemError;
+			goto error;
+		}
+	} while (true);
+
+	rComm->num_inflight_reqs++;
+
+	/* Ensure that the request completes */
+	while (done == 0) {
+		ret = ofi_test(req, &done, NULL);
+		/*
+		 * If testing request completion fails and returns
+		 * not completed, reduce number of inflight requests.
+		 */
+		if (OFI_UNLIKELY((ret != ncclSuccess) && (done == 0))) {
+			rComm->num_inflight_reqs--;
+			goto error;
+		}
+	}
+
+	return ret;
+
+error:
+	if (req)
+		free_nccl_ofi_req(req, false);
+exit:
+	return ret;
+}
+
 static ncclResult_t ofi_closeSend(void *sendComm)
 {
 	sendComm_t *sComm = (sendComm_t *)sendComm;
@@ -1913,8 +2034,9 @@ exit:
 static ncclResult_t ofi_closeRecv(void *recvComm)
 {
 	recvComm_t *rComm = (recvComm_t *)recvComm;
-	int dev;
+	int dev, rc;
 	ncclResult_t ret = ncclSuccess;
+	struct fid_mr *mr_handle = NULL;
 
 	if (OFI_UNLIKELY(recvComm == NULL)) {
 		ret = ncclSystemError;
@@ -1922,6 +2044,16 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 	}
 
 	dev = rComm->dev;
+
+	/* Deregister Flush buffer memory region */
+	mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
+	rc = fi_close((fid_t)mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			      fi_strerror(-rc));
+		goto exit;
+	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);
 	free(recvComm);


### PR DESCRIPTION
*Description of changes:*

This PR hosts 5 patches which allows plugin to supply CUDA buffers to libfabric layer for communication. It also implements flush() API and falls back to non-GDR capable provider on systems which do not support CUDA buffers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
