### PR TITLE
implement overrides for  ndev calculation in EFA_NIC_DUP

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -92,6 +92,11 @@ OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
  */
 OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
 
+/*
+ * Specify the number of network connections created by EFA_NIC_DUP
+ */
+OFI_NCCL_PARAM_INT(nic_dup_connections, "NIC_DUP_CONNECTIONS", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1286,6 +1286,14 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 			ret = ncclSystemError;
 			goto exit;
 		}
+		int nic_dup_connections = ofi_nccl_nic_dup_connections();
+		if(nic_dup_connections > 0){
+			ofi_ndevices = nic_dup_connections;
+			NCCL_OFI_INFO(NCCL_INIT, 
+				"Setting AWS OFI ndev to %d from OFI_NCCL_NIC_DUP_CONNECTIONS",
+				ofi_ndevices
+			);	
+		}
 		// Make the list cyclic to emulate having multiple devices
 		ofi_info_list->next = ofi_info_list;
 		NCCL_OFI_INFO(NCCL_INIT, "Forcing AWS OFI ndev %d", ofi_ndevices);


### PR DESCRIPTION
*Description of changes:*

currently `EFA_NIC_DUP` bases the number of connections
the plugin uses based on the number of GPU's from cudaGetDeviceCount.
This assumption breaks down when `CUDA_VISIBLE_DEVICES` is set to limit
the number of GPU's visible to the process. Currently PyTorch XLA uses this
mechanism for distributed training. This override uses to specify the number
of connections in these scenarios.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Signed-off-by: Harish Tummalacherla hartum@amazon.com