### PR TITLE
OFI-NCCL: Bound structure changes to NCCL v2.12

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -124,6 +124,7 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 struct nccl_ofi_req;
 typedef struct nccl_ofi_req nccl_ofi_req_t;
 
@@ -141,6 +142,7 @@ typedef struct save_comm_state {
 	nccl_ofi_req_t *req;
 	nccl_ofi_comm_stage_t stage;
 } save_comm_state_t;
+#endif
 
 typedef struct listenComm {
 	uint64_t tag;
@@ -148,10 +150,12 @@ typedef struct listenComm {
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Saves temporary state when creating receive communicator object */
 	save_comm_state_t state;
 	/* Saves peer address information */
 	void *buffer;
+#endif
 } listenComm_t;
 
 typedef struct comm {
@@ -190,8 +194,10 @@ typedef struct nccl_ofi_req {
 	/* Associated Device ID */
 	int dev;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Number of receives associated with request */
 	int num_recvs;
+#endif
 
 	/* Size of completed request */
 	size_t size;
@@ -231,8 +237,10 @@ typedef struct pending_reqs_q {
 typedef struct nccl_ofi_handle {
 	char ep_name[MAX_EP_ADDR];
 	uint64_t tag;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Save temporary communicator state when creating send communicator */
 	save_comm_state_t state;
+#endif
 } nccl_ofi_handle_t;
 
 static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");


### PR DESCRIPTION
This patch ensures that comm and req structure changes only applies to
NCCL v2.12 to ensure backwards compatibility.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
