### PR TITLE
OFI-NCCL [Experimental]: Allow configuring number of connections for EFA_NIC_DUP

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,12 @@ The plugin allows to configure the following variables at run-time according to 
       <td>Boolean</td>
       <td>0/1 (Default: 0)</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_NIC_DUP_CONNS</code></td>
+      <td>Set number of NIC connections. This is used to increase hardware utilization. Applicable for P3Dn when using less number of GPUs than 8..</td>
+      <td>Integer</td>
+      <td>x, to set x number of connections. Only overridden for greater than 0 values (Default: 0)</td>
+   </tr>
 </table>
 
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -92,6 +92,13 @@ OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
  */
 OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
 
+#ifdef EFA_NIC_DUP
+/*
+ * Specify the number of network connections created by EFA_NIC_DUP
+ */
+OFI_NCCL_PARAM_INT(nic_dup_conns, "NIC_DUP_CONNS", 0);
+#endif
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif


### PR DESCRIPTION
When using EFA provider with no GDR support, the number of network
connections are determined by the number of GPUs in the system. This
works well for systems with 8 GPUs.

However, there could be cases such as Pytorch XLA which only supplies
one GPU for each process using `CUDA_VISIBLE_DEVICES`. This results in
more collective comms time as the network hardware is under-utilized.

This patch allows users to configure the number of network connections
independent of the number of GPUs in the system.

Signed-off-by: Harish Tummalacherla <hartum@amazon.com>
Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
