### PR TITLE
Fix CentOS 7 build regression

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
  # Install libfabric
  - git clone https://github.com/ofiwg/libfabric.git
  - pushd libfabric
- - git checkout v1.7.x
  - ./autogen.sh
  - ./configure --enable-debug; make -j8; sudo make install
  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
  - git clone https://github.com/ofiwg/libfabric.git
  - pushd libfabric
  - ./autogen.sh
- - ./configure --enable-debug; make -j8; sudo make install
+ - ./configure --enable-debug --disable-psm3; make -j8; sudo make install
  - popd
 
  # Install NCCL

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+@rashikakheria
+@nzmsv

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,5 +5,5 @@
 #
 
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src tests
+SUBDIRS = src tests topology
 EXTRA_DIST = autogen.sh

--- a/README.md
+++ b/README.md
@@ -42,7 +42,6 @@ support the following features as defined in the
 * Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
-* Automatic control and data progress model (`FI_PROGRESS_AUTO`)
 * Communication with remote endpoints (`FI_REMOTE_COMM`)
 
 For GPUDirect RDMA support, it requires these additional features from libfabric

--- a/README.md
+++ b/README.md
@@ -29,12 +29,10 @@ The plug-in currently supports the following distributions:
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
-It requires
-[Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-or later and supports
-[NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.9-1).
-The plug-in also maintains backward compatibility with older NCCL versions up to
-[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
+It requires [Libfabric](http://github.com/ofiwg/libfabric/)
+and [NCCL](http://github.com/NVIDIA/nccl/).  Please see the
+[Release notes](http://github.com/aws/aws-ofi-nccl/releases) for
+information on version compatibility.
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the

--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ The plug-in currently supports the following distributions:
 
 It also requires
 [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.5.6](https://github.com/NVIDIA/nccl/releases/tag/v2.5.6-2).
+and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
+The plug-in also maintains backward compatibility with older NCCL versions
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
+[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -72,6 +75,13 @@ dependencies with the following flags:
   --with-cuda=PATH        Path to non-standard CUDA installation
   --with-nccl=PATH        Path to non-standard NCCL installation
   --with-mpi=PATH         Path to non-standard MPI installation
+```
+
+To enable trace messages for debugging (disabled by default), use the
+following config option:
+
+```
+   --enable-trace         Enable printing trace messages
 ```
 
 ### Running Unit Tests

--- a/README.md
+++ b/README.md
@@ -84,6 +84,32 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+### Plugin Configurations
+
+The plugin allows to configure the following variables at run-time according to your environment.
+
+<table>
+   <thead>
+      <th>Parameter</th>
+      <th>Description</th>
+      <th>Type</th>
+      <th>Accepted Value</th>
+   </thead>
+   <tr>
+      <td><code>OFI_NCCL_USE_IPV6_TCP</code></td>
+      <td>Allow using endpoints with IPv6 addressing format for TCP provider. Users can specify to use a preferred libfabric provider with `FI_PROVIDER` environment variable.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
+   <tr>
+      <td><code>OFI_NCCL_TCP_EXCLUDE_IF</code></td>
+      <td>List of interface names to be filtered out for TCP provider. Users can specify to use a preferred libfabric provider with `FI_PROVIDER` environment variable.</td>
+      <td>String</td>
+      <td>Comma-separated list of interface names (Default: "lo,docker0")</td>
+   </tr>
+</table>
+
+
 ### Running Unit Tests
 
 Running unit tests requires a working MPI installation and a

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The plug-in currently supports the following distributions:
 
 It requires
 [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1).
+and supports [NCCL v2.8.3](https://github.com/NVIDIA/nccl/releases/tag/v2.8.3-1).
 The plug-in also maintains backward compatibility with older NCCL versions upto
 [NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ and operating system bypass.
 The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
-* Redhat Enterprise Linux 7
+* Redhat Enterprise Linux 7 and 8
 * Ubuntu 16.04, 18.04 and 20.04 LTS
-* CentOS 7
+* CentOS 7 and 8
 
 It requires
 [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.8.3](https://github.com/NVIDIA/nccl/releases/tag/v2.8.3-1).
+and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1).
 The plug-in also maintains backward compatibility with older NCCL versions upto
 [NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,14 @@ The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7
-* Ubuntu 16.04 LTS
+* Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
 
-It also requires
-[Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
-The plug-in also maintains backward compatibility with older NCCL versions
-[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
-[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
+It requires
+[Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1).
+The plug-in also maintains backward compatibility with older NCCL versions upto
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -45,6 +44,14 @@ support the following features as defined in the
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
 * Automatic control and data progress model (`FI_PROGRESS_AUTO`)
+* Communication with remote endpoints (`FI_REMOTE_COMM`)
+
+For GPUDirect RDMA support, it requires these additional features from libfabric
+providers. If these are not supported by any provider on system, plug-in turns off
+GPUDirect RDMA support.
+
+* Transfers to/from device memory (`FI_HMEM`)
+* Remote memory operations (`FI_RMA`, `FI_READ`)
 
 ## Getting Started
 
@@ -107,6 +114,12 @@ The plugin allows to configure the following variables at run-time according to 
       <td>String</td>
       <td>Comma-separated list of interface names (Default: "lo,docker0")</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_GDR_FLUSH_DISABLE</code></td>
+      <td>Disable flush operation when using GPUDirect.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
 </table>
 
 
@@ -119,7 +132,7 @@ for your linux distribution. Once MPI is setup, you can use commands like below
 for running any test of your choice.
 
 ```
-mpirun -n 2 --host <host-1>,<host-2> $INSTALL_PREFIX/bin/nccl_message_transfer
+mpirun -n 2 --host <host-1>,<host-2> -x RDMAV_FORK_SAFE=1 $INSTALL_PREFIX/bin/nccl_message_transfer
 ```
 
 **Note:** All tests require 2 MPI ranks to run except [ring.c](tests/ring.c)
@@ -142,7 +155,6 @@ make NCCL_HOME=~/nccl/build/
 ```
 
 3. Run perf tests
-
 ```
 NCCL_DEBUG=INFO build/all_reduce_perf -b 8 -f 2 -e 32M -c 1
 ```
@@ -150,10 +162,6 @@ NCCL_DEBUG=INFO build/all_reduce_perf -b 8 -f 2 -e 32M -c 1
 If you installed the AWS libfabric plugin in a custom prefix, ensure
 `LD_LIBRARY_PATH` is set to include that prefix so the perf test binaries can
 find the plugin.
-
-## Known Issues
-
-The plugin returns only 1 NIC device even if the system supports multiple NICs.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7 and 8
-* Ubuntu 16.04, 18.04 and 20.04 LTS
+* Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
 It requires
 [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1).
-The plug-in also maintains backward compatibility with older NCCL versions upto
+or later and supports
+[NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.9-1).
+The plug-in also maintains backward compatibility with older NCCL versions up to
 [NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 
 Libfabric supports various providers. The plug-in can choose only those which

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,7 +7,7 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
-# v1.2.0 release notes
+# v1.3.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,24 @@
 * Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
 
+# v1.1.1 release notes
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It introduces the following new features and bug fixes.
+
+New Features:
+* Injects a static topology into NCCL for P4d hardware
+* Use EFA provider supplied speed for EFA hardware.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.1.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,8 +4,30 @@
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7.0 and 8.0
-* Ubuntu 16.04, 18.04 and 20.04 LTS
+* Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
+
+# v1.1.3 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.8-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL
+v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).  It was tested with Libfabric
+versions up to [Libfabric v1.12.1](https://github.com/ofiwg/libfabric/releases/tag/v1.12.1).
+
+Ubuntu 16.04 has reached end-of-life and is no longer supported starting with this release.
+
+This release introduces the following bug fixes:
+
+Bug Fixes:
+* Fix bootstrap crash with NCCL 2.9.6 on P4D instances
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.1.2 release notes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,26 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
+# v1.1.4 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.11.4](https://github.com/NVIDIA/nccl/releases/tag/v2.11.4-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.13.2](https://github.com/ofiwg/libfabric/releases/tag/v1.13.2).
+
+New Features:
+* Print version during plugin initialization
+
+Bug Fixes:
+* Print correct error code when failing to register a memory region
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.1.3 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,9 +3,30 @@
 # Supported Distributions
 * Amazon Linux
 * Amazon Linux 2
-* Redhat Enterprise Linux 7.0
+* Redhat Enterprise Linux 7.0 and 8.0
 * Ubuntu 16.04, 18.04 and 20.04 LTS
-* CentOS 7
+* CentOS 7 and 8
+
+# v1.1.2 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0) and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It introduces the following new features and bug fixes.
+
+New Features:
+* Add support for NCCL Net v4 API
+
+Bug Fixes:
+* Handle `flush` disable configuration
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.1.1 release notes
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,8 +4,31 @@
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7.0
-* Ubuntu 16.04 LTS
+* Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
+
+# v1.1.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It introduces the following new features and bug fixes.
+
+New Features:
+* Detect and support multi-NIC environment
+* Support GPUDirect RDMA when libfabric providers support it
+* Add `flush` API support for transfers using CUDA buffers
+
+Bug Fixes:
+* Enable `RDMAV_FORK_SAFE` environment variable
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.0.1 release notes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,26 @@
 # v1.2.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Add P4De topology
+
+Bug Fixes:
+* Retry `fi_cq_readerr` until error-ed request entry is available and log it.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
+# v1.2.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.7](https://github.com/NVIDIA/nccl/releases/tag/v2.12.7-1) while
 maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
 It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,31 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
+# v1.1.5 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.11.4](https://github.com/NVIDIA/nccl/releases/tag/v2.11.4-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Make use of FI_EFA_FORK_SAFE environment variable to allow Libfabric to detect when `MADV_DONTFORK`
+  is not needed (#82).  This feature requires Libfabric v1.13.0 or higher.  When used with an older version
+  of Libfabric, the plugin will continue to set the RDMAV_FORK_SAFE environment variable.
+* Do not request FI_PROGRESS_AUTO feature when listing OFI providers; this feature is unnecessary for the plugin
+  and not requesting it improves interoperability.
+
+Bug Fixes:
+* Ensure that the buffer used for flush is page aligned and allocated with `mmap` instead of `malloc`.
+  This change is needed to correctly support `fork()` with `MADV_DONTFORK` (#77).
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.1.4 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,30 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
+# v1.2.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.12.7](https://github.com/NVIDIA/nccl/releases/tag/v2.12.7-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Add support for NCCL v2.12 with backwards compatibility to previous NCCL versions.
+
+Bug Fixes:
+* Prevent deadlock in connection establishment when using rendezvour providers.
+* Enable flush operations for provider that doesn't require memory registration.
+* Enable successful runs of unit-tests with flush disabled.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+* psm3
+
+
 # v1.1.5 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,29 @@
 * Ubuntu 16.04 LTS
 * CentOS 7
 
+# v1.0.1 release notes
+
+This release supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It also includes bug fixes and testing enhancements.
+
+New Features:
+* Support NCCL v2.6.4
+* Add validation of memory registration APIs and getProperties API in tests.
+
+Bug Fixes:
+* Use fid_mr for memory handle
+* Support disabling trace messages
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.0.0 release notes
 
 This release requires [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,7 +10,7 @@
 # v1.1.3 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-or later and supports [NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.8-1) while
+or later and supports [NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.9-1) while
 maintaining backward compatibility with older NCCL versions (up to [NCCL
 v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).  It was tested with Libfabric
 versions up to [Libfabric v1.12.1](https://github.com/ofiwg/libfabric/releases/tag/v1.12.1).

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.1], [rashika@amazon.com])
+AC_INIT([aws-ofi-nccl], [1.1.4aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AS_IF([test "x${enable_trace}" = "xyes" ],
        AC_MSG_RESULT(yes)],
        [trace=0
        AC_MSG_RESULT(no)])
-AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-debug, 0 otherwise])
+AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-trace, 0 otherwise])
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h cuda_runtime.h], [],[

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.2.0aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.3.0aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_SILENT_RULES([yes])
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
 AM_PROG_AR
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.1.4aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.1.5aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [0.9], [rashika@amazon.com])
+AC_INIT([aws-ofi-nccl], [1.1], [rashika@amazon.com])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
@@ -79,7 +79,8 @@ AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
 AC_CONFIG_FILES([Makefile
                  src/Makefile
-                 tests/Makefile])
+                 tests/Makefile
+                 topology/Makefile])
 LT_INIT([shared disable-static])
 AC_OUTPUT
 echo "*"

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.1.5aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.2.0aws], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -10,7 +10,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -243,7 +242,7 @@ typedef struct nccl_ofi_handle {
 #endif
 } nccl_ofi_handle_t;
 
-static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
+_Static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*
  * Structure for an OFI network device.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -193,6 +194,13 @@ typedef struct pending_reqs_q {
 	pending_reqs_q_elem_t *head;
 	pending_reqs_q_elem_t *tail;
 } pending_reqs_q_t;
+
+typedef struct nccl_ofi_handle {
+	char ep_name[MAX_EP_ADDR];
+	uint64_t tag;
+} nccl_ofi_handle_t;
+
+static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*
  * Structure for an OFI network device.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,6 +103,7 @@ typedef struct free_list {
 typedef struct listenComm {
 	uint64_t tag;
 	struct fid_ep *local_ep;
+	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
 } listenComm_t;
@@ -122,6 +123,7 @@ typedef struct recvComm {
 	uint64_t tag;
 	uint64_t num_inflight_reqs;
 	fi_addr_t remote_ep;
+	fi_addr_t local_ep_addr;
 	struct fid_ep *local_ep;
 	free_list_t *nccl_ofi_reqs_fl;
 } recvComm_t;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -124,6 +124,7 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 struct nccl_ofi_req;
 typedef struct nccl_ofi_req nccl_ofi_req_t;
 
@@ -141,6 +142,7 @@ typedef struct save_comm_state {
 	nccl_ofi_req_t *req;
 	nccl_ofi_comm_stage_t stage;
 } save_comm_state_t;
+#endif
 
 typedef struct listenComm {
 	uint64_t tag;
@@ -148,10 +150,12 @@ typedef struct listenComm {
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Saves temporary state when creating receive communicator object */
 	save_comm_state_t state;
 	/* Saves peer address information */
 	void *buffer;
+#endif
 } listenComm_t;
 
 typedef struct comm {
@@ -190,8 +194,10 @@ typedef struct nccl_ofi_req {
 	/* Associated Device ID */
 	int dev;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Number of receives associated with request */
 	int num_recvs;
+#endif
 
 	/* Size of completed request */
 	size_t size;
@@ -231,8 +237,10 @@ typedef struct pending_reqs_q {
 typedef struct nccl_ofi_handle {
 	char ep_name[MAX_EP_ADDR];
 	uint64_t tag;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Save temporary communicator state when creating send communicator */
 	save_comm_state_t state;
+#endif
 } nccl_ofi_handle_t;
 
 static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -61,6 +61,9 @@ extern "C" {
  */
 #define MIN_TAG_BITS_FOR_RING_ID	(32 + 1)
 
+/* Maximum number of grouped receives */
+#define NCCL_OFI_MAX_RECVS	1
+
 /* This is twice the size of maximum inflight requests supported by NCCL */
 #define NCCL_OFI_MAX_REQUESTS	256
 
@@ -186,6 +189,9 @@ typedef struct nccl_ofi_req {
 
 	/* Associated Device ID */
 	int dev;
+
+	/* Number of receives associated with request */
+	int num_recvs;
 
 	/* Size of completed request */
 	size_t size;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -61,6 +61,9 @@ extern "C" {
 /* Maximum length of directory path */
 #define PATH_MAX	4096
 
+/* Flush read size (bytes) */
+#define NCCL_OFI_FLUSH_SIZE	4
+
 /* NCCL OFI lock for concurrency */
 pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Logger Function */
@@ -106,7 +109,7 @@ typedef struct free_list {
 
 /* Metadata about dummy flush buffer */
 typedef struct flush_buffer {
-	int host_buffer;
+	void *host_buffer;
 	size_t size;
 	/* Memory registration handle of the local buffer */
 	struct fid_mr *mr_handle;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -58,6 +58,9 @@ extern "C" {
 /* This is twice the size of maximum inflight requests supported by NCCL */
 #define NCCL_OFI_MAX_REQUESTS	256
 
+/* Maximum length of directory path */
+#define PATH_MAX	4096
+
 /* NCCL OFI lock for concurrency */
 pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Logger Function */

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -37,9 +37,14 @@ extern "C" {
 #define MAX_BDF_LEN		(25)
 
 /*
- * We have a limit of MAX_HANDLE_SIZE = 64 bytes. Therefore, we can only
- * support an endpoint name of maximum 56 bytes. We are using remaining
- * 8 bytes for tags.
+ * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
+ * An endpoint address buffer of 56 bytes *should* be large enough to hold
+ * all libfabric providers. In case the requirement changes, NCCL v2.12
+ * provides enough room to increase this size but we would need to maintain
+ * backwards compatiblity with all NCCL versions.
+ *
+ * We also store tags and communicator stage information in remaining
+ * part of the handle.
  */
 #define MAX_EP_ADDR		(56)
 
@@ -116,12 +121,34 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
+struct nccl_ofi_req;
+typedef struct nccl_ofi_req nccl_ofi_req_t;
+
+/* Various stages of connection establishment */
+typedef enum nccl_ofi_comm_stage {
+	COMM_CREATE_START = 0,
+	COMM_SEND_CONN,
+	COMM_RECV_CONN,
+	COMM_REQ_PENDING_COMP,
+	COMM_CONNECTED,
+} nccl_ofi_comm_stage_t;
+
+typedef struct save_comm_state {
+	void *comm;
+	nccl_ofi_req_t *req;
+	nccl_ofi_comm_stage_t stage;
+} save_comm_state_t;
+
 typedef struct listenComm {
 	uint64_t tag;
 	struct fid_ep *local_ep;
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
+	/* Saves temporary state when creating receive communicator object */
+	save_comm_state_t state;
+	/* Saves peer address information */
+	void *buffer;
 } listenComm_t;
 
 typedef struct comm {
@@ -198,6 +225,8 @@ typedef struct pending_reqs_q {
 typedef struct nccl_ofi_handle {
 	char ep_name[MAX_EP_ADDR];
 	uint64_t tag;
+	/* Save temporary communicator state when creating send communicator */
+	save_comm_state_t state;
 } nccl_ofi_handle_t;
 
 static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_PARAM_H_
+#define NCCL_OFI_PARAM_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <nccl_ofi_log.h>
+#include <assert.h>
+#include <string.h>
+
+#define OFI_NCCL_PARAM_INT(name, env, default_value) \
+pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+int64_t ofi_nccl_##name() { \
+    assert(default_value != -1LL); \
+    static int64_t value = -1LL; \
+    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    int64_t v; \
+    char *str; \
+    if (value == -1LL) { \
+        value = default_value; \
+        str = getenv("OFI_NCCL_" env); \
+        if (str && strlen(str) > 0) { \
+            errno = 0; \
+            v = strtoll(str, NULL, 0); \
+            if (!errno) { \
+                value = v; \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting %s environment variable to %lu", \
+                              "OFI_NCCL_" env, value); \
+            } else { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, \
+                    "Invalid value %s provided for %s environment variable, using default %s", \
+                    str, "OFI_NCCL_" env, value); \
+            } \
+        } \
+    } \
+    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    return value; \
+}
+
+#define OFI_NCCL_PARAM_STR(name, env, default_value) \
+pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+char *ofi_nccl_##name() { \
+    assert(default_value != NULL); \
+    static char *value = NULL; \
+    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    char *str; \
+    if (value == NULL) { \
+        value = strdup(default_value); \
+        str = getenv("OFI_NCCL_" env); \
+        if (str && strlen(str) > 0) { \
+            errno = 0; \
+            value = strdup(str); \
+            if (!errno) { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting %s environment variable to %s", \
+                              "OFI_NCCL_" env, value); \
+            } else { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, \
+                    "Invalid value %s provided for %s environment variable", \
+                    str, "OFI_NCCL_" env); \
+            } \
+        } \
+    } \
+    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    return value; \
+}
+
+/*
+ * Enable using endpoints with IPv6 addressing format for TCP provider.
+ * By default, we disable using endpoints having IPv6 addressing format.
+ */
+OFI_NCCL_PARAM_INT(use_ipv6_tcp, "USE_IPV6_TCP", 0);
+
+/*
+ * List of interface names (comma-separated) to be filtered out for TCP provider.
+ * By default, it is set to eliminate lo and docker0 interfaces.
+ *
+ * TODO: Remove lo after https://github.com/ofiwg/libfabric/issues/6127 is fixed
+ */
+OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_PARAM_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -83,6 +83,15 @@ OFI_NCCL_PARAM_INT(use_ipv6_tcp, "USE_IPV6_TCP", 0);
  */
 OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
 
+/*
+ * Disable flush operation when using GPUDirect. Flush commands
+ * are used to enforce data consistency at the receiving GPU. It should
+ * only be disabled when underlying libfabric provider or hardware
+ * ensures data consistency.
+ * By default, plugin issues flush commands.
+ */
+OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,7 +5,7 @@
 #
 
 AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
-AM_CFLAGS += -I$(top_srcdir)/include
+AM_CPPFLAGS = -I$(top_srcdir)/include -DXML_DIR=\"${pkgdatadir}/xml\"
 AM_LDFLAGS = -lcudart
 
 lib_LTLIBRARIES = libnccl-net.la

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -276,6 +276,7 @@ exit:
 	return ret;
 }
 
+#ifndef EFA_NIC_DUP
 /*
  * @brief	Returns true if the given provider matches IPv6 addressing format,
  *		interfaces from tcp_if_exclude_list or multiple memory tag formats.
@@ -368,6 +369,7 @@ static void filter_tcp_info_list()
 		ofi_info_list = prev;
 	}
 }
+#endif
 
 /*
  * @brief	Gets the CUDA device associated with the buffer

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1419,7 +1419,12 @@ static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_t *props)
 		goto exit;
 	}
 
-	dev_props.name = strdup(nic_info->device_attr->name);
+	/* name is NULL if device is a part of multirail config */
+	/* overriding default name only if value is available from provider */
+	if (nic_info->device_attr->name) {
+		dev_props.name = strdup(nic_info->device_attr->name);
+	}
+
 	/* Speed reported in Mbps */
 	dev_props.speed = nic_info->link_attr->speed / (1e6);
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2324,6 +2324,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
 	struct fid_mr *mr_handle = NULL;
+	const long page_size = sysconf(_SC_PAGESIZE);
 
 	pthread_mutex_lock(&nccl_ofi_lock);
 	if (nccl_ofi_comp == NULL) {
@@ -2413,8 +2414,6 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->local_ep_addr = lComm->local_ep_addr;
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
-
-	const long page_size = sysconf(_SC_PAGESIZE);
 
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -462,7 +462,7 @@ static ncclResult_t register_mr_buffers(ofiComm_t *comm, void *data,
 			    &mr_attr, 0, mr_handle);
 	if (OFI_UNLIKELY(rc != 0)) {
 		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
-			       type, comm->dev, fi_strerror(-rc));
+			       type, comm->dev, rc, fi_strerror(-rc));
 		ret = ncclSystemError;
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2143,6 +2143,7 @@ error:
 	if (req)
 		free_nccl_ofi_req(req, false);
 exit:
+	*request = NULL;
 	return ret;
 }
 
@@ -2163,6 +2164,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 		 */
 		goto exit;
 	}
+
+	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
+		goto exit;
 
 	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
 	if (ret != ncclSuccess) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1747,7 +1747,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
 
 
@@ -2243,7 +2244,8 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 
 	dev = rComm->dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
 		rc = fi_close((fid_t)mr_handle);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -23,6 +23,20 @@
 #include <cuda_runtime.h>
 #endif
 
+struct ec2_platform_topology {
+	const char* name;
+	const char* topology;
+} platform_topo_map[] = {
+	[0] = {
+		.name = "p4d.24xlarge",
+		.topology = "p4d-24xl-topo.xml"
+	},
+	[1] = {
+		.name = "p4de.24xlarge",
+		.topology = "p4de-24xl-topo.xml"
+	},
+};
+
 static uint32_t libversion = 0;
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
@@ -1050,49 +1064,136 @@ static inline ncclResult_t nccl_ofi_progress(nccl_ofi_t *nccl_ofi_comp)
 }
 
 /*
- * @brief	Checks if the underlying hardware type matches the input platform type.
+ * @brief	Provides EC2 platform type as reported by the
+ * 		first line of
+ *		/sys/devices/virtual/dmi/id/product_name.
+ *		Users of this API *should* free the buffer when a
+ *		Non-NULL string is returned.
  *
- * @return	-1, on error
- *		1, if it matches
- *		0, if it does not match
+ * @return	NULL, on allocation and file system error
+ * 		EC2 platform type, on success
  */
-static int platform_type_matches(char *platform_type)
+static const char* get_platform_type()
 {
 	char file[] = "/sys/devices/virtual/dmi/id/product_name";
 	FILE *fd = NULL;
-	int len = strlen(platform_type);
-	int idx = 0, ret = -1;
 	char ch;
+	size_t len = 0;
+	size_t platform_type_len = 64;
+	char *platform_type = NULL;
 
 	fd = fopen(file, "r");
 	if (fd == NULL) {
 		NCCL_OFI_WARN("Error opening file: %s", file);
-		return -1;
+		goto error;
 	}
 
-	/* Read first line of the file */
+	platform_type = (char *)malloc(sizeof(char)*platform_type_len);
+	if (platform_type == NULL) {
+		NCCL_OFI_WARN("Unable to allocate platform type");
+		goto error;
+	}
+
+	/* Read first line of the file, reallocing the buffer as necessary */
 	while ((feof(fd) == 0) && (ferror(fd) == 0) && ((ch = fgetc(fd)) != '\n')) {
-
-		/* Report mismatch if characters read are more than string length */
-		if (idx == len) {
-			ret = 0;
-			goto exit;
-		}
-
-		/* Fail fast if there's a mismatch */
-		if (ch != platform_type[idx++]) {
-			ret = 0;
-			goto exit;
+		platform_type[len++] = ch;
+		if (len >= platform_type_len) {
+			platform_type = realloc(platform_type, len + platform_type_len);
 		}
 	}
 
-	if (idx == len) {
-		ret = 1;
+	if (ferror(fd)) {
+		NCCL_OFI_WARN("Error reading file: %s", file);
+		goto error;
+	}
+
+	platform_type[len] = '\0';
+
+	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Read %d bytes. EC2 platform type is %s", len, platform_type);
+
+	fclose(fd);
+	return platform_type;
+
+error:
+	if (platform_type)
+		free(platform_type);
+	if (fd)
+		fclose(fd);
+	return platform_type;
+}
+
+/*
+ * @brief	Returns static topology filename for given platform type, if found
+ *
+ * @input	Platform type
+ *
+ * @return	NULL, if no topology found
+ * 		Topology filename, if match found
+ */
+static const char* get_static_topology_file(const char *platform_type)
+{
+	const size_t platform_n = sizeof(platform_topo_map)/sizeof(platform_topo_map[0]);
+
+	for (size_t idx = 0; idx < platform_n; idx++) {
+		if (strcmp(platform_type, platform_topo_map[idx].name) == 0)
+			return platform_topo_map[idx].topology;
+	}
+
+	return NULL;
+}
+
+/*
+ * @brief	Update NCCL's system topology using static pre-configured topology
+ * 		files for supported EC2 platform types.
+ *
+ * @return	0, when we are succesfully able to update NCCL topology or
+ * 		   if we find no match
+ * 		error, on failure
+ */
+static ncclResult_t update_nccl_topology()
+{
+	int ret = ncclSuccess;
+	int rc = 0;
+
+	const char *platform_type = get_platform_type();
+	if (platform_type == NULL) {
+		ret = ncclSystemError;
+		goto exit;
+	}
+
+	const char *topo_file = get_static_topology_file(platform_type);
+	if (topo_file == NULL) {
+		/* No topology file exists for the given platform so return success */
+		goto exit;
+	} else {
+		/* Update topology */
+		char topology_path[PATH_MAX];
+
+		rc = snprintf(topology_path, sizeof(topology_path), "%s/%s",
+				XML_DIR, topo_file);
+		if (rc < 0 || rc >= sizeof(topology_path)) {
+			NCCL_OFI_WARN("Error occurred while forming the complete topology XML file path. RC: %d, Buffer Size: %d, XML dir: %s, Topology file: %s",
+					rc, PATH_MAX, XML_DIR, topo_file);
+			ret = ncclSystemError;
+			goto exit;
+		}
+
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+				"Running on %s platform, Setting NCCL_TOPO_FILE environment variable to %s",
+				platform_type, topology_path);
+
+		rc = setenv("NCCL_TOPO_FILE", topology_path, 1);
+		if (rc != 0) {
+			NCCL_OFI_WARN("Unable to set NCCL_TOPO_FILE");
+			ret = ncclSystemError;
+			goto exit;
+		}
+
 	}
 
 exit:
-	if (fd)
-		fclose(fd);
+	if (platform_type)
+		free((char *)platform_type);
 	return ret;
 }
 
@@ -1107,45 +1208,20 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using " PACKAGE_STRING);
 
 	/*
-	 * Use a static pre-configured topology for p4d.24xlarge platform type.
+	 * Use a static pre-configured topology for supported EC2 platform types
 	 *
-	 * While the actual physical topology is 2 GPUs and a NIC behind a PCIe
-	 * switch, the AWS hypervisor presents this as a separate PCI bus without
-	 * switch. To enable GPUDirect, plugin silently overrides the system topology
-	 * using `NCCL_TOPO_FILE` environment variable to inform NCCL of the
-	 * underlying hardware topology.
+	 * For example, for P4D platform, while the actual physical topology is
+	 * 2 GPUs and a NIC behind a PCIe switch, the AWS hypervisor presents
+	 * this as a separate PCI bus without switch. To enable GPUDirect,
+	 * plugin silently overrides the system topology using `NCCL_TOPO_FILE`
+	 * environment variable to inform NCCL of the underlying hardware topology.
 	 *
 	 * This topology information helps NCCL to form optimal
 	 * graphs by using right GPU-NIC pairs for transfers through network.
 	 */
-	int is_p4 = platform_type_matches("p4d.24xlarge");
-
-	if (is_p4 < 0) {
-		ret = ncclSystemError;
+	ret = update_nccl_topology();
+	if (ret != ncclSuccess)
 		goto exit;
-	} else if (is_p4) {
-		char p4d_topology[PATH_MAX];
-
-		rc = snprintf(p4d_topology, sizeof(p4d_topology), "%s/%s",
-			      XML_DIR, "p4d-24xl-topo.xml");
-		if (rc < 0 || rc >= PATH_MAX) {
-			NCCL_OFI_WARN("Error occurred while forming the complete topology XML file path. RC: %d, Buffer Size: %d, XML dir: %s",
-				rc, PATH_MAX, XML_DIR);
-			ret = ncclSystemError;
-			goto exit;
-		}
-
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
-			      "Running on P4d platform, Setting NCCL_TOPO_FILE environment variable to %s",
-			      p4d_topology);
-
-		rc = setenv("NCCL_TOPO_FILE", p4d_topology, 1);
-		if (rc != 0) {
-			NCCL_OFI_WARN("Unable to set NCCL_TOPO_FILE");
-			ret = ncclSystemError;
-			goto exit;
-		}
-	}
 
 	/*
 	 * FI_EFA_FORK_SAFE environment variable tells Libfabric to enable

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1416,12 +1416,44 @@ exit:
 }
 #endif
 
+/*
+ * @brief	Query local address for a libfabric endpoint
+ *
+ * @param	Network device
+ *
+ * @return	Local EP address, on success
+ * 		NULL, others
+ */
+static inline char *get_local_address(int dev)
+{
+	int ret = 0;
+	size_t namelen = MAX_EP_ADDR;
+	char *local_ep_addr = (char *)calloc(namelen, sizeof(char));
+
+	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
+			(void *)local_ep_addr,
+			&namelen);
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		free(local_ep_addr);
+		return NULL;
+	} else if (ret != 0) {
+		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		free(local_ep_addr);
+		return NULL;
+	}
+
+	return local_ep_addr;
+}
+
+
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
 	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
-	char ep_name[MAX_EP_ADDR] = {0};
-	size_t namelen = sizeof(ep_name);
+	char *local_ep_name = NULL;
 	fi_addr_t local_ep_addr;
 	listenComm_t *lComm = NULL;
 	uint64_t tag;
@@ -1464,27 +1496,13 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	pthread_mutex_unlock(&nccl_ofi_lock);
 
 	/* Build handle */
-	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
-			 (void *)&ep_name,
-			 &namelen);
-	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
-			      namelen, MAX_EP_ADDR);
-		ret = ncclSystemError;
-		goto error;
-	}
-	else if (ret != 0) {
-		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
-		ret = ncclSystemError;
-		goto error;
-	}
+	local_ep_name = get_local_address(dev);
 
-	memcpy(ofi_handle->ep_name, ep_name, MAX_EP_ADDR);
+	memcpy(ofi_handle->ep_name, local_ep_name, MAX_EP_ADDR);
 	ofi_handle->tag = tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
-	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
+	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)local_ep_name, 1,
 				 &local_ep_addr, 0, NULL);
 	if (OFI_UNLIKELY(num_addrs != 1)) {	/* Only 1 address should be inserted into the AV */
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
@@ -1516,6 +1534,286 @@ exit:
 	return ret;
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+/*
+ * @brief	Creates send communication for a peer
+ *
+ * @param	Network device ID
+ * 		Connection Handle transferred OOB by NCCL
+ *
+ * @return	Initialized Send Communicator object, on success
+ * 		NULL, others
+ * @return	0, success
+ * 		error, others
+ *
+ */
+static inline int create_sendComm(int dev, nccl_ofi_handle_t *ofi_handle, sendComm_t **sendComm)
+{
+	int ret = ncclSuccess;
+	char remote_ep_addr[MAX_EP_ADDR] = {0};
+	uint64_t tag = 0ULL;
+	uint64_t max_tag = 0;
+	size_t req_size = sizeof(nccl_ofi_req_t);
+	fi_addr_t remote_addr;
+	sendComm_t *sComm = NULL;
+
+	*sendComm = NULL;
+
+	/*
+	 * Create libfabric components for the given NIC, if not
+	 * already created.
+	 */
+	pthread_mutex_lock(&nccl_ofi_lock);
+	ret = get_nccl_ofi_comp(dev);
+	if (ret) {
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ret;
+	}
+	pthread_mutex_unlock(&nccl_ofi_lock);
+	max_tag = nccl_ofi_component[dev]->max_tag;
+
+	/* Get tag and remote name from handle */
+	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
+	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
+	if (tag < 1 || tag > max_tag) {
+		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
+				dev);
+		return ncclSystemError;
+	}
+
+	/* Insert remote address into AV */
+	ret = fi_av_insert(nccl_ofi_component[dev]->av,
+			   (void *)remote_ep_addr, 1,
+			   &remote_addr, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+				dev, ret);
+		return ncclSystemError;
+	}
+
+	/* Allocate and initialize sendComm */
+	sComm = (sendComm_t *)calloc(1, sizeof(sendComm_t));
+	if (OFI_UNLIKELY(sComm == NULL)) {
+		NCCL_OFI_WARN("Couldn't allocate sendComm for dev %d", dev);
+		return ncclSystemError;
+	}
+
+	sComm->tag = tag;
+	sComm->local_ep = nccl_ofi_component[dev]->ep;
+	sComm->remote_ep = remote_addr;
+	sComm->dev = dev;
+
+	/* Pre-allocated buffers for data path */
+	ret = allocate_ofi_fl(&sComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
+			req_size);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
+				dev);
+		free(sComm);
+		return ret;
+	}
+
+	*sendComm = sComm;
+	return ret;
+}
+
+/*
+ * @brief	Prepare a send request for a given sendComm
+ *
+ * @param	Valid send communicator object
+ *
+ * @return	NCCL OFI request, on success
+ * 		NULL, others
+ */
+static inline nccl_ofi_req_t *prepare_send_req(sendComm_t *sComm)
+{
+	nccl_ofi_req_t *req = NULL;
+
+	req = allocate_nccl_ofi_request(sComm->nccl_ofi_reqs_fl);
+	if (OFI_UNLIKELY(req == NULL)) {
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			      sComm->dev);
+		return NULL;
+	}
+
+	req->sComm = sComm;
+	req->dev = sComm->dev;
+	req->direction = NCCL_OFI_SEND;
+
+	return req;
+}
+
+/*
+ * @brief	Send connect request to send communicator's peer
+ *
+ * @param	Valid send communicator object
+ * 		NCCL OFI request
+ *
+ * @return	0, on successfully sending message
+ * 		-1, on failure to get local EP address
+ * 		-FI_EAGAIN, on lack of provider resources to send message
+ * 		others, on error
+ */
+static ssize_t send_connect_message(sendComm_t *sComm, nccl_ofi_req_t *req)
+{
+	ssize_t rc = 0;
+	int ret = ncclSuccess;
+	char *local_ep_addr = NULL;
+	uint64_t max_tag = nccl_ofi_component[sComm->dev]->max_tag;
+
+	/* Get local EP address to transfer in the connect message */
+	local_ep_addr = get_local_address(sComm->dev);
+	if (local_ep_addr == NULL) {
+		return -1;
+	}
+
+	/*
+	 * TODO: replace it with API of FI_INJECT type when most of
+	 * providers can support it, so that need for completion check
+	 * can be lifted.
+	 */
+	rc = fi_tsend(sComm->local_ep, (void *)local_ep_addr,
+			MAX_EP_ADDR, NULL, sComm->remote_ep,
+			sComm->tag | ~max_tag, &req->ctx);
+	if (rc == -FI_EAGAIN) {
+		/*
+		 * Process completions so that you have enough
+		 * resources for sending connect message
+		 */
+		ret = nccl_ofi_progress(nccl_ofi_component[sComm->dev]);
+		if (ret != ncclSuccess)
+			return ncclSystemError;
+	} else if (rc != 0) {
+		NCCL_OFI_WARN("Unable to send connect message for dev %d. RC: %zd, ERROR: %s",
+			       sComm->dev, rc, fi_strerror(-rc));
+	}
+
+	return rc;
+}
+
+/*
+ * @brief	Non-blocking version of ofi_connect which returns sendComm as NULL
+ *		with an expectation that it will be called again until sendComm != NULL
+ *
+ * @param	Network Device ID
+ * 		Connection Handle (transferred OOB by NCCL)
+ *
+ * @return	sendComm = NULL, if connection hasn't been established
+ * 		sendComm != NULL, once connection is established
+ * @return	0, on success
+ * 		error, on others
+ */
+static ncclResult_t ofi_iconnect(int dev, void *handle, void **sendComm)
+{
+	ncclResult_t ret = ncclSuccess;
+	ssize_t rc = 0;
+
+	*sendComm = NULL;
+
+	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
+		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
+			      dev, ofi_ndevices - 1);
+		return ncclSystemError;
+	}
+
+	if (OFI_UNLIKELY(handle == NULL)) {
+		NCCL_OFI_WARN("Provided handle is NULL");
+		return ncclSystemError;
+	}
+
+	if (OFI_UNLIKELY(nccl_ofi_component == NULL)) {
+		NCCL_OFI_WARN("NCCL OFI component is not initialised.");
+		return ncclSystemError;
+	}
+
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
+
+	/* Extract connection state of the communicator */
+	save_comm_state_t *comm_state = &(ofi_handle->state);
+	nccl_ofi_req_t *req = comm_state->req;
+	sendComm_t *sComm = comm_state->comm;
+
+	/*
+	 * Take appropriate actions based on connection stage of communicator.
+	 *
+	 * Once we have completed the actions for a particular stage, we proceed
+	 * to the next one until failure. This is to ensure we make maximum
+	 * progress in a single function invocation.
+	 */
+	nccl_ofi_comm_stage_t stage = comm_state->stage;
+	switch (stage) {
+		case COMM_CREATE_START:
+			/*
+			 * When we are building the sComm for the first time,
+			 * it should *NOT* come initialized from handle.
+			 */
+			assert(sComm == NULL);
+
+			/* Build sendComm */
+			ret = create_sendComm(dev, ofi_handle, &sComm);
+			if (OFI_UNLIKELY(ret != ncclSuccess))
+				return ret;
+
+			/* Prepare connect request to be sent to peer */
+			req = prepare_send_req(sComm);
+			if (OFI_UNLIKELY(req == NULL)) {
+				free(sComm);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_SEND_CONN;
+
+		case COMM_SEND_CONN:
+			/* Send "connect" message to remote EP */
+			rc = send_connect_message(sComm, req);
+			if (rc == -FI_EAGAIN) {
+				/* Save connection state */
+				comm_state->comm = sComm;
+				comm_state->req = req;
+				return ncclSuccess;
+			}
+			else if (rc != 0) {
+				free(sComm);
+				free_nccl_ofi_req(req, false);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_REQ_PENDING_COMP;
+
+		case COMM_REQ_PENDING_COMP:
+			/* Progress our engine to get completions */
+			ret = nccl_ofi_progress(nccl_ofi_component[dev]);
+			if (OFI_UNLIKELY(ret != ncclSuccess)) {
+				free(sComm);
+				free_nccl_ofi_req(req, false);
+				return ncclSystemError;
+			}
+
+			/* Check if the connect message is sent. */
+			if (req->state != NCCL_OFI_REQ_COMPLETED) {
+				/* Save connection state */
+				comm_state->comm = sComm;
+				comm_state->req = req;
+				return ncclSuccess;
+			}
+
+			comm_state->stage = COMM_CONNECTED;
+
+			break;
+
+		case COMM_RECV_CONN:
+		case COMM_CONNECTED:
+		default:
+			NCCL_OFI_WARN("Invalid state of send communicator object: %d", stage);
+			return ncclSystemError;
+	};
+
+	*sendComm = sComm;
+	free_nccl_ofi_req(req, false);
+
+	return ret;
+}
+#else
 static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1529,7 +1827,6 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	uint64_t max_tag = 0;
 	nccl_ofi_req_t *req = NULL;
 	size_t req_size = sizeof(nccl_ofi_req_t);
-	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1556,21 +1853,21 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	max_tag = nccl_ofi_component[dev]->max_tag;
 
 	/* Parse handle to get tag and remote name */
-	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
-	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
+	memcpy(&remote_ep_addr, (char *)handle, MAX_EP_ADDR);
+	memcpy(&tag, (char *)handle + MAX_EP_ADDR, sizeof(tag));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
-			       dev);
+			      dev);
 		goto exit;
 	}
 
 	/* Insert remote address into AV */
 	ret = fi_av_insert(nccl_ofi_component[dev]->av,
-			   (void *)remote_ep_addr, 1,
-			   &remote_addr, 0, NULL);
+			  (void *)remote_ep_addr, 1,
+			  &remote_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
-			     dev, ret);
+			      dev, ret);
 		ret = ncclSystemError;
 		goto exit;
 	}
@@ -1593,16 +1890,16 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
-			     dev);
+			      dev);
 		goto error;
 	}
 
 	req = allocate_nccl_ofi_request(sComm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(req == NULL)) {
-			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
-				      sComm->dev);
-			goto error;
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			      sComm->dev);
+		goto error;
 	}
 
 	req->sComm = sComm;
@@ -1611,14 +1908,9 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 
 	/* Get local EP address to transfer in the connect message */
 	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
-			 (void *)&local_ep_addr,
-			 &namelen);
-	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
-			      namelen, MAX_EP_ADDR);
-		ret = ncclSystemError;
-		goto error;
-	} else if (ret != 0) {
+			(void *)&local_ep_addr,
+			&namelen);
+	if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;
@@ -1648,7 +1940,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		}
 		else {
 			NCCL_OFI_WARN("Unable to send connect message for dev %d. RC: %zd, ERROR: %s",
-				     dev, rc, fi_strerror(-rc));
+				      dev, rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto error;
 		}
@@ -1675,7 +1967,323 @@ exit:
 		free_nccl_ofi_req(req, false);
 	return ret;
 }
+#endif
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+/*
+ * @brief	Allocate a request to receive peer connection message
+ *
+ * @param	Valid listen communicator object
+ *
+ * @return	NCCL OFI request, on success
+ * 		NULL, on error
+ */
+static nccl_ofi_req_t *prepare_recv_conn(listenComm_t *lComm)
+{
+	nccl_ofi_req_t *req = NULL;
+
+	/* Allocate a NCCL OFI request */
+	req = (nccl_ofi_req_t *)calloc(1, sizeof(nccl_ofi_req_t));
+	if (OFI_UNLIKELY(req == NULL)) {
+		NCCL_OFI_WARN("Unable to allocate nccl_ofi_req_t");
+		return NULL;
+	}
+
+	req->state = NCCL_OFI_REQ_CREATED;
+	req->lComm = lComm;
+	req->dev = lComm->dev;
+
+	return req;
+}
+
+/*
+ * @brief	Post a request to receive peer connection message
+ *
+ * @param	listen communicator object, contains the local EP and device information
+ * 		buffer, to receive connection message
+ * 		NCCL OFI receive request
+ *
+ * @return	0, on successful posting of receive request
+ * 		-FI_EAGAIN, on lack of provider resources to post receive request
+ * 		error, others
+ */
+static ssize_t post_recv_conn(listenComm_t *lComm, char **buffer,
+			      size_t size, nccl_ofi_req_t *req)
+{
+	ssize_t rc = 0;
+	int ret = ncclSuccess;
+	int dev = lComm->dev;
+	uint64_t max_tag;
+
+	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[dev];
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+	if (nccl_ofi_comp == NULL) {
+		NCCL_OFI_WARN("NCCL OFI component for dev %d is uninitialised",
+			      dev);
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ncclSystemError;
+	}
+
+	ret = get_nccl_ofi_comp(dev);
+	if (ret) {
+		pthread_mutex_unlock(&nccl_ofi_lock);
+		return ncclSystemError;
+	}
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	max_tag = nccl_ofi_comp->max_tag;
+
+	/* Post a buffer for receiving connection requests */
+	rc = fi_trecv(lComm->local_ep, (void *)*buffer, size,
+		      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+		      0, &req->ctx);
+	if (rc == -FI_EAGAIN) {
+		/*
+		 * Process completions so that you have enough
+		 * resources for posting receive buffer
+		 */
+		ret = nccl_ofi_progress(nccl_ofi_comp);
+		if (OFI_UNLIKELY(ret != 0))
+			return ncclSystemError;
+	}
+	else if (rc != 0)
+		NCCL_OFI_WARN("Unable to post a buffer for receving connections for dev %d. RC: %zd, ERROR: %s",
+			      dev, rc, fi_strerror(-rc));
+
+	return rc;
+}
+
+/*
+ * @brief	Allocated and registers buffer to flush RDMA operations. On
+ * 		Success, receive communicator holds reference to flush buffer
+ * 		and associated memory handle.
+ *
+ * @param	Valid receive communicator object
+ *
+ * @return	0, on success
+ * 		error, on others
+ */
+static int alloc_and_reg_flush_buff(recvComm_t *rComm)
+{
+	int ret = ncclSuccess;
+	const long page_size = sysconf(_SC_PAGESIZE);
+	struct fid_mr *mr_handle = NULL;
+
+	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
+
+	rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+					     MAP_PRIVATE | MAP_ANON, -1, 0);
+	if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
+		NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)",
+			      errno, strerror(errno));
+		return ncclSystemError;
+	}
+
+	/* Register flush dummy buffer for provider access */
+	ret = register_mr_buffers(rComm, rComm->flush_buff.host_buffer,
+				  page_size, NCCL_PTR_HOST,
+				  &mr_handle);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
+				rComm->dev);
+
+		if (munmap(rComm->flush_buff.host_buffer, page_size)) {
+			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)",
+				      errno, strerror(errno));
+		}
+		rComm->flush_buff.host_buffer = MAP_FAILED;
+	}
+
+	rComm->flush_buff.mr_handle = mr_handle;
+
+	return ret;
+}
+
+/*
+ * @brief	Allocate and setup receive communicator object for a peer. This
+ * 		prepares plugin to receive messages from the given peer.
+ *
+ * @param	Valid listen communicator object
+ * 		Peer address
+ *
+ * @return	Receive communicator object, on success
+ * 		NULL, on error
+ */
+static recvComm_t *prepare_recv_comm(listenComm_t *lComm, char *remote_ep_addr)
+{
+	int ret = ncclSuccess;
+	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[lComm->dev];
+	fi_addr_t remote_ep;
+	recvComm_t *rComm = NULL;
+	size_t req_size = sizeof(nccl_ofi_req_t);
+
+	/* Insert remote EP address to AV */
+	ret = fi_av_insert(nccl_ofi_comp->av, (void *)remote_ep_addr, 1,
+			   &remote_ep, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+			      lComm->dev, fi_strerror(-ret));
+		return NULL;
+	}
+
+	/* Build recvComm */
+	rComm = (recvComm_t *)calloc(1, sizeof(recvComm_t));
+	if (rComm == NULL) {
+		NCCL_OFI_WARN("Unable to allocate receive Comm object for device %d",
+			      lComm->dev);
+		return NULL;
+	}
+
+	rComm->tag = lComm->tag;
+	rComm->local_ep = lComm->local_ep;
+	rComm->local_ep_addr = lComm->local_ep_addr;
+	rComm->remote_ep = remote_ep;
+	rComm->dev = lComm->dev;
+
+	/* Pre-allocated buffers for data path */
+	ret = allocate_ofi_fl(&rComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
+			      req_size);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
+			     lComm->dev);
+		free(rComm);
+		return NULL;
+	}
+
+	/*
+	 * Setup flush resources if using GPUDirect RDMA unless user disables
+	 * flush operations
+	 */
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
+		ret = alloc_and_reg_flush_buff(rComm);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			free(rComm);
+			return NULL;
+		}
+	}
+
+	return rComm;
+}
+
+/*
+ * @brief	Non-blocking version of ofi_accept which returns recvComm as NULL
+ * 		with an expectation that it will be called again until
+ * 		recvComm != NULL
+ *
+ * @param	Listen Communicator object
+ *
+ * @return	recvComm = NULL, if connection hasn't been established
+ * 		recvComm != NULL, once connection is established
+ * @return	0, on success
+ * 		error, on others
+ */
+static ncclResult_t ofi_iaccept(void *listenComm, void **recvComm)
+{
+	ncclResult_t ret = ncclSuccess;
+	ssize_t rc = 0;
+
+	listenComm_t *lComm = (listenComm_t *)listenComm;
+	if (lComm == NULL) {
+		NCCL_OFI_WARN("Invalid listen communicator provided");
+		return ncclSystemError;
+	}
+
+	if (lComm->accepted == true) {
+		NCCL_OFI_WARN("listenComm object already has an active connection.");
+		return ncclSystemError;
+	}
+
+	*recvComm = NULL;
+
+	/* Extract communicator state from listen communicator object */
+	save_comm_state_t *comm_state = &lComm->state;
+	recvComm_t *rComm = comm_state->comm;
+	nccl_ofi_req_t *req = comm_state->req;
+
+	/* Extract peer address from listen communicator's buffer */
+	char *remote_ep_addr = lComm->buffer;
+
+	/*
+	 * Take appropriate actions based on connection stage of communicator.
+	 *
+	 * Once we have completed the actions for a particular stage, we proceed
+	 * to the next one until failure. This is to ensure we make maximum
+	 * progress in a single function invocation.
+	 */
+	nccl_ofi_comm_stage_t stage = comm_state->stage;
+	switch (stage) {
+		case COMM_CREATE_START:
+
+			/* Prepare receive request to accept connections */
+			req = prepare_recv_conn(lComm);
+			if (req == NULL)
+				return ncclSystemError;
+
+			comm_state->stage = COMM_RECV_CONN;
+
+		case COMM_RECV_CONN:
+
+			/* Allocate memory for peer address for the first time ONLY */
+			if (remote_ep_addr == NULL)
+				remote_ep_addr = (char *)calloc(MAX_EP_ADDR, sizeof(char));
+
+			/* Post a receive message to receive peer connections */
+			rc = post_recv_conn(lComm, &remote_ep_addr, MAX_EP_ADDR, req);
+			if (rc == -FI_EAGAIN) {
+				/* Save recv request and buffer address for retry */
+				comm_state->req = req;
+				lComm->buffer = remote_ep_addr;
+				return ncclSuccess;
+			} else if (rc != 0) {
+				free(req);
+				return ncclSystemError;
+			}
+
+			comm_state->stage = COMM_REQ_PENDING_COMP;
+
+		case COMM_REQ_PENDING_COMP:
+
+			/* Progress NCCL OFI engine so that connection is accepted */
+			ret = nccl_ofi_progress(nccl_ofi_component[lComm->dev]);
+			if (OFI_UNLIKELY(ret != 0)) {
+				free(req);
+				return ncclSystemError;
+			}
+
+			if (lComm->accepted != true) {
+				/* Save recv request and buffer to retest completion */
+				comm_state->req = req;
+				lComm->buffer = remote_ep_addr;
+				return ncclSuccess;
+			}
+
+			/* Done processing the request so free it */
+			free(req);
+			comm_state->stage = COMM_CONNECTED;
+
+			break;
+
+		case COMM_SEND_CONN:
+		case COMM_CONNECTED:
+		default:
+			NCCL_OFI_WARN("Invalid state of receive communicator object: %d",
+				      stage);
+			return ncclSystemError;
+	}
+
+	/* Prepare receive communicator object for the received peer connection */
+	rComm = prepare_recv_comm(lComm, remote_ep_addr);
+	if (OFI_UNLIKELY(rComm == NULL))
+		return ncclSystemError;
+
+	comm_state->comm = rComm;
+	*recvComm = rComm;
+
+	return ret;
+}
+#else
 static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1695,7 +2303,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	if (nccl_ofi_comp == NULL) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("NCCL OFI component for dev %d is uninitialised",
-			     dev);
+			      dev);
 		goto unlock;
 	}
 
@@ -1742,7 +2350,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		}
 		else {
 			NCCL_OFI_WARN("Unable to post a buffer for receving connections for dev %d. RC: %zd, ERROR: %s",
-				     dev, rc, fi_strerror(-rc));
+				      dev, rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto exit;
 		}
@@ -1769,7 +2377,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm = (recvComm_t *)calloc(1, sizeof(recvComm_t));
 	if (rComm == NULL) {
 		NCCL_OFI_WARN("Unable to allocate receive Comm object for device %d",
-			     dev);
+			      dev);
 		ret = ncclSystemError;
 		goto exit;
 	}
@@ -1786,7 +2394,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
 		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
-					  MAP_PRIVATE | MAP_ANON, -1, 0);
+				MAP_PRIVATE | MAP_ANON, -1, 0);
 		if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
 			NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)", errno, strerror(errno));
 			ret = ncclSystemError;
@@ -1799,7 +2407,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 					  &mr_handle);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
 			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
-				      dev);
+					dev);
 			goto unmap_flush;
 		}
 		rComm->flush_buff.mr_handle = mr_handle;
@@ -1810,7 +2418,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
-			     dev);
+			      dev);
 		goto error;
 	}
 
@@ -1835,6 +2443,7 @@ exit:
 		free(req);
 	return ret;
 }
+#endif
 
 static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 			      void **mhandle)
@@ -1979,8 +2588,8 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_irecv(void* recvComm, void* data, int size,
-			      void *mhandle, void** request)
+static ncclResult_t ofi_irecv(void* recvComm, void* data, int sizes,
+			      void* mhandle, void** request)
 {
 	ncclResult_t ret = ncclSuccess;
 	ssize_t rc = 0;
@@ -2352,8 +2961,13 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.ptrSupport = ofi_ptrSupport,
 #endif
 	.listen = ofi_listen,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+	.connect = ofi_iconnect,
+	.accept = ofi_iaccept,
+#else
 	.connect = ofi_connect,
 	.accept = ofi_accept,
+#endif
 	.regMr = ofi_regMr,
 	.deregMr = ofi_deregMr,
 	.isend = ofi_isend,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -272,6 +272,7 @@ static int in_list(char *item, char *list)
 	}
 
 exit:
+	free(list_temp);
 	return ret;
 }
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -569,7 +569,6 @@ exit:
  */
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
-	ncclResult_t ret = ncclSuccess;
 	int idx = 0, prov_idx = 0, i, rc = 0;
 	struct fi_info *providers, *prov;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
@@ -577,10 +576,8 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	char *prov_name;
 
 	rc = find_ofi_provider(&providers);
-	if (rc != 0) {
-		ret = ncclSystemError;
+	if (rc != 0)
 		goto error;
-	}
 
 	/*
 	 * Create an array of providers where each index represents
@@ -633,7 +630,7 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		}
 	}
 
-	return ret;
+	return ncclSuccess;
 
 error:
 	if (providers)

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2150,10 +2150,19 @@ exit:
 static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 			      void *mhandle)
 {
-	ncclResult_t ret;
+	ncclResult_t ret = ncclSuccess;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
 	nccl_ofi_req_t *req = NULL;
 	int done = 0;
+
+	if (size == 0) {
+		/*
+		 * Flush is an expensive operation. So, don't send fi_read for
+		 * 0-sized messages. Since, NCCL issues flush for every irecv(),
+		 * we guarantee to sync data to GPU even without it.
+		 */
+		goto exit;
+	}
 
 	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
 	if (ret != ncclSuccess) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1250,8 +1250,10 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	ncclResult_t ret = ncclSuccess;
 	char ep_name[MAX_EP_ADDR] = {0};
 	size_t namelen = sizeof(ep_name);
+	fi_addr_t local_ep_addr;
 	listenComm_t *lComm = NULL;
 	uint64_t tag;
+	int num_addrs;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1299,12 +1301,25 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	memcpy(handle, ep_name, MAX_EP_ADDR);
 	memcpy(handle + MAX_EP_ADDR, &tag, sizeof(tag));
 
+	/* Insert local EP address to AV. This will be used to issue local read operations */
+	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
+				 &local_ep_addr, 0, NULL);
+	if (OFI_UNLIKELY(num_addrs != 1)) {	/* Only 1 address should be inserted into the AV */
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+			      dev, fi_strerror(-ret));
+		ret = ncclSystemError;
+		goto exit;
+	} else {
+		ret = ncclSuccess;
+	}
+
 	/* Build listenComm */
 	lComm = (listenComm_t *)calloc(1, sizeof(listenComm_t));
 	lComm->tag = tag;
 	lComm->local_ep = nccl_ofi_component[dev]->ep;
 	lComm->accepted = false;
 	lComm->dev = dev;
+	lComm->local_ep_addr = local_ep_addr;
 
 	*listenComm = lComm;
 
@@ -1575,6 +1590,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 	rComm->tag = lComm->tag;
 	rComm->local_ep = lComm->local_ep;
+	rComm->local_ep_addr = lComm->local_ep_addr;
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1308,7 +1308,7 @@ static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
 static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
-					  ncclNetProperties_v3_t *props)
+					  ncclNetProperties_t *props)
 {
 	ncclResult_t ret = ncclSuccess;
 
@@ -1333,10 +1333,10 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 	return ret;
 }
 
-static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_v3_t *props)
+static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_t *props)
 {
 	ncclResult_t ret = ncclSuccess;
-	ncclNetProperties_v3_t dev_props = {0};
+	ncclNetProperties_t dev_props = {0};
 	struct fi_info *nic_prov = NULL;
 	struct fid_nic *nic_info = NULL;
 
@@ -2042,14 +2042,13 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
-			      void *mhandle)
+static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
+			       void *mhandle, void **request)
 {
 	ncclResult_t ret = ncclSuccess;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
 	nccl_ofi_req_t *req = NULL;
 	ssize_t rc = 0;
-	int done = 0;
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key;
 
@@ -2136,6 +2135,31 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 
 	rComm->num_inflight_reqs++;
 
+	*request = req;
+
+	return ret;
+
+error:
+	if (req)
+		free_nccl_ofi_req(req, false);
+exit:
+	return ret;
+}
+
+#if (NCCL_VERSION_CODE < NCCL_VERSION(2, 8, 0))
+static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
+			      void *mhandle)
+{
+	ncclResult_t ret;
+	recvComm_t *rComm = (recvComm_t *)recvComm;
+	nccl_ofi_req_t *req = NULL;
+	int done = 0;
+
+	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
+	if (ret != ncclSuccess) {
+		goto exit;
+	}
+
 	/* Ensure that the request completes */
 	while (done == 0) {
 		ret = ofi_test(req, &done, NULL);
@@ -2157,6 +2181,7 @@ error:
 exit:
 	return ret;
 }
+#endif
 
 static ncclResult_t ofi_closeSend(void *sendComm)
 {
@@ -2259,7 +2284,11 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.deregMr = ofi_deregMr,
 	.isend = ofi_isend,
 	.irecv = ofi_irecv,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
+	.iflush = ofi_iflush,
+#else
 	.flush = ofi_flush,
+#endif
 	.test = ofi_test,
 	.closeSend = ofi_closeSend,
 	.closeRecv = ofi_closeRecv,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1905,6 +1905,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key;
 
+	if (ofi_nccl_gdr_flush_disable())
+		goto exit;
+
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		ret = ncclSystemError;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -501,8 +501,9 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	/* Set progress mode to unspec to use the provider's default mode. */
+	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -28,6 +28,8 @@ int ofi_ndevices = -1;
 nccl_ofi_t **nccl_ofi_component = NULL;
 /* Indicates if memory registration of local buffers is required */
 bool local_mr = false;
+/* Indicates if memory registration of device buffers is required */
+bool hmem_mr = false;
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -364,6 +366,107 @@ static void filter_tcp_info_list()
 	}
 }
 
+/*
+ * @brief	Gets the CUDA device associated with the buffer
+ *
+ * @param	data
+ *		Pointer to CUDA buffer.
+ *
+ * @return	Valid CUDA device ID on success
+ *		-1 on error
+ * @return	0 on success
+ *		non-zero on error
+ */
+static ncclResult_t get_cuda_device(void *data, int *device)
+{
+	ncclResult_t ret = ncclSuccess;
+	int cuda_device = -1;
+	struct cudaPointerAttributes attr;
+	cudaError_t cuda_ret = cudaPointerGetAttributes(&attr, data);
+
+	if (cuda_ret != cudaSuccess) {
+		ret = ncclUnhandledCudaError;
+		NCCL_OFI_WARN("Invalid buffer pointer provided");
+		goto exit;
+	}
+
+	if (attr.type == cudaMemoryTypeDevice) {
+		cuda_device = attr.device;
+	}
+	else {
+		ret = ncclInvalidArgument;
+		NCCL_OFI_WARN("Invalid type of buffer provided. Only device memory is expected for NCCL_PTR_CUDA type");
+	}
+
+exit:
+	*device = cuda_device;
+	return ret;
+}
+
+/*
+ * @brief	Registers memory region (both HOST and CUDA)
+ *
+ *
+ * @return	OFI memory handle for data transfer operations
+ * @return	0 on success
+ *		non-zero on error
+ */
+static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
+					int size, int type,
+					struct fid_mr **mr_handle)
+{
+	ncclResult_t ret = ncclSuccess;
+	int rc;
+	struct fi_mr_attr mr_attr = {0};
+	struct iovec iov = {0};
+
+	/* Check if provider requires registration of local buffers */
+	if ((local_mr != true) && (type == NCCL_PTR_HOST)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			"Skip registering host buffer. local_mr: %d", local_mr);
+		goto exit;
+	}
+
+	/* Check if provider requires registration of cuda device buffers */
+	if ((hmem_mr != true) && (type == NCCL_PTR_CUDA)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			"Skip registering CUDA buffer. hmem_mr: %d", hmem_mr);
+		goto exit;
+	}
+
+	/* Populate IOV vector for memory registration */
+	iov.iov_base = data;
+	iov.iov_len = size;
+
+	/* Initialize MR attributes */
+	mr_attr.mr_iov = &iov;
+	mr_attr.iov_count = 1;
+	mr_attr.access = FI_SEND | FI_RECV;
+
+	if (type == NCCL_PTR_HOST) {
+		mr_attr.iface = FI_HMEM_SYSTEM;
+	} else {
+		mr_attr.iface = FI_HMEM_CUDA;
+
+		/* Get CUDA device ID */
+		ret = get_cuda_device(data, &mr_attr.device.cuda);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			goto exit;
+		}
+	}
+
+
+	rc = fi_mr_regattr(nccl_ofi_component[rComm->dev]->domain,
+			    &mr_attr, 0, mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
+		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
+			       type, rComm->dev, fi_strerror(-rc));
+		ret = ncclSystemError;
+	}
+
+exit:
+	return ret;
+}
 
 /*
  * @brief	Calls fi_getinfo() to find a list of usable providers for RDM
@@ -391,15 +494,16 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	}
 
 	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG;
+	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM;
 	hints->mode = FI_CONTEXT;
 
 	hints->ep_attr->type = FI_EP_RDM;
 
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	/* Indicate that the application support local memory registration */
-	hints->domain_attr->mr_mode = FI_MR_LOCAL;
+	/* Indicate that the application support both local
+	 * and device memory registration */
+	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM;
 
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->rx_attr->msg_order = FI_ORDER_SAS;
@@ -901,9 +1005,16 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 
 	/* Check if provider requires local memory registration */
 	if (ofi_info_list->domain_attr->mr_mode & FI_MR_LOCAL) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s required registration of local memory buffers",
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		local_mr = true;
+	}
+
+	/* Check if provider requires heterogeneous memory registration */
+	if (ofi_info_list->domain_attr->mr_mode & FI_MR_HMEM) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of device buffers",
+			       ofi_info_list->fabric_attr->prov_name);
+		hmem_mr = true;
 	}
 
 	/*
@@ -1034,7 +1145,8 @@ exit:
 
 static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 {
-	*supportedTypes = NCCL_PTR_HOST;
+	/* Supports message transfer from both CUDA and HOST buffers */
+	*supportedTypes = NCCL_PTR_HOST | NCCL_PTR_CUDA;
 	return ncclSuccess;
 }
 
@@ -1504,25 +1616,14 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	}
 
-	/* Validate type to be NCCL_PTR_HOST */
-	if (OFI_UNLIKELY(type != NCCL_PTR_HOST)) {
+	/* Validate type of buffer */
+	if ((type != NCCL_PTR_HOST) && (type != NCCL_PTR_CUDA)) {
 		ret = ncclSystemError;
-		NCCL_OFI_WARN("Plugin supports registration of host buffers only");
+		NCCL_OFI_WARN("Invalid buffer type provided: %d", type);
 		goto exit;
 	}
 
-	/* Check if we do registration of local buffers */
-	if (!local_mr) {
-		goto exit;
-	}
-
-	ret = fi_mr_reg(nccl_ofi_component[sComm->dev]->domain, data, size,
-			FI_SEND | FI_RECV, 0, 0, 0, &mr_handle, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to register memory for device %d. RC: %d, Error: %s",
-			      sComm->dev, fi_strerror(-ret));
-		ret = ncclSystemError;
-	}
+	ret = register_mr_buffers(sComm, data, size, type, &mr_handle);
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -1532,6 +1633,7 @@ exit:
 static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 {
 	ncclResult_t ret = ncclSuccess;
+	int rc;
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 
 	/* Validate Comm */
@@ -1541,16 +1643,16 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 		goto exit;
 	}
 
-	/* Check if we do registration of local buffers */
-	if (!local_mr) {
+	if (OFI_LIKELY(mr_handle == NULL)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Null MR handle provided. Skipping deregisteration.");
 		goto exit;
 	}
 
-	ret = fi_close((fid_t)mr_handle);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-			      fi_strerror(-ret));
+	rc = fi_close((fid_t)mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
 		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			      fi_strerror(-rc));
 	}
 
 exit:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -350,9 +350,9 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		*prov_info_list = prov_info_vec[0];
 	else {
 		for (prov_idx = 0; prov_idx < idx; prov_idx++) {
-			prov_name = prov_info_vec[idx]->fabric_attr->prov_name;
+			prov_name = prov_info_vec[prov_idx]->fabric_attr->prov_name;
 			if (in_list(prov_name, prov_include)) {
-				*prov_info_list = prov_info_vec[idx];
+				*prov_info_list = prov_info_vec[prov_idx];
 				break;
 			}
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 #include <stack.h>
 #include <nccl_ofi_param.h>
 #ifdef EFA_NIC_DUP
@@ -1747,19 +1748,27 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
+	const long page_size = sysconf(_SC_PAGESIZE);
+
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
-		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
-
+		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
+		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+					  MAP_PRIVATE | MAP_ANON, -1, 0);
+		if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
+			NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)", errno, strerror(errno));
+			ret = ncclSystemError;
+			goto exit;
+		}
 
 		/* Register flush dummy buffer for provider access */
-		ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
-					  rComm->flush_buff.size, NCCL_PTR_HOST,
+		ret = register_mr_buffers(rComm, rComm->flush_buff.host_buffer,
+					  page_size, NCCL_PTR_HOST,
 					  &mr_handle);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
-			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
 				      dev);
-			goto error;
+			goto unmap_flush;
 		}
 		rComm->flush_buff.mr_handle = mr_handle;
 	}
@@ -1779,6 +1788,11 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 unlock:
 	pthread_mutex_unlock(&nccl_ofi_lock);
+unmap_flush:
+	if (munmap(rComm->flush_buff.host_buffer, page_size)) {
+		NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+	}
+	rComm->flush_buff.host_buffer = MAP_FAILED;
 error:
 	if (mr_handle)
 		fi_close((fid_t)mr_handle);
@@ -2118,7 +2132,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 
 	/* Issue RDMA read */
 	do {
-		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
+		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
 			     fi_mr_desc(rComm->flush_buff.mr_handle),
 			     rComm->local_ep_addr, (uint64_t)data,
@@ -2251,10 +2265,14 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 		rc = fi_close((fid_t)mr_handle);
 		if (OFI_UNLIKELY(rc != 0)) {
 			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			NCCL_OFI_WARN("Unable to de-register flush buffer. RC: %d, Error: %s",
 				      fi_strerror(-rc));
 			goto exit;
 		}
+		if (munmap(rComm->flush_buff.host_buffer, sysconf(_SC_PAGESIZE))) {
+			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+		}
+		rComm->flush_buff.host_buffer = MAP_FAILED;
 	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -411,7 +411,7 @@ exit:
  * @return	0 on success
  *		non-zero on error
  */
-static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
+static ncclResult_t register_mr_buffers(ofiComm_t *comm, void *data,
 					int size, int type,
 					struct fid_mr **mr_handle)
 {
@@ -455,12 +455,11 @@ static ncclResult_t register_mr_buffers(sendComm_t *sComm, void *data,
 		}
 	}
 
-
-	rc = fi_mr_regattr(nccl_ofi_component[rComm->dev]->domain,
+	rc = fi_mr_regattr(nccl_ofi_component[comm->dev]->domain,
 			    &mr_attr, 0, mr_handle);
 	if (OFI_UNLIKELY(rc != 0)) {
 		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
-			       type, rComm->dev, fi_strerror(-rc));
+			       type, comm->dev, fi_strerror(-rc));
 		ret = ncclSystemError;
 	}
 
@@ -494,16 +493,18 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	}
 
 	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM;
+	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_RMA | FI_READ | FI_REMOTE_COMM;
 	hints->mode = FI_CONTEXT;
 
 	hints->ep_attr->type = FI_EP_RDM;
 
 	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
 	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	/* Indicate that the application support both local
-	 * and device memory registration */
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM;
+	/* Set MR mode bits to indicate FI_MR_BASIC registration */
+	hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
+	/* Set MR mode bits to indicate that application allows
+	 * registration of both local and device memory buffers */
+	hints->domain_attr->mr_mode |= FI_MR_LOCAL | FI_MR_HMEM;
 
 	hints->tx_attr->msg_order = FI_ORDER_SAS;
 	hints->rx_attr->msg_order = FI_ORDER_SAS;
@@ -1501,6 +1502,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	fi_addr_t remote_ep;
 	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
+	struct fid_mr *mr_handle = NULL;
 
 	pthread_mutex_lock(&nccl_ofi_lock);
 	if (nccl_ofi_comp == NULL) {
@@ -1530,11 +1532,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 		ret = ncclSystemError;
 		goto exit;
 	}
+
 	req->state = NCCL_OFI_REQ_CREATED;
-
-	if (OFI_UNLIKELY(ret != 0))
-		goto exit;
-
 	req->lComm = lComm;
 	req->dev = dev;
 
@@ -1594,19 +1593,39 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
+	rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
+
+	/* Register flush dummy buffer for provider access */
+	ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
+				  rComm->flush_buff.size, NCCL_PTR_HOST,
+				  &mr_handle);
+	if (OFI_UNLIKELY(ret != ncclSuccess)) {
+		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+			      dev);
+		goto error;
+	}
+	rComm->flush_buff.mr_handle = mr_handle;
+
 	/* Pre-allocated buffers for data path */
 	ret = allocate_ofi_fl(&rComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
 			      req_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 			     dev);
-		goto exit;
+		goto error;
 	}
 
 	*recvComm = rComm;
 
+	goto exit;
+
 unlock:
 	pthread_mutex_unlock(&nccl_ofi_lock);
+error:
+	if (mr_handle)
+		fi_close((fid_t)mr_handle);
+	if (rComm)
+		free(rComm);
 exit:
 	if (req)
 		free(req);
@@ -1619,14 +1638,10 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 	struct fid_mr *mr_handle = NULL;
 	ncclResult_t ret = ncclSuccess;
 
-	/*
-	 * Let's assume the given Comm structure is for sendComm.
-	 * It doesn't matter as we will extract only dev from it
-	 */
-	sendComm_t *sComm = (sendComm_t *)comm;
+	ofiComm_t *ofi_comm = (ofiComm_t *)comm;
 
 	/* Validate Comm */
-	if (OFI_UNLIKELY(sComm == NULL)) {
+	if (OFI_UNLIKELY(ofi_comm == NULL)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Invalid Comm object provided");
 		goto exit;
@@ -1639,7 +1654,7 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	}
 
-	ret = register_mr_buffers(sComm, data, size, type, &mr_handle);
+	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle);
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -1834,13 +1849,6 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
-			      void *mhandle)
-{
-	/* NO-OP until we support NCCL_PTR_CUDA */
-	return ncclSuccess;
-}
-
 static ncclResult_t ofi_test(void* request, int* done, int* size)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1886,6 +1894,119 @@ exit:
 	return ret;
 }
 
+static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
+			      void *mhandle)
+{
+	ncclResult_t ret = ncclSuccess;
+	recvComm_t *rComm = (recvComm_t *)recvComm;
+	nccl_ofi_req_t *req = NULL;
+	ssize_t rc = 0;
+	int done = 0;
+	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
+	uint64_t cuda_key;
+
+	/* Validate recvComm */
+	if (OFI_UNLIKELY(rComm == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid recvComm provided");
+		goto exit;
+	}
+
+	if (OFI_UNLIKELY(mr_handle == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid memory registration handle provided");
+		goto exit;
+	}
+
+	if (size == 0) {
+		/*
+		 * Flush is an expensive operation. So, don't send fi_read for
+		 * 0-sized messages. Since, NCCL issues flush for every irecv(),
+		 * we guarantee to sync data to GPU even without it.
+		 */
+		goto exit;
+	}
+
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
+	if (OFI_UNLIKELY(rComm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Can not support more than %d inflight requests",
+			     NCCL_OFI_MAX_REQUESTS);
+		goto exit;
+	}
+
+	/* Allocate NCCL OFI request */
+	req = allocate_nccl_ofi_request(rComm->nccl_ofi_reqs_fl);
+	if (OFI_UNLIKELY(req == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
+			     rComm->dev);
+		goto exit;
+	}
+
+	req->rComm = rComm;
+	req->dev = rComm->dev;
+	req->direction = NCCL_OFI_RECV;
+
+	/* Extract remote key */
+	cuda_key = fi_mr_key(mr_handle);
+	if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Memory registration may not have completed.");
+		goto error;
+	}
+
+	/* Issue RDMA read */
+	do {
+		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
+			     rComm->flush_buff.size,
+			     fi_mr_desc(rComm->flush_buff.mr_handle),
+			     rComm->local_ep_addr, (uint64_t)data,
+			     cuda_key, &req->ctx);
+		if (rc == 0) {
+			break;
+		}
+		else if (rc == -FI_EAGAIN) {
+			/*
+			 * Process completions so that you have enough
+			 * resources for issuing fi_read
+			 */
+			ret = nccl_ofi_progress(nccl_ofi_component[rComm->dev]);
+			if (OFI_UNLIKELY(ret != ncclSuccess))
+				goto error;
+		}
+		else {
+			NCCL_OFI_WARN("Unable to issue read operation for dev %d. RC: %zd, ERROR: %s",
+				     rComm->dev, rc, fi_strerror(-rc));
+			ret = ncclSystemError;
+			goto error;
+		}
+	} while (true);
+
+	rComm->num_inflight_reqs++;
+
+	/* Ensure that the request completes */
+	while (done == 0) {
+		ret = ofi_test(req, &done, NULL);
+		/*
+		 * If testing request completion fails and returns
+		 * not completed, reduce number of inflight requests.
+		 */
+		if (OFI_UNLIKELY((ret != ncclSuccess) && (done == 0))) {
+			rComm->num_inflight_reqs--;
+			goto error;
+		}
+	}
+
+	return ret;
+
+error:
+	if (req)
+		free_nccl_ofi_req(req, false);
+exit:
+	return ret;
+}
+
 static ncclResult_t ofi_closeSend(void *sendComm)
 {
 	sendComm_t *sComm = (sendComm_t *)sendComm;
@@ -1913,8 +2034,9 @@ exit:
 static ncclResult_t ofi_closeRecv(void *recvComm)
 {
 	recvComm_t *rComm = (recvComm_t *)recvComm;
-	int dev;
+	int dev, rc;
 	ncclResult_t ret = ncclSuccess;
+	struct fid_mr *mr_handle = NULL;
 
 	if (OFI_UNLIKELY(recvComm == NULL)) {
 		ret = ncclSystemError;
@@ -1922,6 +2044,16 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 	}
 
 	dev = rComm->dev;
+
+	/* Deregister Flush buffer memory region */
+	mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
+	rc = fi_close((fid_t)mr_handle);
+	if (OFI_UNLIKELY(rc != 0)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+			      fi_strerror(-rc));
+		goto exit;
+	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);
 	free(recvComm);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -243,22 +243,28 @@ exit:
 	return ret;
 }
 
-static int in_list(char *prov_name, char *prov_include)
+static int in_list(char *item, char *list)
 {
 	int ret = 0;
-	char *name = NULL;
+	char *token = NULL;
+	char *list_temp = strdup(list);
 
-	if (prov_include == NULL)
+	if (list_temp == NULL) {
+		if (list != NULL) {
+			NCCL_OFI_WARN("Unable to duplicate list.");
+			ret = ncclSystemError;
+		}
 		goto exit;
+	}
 
-	name = strtok((char *)prov_include, ",");
+	token = strtok((char *)list_temp, ",");
 
-	while (name) {
-		if (strcmp(prov_name, name) == 0) {
+	while (token) {
+		if (strcmp(item, token) == 0) {
 			ret = 1;
 			goto exit;
 		}
-		name = strtok(NULL, ",");
+		token = strtok(NULL, ",");
 	}
 
 exit:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -895,6 +895,81 @@ static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 	return ncclSuccess;
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
+					  ncclNetProperties_v3_t *props)
+{
+	ncclResult_t ret = ncclSuccess;
+
+	props->name = strdup(nic_prov->domain_attr->name);
+
+	/*
+	 * Currently, libfabric providers provide multiple `fi_info`
+	 * objects for devices with multiple ports. So, safely assume port number
+	 * to be always 1.
+	 */
+	props->port = 1;
+	props->maxComms = nic_prov->domain_attr->ep_cnt;
+	props->guid = dev;
+
+	ret = ofi_pciPath(dev, &props->pciPath);
+	if (ret != ncclSuccess)
+		props->pciPath = NULL;
+
+	ret = ofi_ptrSupport(dev, &props->ptrSupport);
+
+	/* Should be successful for ptrSupport invocation */
+	return ret;
+}
+
+static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_v3_t *props)
+{
+	ncclResult_t ret = ncclSuccess;
+	ncclNetProperties_v3_t dev_props = {0};
+	struct fi_info *nic_prov = NULL;
+	struct fid_nic *nic_info = NULL;
+
+	if (dev < 0 || dev >= ofi_ndevices) {
+		NCCL_OFI_WARN("Incorrect dev %d provided", dev);
+		ret = ncclSystemError;
+		goto error;
+	}
+
+	nic_prov = get_nic_info(dev, ofi_info_list);
+	if (nic_prov == NULL) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "Unable to find provider for dev %d", dev);
+		ret = ncclSystemError;
+		goto error;
+	}
+
+	ret = set_nic_props_default(dev, nic_prov, &dev_props);
+	if (ret != ncclSuccess)
+		goto error;
+
+	/* Change default values as set by NIC attributes */
+	nic_info = (struct fid_nic *)nic_prov->nic;
+	if (nic_info == NULL) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "No NIC info for dev %d. Supplying default values for NIC properties.",
+			      dev);
+		goto exit;
+	}
+
+	dev_props.name = strdup(nic_info->device_attr->name);
+	/* Speed reported in Mbps */
+	dev_props.speed = nic_info->link_attr->speed / (1e6);
+
+	goto exit;
+
+error:
+	props = NULL;
+exit:
+	*props = dev_props;
+	return ret;
+}
+#endif
+
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
@@ -1605,8 +1680,12 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.name = "AWS Libfabric",
 	.init = ofi_init,
 	.devices = ofi_devices,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4)) /* Support NCCL v2.6 */
+	.getProperties = ofi_getProperties,
+#else /* Support NCCL version >= v2.4.x and < v2.6.x */
 	.pciPath = ofi_pciPath,
 	.ptrSupport = ofi_ptrSupport,
+#endif
 	.listen = ofi_listen,
 	.connect = ofi_connect,
 	.accept = ofi_accept,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -284,16 +284,16 @@ exit:
  */
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
-	int ret = ncclSuccess, idx = 0, prov_idx;
+	int ret = ncclSuccess, idx = 0, prov_idx = 0, i;
 	struct fi_info *hints, *providers, *prov;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
+	int info_count[MAX_PROV_INFO] = {0};
 	char *prov_name;
 
 	hints = fi_allocinfo();
 	if (OFI_UNLIKELY(hints == NULL)) {
 		NCCL_OFI_WARN("Unable to allocate fi_info");
-		ret = ncclSystemError;
-		goto exit;
+		goto error;
 	}
 
 	/* Hints to filter providers */
@@ -313,13 +313,11 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	ret = fi_getinfo(ofi_version, NULL, NULL, 0ULL, hints, &providers);
 	if (ret == -FI_ENODATA) {
 		NCCL_OFI_WARN("Could not find any optimal provider");
-		ret = ncclSystemError;
 		goto error;
 	}
 	else if (ret != 0) {
 		NCCL_OFI_WARN("OFI call failed with RC %d, %s", ret,
 			     fi_strerror(-ret));
-		ret = ncclSystemError;
 		goto error;
 	}
 
@@ -334,6 +332,10 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	prov = providers;
 	prov_name = prov->fabric_attr->prov_name;
 	while (prov != NULL && prov->next != NULL) {
+
+		/* Increment number of devices found for the given provider */
+		info_count[idx]++;
+
 		char *name = prov->next->fabric_attr->prov_name;
 		if (strcmp(prov_name, name) != 0) {
 			prov_name = name;
@@ -346,15 +348,29 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		}
 	}
 
-	if (prov_include == NULL)
+	/* To account for the last prov object */
+	if (prov != NULL)
+		info_count[idx]++;
+
+	if (prov_include == NULL) {
 		*prov_info_list = prov_info_vec[0];
+		ofi_ndevices = info_count[0];
+	}
 	else {
-		for (prov_idx = 0; prov_idx < idx; prov_idx++) {
+		for (prov_idx = 0; prov_idx <= idx; prov_idx++) {
 			prov_name = prov_info_vec[prov_idx]->fabric_attr->prov_name;
 			if (in_list(prov_name, prov_include)) {
 				*prov_info_list = prov_info_vec[prov_idx];
+				ofi_ndevices = info_count[prov_idx];
 				break;
 			}
+		}
+	}
+
+	/* Free unused fi_info objects */
+	for (i = 0; i <= idx; i++) {
+		if ((i != prov_idx) && prov_info_vec[i]) {
+			fi_freeinfo(prov_info_vec[i]);
 		}
 	}
 
@@ -365,8 +381,7 @@ error:
 		fi_freeinfo(hints);
 	if (providers)
 		fi_freeinfo(providers);
-exit:
-	return ret;
+	return ncclSystemError;
 }
 
 /*
@@ -777,12 +792,8 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	}
 #else
 	/*
-	 * TODO: Find way to identify unique structures and remove lo.
-	 * For P3 platform, topology is known. Therefore, we return
-	 * the first NIC.
+	 * TODO: Find way to identify unique structures and remove lo for TCP provider.
 	 */
-	ofi_ndevices = 1;
-	ofi_info_list->next = NULL;
 #endif
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s",
 		      ofi_info_list->fabric_attr->prov_name);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -23,6 +23,7 @@
 #include <cuda_runtime.h>
 #endif
 
+static uint32_t libversion = 0;
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
 /* Number of NICs */
@@ -1092,9 +1093,17 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	}
 
 	/*
-	 * RDMAV_FORK_SAFE environment variable makes the rdma-core
-	 * library fork-safe. This significantly increases cost of memory
-	 * registration when huge pages are enabled.
+	 * FI_EFA_FORK_SAFE environment variable tells Libfabric to enable
+	 * fork-safe support in legacy versions of the rdma-core library.
+	 * Libfabric checks if additional handling is required for fork safety,
+	 * and does not introduce this additional overhead of setting MADV_DONTFORK
+	 * for new versions of rdma-core (38.0 and later) and the Linux kernel
+	 * that support copy-on-fork for pinned memory (5.13 and later).
+	 * These new versions are always fork-safe and additional support in userspace
+	 * is not required.
+	 *
+	 * When legacy versions of the kernel and rdma-core are used, setting
+	 * FI_EFA_FORK_SAFE to 1 disables the use of huge pages in Libfabric.
 	 *
 	 * To prevent data corruption, the EFA provider registers an atfork
 	 * handler which will abort the process whenever it believes
@@ -1103,14 +1112,19 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	 * NCCL applications heavily re-use the buffers for communication and
 	 * thus are not sensitive to increased memory registration costs.
 	 * To prevent NCCL based applications from getting aborted when using
-	 * fork(), plugin explicitly enables RDMAV_FORK_SAFE environment
-	 * variable.
+	 * fork(), the plugin explicitly enables FI_EFA_FORK_SAFE environment
+	 * variable, even in legacy environments where the overhead is high.
 	 */
-	if (!getenv("RDMAV_FORK_SAFE")) {
-		NCCL_OFI_INFO(NCCL_INIT, "Setting RDMAV_FORK_SAFE environment variable to 1.");
-		rc = setenv("RDMAV_FORK_SAFE", "1", 1);
+	libversion = fi_version();
+	const char * fork_safe_var_name =
+		(FI_MAJOR(libversion) > 1 || (FI_MAJOR(libversion) == 1 && FI_MINOR(libversion) >= 13))
+		? "FI_EFA_FORK_SAFE"
+		: "RDMAV_FORK_SAFE";
+	if (!getenv(fork_safe_var_name)) {
+		NCCL_OFI_INFO(NCCL_INIT, "Setting %s environment variable to 1", fork_safe_var_name);
+		rc = setenv(fork_safe_var_name, "1", 1);
 		if (rc != 0) {
-			NCCL_OFI_WARN("Unable to set RDMAV_FORK_SAFE");
+			NCCL_OFI_WARN("Unable to set %s", fork_safe_var_name);
 			ret = ncclSystemError;
 			goto exit;
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -960,6 +960,26 @@ static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_v3_t *props)
 	/* Speed reported in Mbps */
 	dev_props.speed = nic_info->link_attr->speed / (1e6);
 
+        /*
+         * TODO: Current libfabric release doesn't report correct speed for
+         * EFA device which leads to slight performance drop. This is because
+         * NCCL reduces parallelism based on overall speed of topology.
+         *
+         * Fix it by explicitly setting the right speed and REMOVE this after
+         * libfabric release with the fix is available.
+         */
+#ifdef EFA_NIC_DUP
+        if (IS_EFA_PROVIDER(nic_prov->fabric_attr->prov_name)) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Correcting speed for EFA provider");
+		dev_props.speed = 1e5; /* 100 Gb/s */
+		/* Make a unique device name for each EFA device */
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Correcting device names");
+		snprintf(dev_props.name, FI_NAME_MAX + 2, "%s%x", nic_info->device_attr->name, dev);
+        }
+        else
+                NCCL_OFI_WARN("Only EFA provider is supported");
+#endif
+
 	goto exit;
 
 error:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -956,7 +956,13 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 		}
 		else if (OFI_UNLIKELY(rc == -FI_EAVAIL)) {
 			rc = fi_cq_readerr(cq, &err_buffer, 0);
-			if (OFI_UNLIKELY(rc < 0)) {
+			if (OFI_UNLIKELY(rc == -FI_EAGAIN)) {
+				/*
+				 * Error not available yet.
+				 * fi_cq_read will keep returning -FI_EAVAIL so just bail out and try again later.
+				 */
+				break;
+			} else if (OFI_UNLIKELY(rc < 0)) {
 				NCCL_OFI_WARN("Unable to read from fi_cq_readerr. RC: %zd. Error: %s",
 					     rc,
 					     fi_cq_strerror(cq,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1350,6 +1350,19 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/*
+	 * Sets intranode latency for EFA networks.
+	 *
+	 * This value is chosen by measuring all reduce latency for
+	 * different NCCL algorithms and using that to calculate intra node
+	 * latency based on NCCL's tuning algorithm.
+	 *
+	 * A few different values around this value were tried to see which
+	 * chose the correct algorithm (tree or ring) most times across
+	 * different message and cluster sizes.
+	 */
+	props->latency = 150;
+
+	/*
 	 * Maximum number of grouped receives. Currently, we set it to 1 to
 	 * maintain single send/recv semantics (similar to NCCL versions < v2.12).
 	 *

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1419,6 +1419,7 @@ exit:
 static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 {
 	ncclResult_t ret = ncclSuccess;
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 	char ep_name[MAX_EP_ADDR] = {0};
 	size_t namelen = sizeof(ep_name);
 	fi_addr_t local_ep_addr;
@@ -1438,6 +1439,9 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 		ret = ncclSystemError;
 		goto error;
 	}
+
+	/* Zero-out the handle */
+	memset(ofi_handle, 0, sizeof(nccl_ofi_handle_t));
 
 	/*
 	 * Create libfabric components for the given NIC, if not
@@ -1460,17 +1464,24 @@ static ncclResult_t ofi_listen(int dev, void *handle, void **listenComm)
 	pthread_mutex_unlock(&nccl_ofi_lock);
 
 	/* Build handle */
-	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid), (void *)&ep_name,
+	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
+			 (void *)&ep_name,
 			 &namelen);
-	if (ret != 0) {
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		ret = ncclSystemError;
+		goto error;
+	}
+	else if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;
 		goto error;
 	}
 
-	memcpy(handle, ep_name, MAX_EP_ADDR);
-	memcpy(handle + MAX_EP_ADDR, &tag, sizeof(tag));
+	memcpy(ofi_handle->ep_name, ep_name, MAX_EP_ADDR);
+	ofi_handle->tag = tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
 	num_addrs = fi_av_insert(nccl_ofi_component[dev]->av, (void *)ep_name, 1,
@@ -1518,6 +1529,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	uint64_t max_tag = 0;
 	nccl_ofi_req_t *req = NULL;
 	size_t req_size = sizeof(nccl_ofi_req_t);
+	nccl_ofi_handle_t *ofi_handle = (nccl_ofi_handle_t *)handle;
 
 	if (OFI_UNLIKELY(dev < 0 || dev >= ofi_ndevices)) {
 		NCCL_OFI_WARN("Incorrect device ID %d provided. Correct values are from 0 to %d",
@@ -1544,8 +1556,8 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	max_tag = nccl_ofi_component[dev]->max_tag;
 
 	/* Parse handle to get tag and remote name */
-	memcpy(&remote_ep_addr, (char *)handle, MAX_EP_ADDR);
-	memcpy(&tag, (char *)handle + MAX_EP_ADDR, sizeof(tag));
+	memcpy(&remote_ep_addr, ofi_handle->ep_name, MAX_EP_ADDR);
+	memcpy(&tag, &ofi_handle->tag, sizeof(tag));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
 			       dev);
@@ -1601,7 +1613,12 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
 			 (void *)&local_ep_addr,
 			 &namelen);
-	if (ret != 0) {
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      namelen, MAX_EP_ADDR);
+		ret = ncclSystemError;
+		goto error;
+	} else if (ret != 0) {
 		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));
 		ret = ncclSystemError;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -571,7 +571,7 @@ exit:
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
 	int idx = 0, prov_idx = 0, i, rc = 0;
-	struct fi_info *providers, *prov;
+	struct fi_info *providers = NULL, *prov = NULL;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
 	int info_count[MAX_PROV_INFO] = {0};
 	char *prov_name;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@
 
 AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
 AM_CFLAGS += -I$(top_srcdir)/include
-AM_LDFLAGS = -lmpi
+AM_LDFLAGS = -lmpi -lcudart
 LDADD = ../src/libnccl-net.la
 CC=mpicc
 

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -92,11 +92,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank + 1);
 	}
@@ -110,11 +112,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank - 1);
 	}

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -59,10 +59,14 @@ int main(int argc, char* argv[])
 	}
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
-	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
@@ -74,7 +78,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
@@ -92,7 +96,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -14,14 +14,13 @@ int main(int argc, char* argv[])
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */
-	int ndev;
+	int ndev, dev;
 	sendComm_t *sComm = NULL;
 	listenComm_t *lComm = NULL;
 	recvComm_t *rComm = NULL;
 	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
 	ncclNet_t *extNet = NULL;
 
-	ncclDebugLogger_t ofi_log_function = NULL;
 	ofi_log_function = logger;
 
 	MPI_Init(&argc, &argv);
@@ -41,6 +40,24 @@ int main(int argc, char* argv[])
 	/* Devices API */
 	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
+
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+	/* Get Properties for the device */
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v3_t props = {0};
+		OFINCCLCHECK(extNet->getProperties(dev, &props));
+		print_dev_props(dev, &props);
+	}
+#else
+	/* Get PCIe path and plugin memory pointer support */
+	for (dev = 0; dev < ndev; dev++) {
+		char *path = NULL;
+		int supported_types = 0;
+		extNet->pciPath(dev, &path);
+		OFINCCLCHECK(extNet->ptrSupport(dev, &supported_types));
+		NCCL_OFI_TRACE(NCCL_INIT, "Dev %d has path %s and supports pointers of type %d", dev, path, supported_types);
+	}
+#endif
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
 	/* Get Properties for the device */
 	for (dev = 0; dev < ndev; dev++) {
-		ncclNetProperties_v3_t props = {0};
+		ncclNetProperties_t props = {0};
 		OFINCCLCHECK(extNet->getProperties(dev, &props));
 		print_dev_props(dev, &props);
 

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
 	/* Get Properties for the device */
 	for (dev = 0; dev < ndev; dev++) {
-		ncclNetProperties_v3_t props = {0};
+		ncclNetProperties_t props = {0};
 		OFINCCLCHECK(extNet->getProperties(dev, &props));
 		print_dev_props(dev, &props);
 
@@ -199,9 +199,20 @@ int main(int argc, char* argv[])
 					NCCL_OFI_TRACE(NCCL_NET,
 						"Issue flush for data consistency. Request idx: %d",
 						idx);
-					OFINCCLCHECK(extNet->flush((void *)rComm,
-							(void *)recv_buf[idx],
-							RECV_SIZE, mhandle[idx]));
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
+					nccl_ofi_req_t *iflush_req = NULL;
+					OFINCCLCHECK(extNet->iflush((void *)rComm,
+								    (void *)recv_buf[idx],
+								    RECV_SIZE, mhandle[idx], (void **)&iflush_req));
+					done = 0;
+					while (!done) {
+						OFINCCLCHECK(extNet->test((void *)iflush_req, &done, NULL));
+					}
+#else
+                    			OFINCCLCHECK(extNet->flush((void *)rComm,
+								   (void *)recv_buf[idx],
+								   RECV_SIZE, mhandle[idx]));
+#endif
 				}
 
 				/* Deregister memory handle */

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -69,22 +69,26 @@ int main(int argc, char* argv[])
         }
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
-	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on dev 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on dev %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
 		/* MPI send */
-		MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, 1, 0, MPI_COMM_WORLD);
+		MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, (rank + 1), 0, MPI_COMM_WORLD);
 
 		/* MPI recv */
 		MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, (rank + 1), 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
@@ -114,7 +118,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");

--- a/tests/ring.c
+++ b/tests/ring.c
@@ -79,9 +79,13 @@ int main(int argc, char *argv[])
         }
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
-	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on device 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on device %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	/* MPI send: Distribute handle to prev and next ranks */
 	MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE,
@@ -97,10 +101,10 @@ int main(int argc, char *argv[])
 
 	/* Connect to next and prev ranks */
 	NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", prev);
-	OFINCCLCHECK(extNet->connect(0, (void *)src_handle_prev, (void **)&sComm_prev));
+	OFINCCLCHECK(extNet->connect(dev, (void *)src_handle_prev, (void **)&sComm_prev));
 
 	NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", next);
-	OFINCCLCHECK(extNet->connect(0, (void *)src_handle_next, (void **)&sComm_next));
+	OFINCCLCHECK(extNet->connect(dev, (void *)src_handle_next, (void **)&sComm_next));
 
 	/*
 	 * Accept API: accept connection from prev rank as the data flow is

--- a/tests/ring.c
+++ b/tests/ring.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
         /* Get Properties for the device */
         for (dev = 0; dev < ndev; dev++) {
-                ncclNetProperties_v3_t props = {0};
+                ncclNetProperties_t props = {0};
                 OFINCCLCHECK(extNet->getProperties(dev, &props));
                 print_dev_props(dev, &props);
 
@@ -209,9 +209,20 @@ int main(int argc, char *argv[])
 					NCCL_OFI_TRACE(NCCL_NET,
 						"Issue flush for data consistency. Request idx: %d",
 						idx);
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
+					nccl_ofi_req_t *iflush_req = NULL;
+					OFINCCLCHECK(extNet->iflush((void *)rComm,
+								    (void *)recv_buf[idx],
+								    RECV_SIZE, recv_mhandle[idx], (void **)&iflush_req));
+					done = 0;
+					while (!done) {
+						OFINCCLCHECK(extNet->test((void *)iflush_req, &done, NULL));
+					}
+#else
 					OFINCCLCHECK(extNet->flush((void *)rComm,
-						     (void *)recv_buf[idx],
-						     RECV_SIZE, recv_mhandle[idx]));
+								   (void *)recv_buf[idx],
+								   RECV_SIZE, recv_mhandle[idx]));
+#endif
 				}
 
 				OFINCCLCHECK(validate_data(recv_buf[idx], expected_buf, SEND_SIZE, buffer_type));

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -11,6 +11,7 @@
 #include <nccl_net.h>
 #include <nccl_ofi.h>
 #include <nccl_ofi_log.h>
+#include <nccl_ofi_param.h>
 #include "mpi.h"
 #include "config.h"
 #include <unistd.h>

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -80,6 +80,9 @@ void print_dev_props(int dev, ncclNetProperties_t *props)
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0))
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Grouped Receives: %d", props->name, props->maxRecvs);
+#endif
 }
 #endif
 

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -71,7 +71,7 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 }
 
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
-void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+void print_dev_props(int dev, ncclNetProperties_t *props)
 {
         NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
         NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -62,6 +62,19 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	va_end(vargs);
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+{
+        NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Plugin Support: %d", props->name, props->ptrSupport);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %d", props->name, props->guid);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+}
+#endif
+
 ncclNet_t *get_extNet(void)
 {
 	void *netPluginLib = NULL;

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -5,4 +5,4 @@
 #
 
 xmldir = ${pkgdatadir}/xml
-xml_DATA = p4d-24xl-topo.xml
+xml_DATA = p4d-24xl-topo.xml p4de-24xl-topo.xml

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -1,0 +1,8 @@
+#
+# Copyright (c) 2020, Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+xmldir = ${pkgdatadir}/xml
+xml_DATA = p4d-24xl-topo.xml

--- a/topology/p4d-24xl-topo.xml
+++ b/topology/p4d-24xl-topo.xml
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2019-2020, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `p4d.24xlarge` platform type.
+This has 2 groups of PCIe hierarchy under each socket. Each group has
+2 GPUs and 1 NIC behind a PCIe switch.
+
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `p4d.24xarge`.
+
+Note: The PCI IDs of GPUs and NICs needs to match the device IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:01.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    </pci> <!-- Switch 0 ends -->
+    <pci busid="ffff:ff:02.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    </pci> <!-- Switch 1 ends -->
+  </cpu>
+  <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:03.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    </pci> <!-- Switch 2 ends -->
+    <pci busid="ffff:ff:04.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    </pci> <!-- Switch 3 ends -->
+  </cpu>
+</system>

--- a/topology/p4d-24xl-topo.xml
+++ b/topology/p4d-24xl-topo.xml
@@ -14,27 +14,27 @@ virtual machine.
 -->
 <system version="1">
   <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
-    <pci busid="ffff:ff:01.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
-        <pci busid="0000:10:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
-        <pci busid="0000:10:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
-        <pci busid="0000:10:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    <pci busid="ffff:ff:01.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
     </pci> <!-- Switch 0 ends -->
-    <pci busid="ffff:ff:02.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
-        <pci busid="0000:20:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
-        <pci busid="0000:20:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
-        <pci busid="0000:20:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    <pci busid="ffff:ff:02.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
     </pci> <!-- Switch 1 ends -->
   </cpu>
   <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
-    <pci busid="ffff:ff:03.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
-        <pci busid="0000:90:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
-        <pci busid="0000:90:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
-        <pci busid="0000:90:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    <pci busid="ffff:ff:03.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
     </pci> <!-- Switch 2 ends -->
-    <pci busid="ffff:ff:04.0" class="0x060400" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
-        <pci busid="0000:a0:1c.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
-        <pci busid="0000:a0:1d.0" class="0x030200" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
-        <pci busid="0000:a0:1b.0" class="0x020000" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    <pci busid="ffff:ff:04.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" vendor="0x10de" device="0x20b0" subsystem_vendor="0x10de" subsystem_device="0x134f" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
     </pci> <!-- Switch 3 ends -->
   </cpu>
 </system>

--- a/topology/p4de-24xl-topo.xml
+++ b/topology/p4de-24xl-topo.xml
@@ -1,0 +1,40 @@
+<!--
+Copyright (c) 2022, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `p4de.24xlarge` platform type.
+This has 2 groups of PCIe hierarchy under each socket. Each group has
+2 GPUs and 1 NIC behind a PCIe switch.
+
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `p4de.24xarge`.
+
+Note: The PCI IDs of GPUs and NICs needs to match the device IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0" affinity="000000ff,ffff0000,00ffffff" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:01.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 0 begins -->
+        <pci busid="0000:10:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 0 -->
+        <pci busid="0000:10:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 1 -->
+        <pci busid="0000:10:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 0 -->
+    </pci> <!-- Switch 0 ends -->
+    <pci busid="ffff:ff:02.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 1 begins -->
+        <pci busid="0000:20:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 2 -->
+        <pci busid="0000:20:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 3 -->
+        <pci busid="0000:20:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 1 -->
+    </pci> <!-- Switch 1 ends -->
+  </cpu>
+  <cpu numaid="1" affinity="ffffff00,0000ffff,ff000000" arch="x86_64" vendor="GenuineIntel" familyid="6" modelid="85">
+    <pci busid="ffff:ff:03.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 2 begins -->
+        <pci busid="0000:90:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 4 -->
+        <pci busid="0000:90:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 5 -->
+        <pci busid="0000:90:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 2 -->
+    </pci> <!-- Switch 2 ends -->
+    <pci busid="ffff:ff:04.0" class="0x060400" vendor="0xffff" device="0xffff" subsystem_vendor="0xffff" subsystem_device="0xffff" link_speed="8 GT/s" link_width="16">  <!-- Switch 3 begins -->
+        <pci busid="0000:a0:1c.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 6 -->
+        <pci busid="0000:a0:1d.0" class="0x030200" vendor="0x10de" device="0x20b2" subsystem_vendor="0x10de" subsystem_device="0x1463" link_speed="8 GT/s" link_width="16"/> <!-- GPU 7 -->
+        <pci busid="0000:a0:1b.0" class="0x020000" vendor="0x1d0f" device="0xefa0" subsystem_vendor="0x1d0f" subsystem_device="0xefa0" link_speed="8 GT/s" link_width="16"/> <!-- NIC 3 -->
+    </pci> <!-- Switch 3 ends -->
+  </cpu>
+</system>


### PR DESCRIPTION
*Issue #, if available:*
P64270667

*Description of changes:*
Use `AC_PROG_CC_STDC` macro to automatically insert `-std=c99` into `CFLAGS` when needed.  This takes care of a regression introduced in v1.2.0 and all future issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
