### PR TITLE
Code cleanups

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -562,7 +562,7 @@ exit:
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
 	int idx = 0, prov_idx = 0, i, rc = 0;
-	struct fi_info *providers, *prov;
+	struct fi_info *providers = NULL, *prov = NULL;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
 	int info_count[MAX_PROV_INFO] = {0};
 	char *prov_name;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -560,7 +560,6 @@ exit:
  */
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
-	ncclResult_t ret = ncclSuccess;
 	int idx = 0, prov_idx = 0, i, rc = 0;
 	struct fi_info *providers, *prov;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
@@ -568,10 +567,8 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	char *prov_name;
 
 	rc = find_ofi_provider(&providers);
-	if (rc != 0) {
-		ret = ncclSystemError;
+	if (rc != 0)
 		goto error;
-	}
 
 	/*
 	 * Create an array of providers where each index represents
@@ -624,7 +621,7 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		}
 	}
 
-	return ret;
+	return ncclSuccess;
 
 error:
 	if (providers)

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -263,6 +263,7 @@ static int in_list(char *item, char *list)
 	}
 
 exit:
+	free(list_temp);
 	return ret;
 }
 


### PR DESCRIPTION
```
commit c67e9bede5deae9ce17290b7a4c07bf08e7d2e58 (HEAD -> master, rajachan/cleanups)
Author: Raghu Raja <craghun@amazon.com>
Date:   Tue Mar 23 21:11:05 2021 +0000

    Initialize *provider to NULL

    This prevents a garbage value in the branch that determines the need to
    free the info object.

    Signed-off-by: Raghu Raja <craghun@amazon.com>

commit f3d1a0eebb0384617c43dfcc05ffc7422ff669b6
Author: Raghu Raja <craghun@amazon.com>
Date:   Tue Mar 23 21:04:03 2021 +0000

    Fix leak of list_temp memory.

    Signed-off-by: Raghu Raja <craghun@amazon.com>

commit d45010f98f06f896ef7399bc38a6c34d922c78c4
Author: Raghu Raja <craghun@amazon.com>
Date:   Tue Mar 23 20:55:10 2021 +0000

    Remove dead return code variable

    `ret` is set in the error path, but never used.

    Signed-off-by: Raghu Raja <craghun@amazon.com>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
