### PR TITLE
OFI-NCCL: Return NULL request when flush is disabled

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1962,6 +1962,7 @@ error:
 	if (req)
 		free_nccl_ofi_req(req, false);
 exit:
+	*request = NULL;
 	return ret;
 }
 
@@ -1982,6 +1983,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 		 */
 		goto exit;
 	}
+
+	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
+		goto exit;
 
 	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
 	if (ret != ncclSuccess) {


### PR DESCRIPTION
Plugin users can disable flush operations when using GPUDirect by using
`OFI_NCCL_GDR_FLUSH_DISABLE` environment variable.

When that happens, return NULL request to NCCL to avoid testing
completion for command which hasn't been issued.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
