### PR TITLE
Update Control Message Tag Bits

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -996,7 +996,7 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 	struct fi_cq_tagged_entry cqe_tagged_buffers[cqe_burst];
 	nccl_ofi_req_t *req = NULL;
 	struct fid_cq *cq = nccl_ofi_comp->cq;
-	uint64_t control_bit_mask = ~(nccl_ofi_comp->max_tag);
+	uint64_t control_bit_mask = nccl_ofi_comp->max_tag + 1;
 
 	while (true) {
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1860,7 +1860,7 @@ static ssize_t send_connect_message(sendComm_t *sComm, nccl_ofi_req_t *req)
 	 */
 	rc = fi_tsend(sComm->local_ep, (void *)local_ep_addr,
 			MAX_EP_ADDR, NULL, sComm->remote_ep,
-			sComm->tag | ~max_tag, &req->ctx);
+			sComm->tag | (max_tag + 1), &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/*
 		 * Process completions so that you have enough
@@ -2112,7 +2112,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		 */
 		rc = fi_tsend(sComm->local_ep, (void *)&local_ep_addr,
 			      MAX_EP_ADDR, NULL, sComm->remote_ep,
-			      sComm->tag | ~max_tag, &req->ctx);
+			      sComm->tag | (max_tag + 1), &req->ctx);
 		if (rc == 0)
 			break;
 		else if (rc == -FI_EAGAIN) {
@@ -2222,7 +2222,7 @@ static ssize_t post_recv_conn(listenComm_t *lComm, char **buffer,
 
 	/* Post a buffer for receiving connection requests */
 	rc = fi_trecv(lComm->local_ep, (void *)*buffer, size,
-		      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+		      NULL, FI_ADDR_UNSPEC, lComm->tag | (max_tag + 1),
 		      0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/*
@@ -2521,7 +2521,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	/* Post a buffer for receiving connection requests */
 	do {
 		rc = fi_trecv(lComm->local_ep, (void *)&remote_ep_addr, MAX_EP_ADDR,
-			      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+			      NULL, FI_ADDR_UNSPEC, lComm->tag | (max_tag + 1),
 			      0, &req->ctx);
 		if (rc == 0)
 			break;

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,7 @@ AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
 AM_CFLAGS += -I$(top_srcdir)/include
 AM_LDFLAGS = -lmpi -lcudart
 LDADD = ../src/libnccl-net.la
-CC=mpicc
+CC ?= mpicc
 
 bin_PROGRAMS = nccl_connection nccl_message_transfer ring
 nccl_connection_SOURCES = nccl_connection.c


### PR DESCRIPTION
Merge #120 master branch to aws
- https://github.com/aws/aws-ofi-nccl/pull/120

*Issue #, if available:*

*Description of changes:*

The max_tag bitmask indicates which bits that can be used in a user tag. The next highest bit is used to denote a control message. Presently, the control message bit is set by OR'ing the negation of max_tag. However, this also sets the ignored bits and some providers flag this as an error. This patch sets only the control message bit in the tag.

There also is a minor update to the Makefile to allow setting CC used to build the tests. This is needed on systems where CC=cc is used to build MPI code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
