### PR TITLE
Retry fi_cq_readerr if it returns -FI_EAGAIN

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -956,7 +956,13 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 		}
 		else if (OFI_UNLIKELY(rc == -FI_EAVAIL)) {
 			rc = fi_cq_readerr(cq, &err_buffer, 0);
-			if (OFI_UNLIKELY(rc < 0)) {
+			if (OFI_UNLIKELY(rc == -FI_EAGAIN)) {
+				/*
+				 * Error not available yet.
+				 * fi_cq_read will keep returning -FI_EAVAIL so just bail out and try again later.
+				 */
+				break;
+			} else if (OFI_UNLIKELY(rc < 0)) {
 				NCCL_OFI_WARN("Unable to read from fi_cq_readerr. RC: %zd. Error: %s",
 					     rc,
 					     fi_cq_strerror(cq,


### PR DESCRIPTION
An error entry may not be written immediately when a request fails and `fi_cq_read` returns -FI_EAVAIL.  In this case, `fi_cq_readerr` will return `-FI_EAGAIN`.  Do not fail if this occurs and retry instead.