### PR TITLE
Fix EFA_NIC_DUP when only a single GPU is visible

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1280,7 +1280,12 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 			ret = ncclUnhandledCudaError;
 			goto exit;
 		}
-		ofi_ndevices /= 2;
+		if (ofi_ndevices > 1)
+			ofi_ndevices /= 2;
+		if (ofi_ndevices < 1) {
+			ret = ncclSystemError;
+			goto exit;
+		}
 		// Make the list cyclic to emulate having multiple devices
 		ofi_info_list->next = ofi_info_list;
 		NCCL_OFI_INFO(NCCL_INIT, "Forcing AWS OFI ndev %d", ofi_ndevices);


### PR DESCRIPTION
*Issue #, if available:*
P63722188

*Description of changes:*
If `CUDA_VISIBLE_DEVICES` is set such that only a single GPU is visible on a p3dn, the current code will detect 0 devices and fail the plugin load.  Work around this by keeping at least 1 device visible.  Note that this fix does not achieve the bandwidth benefits of `EFA_NIC_DUP`, but at least the plugin will work.  Performance will be addressed in a separate change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
