### PR TITLE
Add support for CUDA GDR flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,17 @@ The plugin allows to configure the following variables at run-time according to 
       <td>Boolean</td>
       <td>0/1 (Default: 0)</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_CUDA_FLUSH_ENABLE</code></td>
+      <td>When using GPUDirect use the cudaDeviceFlushGPUDirectRDMAWrites to
+      enforce data consistency at the receiving GPU. Requires CUDA 11.3 or
+      later. Note that this function only provides a GPU memory fence and
+      requires that data has already been delivered to GPU memory. Some
+      networks and PCIe configurations require an additional network-level
+      flush that is not provided by this option.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
 </table>
 
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -92,6 +92,16 @@ OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
  */
 OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
 
+/*
+ * When using GPUDirect use the cudaDeviceFlushGPUDirectRDMAWrites
+ * to enforce data consistency at the receiving GPU. Requires CUDA 11.3 or
+ * later. Note that this function only provides a GPU memory fence and requires
+ * that data has already been delivered to GPU memory. Some networks and
+ * PCIe configurations require an additional network-level flush that
+ * is not provided by this option.
+ */
+OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Add support for implementing flush operations as a call to `cudaDeviceFlushGPUDirectRDMAWrites` on CUDA 11.3 and later. User must enable this by setting `OFI_NCCL_CUDA_FLUSH_ENABLE`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
