### PR TITLE
OFI-NCCL [Experimental]: Add P4De topology

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,26 @@
 # v1.2.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Add P4De topology
+
+Bug Fixes:
+* Retry `fi_cq_readerr` until error-ed request entry is available and log it.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
+# v1.2.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.7](https://github.com/NVIDIA/nccl/releases/tag/v2.12.7-1) while
 maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
 It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.2.0aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.3.0aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -23,6 +23,20 @@
 #include <cuda_runtime.h>
 #endif
 
+struct ec2_platform_topology {
+	const char* name;
+	const char* topology;
+} platform_topo_map[] = {
+	[0] = {
+		.name = "p4d.24xlarge",
+		.topology = "p4d-24xl-topo.xml"
+	},
+	[1] = {
+		.name = "p4de.24xlarge",
+		.topology = "p4de-24xl-topo.xml"
+	},
+};
+
 static uint32_t libversion = 0;
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
@@ -1050,49 +1064,136 @@ static inline ncclResult_t nccl_ofi_progress(nccl_ofi_t *nccl_ofi_comp)
 }
 
 /*
- * @brief	Checks if the underlying hardware type matches the input platform type.
+ * @brief	Provides EC2 platform type as reported by the
+ * 		first line of
+ *		/sys/devices/virtual/dmi/id/product_name.
+ *		Users of this API *should* free the buffer when a
+ *		Non-NULL string is returned.
  *
- * @return	-1, on error
- *		1, if it matches
- *		0, if it does not match
+ * @return	NULL, on allocation and file system error
+ * 		EC2 platform type, on success
  */
-static int platform_type_matches(char *platform_type)
+static const char* get_platform_type()
 {
 	char file[] = "/sys/devices/virtual/dmi/id/product_name";
 	FILE *fd = NULL;
-	int len = strlen(platform_type);
-	int idx = 0, ret = -1;
 	char ch;
+	size_t len = 0;
+	size_t platform_type_len = 64;
+	char *platform_type = NULL;
 
 	fd = fopen(file, "r");
 	if (fd == NULL) {
 		NCCL_OFI_WARN("Error opening file: %s", file);
-		return -1;
+		goto error;
 	}
 
-	/* Read first line of the file */
+	platform_type = (char *)malloc(sizeof(char)*platform_type_len);
+	if (platform_type == NULL) {
+		NCCL_OFI_WARN("Unable to allocate platform type");
+		goto error;
+	}
+
+	/* Read first line of the file, reallocing the buffer as necessary */
 	while ((feof(fd) == 0) && (ferror(fd) == 0) && ((ch = fgetc(fd)) != '\n')) {
-
-		/* Report mismatch if characters read are more than string length */
-		if (idx == len) {
-			ret = 0;
-			goto exit;
-		}
-
-		/* Fail fast if there's a mismatch */
-		if (ch != platform_type[idx++]) {
-			ret = 0;
-			goto exit;
+		platform_type[len++] = ch;
+		if (len >= platform_type_len) {
+			platform_type = realloc(platform_type, len + platform_type_len);
 		}
 	}
 
-	if (idx == len) {
-		ret = 1;
+	if (ferror(fd)) {
+		NCCL_OFI_WARN("Error reading file: %s", file);
+		goto error;
+	}
+
+	platform_type[len] = '\0';
+
+	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Read %d bytes. EC2 platform type is %s", len, platform_type);
+
+	fclose(fd);
+	return platform_type;
+
+error:
+	if (platform_type)
+		free(platform_type);
+	if (fd)
+		fclose(fd);
+	return platform_type;
+}
+
+/*
+ * @brief	Returns static topology filename for given platform type, if found
+ *
+ * @input	Platform type
+ *
+ * @return	NULL, if no topology found
+ * 		Topology filename, if match found
+ */
+static const char* get_static_topology_file(const char *platform_type)
+{
+	const size_t platform_n = sizeof(platform_topo_map)/sizeof(platform_topo_map[0]);
+
+	for (size_t idx = 0; idx < platform_n; idx++) {
+		if (strcmp(platform_type, platform_topo_map[idx].name) == 0)
+			return platform_topo_map[idx].topology;
+	}
+
+	return NULL;
+}
+
+/*
+ * @brief	Update NCCL's system topology using static pre-configured topology
+ * 		files for supported EC2 platform types.
+ *
+ * @return	0, when we are succesfully able to update NCCL topology or
+ * 		   if we find no match
+ * 		error, on failure
+ */
+static ncclResult_t update_nccl_topology()
+{
+	int ret = ncclSuccess;
+	int rc = 0;
+
+	const char *platform_type = get_platform_type();
+	if (platform_type == NULL) {
+		ret = ncclSystemError;
+		goto exit;
+	}
+
+	const char *topo_file = get_static_topology_file(platform_type);
+	if (topo_file == NULL) {
+		/* No topology file exists for the given platform so return success */
+		goto exit;
+	} else {
+		/* Update topology */
+		char topology_path[PATH_MAX];
+
+		rc = snprintf(topology_path, sizeof(topology_path), "%s/%s",
+				XML_DIR, topo_file);
+		if (rc < 0 || rc >= sizeof(topology_path)) {
+			NCCL_OFI_WARN("Error occurred while forming the complete topology XML file path. RC: %d, Buffer Size: %d, XML dir: %s, Topology file: %s",
+					rc, PATH_MAX, XML_DIR, topo_file);
+			ret = ncclSystemError;
+			goto exit;
+		}
+
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+				"Running on %s platform, Setting NCCL_TOPO_FILE environment variable to %s",
+				platform_type, topology_path);
+
+		rc = setenv("NCCL_TOPO_FILE", topology_path, 1);
+		if (rc != 0) {
+			NCCL_OFI_WARN("Unable to set NCCL_TOPO_FILE");
+			ret = ncclSystemError;
+			goto exit;
+		}
+
 	}
 
 exit:
-	if (fd)
-		fclose(fd);
+	if (platform_type)
+		free((char *)platform_type);
 	return ret;
 }
 
@@ -1107,45 +1208,20 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using " PACKAGE_STRING);
 
 	/*
-	 * Use a static pre-configured topology for p4d.24xlarge platform type.
+	 * Use a static pre-configured topology for supported EC2 platform types
 	 *
-	 * While the actual physical topology is 2 GPUs and a NIC behind a PCIe
-	 * switch, the AWS hypervisor presents this as a separate PCI bus without
-	 * switch. To enable GPUDirect, plugin silently overrides the system topology
-	 * using `NCCL_TOPO_FILE` environment variable to inform NCCL of the
-	 * underlying hardware topology.
+	 * For example, for P4D platform, while the actual physical topology is
+	 * 2 GPUs and a NIC behind a PCIe switch, the AWS hypervisor presents
+	 * this as a separate PCI bus without switch. To enable GPUDirect,
+	 * plugin silently overrides the system topology using `NCCL_TOPO_FILE`
+	 * environment variable to inform NCCL of the underlying hardware topology.
 	 *
 	 * This topology information helps NCCL to form optimal
 	 * graphs by using right GPU-NIC pairs for transfers through network.
 	 */
-	int is_p4 = platform_type_matches("p4d.24xlarge");
-
-	if (is_p4 < 0) {
-		ret = ncclSystemError;
+	ret = update_nccl_topology();
+	if (ret != ncclSuccess)
 		goto exit;
-	} else if (is_p4) {
-		char p4d_topology[PATH_MAX];
-
-		rc = snprintf(p4d_topology, sizeof(p4d_topology), "%s/%s",
-			      XML_DIR, "p4d-24xl-topo.xml");
-		if (rc < 0 || rc >= PATH_MAX) {
-			NCCL_OFI_WARN("Error occurred while forming the complete topology XML file path. RC: %d, Buffer Size: %d, XML dir: %s",
-				rc, PATH_MAX, XML_DIR);
-			ret = ncclSystemError;
-			goto exit;
-		}
-
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
-			      "Running on P4d platform, Setting NCCL_TOPO_FILE environment variable to %s",
-			      p4d_topology);
-
-		rc = setenv("NCCL_TOPO_FILE", p4d_topology, 1);
-		if (rc != 0) {
-			NCCL_OFI_WARN("Unable to set NCCL_TOPO_FILE");
-			ret = ncclSystemError;
-			goto exit;
-		}
-	}
 
 	/*
 	 * FI_EFA_FORK_SAFE environment variable tells Libfabric to enable

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -5,4 +5,4 @@
 #
 
 xmldir = ${pkgdatadir}/xml
-xml_DATA = p4d-24xl-topo.xml
+xml_DATA = p4d-24xl-topo.xml p4de-24xl-topo.xml

--- a/topology/p4de-24xl-topo.xml
+++ b/topology/p4de-24xl-topo.xml
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2022, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `p4de.24xlarge` platform type.
+This has 2 groups of PCIe hierarchy under each socket. Each group has
+2 GPUs and 1 NIC behind a PCIe switch.
+
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `p4de.24xarge`.
+
+Note: The PCI IDs of GPUs and NICs needs to match the device IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:01.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    </pci> <!-- Switch 0 ends -->
+    <pci busid="ffff:ff:02.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    </pci> <!-- Switch 1 ends -->
+  </cpu>
+  <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:03.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    </pci> <!-- Switch 2 ends -->
+    <pci busid="ffff:ff:04.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    </pci> <!-- Switch 3 ends -->
+  </cpu>
+</system>


### PR DESCRIPTION
This patch adds the right system topology for P4De platform. The
topology file is very similar to already available P4D topology
with minor changes to GPUs device IDs (80G support).

This patch also introduces refactoring to topology update logic
to enable less painful addition of new platforms.

Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
