### PR TITLE
Fix crash in case if underlying provider exposes multirail devices

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1237,7 +1237,12 @@ static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_t *props)
 		goto exit;
 	}
 
-	dev_props.name = strdup(nic_info->device_attr->name);
+	/* name is NULL if device is a part of multirail config */
+	/* overriding default name only if value is available from provider */
+	if (nic_info->device_attr->name) {
+		dev_props.name = strdup(nic_info->device_attr->name);
+	}
+
 	/* Speed reported in Mbps */
 	dev_props.speed = nic_info->link_attr->speed / (1e6);
 


### PR DESCRIPTION
Issue: *https://github.com/aws/aws-ofi-nccl/issues/102*

When exposing multirail devices, underlying providers typically set name of "virtual" ultiail device to NULL, while keeping speed field filled. Strdup of NULL leads to segfault.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
