### PR TITLE
OFI-NCCL: Return success for 0-sized flush messages

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2150,10 +2150,19 @@ exit:
 static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 			      void *mhandle)
 {
-	ncclResult_t ret;
+	ncclResult_t ret = ncclSuccess;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
 	nccl_ofi_req_t *req = NULL;
 	int done = 0;
+
+	if (size == 0) {
+		/*
+		 * Flush is an expensive operation. So, don't send fi_read for
+		 * 0-sized messages. Since, NCCL issues flush for every irecv(),
+		 * we guarantee to sync data to GPU even without it.
+		 */
+		goto exit;
+	}
 
 	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
 	if (ret != ncclSuccess) {


### PR DESCRIPTION
For NCCL versions (v2.7.8 and less), flush() should exit sooner when
receiving 0-sized requests. We do not need to submit read requests or
test completions for 0-sized flush commands.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
