### PR TITLE
[aws] Set the fi_progress_mode as unspec in the hints of fi_info

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ support the following features as defined in the
 * Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
-* Automatic control and data progress model (`FI_PROGRESS_AUTO`)
 * Communication with remote endpoints (`FI_REMOTE_COMM`)
 
 For GPUDirect RDMA support, it requires these additional features from libfabric

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -501,8 +501,9 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	/* Set progress mode to unspec to use the provider's default mode. */
+	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;


### PR DESCRIPTION
Currently, aws-ofi-nccl requests FI_PROGRESS_AUTO in the
control and data progress mode of fi_info's hints. However,
EFA does not really support FI_PROGRESS_AUTO and will fail the
fi_getinfo call if user request it in future versions.
See https://github.com/ofiwg/libfabric/issues/7313.

aws-ofi-nccl does not really need FI_PROGRESS_AUTO, so it's safe
to set the fi_progress_mode as unspec in hints of fi_info so it
can use the default progress mode of the provider.

Signed-off-by: Shi Jin <sjina@amazon.com>
(cherry picked from commit 26cc1eac2b58b920137cb669a5f156cf89ef84eb)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
