### PR TITLE
Use FI_EFA_FORK_SAFE environment variable to enable fork safety support

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -23,6 +23,7 @@
 #include <cuda_runtime.h>
 #endif
 
+static uint32_t libversion = 0;
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
 /* Number of NICs */
@@ -1092,9 +1093,17 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	}
 
 	/*
-	 * RDMAV_FORK_SAFE environment variable makes the rdma-core
-	 * library fork-safe. This significantly increases cost of memory
-	 * registration when huge pages are enabled.
+	 * FI_EFA_FORK_SAFE environment variable tells Libfabric to enable
+	 * fork-safe support in legacy versions of the rdma-core library.
+	 * Libfabric checks if additional handling is required for fork safety,
+	 * and does not introduce this additional overhead of setting MADV_DONTFORK
+	 * for new versions of rdma-core (38.0 and later) and the Linux kernel
+	 * that support copy-on-fork for pinned memory (5.13 and later).
+	 * These new versions are always fork-safe and additional support in userspace
+	 * is not required.
+	 *
+	 * When legacy versions of the kernel and rdma-core are used, setting
+	 * FI_EFA_FORK_SAFE to 1 disables the use of huge pages in Libfabric.
 	 *
 	 * To prevent data corruption, the EFA provider registers an atfork
 	 * handler which will abort the process whenever it believes
@@ -1103,14 +1112,19 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	 * NCCL applications heavily re-use the buffers for communication and
 	 * thus are not sensitive to increased memory registration costs.
 	 * To prevent NCCL based applications from getting aborted when using
-	 * fork(), plugin explicitly enables RDMAV_FORK_SAFE environment
-	 * variable.
+	 * fork(), the plugin explicitly enables FI_EFA_FORK_SAFE environment
+	 * variable, even in legacy environments where the overhead is high.
 	 */
-	if (!getenv("RDMAV_FORK_SAFE")) {
-		NCCL_OFI_INFO(NCCL_INIT, "Setting RDMAV_FORK_SAFE environment variable to 1.");
-		rc = setenv("RDMAV_FORK_SAFE", "1", 1);
+	libversion = fi_version();
+	const char * fork_safe_var_name =
+		(FI_MAJOR(libversion) > 1 || (FI_MAJOR(libversion) == 1 && FI_MINOR(libversion) >= 13))
+		? "FI_EFA_FORK_SAFE"
+		: "RDMAV_FORK_SAFE";
+	if (!getenv(fork_safe_var_name)) {
+		NCCL_OFI_INFO(NCCL_INIT, "Setting %s environment variable to 1", fork_safe_var_name);
+		rc = setenv(fork_safe_var_name, "1", 1);
 		if (rc != 0) {
-			NCCL_OFI_WARN("Unable to set RDMAV_FORK_SAFE");
+			NCCL_OFI_WARN("Unable to set %s", fork_safe_var_name);
 			ret = ncclSystemError;
 			goto exit;
 		}


### PR DESCRIPTION
This makes use of compatibility checks in Libfabric and only enables
the feature when it is needed.  When running with a newer kernel with
copy-on-fork support and recent rdma-core, additional fork safety
support is not required and so the variable is silently ignored.

Using FI_EFA_FORK_SAFE instead of FI_EFA_FORK_SAFE does the right
thing on both new and legacy systems.

*Issue #, if available:*
NCCLOFI-273

*Description of changes:*
Use FI_EFA_FORK_SAFE environment variable instead of RDMAV_FORK_SAFE

Tested with all relevant providers on P4 instances

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
