### PR TITLE
Fix CentOS 7 build regression (master)

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,7 +7,7 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
-# v1.2.0 release notes
+# v1.3.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_SILENT_RULES([yes])
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
 AM_PROG_AR
 


### PR DESCRIPTION
*Issue #, if available:*
P64270667

*Description of changes:*
Use `AC_PROG_CC_STDC` macro to automatically insert `-std=c99` into `CFLAGS` when needed. This takes care of a regression introduced in `v1.2.0` and all future issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
