### PR TITLE
Fix reuse check in ofi_iaccept

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2357,8 +2357,8 @@ static ncclResult_t ofi_iaccept(void *listenComm, void **recvComm)
 		return ncclSystemError;
 	}
 
-	if (lComm->accepted == true) {
-		NCCL_OFI_WARN("listenComm object already has an active connection.");
+	if (lComm->state.stage != COMM_REQ_PENDING_COMP && lComm->accepted) {
+		NCCL_OFI_WARN("listenComm %p object already has an active connection (%d).", listenComm, lComm->accepted);
 		return ncclSystemError;
 	}
 


### PR DESCRIPTION
In a non-blocking accept, it is possible for a listenComm to
progress and transition to an accepted state between two calls to
ofi_iaccept, for example if other calls to the plugin call the
progress function.

Signed-off-by: Sylvain Jeaugey <sjeaugey@nvidia.com>
Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
