### PR TITLE
Add support for NCCL v2.12

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -193,6 +194,13 @@ typedef struct pending_reqs_q {
 	pending_reqs_q_elem_t *head;
 	pending_reqs_q_elem_t *tail;
 } pending_reqs_q_t;
+
+typedef struct nccl_ofi_handle {
+	char ep_name[MAX_EP_ADDR];
+	uint64_t tag;
+} nccl_ofi_handle_t;
+
+static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*
  * Structure for an OFI network device.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -61,6 +61,9 @@ extern "C" {
  */
 #define MIN_TAG_BITS_FOR_RING_ID	(32 + 1)
 
+/* Maximum number of grouped receives */
+#define NCCL_OFI_MAX_RECVS	1
+
 /* This is twice the size of maximum inflight requests supported by NCCL */
 #define NCCL_OFI_MAX_REQUESTS	256
 
@@ -186,6 +189,9 @@ typedef struct nccl_ofi_req {
 
 	/* Associated Device ID */
 	int dev;
+
+	/* Number of receives associated with request */
+	int num_recvs;
 
 	/* Size of completed request */
 	size_t size;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -37,9 +37,14 @@ extern "C" {
 #define MAX_BDF_LEN		(25)
 
 /*
- * We have a limit of MAX_HANDLE_SIZE = 64 bytes. Therefore, we can only
- * support an endpoint name of maximum 56 bytes. We are using remaining
- * 8 bytes for tags.
+ * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
+ * An endpoint address buffer of 56 bytes *should* be large enough to hold
+ * all libfabric providers. In case the requirement changes, NCCL v2.12
+ * provides enough room to increase this size but we would need to maintain
+ * backwards compatiblity with all NCCL versions.
+ *
+ * We also store tags and communicator stage information in remaining
+ * part of the handle.
  */
 #define MAX_EP_ADDR		(56)
 
@@ -116,12 +121,34 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
+struct nccl_ofi_req;
+typedef struct nccl_ofi_req nccl_ofi_req_t;
+
+/* Various stages of connection establishment */
+typedef enum nccl_ofi_comm_stage {
+	COMM_CREATE_START = 0,
+	COMM_SEND_CONN,
+	COMM_RECV_CONN,
+	COMM_REQ_PENDING_COMP,
+	COMM_CONNECTED,
+} nccl_ofi_comm_stage_t;
+
+typedef struct save_comm_state {
+	void *comm;
+	nccl_ofi_req_t *req;
+	nccl_ofi_comm_stage_t stage;
+} save_comm_state_t;
+
 typedef struct listenComm {
 	uint64_t tag;
 	struct fid_ep *local_ep;
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
+	/* Saves temporary state when creating receive communicator object */
+	save_comm_state_t state;
+	/* Saves peer address information */
+	void *buffer;
 } listenComm_t;
 
 typedef struct comm {
@@ -198,6 +225,8 @@ typedef struct pending_reqs_q {
 typedef struct nccl_ofi_handle {
 	char ep_name[MAX_EP_ADDR];
 	uint64_t tag;
+	/* Save temporary communicator state when creating send communicator */
+	save_comm_state_t state;
 } nccl_ofi_handle_t;
 
 static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1416,12 +1416,44 @@ exit:
 }
 #endif
 
+/*
+ * @brief	Query local address for a libfabric endpoint
+ *
+ * @param	Network device
+ *
+ * @return	Local EP address, on success
+ * 		NULL, others
+ */
+static inline char *get_local_address(int dev)
+{
+	int ret = 0;
+	size_t namelen = MAX_EP_ADDR;
+	char *local_ep_addr = (char *)calloc(namelen, sizeof(char));
+
+	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
+			(void *)local_ep_addr,
+			&namelen);
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		free(local_ep_addr);
+		return NULL;
+	} else if (ret != 0) {
+		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		free(local_ep_addr);
+		return NULL;
+	}
+
+	return local_ep_addr;
+}
+
+
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
 	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
-	char ep_name[MAX_EP_ADDR] = {0};
-	size_t namelen = sizeof(ep_name);
+	char *local_ep_name = NULL;
 	fi_addr_t local_ep_addr;
 	listenComm_t *lComm = NULL;
 	uint64_t tag;
@@ -1464,27 +1496,13 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	pthread_mutex_unlock(&nccl_ofi_lock);
 
 	/* Build handle */
-	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
-			 (void *)&ep_name,
-			 &namelen);
-	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
-			      namelen, MAX_EP_ADDR);
-		ret = ncclSystemError;
-		goto error;
-	}
-	else if (ret != 0) {
-		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
-		ret = ncclSystemError;
-		goto error;
-	}
+	local_ep_name = get_local_address(dev);
 
-	memcpy(ofi_handle->ep_name, ep_name, MAX_EP_ADDR);
+	memcpy(ofi_handle->ep_name, local_ep_name, MAX_EP_ADDR);
 	ofi_handle->tag = tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
-	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
+	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)local_ep_name, 1,
 				 &local_ep_addr, 0, NULL);
 	if (OFI_UNLIKELY(num_addrs != 1)) {	/* Only 1 address should be inserted into the AV */
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
@@ -1516,6 +1534,286 @@ exit:
 	return ret;
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+/*
+ * @brief	Creates send communication for a peer
+ *
+ * @param	Network device ID
+ * 		Connection Handle transferred OOB by NCCL
+ *
+ * @return	Initialized Send Communicator object, on success
+ * 		NULL, others
+ * @return	0, success
+ * 		error, others
+ *
+ */
+static inline int create_sendComm(int dev, nccl_ofi_handle_t *ofi_handle, sendComm_t **sendComm)
+{
+	int ret = ncclSuccess;
+	char remote_ep_addr[MAX_EP_ADDR] = {0};
+	uint64_t tag = 0ULL;
+	uint64_t max_tag = 0;
+	size_t req_size = sizeof(nccl_ofi_req_t);
+	fi_addr_t remote_addr;
+	sendComm_t *sComm = NULL;
+
+	*sendComm = NULL;
+
+	/*
+	 * Create libfabric components for the given NIC, if not
+	 * already created.
+	 */
+	pthread_mutex_lock(&nccl_ofi_lock);
+	ret = get_nccl_ofi_comp(dev);
+	if (ret) {
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ret;
+	}
+	pthread_mutex_unlock(&nccl_ofi_lock);
+	max_tag = nccl_ofi_component[dev]->max_tag;
+
+	/* Get tag and remote name from handle */
+	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
+	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
+	if (tag < 1 || tag > max_tag) {
+		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
+				dev);
+		return ncclSystemError;
+	}
+
+	/* Insert remote address into AV */
+	ret = fi_av_insert(nccl_ofi_component[dev]->av,
+			   (void *)remote_ep_addr, 1,
+			   &remote_addr, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+				dev, ret);
+		return ncclSystemError;
+	}
+
+	/* Allocate and initialize sendComm */
+	sComm = (sendComm_t *)calloc(1, sizeof(sendComm_t));
+	if (OFI_UNLIKELY(sComm == NULL)) {
+		NCCL_OFI_WARN("Couldn't allocate sendComm for dev %d", dev);
+		return ncclSystemError;
+	}
+
+	sComm->tag = tag;
+	sComm->local_ep = nccl_ofi_component[dev]->ep;
+	sComm->remote_ep = remote_addr;
+	sComm->dev = dev;
+
+	/* Pre-allocated buffers for data path */
+	ret = allocate_ofi_fl(&sComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
+			req_size);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
+				dev);
+		free(sComm);
+		return ret;
+	}
+
+	*sendComm = sComm;
+	return ret;
+}
+
+/*
+ * @brief	Prepare a send request for a given sendComm
+ *
+ * @param	Valid send communicator object
+ *
+ * @return	NCCL OFI request, on success
+ * 		NULL, others
+ */
+static inline nccl_ofi_req_t *prepare_send_req(sendComm_t *sComm)
+{
+	nccl_ofi_req_t *req = NULL;
+
+	req = allocate_nccl_ofi_request(sComm->nccl_ofi_reqs_fl);
+	if (OFI_UNLIKELY(req == NULL)) {
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			      sComm->dev);
+		return NULL;
+	}
+
+	req->sComm = sComm;
+	req->dev = sComm->dev;
+	req->direction = NCCL_OFI_SEND;
+
+	return req;
+}
+
+/*
+ * @brief	Send connect request to send communicator's peer
+ *
+ * @param	Valid send communicator object
+ * 		NCCL OFI request
+ *
+ * @return	0, on successfully sending message
+ * 		-1, on failure to get local EP address
+ * 		-FI_EAGAIN, on lack of provider resources to send message
+ * 		others, on error
+ */
+static ssize_t send_connect_message(sendComm_t *sComm, nccl_ofi_req_t *req)
+{
+	ssize_t rc = 0;
+	int ret = ncclSuccess;
+	char *local_ep_addr = NULL;
+	uint64_t max_tag = nccl_ofi_component[sComm->dev]->max_tag;
+
+	/* Get local EP address to transfer in the connect message */
+	local_ep_addr = get_local_address(sComm->dev);
+	if (local_ep_addr == NULL) {
+		return -1;
+	}
+
+	/*
+	 * TODO: replace it with API of FI_INJECT type when most of
+	 * providers can support it, so that need for completion check
+	 * can be lifted.
+	 */
+	rc = fi_tsend(sComm->local_ep, (void *)local_ep_addr,
+			MAX_EP_ADDR, NULL, sComm->remote_ep,
+			sComm->tag | ~max_tag, &req->ctx);
+	if (rc == -FI_EAGAIN) {
+		/*
+		 * Process completions so that you have enough
+		 * resources for sending connect message
+		 */
+		ret = nccl_ofi_progress(nccl_ofi_component[sComm->dev]);
+		if (ret != ncclSuccess)
+			return ncclSystemError;
+	} else if (rc != 0) {
+		NCCL_OFI_WARN("Unable to send connect message for dev %d. RC: %zd, ERROR: %s",
+			       sComm->dev, rc, fi_strerror(-rc));
+	}
+
+	return rc;
+}
+
+/*
+ * @brief	Non-blocking version of ofi_connect which returns sendComm as NULL
+ *		with an expectation that it will be called again until sendComm != NULL
+ *
+ * @param	Network Device ID
+ * 		Connection Handle (transferred OOB by NCCL)
+ *
+ * @return	sendComm = NULL, if connection hasn't been established
+ * 		sendComm != NULL, once connection is established
+ * @return	0, on success
+ * 		error, on others
+ */
+static ncclResult_t ofi_iconnect(int dev, void *handle, void **sendComm)
+{
+	ncclResult_t ret = ncclSuccess;
+	ssize_t rc = 0;
+
+	*sendComm = NULL;
+
+	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
+		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
+			      dev, ofi_ndevices - 1);
+		return ncclSystemError;
+	}
+
+	if (OFI_UNLIKELY(handle == NULL)) {
+		NCCL_OFI_WARN("Provided handle is NULL");
+		return ncclSystemError;
+	}
+
+	if (OFI_UNLIKELY(nccl_ofi_component == NULL)) {
+		NCCL_OFI_WARN("NCCL OFI component is not initialised.");
+		return ncclSystemError;
+	}
+
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
+
+	/* Extract connection state of the communicator */
+	save_comm_state_t *comm_state = &(ofi_handle->state);
+	nccl_ofi_req_t *req = comm_state->req;
+	sendComm_t *sComm = comm_state->comm;
+
+	/*
+	 * Take appropriate actions based on connection stage of communicator.
+	 *
+	 * Once we have completed the actions for a particular stage, we proceed
+	 * to the next one until failure. This is to ensure we make maximum
+	 * progress in a single function invocation.
+	 */
+	nccl_ofi_comm_stage_t stage = comm_state->stage;
+	switch (stage) {
+		case COMM_CREATE_START:
+			/*
+			 * When we are building the sComm for the first time,
+			 * it should *NOT* come initialized from handle.
+			 */
+			assert(sComm == NULL);
+
+			/* Build sendComm */
+			ret = create_sendComm(dev, ofi_handle, &sComm);
+			if (OFI_UNLIKELY(ret != ncclSuccess))
+				return ret;
+
+			/* Prepare connect request to be sent to peer */
+			req = prepare_send_req(sComm);
+			if (OFI_UNLIKELY(req == NULL)) {
+				free(sComm);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_SEND_CONN;
+
+		case COMM_SEND_CONN:
+			/* Send "connect" message to remote EP */
+			rc = send_connect_message(sComm, req);
+			if (rc == -FI_EAGAIN) {
+				/* Save connection state */
+				comm_state->comm = sComm;
+				comm_state->req = req;
+				return ncclSuccess;
+			}
+			else if (rc != 0) {
+				free(sComm);
+				free_nccl_ofi_req(req, false);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_REQ_PENDING_COMP;
+
+		case COMM_REQ_PENDING_COMP:
+			/* Progress our engine to get completions */
+			ret = nccl_ofi_progress(nccl_ofi_component[dev]);
+			if (OFI_UNLIKELY(ret != ncclSuccess)) {
+				free(sComm);
+				free_nccl_ofi_req(req, false);
+				return ncclSystemError;
+			}
+
+			/* Check if the connect message is sent. */
+			if (req->state != NCCL_OFI_REQ_COMPLETED) {
+				/* Save connection state */
+				comm_state->comm = sComm;
+				comm_state->req = req;
+				return ncclSuccess;
+			}
+
+			comm_state->stage = COMM_CONNECTED;
+
+			break;
+
+		case COMM_RECV_CONN:
+		case COMM_CONNECTED:
+		default:
+			NCCL_OFI_WARN("Invalid state of send communicator object: %d", stage);
+			return ncclSystemError;
+	};
+
+	*sendComm = sComm;
+	free_nccl_ofi_req(req, false);
+
+	return ret;
+}
+#else
 static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1529,7 +1827,6 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	uint64_t max_tag = 0;
 	nccl_ofi_req_t *req = NULL;
 	size_t req_size = sizeof(nccl_ofi_req_t);
-	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1556,21 +1853,21 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	max_tag = nccl_ofi_component[dev]->max_tag;
 
 	/* Parse handle to get tag and remote name */
-	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
-	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
+	memcpy(&remote_ep_addr, (char *)handle, MAX_EP_ADDR);
+	memcpy(&tag, (char *)handle + MAX_EP_ADDR, sizeof(tag));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
-			       dev);
+			      dev);
 		goto exit;
 	}
 
 	/* Insert remote address into AV */
 	ret = fi_av_insert(nccl_ofi_component[dev]->av,
-			   (void *)remote_ep_addr, 1,
-			   &remote_addr, 0, NULL);
+			  (void *)remote_ep_addr, 1,
+			  &remote_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
-			     dev, ret);
+			      dev, ret);
 		ret = ncclSystemError;
 		goto exit;
 	}
@@ -1593,16 +1890,16 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
-			     dev);
+			      dev);
 		goto error;
 	}
 
 	req = allocate_nccl_ofi_request(sComm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(req == NULL)) {
-			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
-				      sComm->dev);
-			goto error;
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			      sComm->dev);
+		goto error;
 	}
 
 	req->sComm = sComm;
@@ -1611,14 +1908,9 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 
 	/* Get local EP address to transfer in the connect message */
 	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
-			 (void *)&local_ep_addr,
-			 &namelen);
-	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
-			      namelen, MAX_EP_ADDR);
-		ret = ncclSystemError;
-		goto error;
-	} else if (ret != 0) {
+			(void *)&local_ep_addr,
+			&namelen);
+	if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;
@@ -1648,7 +1940,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		}
 		else {
 			NCCL_OFI_WARN("Unable to send connect message for dev %d. RC: %zd, ERROR: %s",
-				     dev, rc, fi_strerror(-rc));
+				      dev, rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto error;
 		}
@@ -1675,7 +1967,323 @@ exit:
 		free_nccl_ofi_req(req, false);
 	return ret;
 }
+#endif
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+/*
+ * @brief	Allocate a request to receive peer connection message
+ *
+ * @param	Valid listen communicator object
+ *
+ * @return	NCCL OFI request, on success
+ * 		NULL, on error
+ */
+static nccl_ofi_req_t *prepare_recv_conn(listenComm_t *lComm)
+{
+	nccl_ofi_req_t *req = NULL;
+
+	/* Allocate a NCCL OFI request */
+	req = (nccl_ofi_req_t *)calloc(1, sizeof(nccl_ofi_req_t));
+	if (OFI_UNLIKELY(req == NULL)) {
+		NCCL_OFI_WARN("Unable to allocate nccl_ofi_req_t");
+		return NULL;
+	}
+
+	req->state = NCCL_OFI_REQ_CREATED;
+	req->lComm = lComm;
+	req->dev = lComm->dev;
+
+	return req;
+}
+
+/*
+ * @brief	Post a request to receive peer connection message
+ *
+ * @param	listen communicator object, contains the local EP and device information
+ * 		buffer, to receive connection message
+ * 		NCCL OFI receive request
+ *
+ * @return	0, on successful posting of receive request
+ * 		-FI_EAGAIN, on lack of provider resources to post receive request
+ * 		error, others
+ */
+static ssize_t post_recv_conn(listenComm_t *lComm, char **buffer,
+			      size_t size, nccl_ofi_req_t *req)
+{
+	ssize_t rc = 0;
+	int ret = ncclSuccess;
+	int dev = lComm->dev;
+	uint64_t max_tag;
+
+	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[dev];
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+	if (nccl_ofi_comp == NULL) {
+		NCCL_OFI_WARN("NCCL OFI component for dev %d is uninitialised",
+			      dev);
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ncclSystemError;
+	}
+
+	ret = get_nccl_ofi_comp(dev);
+	if (ret) {
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ncclSystemError;
+	}
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	max_tag = nccl_ofi_comp->max_tag;
+
+	/* Post a buffer for receiving connection requests */
+	rc = fi_trecv(lComm->local_ep, (void *)*buffer, size,
+		      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+		      0, &req->ctx);
+	if (rc == -FI_EAGAIN) {
+		/*
+		 * Process completions so that you have enough
+		 * resources for posting receive buffer
+		 */
+		ret = nccl_ofi_progress(nccl_ofi_comp);
+		if (OFI_UNLIKELY(ret != 0))
+			return ncclSystemError;
+	}
+	else if (rc != 0)
+		NCCL_OFI_WARN("Unable to post a buffer for receving connections for dev %d. RC: %zd, ERROR: %s",
+			      dev, rc, fi_strerror(-rc));
+
+	return rc;
+}
+
+/*
+ * @brief	Allocated and registers buffer to flush RDMA operations. On
+ * 		Success, receive communicator holds reference to flush buffer
+ * 		and associated memory handle.
+ *
+ * @param	Valid receive communicator object
+ *
+ * @return	0, on success
+ * 		error, on others
+ */
+static int alloc_and_reg_flush_buff(recvComm_t *rComm)
+{
+	int ret = ncclSuccess;
+	const long page_size = sysconf(_SC_PAGESIZE);
+	struct fid_mr *mr_handle = NULL;
+
+	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
+
+	rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+					     MAP_PRIVATE | MAP_ANON, -1, 0);
+	if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
+		NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)",
+			      errno, strerror(errno));
+		return ncclSystemError;
+	}
+
+	/* Register flush dummy buffer for provider access */
+	ret = register_mr_buffers(rComm, rComm->flush_buff.host_buffer,
+				  page_size, NCCL_PTR_HOST,
+				  &mr_handle);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
+				rComm->dev);
+
+		if (munmap(rComm->flush_buff.host_buffer, page_size)) {
+			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)",
+				      errno, strerror(errno));
+		}
+		rComm->flush_buff.host_buffer = MAP_FAILED;
+	}
+
+	rComm->flush_buff.mr_handle = mr_handle;
+
+	return ret;
+}
+
+/*
+ * @brief	Allocate and setup receive communicator object for a peer. This
+ * 		prepares plugin to receive messages from the given peer.
+ *
+ * @param	Valid listen communicator object
+ * 		Peer address
+ *
+ * @return	Receive communicator object, on success
+ * 		NULL, on error
+ */
+static recvComm_t *prepare_recv_comm(listenComm_t *lComm, char *remote_ep_addr)
+{
+	int ret = ncclSuccess;
+	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[lComm->dev];
+	fi_addr_t remote_ep;
+	recvComm_t *rComm = NULL;
+	size_t req_size = sizeof(nccl_ofi_req_t);
+
+	/* Insert remote EP address to AV */
+	ret = fi_av_insert(nccl_ofi_comp->av, (void *)remote_ep_addr, 1,
+			   &remote_ep, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+			      lComm->dev, fi_strerror(-ret));
+		return NULL;
+	}
+
+	/* Build recvComm */
+	rComm = (recvComm_t *)calloc(1, sizeof(recvComm_t));
+	if (rComm == NULL) {
+		NCCL_OFI_WARN("Unable to allocate receive Comm object for device %d",
+			      lComm->dev);
+		return NULL;
+	}
+
+	rComm->tag = lComm->tag;
+	rComm->local_ep = lComm->local_ep;
+	rComm->local_ep_addr = lComm->local_ep_addr;
+	rComm->remote_ep = remote_ep;
+	rComm->dev = lComm->dev;
+
+	/* Pre-allocated buffers for data path */
+	ret = allocate_ofi_fl(&rComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
+			      req_size);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
+			     lComm->dev);
+		free(rComm);
+		return NULL;
+	}
+
+	/*
+	 * Setup flush resources if using GPUDirect RDMA unless user disables
+	 * flush operations
+	 */
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
+		ret = alloc_and_reg_flush_buff(rComm);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			free(rComm);
+			return NULL;
+		}
+	}
+
+	return rComm;
+}
+
+/*
+ * @brief	Non-blocking version of ofi_accept which returns recvComm as NULL
+ * 		with an expectation that it will be called again until
+ * 		recvComm != NULL
+ *
+ * @param	Listen Communicator object
+ *
+ * @return	recvComm = NULL, if connection hasn't been established
+ * 		recvComm != NULL, once connection is established
+ * @return	0, on success
+ * 		error, on others
+ */
+static ncclResult_t ofi_iaccept(void *listenComm, void **recvComm)
+{
+	ncclResult_t ret = ncclSuccess;
+	ssize_t rc = 0;
+
+	listenComm_t *lComm = (listenComm_t *)listenComm;
+	if (lComm == NULL) {
+		NCCL_OFI_WARN("Invalid listen communicator provided");
+		return ncclSystemError;
+	}
+
+	if (lComm->accepted == true) {
+		NCCL_OFI_WARN("listenComm object already has an active connection.");
+		return ncclSystemError;
+	}
+
+	*recvComm = NULL;
+
+	/* Extract communicator state from listen communicator object */
+	save_comm_state_t *comm_state = &lComm->state;
+	recvComm_t *rComm = comm_state->comm;
+	nccl_ofi_req_t *req = comm_state->req;
+
+	/* Extract peer address from listen communicator's buffer */
+	char *remote_ep_addr = lComm->buffer;
+
+	/*
+	 * Take appropriate actions based on connection stage of communicator.
+	 *
+	 * Once we have completed the actions for a particular stage, we proceed
+	 * to the next one until failure. This is to ensure we make maximum
+	 * progress in a single function invocation.
+	 */
+	nccl_ofi_comm_stage_t stage = comm_state->stage;
+	switch (stage) {
+		case COMM_CREATE_START:
+
+			/* Prepare receive request to accept connections */
+			req = prepare_recv_conn(lComm);
+			if (req == NULL)
+				return ncclSystemError;
+
+			comm_state->stage = COMM_RECV_CONN;
+
+		case COMM_RECV_CONN:
+
+			/* Allocate memory for peer address for the first time ONLY */
+			if (remote_ep_addr == NULL)
+				remote_ep_addr = (char *)calloc(MAX_EP_ADDR, sizeof(char));
+
+			/* Post a receive message to receive peer connections */
+			rc = post_recv_conn(lComm, &remote_ep_addr, MAX_EP_ADDR, req);
+			if (rc == -FI_EAGAIN) {
+				/* Save recv request and buffer address for retry */
+				comm_state->req = req;
+				lComm->buffer = remote_ep_addr;
+				return ncclSuccess;
+			} else if (rc != 0) {
+				free(req);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_REQ_PENDING_COMP;
+
+		case COMM_REQ_PENDING_COMP:
+
+			/* Progress NCCL OFI engine so that connection is accepted */
+			ret = nccl_ofi_progress(nccl_ofi_component[lComm->dev]);
+			if (OFI_UNLIKELY(ret != 0)) {
+				free(req);
+				return ncclSystemError;
+			}
+
+			if (lComm->accepted != true) {
+				/* Save recv request and buffer to retest completion */
+				comm_state->req = req;
+				lComm->buffer = remote_ep_addr;
+				return ncclSuccess;
+			}
+
+			/* Done processing the request so free it */
+			free(req);
+			comm_state->stage = COMM_CONNECTED;
+
+			break;
+
+		case COMM_SEND_CONN:
+		case COMM_CONNECTED:
+		default:
+			NCCL_OFI_WARN("Invalid state of receive communicator object: %d",
+				      stage);
+			return ncclSystemError;
+	}
+
+	/* Prepare receive communicator object for the received peer connection */
+	rComm = prepare_recv_comm(lComm, remote_ep_addr);
+	if (OFI_UNLIKELY(rComm == NULL))
+		return ncclSystemError;
+
+	comm_state->comm = rComm;
+	*recvComm = rComm;
+
+	return ret;
+}
+#else
 static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1695,7 +2303,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	if (nccl_ofi_comp == NULL) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("NCCL OFI component for dev %d is uninitialised",
-			     dev);
+			      dev);
 		goto unlock;
 	}
 
@@ -1742,7 +2350,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		}
 		else {
 			NCCL_OFI_WARN("Unable to post a buffer for receving connections for dev %d. RC: %zd, ERROR: %s",
-				     dev, rc, fi_strerror(-rc));
+				      dev, rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto exit;
 		}
@@ -1769,7 +2377,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm = (recvComm_t *)calloc(1, sizeof(recvComm_t));
 	if (rComm == NULL) {
 		NCCL_OFI_WARN("Unable to allocate receive Comm object for device %d",
-			     dev);
+			      dev);
 		ret = ncclSystemError;
 		goto exit;
 	}
@@ -1786,7 +2394,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
 		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
-					  MAP_PRIVATE | MAP_ANON, -1, 0);
+				MAP_PRIVATE | MAP_ANON, -1, 0);
 		if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
 			NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)", errno, strerror(errno));
 			ret = ncclSystemError;
@@ -1799,7 +2407,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 					  &mr_handle);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
 			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
-				      dev);
+					dev);
 			goto unmap_flush;
 		}
 		rComm->flush_buff.mr_handle = mr_handle;
@@ -1810,7 +2418,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
-			     dev);
+			      dev);
 		goto error;
 	}
 
@@ -1835,6 +2443,7 @@ exit:
 		free(req);
 	return ret;
 }
+#endif
 
 static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 			      void **mhandle)
@@ -1979,8 +2588,8 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_irecv(void* recvComm, void* data, int size,
-			      void *mhandle, void** request)
+static ncclResult_t ofi_irecv(void* recvComm, void* data, int sizes,
+			      void* mhandle, void** request)
 {
 	ncclResult_t ret = ncclSuccess;
 	ssize_t rc = 0;
@@ -2352,8 +2961,13 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.ptrSupport = ofi_ptrSupport,
 #endif
 	.listen = ofi_listen,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+	.connect = ofi_iconnect,
+	.accept = ofi_iaccept,
+#else
 	.connect = ofi_connect,
 	.accept = ofi_accept,
+#endif
 	.regMr = ofi_regMr,
 	.deregMr = ofi_deregMr,
 	.isend = ofi_isend,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1350,6 +1350,19 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/*
+	 * Sets intranode latency for EFA networks.
+	 *
+	 * This value is chosen by measuring all reduce latency for
+	 * different NCCL algorithms and using that to calculate intra node
+	 * latency based on NCCL's tuning algorithm.
+	 *
+	 * A few different values around this value were tried to see which
+	 * chose the correct algorithm (tree or ring) most times across
+	 * different message and cluster sizes.
+	 */
+	props->latency = 150;
+
+	/*
 	 * Maximum number of grouped receives. Currently, we set it to 1 to
 	 * maintain single send/recv semantics (similar to NCCL versions < v2.12).
 	 *

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1419,6 +1419,7 @@ exit:
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 	char ep_name[MAX_EP_ADDR] = {0};
 	size_t namelen = sizeof(ep_name);
 	fi_addr_t local_ep_addr;
@@ -1438,6 +1439,9 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 		ret = ncclSystemError;
 		goto error;
 	}
+
+	/* Zero-out the handle */
+	memset(ofi_handle, 0, sizeof(nccl_ofi_handle_t));
 
 	/*
 	 * Create libfabric components for the given NIC, if not
@@ -1460,17 +1464,24 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	pthread_mutex_unlock(&nccl_ofi_lock);
 
 	/* Build handle */
-	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid), (void *)&ep_name,
+	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
+			 (void *)&ep_name,
 			 &namelen);
-	if (ret != 0) {
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		ret = ncclSystemError;
+		goto error;
+	}
+	else if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;
 		goto error;
 	}
 
-	memcpy(handle, ep_name, MAX_EP_ADDR);
-	memcpy(handle + MAX_EP_ADDR, &tag, sizeof(tag));
+	memcpy(ofi_handle->ep_name, ep_name, MAX_EP_ADDR);
+	ofi_handle->tag = tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
 	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
@@ -1518,6 +1529,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	uint64_t max_tag = 0;
 	nccl_ofi_req_t *req = NULL;
 	size_t req_size = sizeof(nccl_ofi_req_t);
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1544,8 +1556,8 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	max_tag = nccl_ofi_component[dev]->max_tag;
 
 	/* Parse handle to get tag and remote name */
-	memcpy(&remote_ep_addr, (char *)handle, MAX_EP_ADDR);
-	memcpy(&tag, (char *)handle + MAX_EP_ADDR, sizeof(tag));
+	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
+	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
 			       dev);
@@ -1601,7 +1613,12 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
 			 (void *)&local_ep_addr,
 			 &namelen);
-	if (ret != 0) {
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		ret = ncclSystemError;
+		goto error;
+	} else if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -92,11 +92,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank + 1);
 	}
@@ -110,11 +112,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank - 1);
 	}

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -11,6 +11,7 @@
 #include <nccl_net.h>
 #include <nccl_ofi.h>
 #include <nccl_ofi_log.h>
+#include <nccl_ofi_param.h>
 #include "mpi.h"
 #include "config.h"
 #include <unistd.h>

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -80,6 +80,9 @@ void print_dev_props(int dev, ncclNetProperties_t *props)
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0))
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Grouped Receives: %d", props->name, props->maxRecvs);
+#endif
 }
 #endif
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
NCCL 2.12 Preview PR (https://github.com/NVIDIA/nccl/pull/624/commits/906eb4135c99c30d3a01648233840d3c49cacce2) introduces a new version V5 of the Net Plugin API.

This PR introduces the following major changes to support NCCL v2.12
* Add support for non-blocking connect/accept.
* Add API changes for irecv/isend (Currently, we do not support grouped receives)
* Set intranode latency for EFA networks
* Modify tests to support v2.12 testing and plugin configurations.

*Testing*
These changes have been tested with EFA provider on AWS EC2 infrastructure for NCCL v2.11 and NCCL v2.12.
Test include single and multi-node testing of plugin unit tests and all_reduce test from NCCL-tests benchmark suite.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
