### PR TITLE
Use page-aligned buffer for flush

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -61,6 +61,9 @@ extern "C" {
 /* Maximum length of directory path */
 #define PATH_MAX	4096
 
+/* Flush read size (bytes) */
+#define NCCL_OFI_FLUSH_SIZE	4
+
 /* NCCL OFI lock for concurrency */
 pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Logger Function */
@@ -106,7 +109,7 @@ typedef struct free_list {
 
 /* Metadata about dummy flush buffer */
 typedef struct flush_buffer {
-	int host_buffer;
+	void *host_buffer;
 	size_t size;
 	/* Memory registration handle of the local buffer */
 	struct fid_mr *mr_handle;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1747,7 +1747,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
 
 
@@ -2243,7 +2244,8 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 
 	dev = rComm->dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
 		rc = fi_close((fid_t)mr_handle);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 #include <stack.h>
 #include <nccl_ofi_param.h>
 #ifdef EFA_NIC_DUP
@@ -1747,19 +1748,27 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
+	const long page_size = sysconf(_SC_PAGESIZE);
+
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
-		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
-
+		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
+		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+					  MAP_PRIVATE | MAP_ANON, -1, 0);
+		if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
+			NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)", errno, strerror(errno));
+			ret = ncclSystemError;
+			goto exit;
+		}
 
 		/* Register flush dummy buffer for provider access */
-		ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
-					  rComm->flush_buff.size, NCCL_PTR_HOST,
+		ret = register_mr_buffers(rComm, rComm->flush_buff.host_buffer,
+					  page_size, NCCL_PTR_HOST,
 					  &mr_handle);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
-			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
 				      dev);
-			goto error;
+			goto unmap_flush;
 		}
 		rComm->flush_buff.mr_handle = mr_handle;
 	}
@@ -1779,6 +1788,11 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 unlock:
 	pthread_mutex_unlock(&nccl_ofi_lock);
+unmap_flush:
+	if (munmap(rComm->flush_buff.host_buffer, page_size)) {
+		NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+	}
+	rComm->flush_buff.host_buffer = MAP_FAILED;
 error:
 	if (mr_handle)
 		fi_close((fid_t)mr_handle);
@@ -2118,7 +2132,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 
 	/* Issue RDMA read */
 	do {
-		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
+		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
 			     fi_mr_desc(rComm->flush_buff.mr_handle),
 			     rComm->local_ep_addr, (uint64_t)data,
@@ -2251,10 +2265,14 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 		rc = fi_close((fid_t)mr_handle);
 		if (OFI_UNLIKELY(rc != 0)) {
 			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			NCCL_OFI_WARN("Unable to de-register flush buffer. RC: %d, Error: %s",
 				      fi_strerror(-rc));
 			goto exit;
 		}
+		if (munmap(rComm->flush_buff.host_buffer, sysconf(_SC_PAGESIZE))) {
+			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+		}
+		rComm->flush_buff.host_buffer = MAP_FAILED;
 	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);


### PR DESCRIPTION
*Description of changes:*

The plugin requests fork safe behavior from Libfabric.  This causes memory registrations to call `madvise` `MADV_DONTFORK` on the underlying pages.  However, there is no special handling for buffers that are not page-aligned (both in starting address and size): `rdma-core` will simply round to a page boundary.  This means that the data that happens to share a page with a registered buffer will not be propagated to a child when the parent forks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
