### PR TITLE
OFI-NCCL [Experimental]: Add P4De topology

### DIFF
--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -5,4 +5,4 @@
 #
 
 xmldir = ${pkgdatadir}/xml
-xml_DATA = p4d-24xl-topo.xml
+xml_DATA = p4d-24xl-topo.xml p4de-24xl-topo.xml

--- a/topology/p4de-24xl-topo.xml
+++ b/topology/p4de-24xl-topo.xml
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2022, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `p4de.24xlarge` platform type.
+This has 2 groups of PCIe hierarchy under each socket. Each group has
+2 GPUs and 1 NIC behind a PCIe switch.
+
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `p4de.24xarge`.
+
+Note: The PCI IDs of GPUs and NICs needs to match the device IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:01.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    </pci> <!-- Switch 0 ends -->
+    <pci busid="ffff:ff:02.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    </pci> <!-- Switch 1 ends -->
+  </cpu>
+  <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:03.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    </pci> <!-- Switch 2 ends -->
+    <pci busid="ffff:ff:04.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    </pci> <!-- Switch 3 ends -->
+  </cpu>
+</system>


### PR DESCRIPTION
This patch adds the right system topology for P4De platform. The
topology file is very similar to already available P4D topology
with minor changes to GPUs device IDs (80G support).

This patch also introduces refactoring to topology update logic
to enable less painful addition of new platforms.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
