### PR TITLE
Add attributes required by NCCL 2.9.6 to P4D topology file

### DIFF
--- a/topology/p4d-24xl-topo.xml
+++ b/topology/p4d-24xl-topo.xml
@@ -14,27 +14,27 @@ virtual machine.
 -->
 <system version="1">
   <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
-    <pci busid="ffff:ff:01.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
-        <pci busid="0000:10:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
-        <pci busid="0000:10:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
-        <pci busid="0000:10:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    <pci busid="ffff:ff:01.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
     </pci> <!-- Switch 0 ends -->
-    <pci busid="ffff:ff:02.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
-        <pci busid="0000:20:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
-        <pci busid="0000:20:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
-        <pci busid="0000:20:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    <pci busid="ffff:ff:02.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
     </pci> <!-- Switch 1 ends -->
   </cpu>
   <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
-    <pci busid="ffff:ff:03.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
-        <pci busid="0000:90:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
-        <pci busid="0000:90:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
-        <pci busid="0000:90:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    <pci busid="ffff:ff:03.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
     </pci> <!-- Switch 2 ends -->
-    <pci busid="ffff:ff:04.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
-        <pci busid="0000:a0:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
-        <pci busid="0000:a0:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
-        <pci busid="0000:a0:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    <pci busid="ffff:ff:04.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
     </pci> <!-- Switch 3 ends -->
   </cpu>
 </system>


### PR DESCRIPTION
NCCL 2.9.6 added a couple of new attributes to the `pci` nodes in the topology file.  NCCL attempts to read any attributes that are not supplied in the file from sysfs.  However, this fails for the dummy PCI switch nodes because they don't actually exists in sysfs.  As a result NCCL fails to initialize.

Fix this by supplying dummy values for the dummy nodes.  The real device nodes have actual values (verified on a P4D system).

A better fix may be to make NCCL not attempt to read these values nodes with PCI switch device class, however that would require a new NCCL release.  Changing the topology file keeps the impact isolated to the NCCL plugin.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.