### PR TITLE
Fail configuration without mpicc; allow compilation with exclusion of tests subdirectory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ install:
  # Install libfabric
  - git clone https://github.com/ofiwg/libfabric.git
  - pushd libfabric
- - git checkout v1.7.x
  - ./autogen.sh
  - ./configure --enable-debug; make -j8; sudo make install
  - popd

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ install:
  - git clone https://github.com/ofiwg/libfabric.git
  - pushd libfabric
  - ./autogen.sh
- - ./configure --enable-debug; make -j8; sudo make install
+ - ./configure --enable-debug --disable-psm3; make -j8; sudo make install
  - popd
 
  # Install NCCL

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+@rashikakheria
+@nzmsv

--- a/Makefile.am
+++ b/Makefile.am
@@ -5,5 +5,5 @@
 #
 
 ACLOCAL_AMFLAGS = -I m4
-SUBDIRS = src tests
+SUBDIRS = src @TEST_DIR@
 EXTRA_DIST = autogen.sh

--- a/README.md
+++ b/README.md
@@ -81,6 +81,32 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+### Plugin Configurations
+
+The plugin allows to configure the following variables at run-time according to your environment.
+
+<table>
+   <thead>
+      <th>Parameter</th>
+      <th>Description</th>
+      <th>Type</th>
+      <th>Accepted Value</th>
+   </thead>
+   <tr>
+      <td><code>OFI_NCCL_USE_IPV6_TCP</code></td>
+      <td>Allow using endpoints with IPv6 addressing format for TCP provider. Users can specify to use a preferred libfabric provider with `FI_PROVIDER` environment variable.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
+   <tr>
+      <td><code>OFI_NCCL_TCP_EXCLUDE_IF</code></td>
+      <td>List of interface names to be filtered out for TCP provider. Users can specify to use a preferred libfabric provider with `FI_PROVIDER` environment variable.</td>
+      <td>String</td>
+      <td>Comma-separated list of interface names (Default: "lo,docker0")</td>
+   </tr>
+</table>
+
+
 ### Running Unit Tests
 
 Running unit tests requires a working MPI installation and a

--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ support the following features as defined in the
 * Data transfer context structures (`FI_CONTEXT`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
-* Automatic control and data progress model (`FI_PROGRESS_AUTO`)
 * Communication with remote endpoints (`FI_REMOTE_COMM`)
 
 For GPUDirect RDMA support, it requires these additional features from libfabric

--- a/README.md
+++ b/README.md
@@ -26,12 +26,11 @@ The plug-in currently supports the following distributions:
 * Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
 
-It also requires
-[Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
-The plug-in also maintains backward compatibility with older NCCL versions
-[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
-[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
+It requires
+[Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1).
+The plug-in also maintains backward compatibility with older NCCL versions upto
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -42,6 +41,14 @@ support the following features as defined in the
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
 * Automatic control and data progress model (`FI_PROGRESS_AUTO`)
+* Communication with remote endpoints (`FI_REMOTE_COMM`)
+
+For GPUDirect RDMA support, it requires these additional features from libfabric
+providers. If these are not supported by any provider on system, plug-in turns off
+GPUDirect RDMA support.
+
+* Transfers to/from device memory (`FI_HMEM`)
+* Remote memory operations (`FI_RMA`, `FI_READ`)
 
 ## Getting Started
 
@@ -104,6 +111,12 @@ The plugin allows to configure the following variables at run-time according to 
       <td>String</td>
       <td>Comma-separated list of interface names (Default: "lo,docker0")</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_GDR_FLUSH_DISABLE</code></td>
+      <td>Disable flush operation when using GPUDirect.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
 </table>
 
 
@@ -139,7 +152,6 @@ make NCCL_HOME=~/nccl/build/
 ```
 
 3. Run perf tests
-
 ```
 NCCL_DEBUG=INFO build/all_reduce_perf -b 8 -f 2 -e 32M -c 1
 ```
@@ -147,10 +159,6 @@ NCCL_DEBUG=INFO build/all_reduce_perf -b 8 -f 2 -e 32M -c 1
 If you installed the AWS libfabric plugin in a custom prefix, ensure
 `LD_LIBRARY_PATH` is set to include that prefix so the perf test binaries can
 find the plugin.
-
-## Known Issues
-
-The plugin returns only 1 NIC device even if the system supports multiple NICs.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -23,14 +23,13 @@ The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7 and 8
-* Ubuntu 16.04, 18.04 and 20.04 LTS
+* Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
-It requires
-[Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1).
-The plug-in also maintains backward compatibility with older NCCL versions upto
-[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
+It requires [Libfabric](http://github.com/ofiwg/libfabric/)
+and [NCCL](http://github.com/NVIDIA/nccl/).  Please see the
+[Release notes](http://github.com/aws/aws-ofi-nccl/releases) for
+information on version compatibility.
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The plug-in currently supports the following distributions:
 
 It requires
 [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1).
+and supports [NCCL v2.8.3](https://github.com/NVIDIA/nccl/releases/tag/v2.8.3-1).
 The plug-in also maintains backward compatibility with older NCCL versions upto
 [NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7
-* Ubuntu 16.04 LTS
+* Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
 
 It also requires

--- a/README.md
+++ b/README.md
@@ -28,7 +28,10 @@ The plug-in currently supports the following distributions:
 
 It also requires
 [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)
-and supports [NCCL v2.5.6](https://github.com/NVIDIA/nccl/releases/tag/v2.5.6-2).
+and supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1).
+The plug-in also maintains backward compatibility with older NCCL versions
+[NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and
+[NCCL v2.5.x](https://github.com/NVIDIA/nccl/releases/tag/v2.5.7-1)
 
 Libfabric supports various providers. The plug-in can choose only those which
 support the following features as defined in the
@@ -69,6 +72,13 @@ dependencies with the following flags:
   --with-cuda=PATH        Path to non-standard CUDA installation
   --with-nccl=PATH        Path to non-standard NCCL installation
   --with-mpi=PATH         Path to non-standard MPI installation
+```
+
+To enable trace messages for debugging (disabled by default), use the
+following config option:
+
+```
+   --enable-trace         Enable printing trace messages
 ```
 
 ### Running Unit Tests

--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ and operating system bypass.
 The plug-in currently supports the following distributions:
 * Amazon Linux
 * Amazon Linux 2
-* Redhat Enterprise Linux 7
+* Redhat Enterprise Linux 7 and 8
 * Ubuntu 16.04, 18.04 and 20.04 LTS
-* CentOS 7
+* CentOS 7 and 8
 
 It requires
 [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
-and supports [NCCL v2.8.3](https://github.com/NVIDIA/nccl/releases/tag/v2.8.3-1).
+and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1).
 The plug-in also maintains backward compatibility with older NCCL versions upto
 [NCCL v2.4.x](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1).
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,7 +7,7 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
-# v1.2.0 release notes
+# v1.3.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,8 +4,45 @@
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7.0 and 8.0
-* Ubuntu 16.04, 18.04 and 20.04 LTS
+* Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
+
+# v1.1.4 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.11.4](https://github.com/NVIDIA/nccl/releases/tag/v2.11.4-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.13.2](https://github.com/ofiwg/libfabric/releases/tag/v1.13.2).
+
+New Features:
+* Print version during plugin initialization
+
+Bug Fixes:
+* Print correct error code when failing to register a memory region
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
+# v1.1.3 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.9.9](https://github.com/NVIDIA/nccl/releases/tag/v2.9.9-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL
+v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).  It was tested with Libfabric
+versions up to [Libfabric v1.12.1](https://github.com/ofiwg/libfabric/releases/tag/v1.12.1).
+
+Ubuntu 16.04 has reached end-of-life and is no longer supported starting with this release.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.1.2 release notes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -4,8 +4,31 @@
 * Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7.0
-* Ubuntu 16.04 LTS
+* Ubuntu 16.04, 18.04 and 20.04 LTS
 * CentOS 7
+
+# v1.1.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)and supports [NCCL v2.7.8](https://github.com/NVIDIA/nccl/releases/tag/v2.7.8-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It introduces the following new features and bug fixes.
+
+New Features:
+* Detect and support multi-NIC environment
+* Support GPUDirect RDMA when libfabric providers support it
+* Add `flush` API support for transfers using CUDA buffers
+
+Bug Fixes:
+* Enable `RDMAV_FORK_SAFE` environment variable
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.0.1 release notes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -3,9 +3,30 @@
 # Supported Distributions
 * Amazon Linux
 * Amazon Linux 2
-* Redhat Enterprise Linux 7.0
+* Redhat Enterprise Linux 7.0 and 8.0
 * Ubuntu 16.04, 18.04 and 20.04 LTS
-* CentOS 7
+* CentOS 7 and 8
+
+# v1.1.2 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0) and supports [NCCL v2.8.4](https://github.com/NVIDIA/nccl/releases/tag/v2.8.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It introduces the following new features and bug fixes.
+
+New Features:
+* Add support for NCCL Net v4 API
+
+Bug Fixes:
+* Handle `flush` disable configuration
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
 
 # v1.1.0 release notes
 

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,32 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
+# v1.1.5 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.11.4](https://github.com/NVIDIA/nccl/releases/tag/v2.11.4-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Make use of FI_EFA_FORK_SAFE environment variable to allow Libfabric to detect when `MADV_DONTFORK`
+  is not needed (#82).  This feature requires Libfabric v1.13.0 or higher.  When used with an older version
+  of Libfabric, the plugin will continue to set the RDMAV_FORK_SAFE environment variable.
+* Do not request FI_PROGRESS_AUTO feature when listing OFI providers; this feature is unnecessary for the plugin
+  and not requesting it improves interoperability.
+
+Bug Fixes:
+* Ensure that the buffer used for flush is page aligned and allocated with `mmap` instead of `malloc`.
+  This change is needed to correctly support `fork()` with `MADV_DONTFORK` (#77).
+* Fix crash when used with a GDR-capable provider that does not require memory registration (#81).
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.1.4 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -10,6 +10,28 @@
 # v1.2.0 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.12.10](https://github.com/NVIDIA/nccl/releases/tag/v2.12.10-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Log error-ed request entry.
+
+Bug Fixes:
+* Retry `fi_cq_readerr` until error-ed request entry is available.
+* Fix crash for providers supporting multi-rail devices.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+* psm3
+
+# v1.2.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.12.7](https://github.com/NVIDIA/nccl/releases/tag/v2.12.7-1) while
 maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
 It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,30 @@
 * Ubuntu 18.04 and 20.04 LTS
 * CentOS 7 and 8
 
+# v1.2.0 release notes
+
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.12.7](https://github.com/NVIDIA/nccl/releases/tag/v2.12.7-1) while
+maintaining backward compatibility with older NCCL versions (up to [NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+It was tested with Libfabric versions up to [Libfabric v1.14.0](https://github.com/ofiwg/libfabric/releases/tag/v1.14.0).
+
+New Features:
+* Add support for NCCL v2.12 with backwards compatibility to previous NCCL versions.
+
+Bug Fixes:
+* Prevent deadlock in connection establishment when using rendezvour providers.
+* Enable flush operations for provider that doesn't require memory registration.
+* Enable successful runs of unit-tests with flush disabled.
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+* psm3
+
+
 # v1.1.5 release notes
 
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -7,6 +7,29 @@
 * Ubuntu 16.04 LTS
 * CentOS 7
 
+# v1.0.1 release notes
+
+This release supports [NCCL v2.6.4](https://github.com/NVIDIA/nccl/releases/tag/v2.6.4-1)
+while maintaining backward compatibility with older NCCL versions (upto
+[NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1)).
+
+It also includes bug fixes and testing enhancements.
+
+New Features:
+* Support NCCL v2.6.4
+* Add validation of memory registration APIs and getProperties API in tests.
+
+Bug Fixes:
+* Use fid_mr for memory handle
+* Support disabling trace messages
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code:
+* tcp;ofi_rxm
+* sockets
+* efa
+
 # v1.0.0 release notes
 
 This release requires [Libfabric v1.9.x](https://github.com/ofiwg/libfabric/tree/v1.9.x)

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.2.0], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.3.0], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -62,7 +62,7 @@ AS_IF([test "x${enable_trace}" = "xyes" ],
        AC_MSG_RESULT(yes)],
        [trace=0
        AC_MSG_RESULT(no)])
-AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-debug, 0 otherwise])
+AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-trace, 0 otherwise])
 
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h cuda_runtime.h], [],[

--- a/configure.ac
+++ b/configure.ac
@@ -17,6 +17,7 @@ AC_PROG_CC
 AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
 AM_PROG_AR
+AC_CHECK_PROG(MPICC_FOUND, [mpicc], "yes")
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
@@ -54,7 +55,7 @@ AC_ARG_WITH([mpi],
             [AS_IF([test -d $withval/lib64], [mpi_libdir="lib64"], [mpi_libdir="lib"])
              CFLAGS="-I$withval/include $CFLAGS"
              LDFLAGS="-L$withval/$mpi_libdir $LDFLAGS"],
-            [])
+            [AS_IF([test "$MPICC_FOUND" == "yes"], [], AC_MSG_ERROR([--with-mpi= argument missing]))])
 
 AC_ARG_ENABLE(trace, [AS_HELP_STRING([--enable-trace], [Enable printing trace messages])], [], [enable_trace=no])
 AC_MSG_CHECKING([whether to enable trace messages])

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,7 @@ AM_SILENT_RULES([yes])
 
 # Checks for programs.
 AC_PROG_CC
+AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
 AM_PROG_AR
 

--- a/configure.ac
+++ b/configure.ac
@@ -17,7 +17,17 @@ AC_PROG_CC
 AC_PROG_CC_STDC
 AC_PROG_MAKE_SET
 AM_PROG_AR
-AC_CHECK_PROG(MPICC_FOUND, [mpicc], "yes")
+
+# If an mpicc executable is found or tests are disabled, bypass the check for
+# whether --with-mpi= is specified.
+AC_CHECK_PROG(BYPASS_MPICC_CHECK, [mpicc], "yes", "no")
+AC_ARG_ENABLE([tests], AS_HELP_STRING([--disable-tests], [Disable test binaries]))
+AS_IF([test "x$enable_tests" != "xno"], [
+            AC_SUBST(TEST_DIR, "tests")
+], [
+            AC_SUBST(TEST_DIR, "")
+            AC_SUBST(BYPASS_MPICC_CHECK, "yes")
+])
 
 # Checks for typedefs, structures, and compiler characteristics.
 AC_CHECK_HEADER_STDBOOL
@@ -55,7 +65,7 @@ AC_ARG_WITH([mpi],
             [AS_IF([test -d $withval/lib64], [mpi_libdir="lib64"], [mpi_libdir="lib"])
              CFLAGS="-I$withval/include $CFLAGS"
              LDFLAGS="-L$withval/$mpi_libdir $LDFLAGS"],
-            [AS_IF([test "$MPICC_FOUND" == "yes"], [], AC_MSG_ERROR([--with-mpi= argument missing]))])
+            [AS_IF([test "$BYPASS_MPICC_CHECK" == "yes"], [], AC_MSG_ERROR([--with-mpi= argument missing]))])
 
 AC_ARG_ENABLE(trace, [AS_HELP_STRING([--enable-trace], [Enable printing trace messages])], [], [enable_trace=no])
 AC_MSG_CHECKING([whether to enable trace messages])

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.1.5], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.2.0], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [0.9], [rashika@amazon.com])
+AC_INIT([aws-ofi-nccl], [1.1.4], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/configure.ac
+++ b/configure.ac
@@ -5,7 +5,7 @@
 #
 
 AC_PREREQ([2.69])
-AC_INIT([aws-ofi-nccl], [1.1.4], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.1.5], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -10,7 +10,6 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
-#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -240,7 +239,7 @@ typedef struct nccl_ofi_handle {
 #endif
 } nccl_ofi_handle_t;
 
-static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
+_Static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*
  * Structure for an OFI network device.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,6 +103,7 @@ typedef struct free_list {
 typedef struct listenComm {
 	uint64_t tag;
 	struct fid_ep *local_ep;
+	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
 } listenComm_t;
@@ -122,6 +123,7 @@ typedef struct recvComm {
 	uint64_t tag;
 	uint64_t num_inflight_reqs;
 	fi_addr_t remote_ep;
+	fi_addr_t local_ep_addr;
 	struct fid_ep *local_ep;
 	free_list_t *nccl_ofi_reqs_fl;
 } recvComm_t;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -61,6 +61,9 @@ extern "C" {
  */
 #define MIN_TAG_BITS_FOR_RING_ID	(32 + 1)
 
+/* Maximum number of grouped receives */
+#define NCCL_OFI_MAX_RECVS	1
+
 /* This is twice the size of maximum inflight requests supported by NCCL */
 #define NCCL_OFI_MAX_REQUESTS	256
 
@@ -183,6 +186,9 @@ typedef struct nccl_ofi_req {
 
 	/* Associated Device ID */
 	int dev;
+
+	/* Number of receives associated with request */
+	int num_recvs;
 
 	/* Size of completed request */
 	size_t size;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -58,6 +58,9 @@ extern "C" {
 /* This is twice the size of maximum inflight requests supported by NCCL */
 #define NCCL_OFI_MAX_REQUESTS	256
 
+/* Flush read size (bytes) */
+#define NCCL_OFI_FLUSH_SIZE	4
+
 /* NCCL OFI lock for concurrency */
 pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Logger Function */
@@ -103,7 +106,7 @@ typedef struct free_list {
 
 /* Metadata about dummy flush buffer */
 typedef struct flush_buffer {
-	int host_buffer;
+	void *host_buffer;
 	size_t size;
 	/* Memory registration handle of the local buffer */
 	struct fid_mr *mr_handle;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -121,6 +121,7 @@ typedef struct flush_buffer {
 	struct fid_mr *mr_handle;
 } flush_buffer_t;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 struct nccl_ofi_req;
 typedef struct nccl_ofi_req nccl_ofi_req_t;
 
@@ -138,6 +139,7 @@ typedef struct save_comm_state {
 	nccl_ofi_req_t *req;
 	nccl_ofi_comm_stage_t stage;
 } save_comm_state_t;
+#endif
 
 typedef struct listenComm {
 	uint64_t tag;
@@ -145,10 +147,12 @@ typedef struct listenComm {
 	fi_addr_t local_ep_addr;
 	int dev;
 	bool accepted;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Saves temporary state when creating receive communicator object */
 	save_comm_state_t state;
 	/* Saves peer address information */
 	void *buffer;
+#endif
 } listenComm_t;
 
 typedef struct comm {
@@ -187,8 +191,10 @@ typedef struct nccl_ofi_req {
 	/* Associated Device ID */
 	int dev;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Number of receives associated with request */
 	int num_recvs;
+#endif
 
 	/* Size of completed request */
 	size_t size;
@@ -228,8 +234,10 @@ typedef struct pending_reqs_q {
 typedef struct nccl_ofi_handle {
 	char ep_name[MAX_EP_ADDR];
 	uint64_t tag;
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
 	/* Save temporary communicator state when creating send communicator */
 	save_comm_state_t state;
+#endif
 } nccl_ofi_handle_t;
 
 static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -10,6 +10,7 @@ extern "C" {
 #endif
 
 #include <stdbool.h>
+#include <assert.h>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -190,6 +191,13 @@ typedef struct pending_reqs_q {
 	pending_reqs_q_elem_t *head;
 	pending_reqs_q_elem_t *tail;
 } pending_reqs_q_t;
+
+typedef struct nccl_ofi_handle {
+	char ep_name[MAX_EP_ADDR];
+	uint64_t tag;
+} nccl_ofi_handle_t;
+
+static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*
  * Structure for an OFI network device.

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2020 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_PARAM_H_
+#define NCCL_OFI_PARAM_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <nccl_ofi_log.h>
+#include <assert.h>
+#include <string.h>
+
+#define OFI_NCCL_PARAM_INT(name, env, default_value) \
+pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+int64_t ofi_nccl_##name() { \
+    assert(default_value != -1LL); \
+    static int64_t value = -1LL; \
+    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    int64_t v; \
+    char *str; \
+    if (value == -1LL) { \
+        value = default_value; \
+        str = getenv("OFI_NCCL_" env); \
+        if (str && strlen(str) > 0) { \
+            errno = 0; \
+            v = strtoll(str, NULL, 0); \
+            if (!errno) { \
+                value = v; \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting %s environment variable to %lu", \
+                              "OFI_NCCL_" env, value); \
+            } else { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, \
+                    "Invalid value %s provided for %s environment variable, using default %s", \
+                    str, "OFI_NCCL_" env, value); \
+            } \
+        } \
+    } \
+    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    return value; \
+}
+
+#define OFI_NCCL_PARAM_STR(name, env, default_value) \
+pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
+char *ofi_nccl_##name() { \
+    assert(default_value != NULL); \
+    static char *value = NULL; \
+    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    char *str; \
+    if (value == NULL) { \
+        value = strdup(default_value); \
+        str = getenv("OFI_NCCL_" env); \
+        if (str && strlen(str) > 0) { \
+            errno = 0; \
+            value = strdup(str); \
+            if (!errno) { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting %s environment variable to %s", \
+                              "OFI_NCCL_" env, value); \
+            } else { \
+                NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, \
+                    "Invalid value %s provided for %s environment variable", \
+                    str, "OFI_NCCL_" env); \
+            } \
+        } \
+    } \
+    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    return value; \
+}
+
+/*
+ * Enable using endpoints with IPv6 addressing format for TCP provider.
+ * By default, we disable using endpoints having IPv6 addressing format.
+ */
+OFI_NCCL_PARAM_INT(use_ipv6_tcp, "USE_IPV6_TCP", 0);
+
+/*
+ * List of interface names (comma-separated) to be filtered out for TCP provider.
+ * By default, it is set to eliminate lo and docker0 interfaces.
+ *
+ * TODO: Remove lo after https://github.com/ofiwg/libfabric/issues/6127 is fixed
+ */
+OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_PARAM_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -83,6 +83,15 @@ OFI_NCCL_PARAM_INT(use_ipv6_tcp, "USE_IPV6_TCP", 0);
  */
 OFI_NCCL_PARAM_STR(exclude_tcp_if, "EXCLUDE_TCP_IF", "lo,docker0");
 
+/*
+ * Disable flush operation when using GPUDirect. Flush commands
+ * are used to enforce data consistency at the receiving GPU. It should
+ * only be disabled when underlying libfabric provider or hardware
+ * ensures data consistency.
+ * By default, plugin issues flush commands.
+ */
+OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,7 @@
 
 AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
 AM_CFLAGS += -I$(top_srcdir)/include
+AM_LDFLAGS = -lcudart
 
 lib_LTLIBRARIES = libnccl-net.la
 libnccl_net_la_SOURCES = nccl_ofi_net.c

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2142,8 +2142,8 @@ static ncclResult_t ofi_iaccept(void *listenComm, void **recvComm)
 		return ncclSystemError;
 	}
 
-	if (lComm->accepted == true) {
-		NCCL_OFI_WARN("listenComm object already has an active connection.");
+	if (lComm->state.stage != COMM_REQ_PENDING_COMP && lComm->accepted) {
+		NCCL_OFI_WARN("listenComm %p object already has an active connection (%d).", listenComm, lComm->accepted);
 		return ncclSystemError;
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1569,7 +1569,7 @@ static ssize_t send_connect_message(sendComm_t *sComm, nccl_ofi_req_t *req)
 	 */
 	rc = fi_tsend(sComm->local_ep, (void *)local_ep_addr,
 			MAX_EP_ADDR, NULL, sComm->remote_ep,
-			sComm->tag | ~max_tag, &req->ctx);
+			sComm->tag | (max_tag + 1), &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/*
 		 * Process completions so that you have enough
@@ -1872,7 +1872,7 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		 */
 		rc = fi_tsend(sComm->local_ep, (void *)conn_info,
 			      sizeof(*conn_info), NULL, sComm->remote_ep,
-			      sComm->tag | ~max_tag, &req->ctx);
+			      sComm->tag | (max_tag + 1), &req->ctx);
 		if (rc == 0)
 			break;
 		else if (rc == -FI_EAGAIN) {
@@ -1989,7 +1989,7 @@ static ssize_t post_recv_conn(listenComm_t *lComm, char **buffer,
 
 	/* Post a buffer for receiving connection requests */
 	rc = fi_trecv(lComm->local_ep, (void *)*buffer, size,
-		      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+		      NULL, FI_ADDR_UNSPEC, lComm->tag | (max_tag + 1),
 		      0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/*
@@ -2288,7 +2288,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	/* Post a buffer for receiving connection requests */
 	do {
 		rc = fi_trecv(lComm->local_ep, (void *)&conn_info, sizeof(conn_info),
-			      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
+			      NULL, FI_ADDR_UNSPEC, lComm->tag | (max_tag + 1),
 			      0, &req->ctx);
 		if (rc == 0)
 			break;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -453,7 +453,7 @@ static ncclResult_t register_mr_buffers(ofiComm_t *comm, void *data,
 			    &mr_attr, 0, mr_handle);
 	if (OFI_UNLIKELY(rc != 0)) {
 		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
-			       type, comm->dev, fi_strerror(-rc));
+			       type, comm->dev, rc, fi_strerror(-rc));
 		ret = ncclSystemError;
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -562,7 +562,7 @@ exit:
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
 	int idx = 0, prov_idx = 0, i, rc = 0;
-	struct fi_info *providers, *prov;
+	struct fi_info *providers = NULL, *prov = NULL;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
 	int info_count[MAX_PROV_INFO] = {0};
 	char *prov_name;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -9,6 +9,7 @@
 #include <string.h>
 #include <unistd.h>
 #include <stack.h>
+#include <nccl_ofi_param.h>
 
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
@@ -16,16 +17,6 @@ struct fi_info* ofi_info_list = NULL;
 int ofi_ndevices = -1;
 /* NCCL OFI component array for all NICs */
 nccl_ofi_t **nccl_ofi_component = NULL;
-/*
- * List of interface names to be filtered out for TCP provider.
- * Currently, it is set to default value as set by tcp_if_exclude_default.
- */
-char *tcp_if_exclude_list = NULL;
-/* Configure using IPv6 interfaces for TCP provider. Default behaviour is
- * to avoid using IPv6 interfaces.
- * TODO: Allow users to configure at runtime.
- */
-bool use_ipv6_tcp = false;
 /* Indicates if memory registration of local buffers is required */
 bool local_mr = false;
 
@@ -272,8 +263,8 @@ exit:
 }
 
 /*
- * @brief	Returns true if the given provider matches IPv6 addressing format
- *		and interfaces from `tcp_if_exclude_list`
+ * @brief	Returns true if the given provider matches IPv6 addressing format,
+ *		interfaces from tcp_if_exclude_list or multiple memory tag formats.
  *
  * @return 	true, if success
  *		false, otherwise
@@ -281,9 +272,11 @@ exit:
 static bool match_prov_info(char *name, uint32_t addr_format,
 			    uint64_t mem_tag_format, uint64_t expected_mem_tag_format)
 {
+	char *tcp_if_exclude_list = ofi_nccl_exclude_tcp_if();
+
 	if (in_list(name, tcp_if_exclude_list)) {
 		return true;
-	} else if (!use_ipv6_tcp && (addr_format == FI_SOCKADDR_IN6)) {
+	} else if (!ofi_nccl_use_ipv6_tcp() && (addr_format == FI_SOCKADDR_IN6)) {
 		return true;
 	} else if (mem_tag_format != expected_mem_tag_format) {
 		/* TODO: Remove after https://github.com/ofiwg/libfabric/issues/6126 is fixed */
@@ -829,8 +822,6 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	ncclResult_t ret = ncclSuccess;
 	char *prov_include = NULL;
 	int idx, rc;
-	/* TODO: Remove lo after https://github.com/ofiwg/libfabric/issues/6127 is fixed */
-	char tcp_if_exclude_default[] = "lo,docker0";
 
 	ofi_log_function = logFunction;
 
@@ -859,10 +850,6 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		}
 	}
 
-	/* TODO: Allow configuring TCP interface exclude list at runtime */
-	/* Use default list of TCP interface names to exclude */
-	tcp_if_exclude_list = strdup(tcp_if_exclude_default);
-
 	/* Get list of NICs fi_info structures for a single provider */
 	ret = get_ofi_provider(prov_include, &ofi_info_list);
 	if (ret != 0 || ofi_info_list == NULL) {
@@ -874,7 +861,7 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	if (strncmp("tcp", ofi_info_list->fabric_attr->prov_name, strlen("tcp")) == 0) {
 		filter_tcp_info_list();
 		if (OFI_UNLIKELY(ofi_info_list == NULL)) {
-			NCCL_OFI_WARN("No viable endpoint found for TCP provider.");
+			NCCL_OFI_WARN("No viable endpoint found for TCP provider. Try and relax the filters using OFI_NCCL_USE_IPV6_TCP or OFI_NCCL_EXCLUDE_TCP_IF environment variables");
 			ret = ncclSystemError;
 			goto exit;
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -945,7 +945,13 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 		}
 		else if (OFI_UNLIKELY(rc == -FI_EAVAIL)) {
 			rc = fi_cq_readerr(cq, &err_buffer, 0);
-			if (OFI_UNLIKELY(rc < 0)) {
+			if (OFI_UNLIKELY(rc == -FI_EAGAIN)) {
+				/*
+				 * Error not available yet.
+				 * fi_cq_read will keep returning -FI_EAVAIL so just bail out and try again later.
+				 */
+				break;
+			} else if (OFI_UNLIKELY(rc < 0)) {
 				NCCL_OFI_WARN("Unable to read from fi_cq_readerr. RC: %zd. Error: %s",
 					     rc,
 					     fi_cq_strerror(cq,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1,3 +1,5 @@
+#include "config.h"
+
 /*
  * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
  * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
@@ -169,7 +171,7 @@ static inline int free_nccl_ofi_req(nccl_ofi_req_t *req, bool dec_inflight_cmds)
 		sComm = req->sComm;
 		if (OFI_UNLIKELY(sComm == NULL)) {
 			ret = ncclSystemError;
-			NCCL_OFI_WARN("Invalid sComm provided for request of device %d\n",
+			NCCL_OFI_WARN("Invalid sComm provided for request of device %d",
 				      sComm->dev);
 			goto exit;
 		}
@@ -986,6 +988,8 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 
 	ofi_log_function = logFunction;
 
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using " PACKAGE_STRING);
+
 	/*
 	 * RDMAV_FORK_SAFE environment variable makes the rdma-core
 	 * library fork-safe. This significantly increases cost of memory
@@ -1062,6 +1066,9 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	}
 
 exit:
+	if (ret != ncclSuccess) {
+		NCCL_OFI_WARN(PACKAGE_NAME " initialization failed");
+	}
 	return ret;
 }
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -560,7 +560,6 @@ exit:
  */
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
-	ncclResult_t ret = ncclSuccess;
 	int idx = 0, prov_idx = 0, i, rc = 0;
 	struct fi_info *providers, *prov;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
@@ -568,10 +567,8 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	char *prov_name;
 
 	rc = find_ofi_provider(&providers);
-	if (rc != 0) {
-		ret = ncclSystemError;
+	if (rc != 0)
 		goto error;
-	}
 
 	/*
 	 * Create an array of providers where each index represents
@@ -624,7 +621,7 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		}
 	}
 
-	return ret;
+	return ncclSuccess;
 
 error:
 	if (providers)

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1040,6 +1040,9 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		local_mr = true;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
+			       ofi_info_list->fabric_attr->prov_name);
 	}
 
 	/* Check if provider requires heterogeneous memory registration */
@@ -1047,6 +1050,9 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of device buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		hmem_mr = true;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of device buffers",
+			       ofi_info_list->fabric_attr->prov_name);
 	}
 
 	/*
@@ -1874,7 +1880,9 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 	nccl_ofi_req_t *req = NULL;
 	ssize_t rc = 0;
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
-	uint64_t cuda_key;
+	uint64_t cuda_key = 0ULL;
+	void* desc = NULL;
+
 
 	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
 		goto exit;
@@ -1883,12 +1891,6 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Invalid recvComm provided");
-		goto exit;
-	}
-
-	if (OFI_UNLIKELY(mr_handle == NULL)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Invalid memory registration handle provided");
 		goto exit;
 	}
 
@@ -1922,19 +1924,22 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
-	/* Extract remote key */
-	cuda_key = fi_mr_key(mr_handle);
-	if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Memory registration may not have completed.");
-		goto error;
+	if (mr_handle != NULL) {
+		/* Extract remote key */
+		desc = fi_mr_desc(mr_handle);
+		cuda_key = fi_mr_key(mr_handle);
+		if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
+			ret = ncclSystemError;
+			NCCL_OFI_WARN("Memory registration may not have completed.");
+			goto error;
+		}
 	}
 
 	/* Issue RDMA read */
 	do {
 		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
-			     fi_mr_desc(rComm->flush_buff.mr_handle),
+			     desc,
 			     rComm->local_ep_addr, (uint64_t)data,
 			     cuda_key, &req->ctx);
 		if (rc == 0) {
@@ -2061,12 +2066,14 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 	if (support_gdr) {
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
-		rc = fi_close((fid_t)mr_handle);
-		if (OFI_UNLIKELY(rc != 0)) {
-			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-				      fi_strerror(-rc));
-			goto exit;
+		if (mr_handle) {
+			rc = fi_close((fid_t)mr_handle);
+			if (OFI_UNLIKELY(rc != 0)) {
+				ret = ncclSystemError;
+				NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+					      fi_strerror(-rc));
+				goto exit;
+			}
 		}
 	}
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -341,9 +341,9 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 		*prov_info_list = prov_info_vec[0];
 	else {
 		for (prov_idx = 0; prov_idx < idx; prov_idx++) {
-			prov_name = prov_info_vec[idx]->fabric_attr->prov_name;
+			prov_name = prov_info_vec[prov_idx]->fabric_attr->prov_name;
 			if (in_list(prov_name, prov_include)) {
-				*prov_info_list = prov_info_vec[idx];
+				*prov_info_list = prov_info_vec[prov_idx];
 				break;
 			}
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1583,7 +1583,8 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
 
 
@@ -2078,7 +2079,8 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 
 	dev = rComm->dev;
 
-	if (support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
 		if (mr_handle) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1326,14 +1326,64 @@ exit:
 	return ret;
 }
 
+struct connection_info {
+	char ep_name[MAX_EP_ADDR];
+	size_t ep_namelen;
+	nccl_ofi_req_t* req;
+	struct connection_info* memory_buffer;
+	bool connect_to_self;
+};
+
+struct connection_info* allocate_connection_info(int dev, nccl_ofi_req_t *req, char* remote_ep_name)
+{
+	struct connection_info* conn_info = (struct connection_info*)calloc(1, sizeof(*conn_info));
+	if (OFI_UNLIKELY(conn_info == NULL)) {
+		return NULL;
+	}
+	conn_info->ep_namelen = sizeof(conn_info->ep_name);
+
+	/* Get local EP address to transfer in the connect message */
+	int ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
+			 (void *)conn_info->ep_name,
+			 &(conn_info->ep_namelen));
+	if (ret != 0) {
+		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		free(conn_info);
+		return NULL;
+	}
+
+	conn_info->req = req;
+	/* for future freeing conn_info buffer */
+	conn_info->memory_buffer = conn_info;
+	conn_info->connect_to_self = (memcmp(conn_info->ep_name, remote_ep_name, conn_info->ep_namelen) == 0);
+
+	return conn_info;
+}
+
+ncclResult_t process_connect_completion(struct connection_info* conn_info)
+{
+	/* process postponed completions */
+	do {
+		ncclResult_t ret = nccl_ofi_progress(nccl_ofi_component[conn_info->req->dev]);
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
+	} while (conn_info->req->state != NCCL_OFI_REQ_COMPLETED);
+	free_nccl_ofi_req(conn_info->req, false);
+	free(conn_info->memory_buffer);
+	NCCL_OFI_TRACE(NCCL_NET, "Processed completion for connect message");
+	return ncclSuccess;
+}
+
+
 static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
 	ssize_t rc = 0;
 	uint64_t tag = 0ULL;
 	char remote_ep_addr[MAX_EP_ADDR] = {0};
-	char local_ep_addr[MAX_EP_ADDR] = {0};
-	size_t namelen = sizeof(local_ep_addr);
+	struct connection_info* conn_info = NULL;
 	fi_addr_t remote_addr;
 	sendComm_t *sComm = NULL;
 	uint64_t max_tag = 0;
@@ -1418,13 +1468,9 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	req->dev = sComm->dev;
 	req->direction = NCCL_OFI_SEND;
 
-	/* Get local EP address to transfer in the connect message */
-	ret = fi_getname(&(nccl_ofi_component[dev]->ep->fid),
-			 (void *)&local_ep_addr,
-			 &namelen);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
+	conn_info = allocate_connection_info(dev, req, remote_ep_addr);
+	if (OFI_UNLIKELY(conn_info == NULL)) {
+		NCCL_OFI_WARN("Couldn't allocate connection_info for dev %d", dev);
 		ret = ncclSystemError;
 		goto error;
 	}
@@ -1436,8 +1482,8 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 		 * providers can support it, so that need for completion check
 		 * below can be lifted.
 		 */
-		rc = fi_tsend(sComm->local_ep, (void *)&local_ep_addr,
-			      MAX_EP_ADDR, NULL, sComm->remote_ep,
+		rc = fi_tsend(sComm->local_ep, (void *)conn_info,
+			      sizeof(*conn_info), NULL, sComm->remote_ep,
 			      sComm->tag | ~max_tag, &req->ctx);
 		if (rc == 0)
 			break;
@@ -1459,11 +1505,13 @@ static ncclResult_t ofi_connect(int dev, void *handle, void **sendComm)
 	} while (true);
 
 	/* Ensure the message is sent. */
-	do {
-		ret = nccl_ofi_progress(nccl_ofi_component[dev]);
-		if (OFI_UNLIKELY(ret != 0))
+	/* Skip this step for sending to self */
+	if (!conn_info->connect_to_self) {
+		ret = process_connect_completion(conn_info);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
 			goto error;
-	} while (req->state != NCCL_OFI_REQ_COMPLETED);
+		}
+	}
 
 	*sendComm = sComm;
 
@@ -1474,9 +1522,14 @@ unlock:
 error:
 	if (sComm)
 		free(sComm);
-exit:
+
+	if (conn_info) {
+		free(conn_info);
+	}
+
 	if (req)
 		free_nccl_ofi_req(req, false);
+exit:
 	return ret;
 }
 
@@ -1489,7 +1542,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	int dev = lComm->dev;
 	nccl_ofi_t *nccl_ofi_comp = nccl_ofi_component[dev];
 	nccl_ofi_req_t *req = NULL;
-	char remote_ep_addr[MAX_EP_ADDR] = {0};
+	struct connection_info conn_info = {0};
 	fi_addr_t remote_ep;
 	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
@@ -1530,7 +1583,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 	/* Post a buffer for receiving connection requests */
 	do {
-		rc = fi_trecv(lComm->local_ep, (void *)&remote_ep_addr, MAX_EP_ADDR,
+		rc = fi_trecv(lComm->local_ep, (void *)&conn_info, sizeof(conn_info),
 			      NULL, FI_ADDR_UNSPEC, lComm->tag | ~max_tag,
 			      0, &req->ctx);
 		if (rc == 0)
@@ -1559,8 +1612,19 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 			goto exit;
 	}
 
+	if (conn_info.connect_to_self) {
+		NCCL_OFI_TRACE(NCCL_NET, "Accept from self");
+		ret = process_connect_completion(&conn_info);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			goto error;
+		}
+	}
+	else {
+		NCCL_OFI_TRACE(NCCL_NET, "Accept from remote");
+	}
+
 	/* Insert remote EP address to AV */
-	ret = fi_av_insert(nccl_ofi_comp->av, (void *)remote_ep_addr, 1,
+	ret = fi_av_insert(nccl_ofi_comp->av, (void *)conn_info.ep_name, 1,
 			   &remote_ep, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -234,22 +234,28 @@ exit:
 	return ret;
 }
 
-static int in_list(char *prov_name, char *prov_include)
+static int in_list(char *item, char *list)
 {
 	int ret = 0;
-	char *name = NULL;
+	char *token = NULL;
+	char *list_temp = strdup(list);
 
-	if (prov_include == NULL)
+	if (list_temp == NULL) {
+		if (list != NULL) {
+			NCCL_OFI_WARN("Unable to duplicate list.");
+			ret = ncclSystemError;
+		}
 		goto exit;
+	}
 
-	name = strtok((char *)prov_include, ",");
+	token = strtok((char *)list_temp, ",");
 
-	while (name) {
-		if (strcmp(prov_name, name) == 0) {
+	while (token) {
+		if (strcmp(item, token) == 0) {
 			ret = 1;
 			goto exit;
 		}
-		name = strtok(NULL, ",");
+		token = strtok(NULL, ",");
 	}
 
 exit:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1805,6 +1805,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key;
 
+	if (ofi_nccl_gdr_flush_disable())
+		goto exit;
+
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		ret = ncclSystemError;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1179,6 +1179,20 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 	props->maxComms = nic_prov->domain_attr->ep_cnt;
 	props->guid = dev;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+	/*
+	 * Maximum number of grouped receives. Currently, we set it to 1 to
+	 * maintain single send/recv semantics (similar to NCCL versions < v2.12).
+	 *
+	 * Grouped receives are useful for alltoall collectives where one
+	 * receiver is expected to receive from multiple remote GPUs using
+	 * PXN(PCIe X NVLINK) feature. Other collectives like allreduce aren't
+	 * impacted with this feature as NCCL doesn't aggregate receives from
+	 * same source.
+	 */
+	props->maxRecvs = NCCL_OFI_MAX_RECVS;
+#endif
+
 	ret = ofi_pciPath(dev, &props->pciPath);
 	if (ret != ncclSuccess)
 		props->pciPath = NULL;
@@ -1966,7 +1980,6 @@ static int alloc_and_reg_flush_buff(recvComm_t *rComm)
 	if (OFI_UNLIKELY(ret != ncclSuccess)) {
 		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
 				rComm->dev);
-
 		if (munmap(rComm->flush_buff.host_buffer, page_size)) {
 			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)",
 				      errno, strerror(errno));
@@ -2393,8 +2406,13 @@ exit:
 	return ret;
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
+			      int tag, void *mhandle, void** request)
+#else
 static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 			      void *mhandle, void** request)
+#endif
 {
 	ncclResult_t ret = ncclSuccess;
 	ssize_t rc = 0;
@@ -2417,6 +2435,11 @@ static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 			     NCCL_OFI_MAX_REQUESTS);
 		goto error;
 	}
+
+	/*
+	 * TODO: Use NCCL provided tags when using grouped receives aka
+	 * props->maxRecvs > 1.
+	 */
 
 	/* Allocate NCCL OFI request */
 	req = allocate_nccl_ofi_request(sComm->nccl_ofi_reqs_fl);
@@ -2478,14 +2501,18 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_irecv(void* recvComm, void* data, int sizes,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+static ncclResult_t ofi_irecv(void* recvComm, int n, void** buffers, int* sizes,
+			      int *tags, void** mhandles, void** request)
+#else
+static ncclResult_t ofi_irecv(void* recvComm, void* buffer, int size,
 			      void* mhandle, void** request)
+#endif
 {
 	ncclResult_t ret = ncclSuccess;
 	ssize_t rc = 0;
 	nccl_ofi_req_t *req = NULL;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
-	void *desc = NULL;
 
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
@@ -2520,12 +2547,53 @@ static ncclResult_t ofi_irecv(void* recvComm, void* data, int sizes,
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+	req->num_recvs = n;
+
+	if (OFI_UNLIKELY(mhandles == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Memory handles array is NULL");
+		goto error;
+	}
+
+	/* Currently, plugin doesn't support grouped receives */
+	assert(n == 1);
+	for (int recv_n = 0; recv_n < n; recv_n++) {
+		void *desc = NULL;
+
+		if (mhandles[recv_n] != NULL) {
+			desc = fi_mr_desc(mhandles[recv_n]);
+		}
+
+		/*
+		 * TODO: Use NCCL provided tags when plugin supports grouped
+		 * receives aka props->maxRecvs > 1.
+		 */
+
+		/* Try posting buffer to local EP */
+		rc = fi_trecv(rComm->local_ep, buffers[recv_n], sizes[recv_n],
+			      desc, FI_ADDR_UNSPEC, rComm->tag, 0, &req->ctx);
+		if (rc == -FI_EAGAIN) {
+			/* Return NULL request */
+			*request = NULL;
+			goto error;
+		}
+		else if (rc != 0) {
+			NCCL_OFI_WARN("Unable to post receive buffer for dev %d. RC: %zd, ERROR: %s",
+					rComm->dev, rc, fi_strerror(-rc));
+			ret = ncclSystemError;
+			goto error;
+		}
+
+	}
+#else
+	void *desc = NULL;
 	if (mhandle != NULL)
 		desc = fi_mr_desc(mhandle);
 
 	/* Try posting buffer to local EP */
-	rc = fi_trecv(rComm->local_ep, data, size, desc,
-		      FI_ADDR_UNSPEC, rComm->tag, 0, &req->ctx);
+	rc = fi_trecv(rComm->local_ep, buffer, size,
+			desc, FI_ADDR_UNSPEC, rComm->tag, 0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/* Return NULL request */
 		*request = NULL;
@@ -2533,10 +2601,11 @@ static ncclResult_t ofi_irecv(void* recvComm, void* data, int sizes,
 	}
 	else if (rc != 0) {
 		NCCL_OFI_WARN("Unable to post receive buffer for dev %d. RC: %zd, ERROR: %s",
-			       rComm->dev, rc, fi_strerror(-rc));
+				rComm->dev, rc, fi_strerror(-rc));
 		ret = ncclSystemError;
 		goto error;
 	}
+#endif
 
 	rComm->num_inflight_reqs++;
 
@@ -2597,17 +2666,21 @@ exit:
 	return ret;
 }
 
-static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
-			       void *mhandle, void **request)
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+static ncclResult_t ofi_iflush(void* recvComm, int n, void** buffers, int* sizes,
+			       void** mhandles, void** request)
+#else
+static ncclResult_t ofi_iflush(void* recvComm, void* buffer, int size,
+			       void* mhandle, void** request)
+#endif
 {
 	ncclResult_t ret = ncclSuccess;
 	recvComm_t *rComm = (recvComm_t *)recvComm;
 	nccl_ofi_req_t *req = NULL;
 	ssize_t rc = 0;
-	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key = 0ULL;
-	void* desc = NULL;
-
+	struct fid_mr *mr_handle = NULL;
+	void *data = NULL;
 
 	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
 		goto exit;
@@ -2619,6 +2692,42 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 		goto exit;
 	}
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
+	/* Plugin only supports one receive per request */
+	assert(n == 1);
+
+	/*
+	 * Find the non-zero request for which we will issue flush.
+	 * A single operation can flush all request at once.
+	 */
+	int flush_n = -1;
+	for (int recv_n = 0; recv_n < n; recv_n++) {
+		if (sizes[recv_n] != 0) {
+			flush_n = recv_n;
+			break;
+		}
+	}
+
+	if (flush_n == -1) {
+		/*
+		 * Flush is an expensive operation. So, don't send fi_read for
+		 * 0-sized messages. Since, NCCL issues flush for every irecv(),
+		 * we guarantee to sync data to GPU even without it.
+		 */
+		goto exit;
+	}
+
+	if (mhandles && mhandles[flush_n])
+		mr_handle = (struct fid_mr *)mhandles[flush_n];
+
+	if (OFI_UNLIKELY(mr_handle == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid memory registration handle provided");
+		goto exit;
+	}
+
+	data = buffers[flush_n];
+#else
 	if (size == 0) {
 		/*
 		 * Flush is an expensive operation. So, don't send fi_read for
@@ -2628,11 +2737,21 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 		goto exit;
 	}
 
+	mr_handle = (struct fid_mr *)mhandle;
+	if (OFI_UNLIKELY(mr_handle == NULL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Invalid memory registration handle provided");
+		goto exit;
+	}
+
+	data = buffer;
+#endif
+
 	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
 	if (OFI_UNLIKELY(rComm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			     NCCL_OFI_MAX_REQUESTS);
+				NCCL_OFI_MAX_REQUESTS);
 		goto exit;
 	}
 
@@ -2649,22 +2768,19 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
-	if (mr_handle != NULL) {
-		/* Extract remote key */
-		desc = fi_mr_desc(mr_handle);
-		cuda_key = fi_mr_key(mr_handle);
-		if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
-			ret = ncclSystemError;
-			NCCL_OFI_WARN("Memory registration may not have completed.");
-			goto error;
-		}
+	/* Extract remote key */
+	cuda_key = fi_mr_key(mr_handle);
+	if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
+		ret = ncclSystemError;
+		NCCL_OFI_WARN("Memory registration may not have completed.");
+		goto error;
 	}
 
 	/* Issue RDMA read */
 	do {
 		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
-			     desc,
+			     fi_mr_desc(rComm->flush_buff.mr_handle),
 			     rComm->local_ep_addr, (uint64_t)data,
 			     cuda_key, &req->ctx);
 		if (rc == 0) {
@@ -2681,7 +2797,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 		}
 		else {
 			NCCL_OFI_WARN("Unable to issue read operation for dev %d. RC: %zd, ERROR: %s",
-				     rComm->dev, rc, fi_strerror(-rc));
+					rComm->dev, rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto error;
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -21,6 +21,8 @@ nccl_ofi_t **nccl_ofi_component = NULL;
 bool local_mr = false;
 /* Indicates if memory registration of device buffers is required */
 bool hmem_mr = false;
+/* Indicates if GPUDirect is supported by libfabric provider */
+bool support_gdr = true;
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -459,6 +461,93 @@ exit:
 }
 
 /*
+ * @brief	Returns hints info structure depending on GPUDirect support requirement
+ */
+static void get_hints(struct fi_info *hints, int request_gdr)
+{
+	if (request_gdr) {
+		hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_RMA | FI_READ | FI_REMOTE_COMM;
+		/*
+		 * Set MR mode bits to indicate that application allows
+		 * registration of both local and device memory buffers
+		 */
+		hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM;
+	}
+	else {
+		hints->caps = FI_TAGGED | FI_MSG | FI_REMOTE_COMM;
+		/*
+		 * Set MR mode bits to indicate that application allows
+		 * registration of both local memory buffers
+		 */
+		hints->domain_attr->mr_mode = FI_MR_LOCAL;
+	}
+
+	hints->mode = FI_CONTEXT;
+
+	hints->ep_attr->type = FI_EP_RDM;
+
+	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
+	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+
+	/* Set MR mode bits to indicate FI_MR_BASIC registration */
+	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
+
+	hints->tx_attr->msg_order = FI_ORDER_SAS;
+	hints->rx_attr->msg_order = FI_ORDER_SAS;
+}
+
+/*
+ * @brief	Returns provider info structure. It first tries to get providers
+ *		which supports GPUDirect. If not found, it re-tries to search for
+ *		provider supporting tagged messaging and RDM endpoints.
+ */
+static int find_ofi_provider(struct fi_info **providers)
+{
+	int rc = 0;
+	struct fi_info *gdr_hints, *hints;
+
+	gdr_hints = fi_allocinfo();
+	hints = fi_allocinfo();
+	if ((gdr_hints == NULL) || (hints == NULL)) {
+		NCCL_OFI_WARN("Unable to allocate hints fi_info structure");
+		rc = -FI_ENOMEM;
+		goto exit;
+	}
+
+	/* Get hints for GPUDirect capable provider */
+	get_hints(gdr_hints, true);
+
+	rc = fi_getinfo(ofi_version, NULL, NULL, 0ULL, gdr_hints, providers);
+	if (rc == -FI_ENODATA) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			       "Could not find any optimal provider supporting GPUDirect RDMA");
+
+		/* Indicate that plugin doesn't support transfers using GPU buffers */
+		support_gdr = false;
+
+		/* Re-try finding non-GPUDirect capable provider */
+		get_hints(hints, false);
+
+		rc = fi_getinfo(ofi_version, NULL, NULL, 0ULL, hints, providers);
+		if (rc == -FI_ENODATA) {
+			NCCL_OFI_WARN("Couldn't find any optimal provider");
+		} else if (rc != 0) {
+			NCCL_OFI_WARN("OFI call failed with RC %d, %s", rc, fi_strerror(-rc));
+		}
+	}
+	else if (rc != 0) {
+		NCCL_OFI_WARN("OFI call failed with RC %d, %s", rc, fi_strerror(-rc));
+	}
+
+exit:
+	if (gdr_hints)
+		fi_freeinfo(gdr_hints);
+	if (hints)
+		fi_freeinfo(hints);
+	return rc;
+}
+
+/*
  * @brief	Calls fi_getinfo() to find a list of usable providers for RDM
  *		tagged endpoints.
  *
@@ -471,47 +560,18 @@ exit:
  */
 static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 {
-	int ret = ncclSuccess, idx = 0, prov_idx = 0, i;
-	struct fi_info *hints, *providers, *prov;
+	ncclResult_t ret = ncclSuccess;
+	int idx = 0, prov_idx = 0, i, rc = 0;
+	struct fi_info *providers, *prov;
 	struct fi_info *prov_info_vec[MAX_PROV_INFO] = {NULL};
 	int info_count[MAX_PROV_INFO] = {0};
 	char *prov_name;
 
-	hints = fi_allocinfo();
-	if (OFI_UNLIKELY(hints == NULL)) {
-		NCCL_OFI_WARN("Unable to allocate fi_info");
+	rc = find_ofi_provider(&providers);
+	if (rc != 0) {
+		ret = ncclSystemError;
 		goto error;
 	}
-
-	/* Hints to filter providers */
-	hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_RMA | FI_READ | FI_REMOTE_COMM;
-	hints->mode = FI_CONTEXT;
-
-	hints->ep_attr->type = FI_EP_RDM;
-
-	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
-	/* Set MR mode bits to indicate FI_MR_BASIC registration */
-	hints->domain_attr->mr_mode = FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;
-	/* Set MR mode bits to indicate that application allows
-	 * registration of both local and device memory buffers */
-	hints->domain_attr->mr_mode |= FI_MR_LOCAL | FI_MR_HMEM;
-
-	hints->tx_attr->msg_order = FI_ORDER_SAS;
-	hints->rx_attr->msg_order = FI_ORDER_SAS;
-
-	ret = fi_getinfo(ofi_version, NULL, NULL, 0ULL, hints, &providers);
-	if (ret == -FI_ENODATA) {
-		NCCL_OFI_WARN("Could not find any optimal provider");
-		goto error;
-	}
-	else if (ret != 0) {
-		NCCL_OFI_WARN("OFI call failed with RC %d, %s", ret,
-			     fi_strerror(-ret));
-		goto error;
-	}
-
-	fi_freeinfo(hints);
 
 	/*
 	 * Create an array of providers where each index represents
@@ -567,8 +627,6 @@ static int get_ofi_provider(char *prov_include, struct fi_info **prov_info_list)
 	return ret;
 
 error:
-	if (hints)
-		fi_freeinfo(hints);
 	if (providers)
 		fi_freeinfo(providers);
 	return ncclSystemError;
@@ -1066,8 +1124,14 @@ exit:
 
 static ncclResult_t ofi_ptrSupport(int dev, int *supportedTypes)
 {
-	/* Supports message transfer from both CUDA and HOST buffers */
-	*supportedTypes = NCCL_PTR_HOST | NCCL_PTR_CUDA;
+	if (support_gdr) {
+		/* Supports message transfer from both CUDA and HOST buffers */
+		*supportedTypes = NCCL_PTR_HOST | NCCL_PTR_CUDA;
+	} else {
+		/* Supports message transfer from both HOST buffers */
+		*supportedTypes = NCCL_PTR_HOST;
+	}
+
 	return ncclSuccess;
 }
 
@@ -1493,18 +1557,21 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
-	rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
+	if (support_gdr) {
+		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
 
-	/* Register flush dummy buffer for provider access */
-	ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
-				  rComm->flush_buff.size, NCCL_PTR_HOST,
-				  &mr_handle);
-	if (OFI_UNLIKELY(ret != ncclSuccess)) {
-		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
-			      dev);
-		goto error;
+
+		/* Register flush dummy buffer for provider access */
+		ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
+					  rComm->flush_buff.size, NCCL_PTR_HOST,
+					  &mr_handle);
+		if (OFI_UNLIKELY(ret != ncclSuccess)) {
+			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+				      dev);
+			goto error;
+		}
+		rComm->flush_buff.mr_handle = mr_handle;
 	}
-	rComm->flush_buff.mr_handle = mr_handle;
 
 	/* Pre-allocated buffers for data path */
 	ret = allocate_ofi_fl(&rComm->nccl_ofi_reqs_fl, NCCL_OFI_MAX_REQUESTS,
@@ -1805,7 +1872,7 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 	uint64_t cuda_key;
 
-	if (ofi_nccl_gdr_flush_disable())
+	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
 		goto exit;
 
 	/* Validate recvComm */
@@ -1948,14 +2015,16 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 
 	dev = rComm->dev;
 
-	/* Deregister Flush buffer memory region */
-	mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
-	rc = fi_close((fid_t)mr_handle);
-	if (OFI_UNLIKELY(rc != 0)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-			      fi_strerror(-rc));
-		goto exit;
+	if (support_gdr) {
+		/* Deregister Flush buffer memory region */
+		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
+		rc = fi_close((fid_t)mr_handle);
+		if (OFI_UNLIKELY(rc != 0)) {
+			ret = ncclSystemError;
+			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+				      fi_strerror(-rc));
+			goto exit;
+		}
 	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -10,6 +10,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
+#include <sys/mman.h>
 #include <stack.h>
 #include <nccl_ofi_param.h>
 
@@ -1583,19 +1584,27 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
+	const long page_size = sysconf(_SC_PAGESIZE);
+
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
-		rComm->flush_buff.size = sizeof(rComm->flush_buff.host_buffer);
-
+		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
+		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
+					  MAP_PRIVATE | MAP_ANON, -1, 0);
+		if (OFI_UNLIKELY(rComm->flush_buff.host_buffer == MAP_FAILED)) {
+			NCCL_OFI_WARN("Unable to allocate flush buffer (%d %s)", errno, strerror(errno));
+			ret = ncclSystemError;
+			goto exit;
+		}
 
 		/* Register flush dummy buffer for provider access */
-		ret = register_mr_buffers(rComm, &rComm->flush_buff.host_buffer,
-					  rComm->flush_buff.size, NCCL_PTR_HOST,
+		ret = register_mr_buffers(rComm, rComm->flush_buff.host_buffer,
+					  page_size, NCCL_PTR_HOST,
 					  &mr_handle);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
-			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev:  %d",
+			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
 				      dev);
-			goto error;
+			goto unmap_flush;
 		}
 		rComm->flush_buff.mr_handle = mr_handle;
 	}
@@ -1615,6 +1624,11 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 
 unlock:
 	pthread_mutex_unlock(&nccl_ofi_lock);
+unmap_flush:
+	if (munmap(rComm->flush_buff.host_buffer, page_size)) {
+		NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+	}
+	rComm->flush_buff.host_buffer = MAP_FAILED;
 error:
 	if (mr_handle)
 		fi_close((fid_t)mr_handle);
@@ -1953,7 +1967,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* data, int size,
 
 	/* Issue RDMA read */
 	do {
-		rc = fi_read(rComm->local_ep, &rComm->flush_buff.host_buffer,
+		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
 			     desc,
 			     rComm->local_ep_addr, (uint64_t)data,
@@ -2092,6 +2106,10 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 				goto exit;
 			}
 		}
+		if (munmap(rComm->flush_buff.host_buffer, sysconf(_SC_PAGESIZE))) {
+			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));
+		}
+		rComm->flush_buff.host_buffer = MAP_FAILED;
 	}
 
 	free_ofi_fl(rComm->nccl_ofi_reqs_fl);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -489,8 +489,9 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->control_progress = FI_PROGRESS_AUTO;
-	hints->domain_attr->data_progress = FI_PROGRESS_AUTO;
+	/* Set progress mode to unspec to use the provider's default mode. */
+	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -263,6 +263,7 @@ static int in_list(char *item, char *list)
 	}
 
 exit:
+	free(list_temp);
 	return ret;
 }
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -706,9 +706,34 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 {
 	ncclResult_t ret = ncclSuccess;
 	char *prov_include = NULL;
-	int idx;
+	int idx, rc;
 
 	ofi_log_function = logFunction;
+
+	/*
+	 * RDMAV_FORK_SAFE environment variable makes the rdma-core
+	 * library fork-safe. This significantly increases cost of memory
+	 * registration when huge pages are enabled.
+	 *
+	 * To prevent data corruption, the EFA provider registers an atfork
+	 * handler which will abort the process whenever it believes
+	 * rdma-core is not fork-safe.
+	 *
+	 * NCCL applications heavily re-use the buffers for communication and
+	 * thus are not sensitive to increased memory registration costs.
+	 * To prevent NCCL based applications from getting aborted when using
+	 * fork(), plugin explicitly enables RDMAV_FORK_SAFE environment
+	 * variable.
+	 */
+	if (!getenv("RDMAV_FORK_SAFE")) {
+		NCCL_OFI_INFO(NCCL_INIT, "Setting RDMAV_FORK_SAFE environment variable to 1.");
+		rc = setenv("RDMAV_FORK_SAFE", "1", 1);
+		if (rc != 0) {
+			NCCL_OFI_WARN("Unable to set RDMAV_FORK_SAFE");
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
 
 	/* Get list of NICs fi_info structures for a single provider */
 	ret = get_ofi_provider(prov_include, &ofi_info_list);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -971,7 +971,7 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 	struct fi_cq_tagged_entry cqe_tagged_buffers[cqe_burst];
 	nccl_ofi_req_t *req = NULL;
 	struct fid_cq *cq = nccl_ofi_comp->cq;
-	uint64_t control_bit_mask = ~(nccl_ofi_comp->max_tag);
+	uint64_t control_bit_mask = nccl_ofi_comp->max_tag + 1;
 
 	while (true) {
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -16,9 +16,18 @@ struct fi_info* ofi_info_list = NULL;
 int ofi_ndevices = -1;
 /* NCCL OFI component array for all NICs */
 nccl_ofi_t **nccl_ofi_component = NULL;
+/*
+ * List of interface names to be filtered out for TCP provider.
+ * Currently, it is set to default value as set by tcp_if_exclude_default.
+ */
+char *tcp_if_exclude_list = NULL;
+/* Configure using IPv6 interfaces for TCP provider. Default behaviour is
+ * to avoid using IPv6 interfaces.
+ * TODO: Allow users to configure at runtime.
+ */
+bool use_ipv6_tcp = false;
 /* Indicates if memory registration of local buffers is required */
 bool local_mr = false;
-
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -261,6 +270,98 @@ static int in_list(char *item, char *list)
 exit:
 	return ret;
 }
+
+/*
+ * @brief	Returns true if the given provider matches IPv6 addressing format
+ *		and interfaces from `tcp_if_exclude_list`
+ *
+ * @return 	true, if success
+ *		false, otherwise
+ */
+static bool match_prov_info(char *name, uint32_t addr_format,
+			    uint64_t mem_tag_format, uint64_t expected_mem_tag_format)
+{
+	if (in_list(name, tcp_if_exclude_list)) {
+		return true;
+	} else if (!use_ipv6_tcp && (addr_format == FI_SOCKADDR_IN6)) {
+		return true;
+	} else if (mem_tag_format != expected_mem_tag_format) {
+		/* TODO: Remove after https://github.com/ofiwg/libfabric/issues/6126 is fixed */
+		/* RxM utility provider adds `FI_COLLECTIVE` capability
+		 * which ends up duplicating the fi_info structures. That
+		 * is because the size of the supported tag changes when
+		 * `FI_COLLECTIVE` is enabled.
+		 * This happens even when applications do not request for
+		 * this capability in hints.
+		 * For now, we choose one tag format and use that to filter all
+		 * info objects.
+		 */
+		return true;
+	}
+
+	return false;
+}
+
+/*
+ * @brief	Removes info objects from global `ofi_info_list` matching
+ *		certain criteria for TCP provider.
+ */
+static void filter_tcp_info_list()
+{
+	struct fi_info *prev = NULL, *curr = NULL;
+	struct fi_info *delete_info = NULL;
+	bool delete_prov = false;
+	uint64_t expected_mem_tag_format = 0;
+
+	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Removing unnecessary interfaces and address formats for TCP provider");
+
+	curr = ofi_info_list;
+	expected_mem_tag_format = curr->ep_attr->mem_tag_format;
+
+	while (curr != NULL) {
+
+		/* Check if interface name and format matches deletion criteria */
+		delete_prov = match_prov_info(curr->domain_attr->name,
+					      curr->addr_format,
+					      curr->ep_attr->mem_tag_format,
+					      expected_mem_tag_format);
+		if (delete_prov) {
+
+			if (prev != NULL) {
+				prev->next = curr->next;
+			}
+			ofi_ndevices--;
+
+			delete_info = curr;
+			curr = curr->next;
+
+			/* Delete node matching criteria */
+			delete_info->next = NULL;
+			fi_freeinfo(delete_info);
+		}
+		else {
+			if (prev == NULL) {
+				/*
+				 * Update HEAD of ofi_info_list to point to first endpoint which
+				 * can be used for communication.
+				 */
+				ofi_info_list = curr;
+			}
+
+			prev = curr;
+			curr = curr->next;
+		}
+	}
+
+	/*
+	 * In case all info objects match the filter criteria,
+	 * update HEAD of ofi_info_list to point to NULL.
+	 */
+	if (prev == NULL) {
+		ofi_info_list = prev;
+	}
+}
+
 
 /*
  * @brief	Calls fi_getinfo() to find a list of usable providers for RDM
@@ -728,6 +829,8 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	ncclResult_t ret = ncclSuccess;
 	char *prov_include = NULL;
 	int idx, rc;
+	/* TODO: Remove lo after https://github.com/ofiwg/libfabric/issues/6127 is fixed */
+	char tcp_if_exclude_default[] = "lo,docker0";
 
 	ofi_log_function = logFunction;
 
@@ -756,6 +859,10 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		}
 	}
 
+	/* TODO: Allow configuring TCP interface exclude list at runtime */
+	/* Use default list of TCP interface names to exclude */
+	tcp_if_exclude_list = strdup(tcp_if_exclude_default);
+
 	/* Get list of NICs fi_info structures for a single provider */
 	ret = get_ofi_provider(prov_include, &ofi_info_list);
 	if (ret != 0 || ofi_info_list == NULL) {
@@ -763,9 +870,16 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 		goto exit;
 	}
 
-	/*
-	 * TODO: Find way to identify unique structures and remove lo for TCP provider.
-	 */
+	/* If TCP provider is selected, filter out unnecessary interfaces and address formats */
+	if (strncmp("tcp", ofi_info_list->fabric_attr->prov_name, strlen("tcp")) == 0) {
+		filter_tcp_info_list();
+		if (OFI_UNLIKELY(ofi_info_list == NULL)) {
+			NCCL_OFI_WARN("No viable endpoint found for TCP provider.");
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
+
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s",
 		      ofi_info_list->fabric_attr->prov_name);
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -99,6 +99,50 @@ void free_ofi_fl(free_list_t *nccl_ofi_req_fl)
 	free(nccl_ofi_req_fl);
 }
 
+static const char *nccl_ofi_req_state_str(nccl_ofi_req_state_t state)
+{
+	switch(state) {
+	case NCCL_OFI_REQ_CREATED:
+		return "CREATED";
+	case NCCL_OFI_REQ_PENDING:
+		return "PENDING";
+	case NCCL_OFI_REQ_COMPLETED:
+		return "COMPLETED";
+	case NCCL_OFI_REQ_ERROR:
+		return "ERROR";
+	default:
+		return "unknown";
+	}
+}
+
+static const char *nccl_ofi_req_direction_str(nccl_ofi_req_state_t state)
+{
+	switch(state) {
+	case NCCL_OFI_SEND:
+		return "SEND";
+	case NCCL_OFI_RECV:
+		return "RECV";
+	default:
+		return "unknown";
+	}
+}
+
+/*
+ * @brief	Print NCCL OFI request information
+ */
+static const char *nccl_ofi_request_str(nccl_ofi_req_t *req)
+{
+	static char buf[256];
+	snprintf(buf, sizeof(buf), "{ buffer_index: %lu, dev: %d, size: %zu, state: %s, direction: %s }",
+		req->buffer_index,
+		req->dev,
+		req->size,
+		nccl_ofi_req_state_str(req->state),
+		nccl_ofi_req_direction_str(req->direction)
+	);
+	return buf;
+}
+
 /*
  * @brief	Assign an allocated NCCL OFI request buffer
  */
@@ -954,16 +998,21 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 			} else if (OFI_UNLIKELY(rc < 0)) {
 				NCCL_OFI_WARN("Unable to read from fi_cq_readerr. RC: %zd. Error: %s",
 					     rc,
-					     fi_cq_strerror(cq,
-						err_buffer.prov_errno,
-						err_buffer.err_data, NULL, 0));
+					     fi_strerror(-rc));
 				ret = ncclSystemError;
 				goto exit;
 			}
 
-			/* TODO: Add debug log to dump failed request details */
 			req = container_of(err_buffer.op_context,
 					   nccl_ofi_req_t, ctx);
+			NCCL_OFI_WARN("Request %p completed with error. RC: %d. Error: %s. Completed length: %ld, Request: %s",
+					req,
+					err_buffer.err,
+				    fi_cq_strerror(cq,
+						err_buffer.prov_errno,
+						err_buffer.err_data, NULL, 0),
+					(long)err_buffer.len,
+					nccl_ofi_request_str(req));
 			req->state = NCCL_OFI_REQ_ERROR;
 			req->size = err_buffer.len;
 		}
@@ -973,7 +1022,7 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 		}
 		else {
 			NCCL_OFI_WARN("Unable to retrieve completion queue entries. RC: %zd, ERROR: %s",
-				     rc, fi_strerror(-ret));
+				     rc, fi_strerror(-rc));
 			ret = ncclSystemError;
 			goto exit;
 		}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1962,6 +1962,7 @@ error:
 	if (req)
 		free_nccl_ofi_req(req, false);
 exit:
+	*request = NULL;
 	return ret;
 }
 
@@ -1982,6 +1983,9 @@ static ncclResult_t ofi_flush(void* recvComm, void* data, int size,
 		 */
 		goto exit;
 	}
+
+	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
+		goto exit;
 
 	ret = OFI_UNLIKELY(ofi_iflush(recvComm, data, size, mhandle, (void **)&req));
 	if (ret != ncclSuccess) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2190,6 +2190,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	uint64_t max_tag;
 	size_t req_size = sizeof(nccl_ofi_req_t);
 	struct fid_mr *mr_handle = NULL;
+	const long page_size = sysconf(_SC_PAGESIZE);
 
 	pthread_mutex_lock(&nccl_ofi_lock);
 	if (nccl_ofi_comp == NULL) {
@@ -2290,8 +2291,6 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->local_ep_addr = lComm->local_ep_addr;
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
-
-	const long page_size = sysconf(_SC_PAGESIZE);
 
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1237,7 +1237,12 @@ static ncclResult_t ofi_getProperties(int dev, ncclNetProperties_t *props)
 		goto exit;
 	}
 
-	dev_props.name = strdup(nic_info->device_attr->name);
+	/* name is NULL if device is a part of multirail config */
+	/* overriding default name only if value is available from provider */
+	if (nic_info->device_attr->name) {
+		dev_props.name = strdup(nic_info->device_attr->name);
+	}
+
 	/* Speed reported in Mbps */
 	dev_props.speed = nic_info->link_attr->speed / (1e6);
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -8,7 +8,7 @@ AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
 AM_CFLAGS += -I$(top_srcdir)/include
 AM_LDFLAGS = -lmpi -lcudart
 LDADD = ../src/libnccl-net.la
-CC=mpicc
+CC ?= mpicc
 
 bin_PROGRAMS = nccl_connection nccl_message_transfer ring
 nccl_connection_SOURCES = nccl_connection.c

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,7 +6,7 @@
 
 AM_CFLAGS = -g -O3 -Wall -fPIC -Wno-sign-compare
 AM_CFLAGS += -I$(top_srcdir)/include
-AM_LDFLAGS = -lmpi
+AM_LDFLAGS = -lmpi -lcudart
 LDADD = ../src/libnccl-net.la
 CC=mpicc
 

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -92,11 +92,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank + 1);
 	}
@@ -110,11 +112,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-		OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 			      rank - 1);
 	}

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -59,10 +59,14 @@ int main(int argc, char* argv[])
 	}
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
-	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_INIT, "Server: Listening on dev %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
@@ -74,7 +78,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
@@ -92,7 +96,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -14,14 +14,13 @@ int main(int argc, char* argv[])
 	char name[MPI_MAX_PROCESSOR_NAME];
 
 	/* Plugin defines */
-	int ndev;
+	int ndev, dev;
 	sendComm_t *sComm = NULL;
 	listenComm_t *lComm = NULL;
 	recvComm_t *rComm = NULL;
 	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
 	ncclNet_t *extNet = NULL;
 
-	ncclDebugLogger_t ofi_log_function = NULL;
 	ofi_log_function = logger;
 
 	MPI_Init(&argc, &argv);
@@ -41,6 +40,24 @@ int main(int argc, char* argv[])
 	/* Devices API */
 	OFINCCLCHECK(extNet->devices(&ndev));
 	NCCL_OFI_INFO(NCCL_INIT, "Received %d network devices", ndev);
+
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+	/* Get Properties for the device */
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v3_t props = {0};
+		OFINCCLCHECK(extNet->getProperties(dev, &props));
+		print_dev_props(dev, &props);
+	}
+#else
+	/* Get PCIe path and plugin memory pointer support */
+	for (dev = 0; dev < ndev; dev++) {
+		char *path = NULL;
+		int supported_types = 0;
+		extNet->pciPath(dev, &path);
+		OFINCCLCHECK(extNet->ptrSupport(dev, &supported_types));
+		NCCL_OFI_TRACE(NCCL_INIT, "Dev %d has path %s and supports pointers of type %d", dev, path, supported_types);
+	}
+#endif
 
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];

--- a/tests/nccl_connection.c
+++ b/tests/nccl_connection.c
@@ -47,7 +47,7 @@ int main(int argc, char* argv[])
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
 	/* Get Properties for the device */
 	for (dev = 0; dev < ndev; dev++) {
-		ncclNetProperties_v3_t props = {0};
+		ncclNetProperties_t props = {0};
 		OFINCCLCHECK(extNet->getProperties(dev, &props));
 		print_dev_props(dev, &props);
 

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -69,22 +69,26 @@ int main(int argc, char* argv[])
         }
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
-	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on dev 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on dev %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	if (rank == 0) {
 
 		/* MPI send */
-		MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, 1, 0, MPI_COMM_WORLD);
+		MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, (rank + 1), 0, MPI_COMM_WORLD);
 
 		/* MPI recv */
 		MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, (rank + 1), 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", rank + 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
@@ -114,7 +118,7 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", rank - 1);
-		OFINCCLCHECK(extNet->connect(0, (void *)src_handle, (void **)&sComm));
+		OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -179,13 +179,13 @@ int main(int argc, char* argv[])
 
 		/* Connect API */
 		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", rank - 1);
-    while (sComm == NULL)
-		  OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
+		while (sComm == NULL)
+			OFINCCLCHECK(extNet->connect(dev, (void *)src_handle, (void **)&sComm));
 
 		/* Accept API */
 		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
-    while (rComm == NULL)
-		  OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
+		while (rComm == NULL)
+			OFINCCLCHECK(extNet->accept((void *)lComm, (void **)&rComm));
 		NCCL_OFI_INFO(NCCL_NET, "Successfully accepted connection from rank %d",
 				rank - 1);
 
@@ -223,30 +223,33 @@ int main(int argc, char* argv[])
 				inflight_reqs--;
 				req_completed[idx] = 1;
 
-				if ((rank == 1) && (buffer_type == NCCL_PTR_CUDA)) {
-					NCCL_OFI_TRACE(NCCL_NET,
-						"Issue flush for data consistency. Request idx: %d",
-						idx);
+				/* Invoke flush operations unless user has explicitly disabled it. */
+				if (!ofi_nccl_gdr_flush_disable()) {
+					if ((rank == 1) && (buffer_type == NCCL_PTR_CUDA)) {
+						NCCL_OFI_TRACE(NCCL_NET,
+								"Issue flush for data consistency. Request idx: %d",
+								idx);
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
-					nccl_ofi_req_t *iflush_req = NULL;
+						nccl_ofi_req_t *iflush_req = NULL;
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0)) /* Support NCCL v2.12 */
-					OFINCCLCHECK(extNet->iflush((void *)rComm, nrecv,
-								    (void **)&recv_buf[idx],
-								    sizes, &mhandle[idx], (void **)&iflush_req));
+						OFINCCLCHECK(extNet->iflush((void *)rComm, nrecv,
+									(void **)&recv_buf[idx],
+									sizes, &mhandle[idx], (void **)&iflush_req));
 #else
-					OFINCCLCHECK(extNet->iflush((void *)rComm,
-								    (void **)recv_buf[idx],
-								    RECV_SIZE, mhandle[idx], (void **)&iflush_req));
+						OFINCCLCHECK(extNet->iflush((void *)rComm,
+									(void **)recv_buf[idx],
+									RECV_SIZE, mhandle[idx], (void **)&iflush_req));
 #endif
-					done = 0;
-					while (!done) {
-						OFINCCLCHECK(extNet->test((void *)iflush_req, &done, NULL));
+						done = 0;
+						while (!done) {
+							OFINCCLCHECK(extNet->test((void *)iflush_req, &done, NULL));
+						}
+#else
+						OFINCCLCHECK(extNet->flush((void *)rComm,
+									(void *)recv_buf[idx],
+									RECV_SIZE, mhandle[idx]));
+#endif
 					}
-#else
-					OFINCCLCHECK(extNet->flush((void *)rComm,
-								   (void *)recv_buf[idx],
-								   RECV_SIZE, mhandle[idx]));
-#endif
 				}
 
 				/* Deregister memory handle */
@@ -254,7 +257,10 @@ int main(int argc, char* argv[])
 					OFINCCLCHECK(extNet->deregMr((void *)sComm, mhandle[idx]));
 				}
 				else if (rank == 1) {
-					OFINCCLCHECK(validate_data(recv_buf[idx], expected_buf, SEND_SIZE, buffer_type));
+					if ((buffer_type == NCCL_PTR_CUDA) && !ofi_nccl_gdr_flush_disable()) {
+						/* Data validation may fail if flush operations are disabled */
+					} else
+						OFINCCLCHECK(validate_data(recv_buf[idx], expected_buf, SEND_SIZE, buffer_type));
 
 					OFINCCLCHECK(extNet->deregMr((void *)rComm, mhandle[idx]));
 				}

--- a/tests/ring.c
+++ b/tests/ring.c
@@ -79,9 +79,13 @@ int main(int argc, char *argv[])
         }
 #endif
 
+	/* Choose specific device per rank for communication */
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+	dev = rand() % ndev;
+
 	/* Listen API */
-	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on device 0");
-	OFINCCLCHECK(extNet->listen(0, (void *)&handle, (void **)&lComm));
+	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on device %d", dev);
+	OFINCCLCHECK(extNet->listen(dev, (void *)&handle, (void **)&lComm));
 
 	/* MPI send: Distribute handle to prev and next ranks */
 	MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE,
@@ -97,10 +101,10 @@ int main(int argc, char *argv[])
 
 	/* Connect to next and prev ranks */
 	NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", prev);
-	OFINCCLCHECK(extNet->connect(0, (void *)src_handle_prev, (void **)&sComm_prev));
+	OFINCCLCHECK(extNet->connect(dev, (void *)src_handle_prev, (void **)&sComm_prev));
 
 	NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", next);
-	OFINCCLCHECK(extNet->connect(0, (void *)src_handle_next, (void **)&sComm_next));
+	OFINCCLCHECK(extNet->connect(dev, (void *)src_handle_next, (void **)&sComm_next));
 
 	/*
 	 * Accept API: accept connection from prev rank as the data flow is

--- a/tests/ring.c
+++ b/tests/ring.c
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
         /* Get Properties for the device */
         for (dev = 0; dev < ndev; dev++) {
-                ncclNetProperties_v3_t props = {0};
+                ncclNetProperties_t props = {0};
                 OFINCCLCHECK(extNet->getProperties(dev, &props));
                 print_dev_props(dev, &props);
 
@@ -209,9 +209,20 @@ int main(int argc, char *argv[])
 					NCCL_OFI_TRACE(NCCL_NET,
 						"Issue flush for data consistency. Request idx: %d",
 						idx);
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 8, 0)) /* Support NCCL v2.8 */
+					nccl_ofi_req_t *iflush_req = NULL;
+					OFINCCLCHECK(extNet->iflush((void *)rComm,
+								    (void *)recv_buf[idx],
+								    RECV_SIZE, recv_mhandle[idx], (void **)&iflush_req));
+					done = 0;
+					while (!done) {
+						OFINCCLCHECK(extNet->test((void *)iflush_req, &done, NULL));
+					}
+#else
 					OFINCCLCHECK(extNet->flush((void *)rComm,
-						     (void *)recv_buf[idx],
-						     RECV_SIZE, recv_mhandle[idx]));
+								   (void *)recv_buf[idx],
+								   RECV_SIZE, recv_mhandle[idx]));
+#endif
 				}
 
 				OFINCCLCHECK(validate_data(recv_buf[idx], expected_buf, SEND_SIZE, buffer_type));

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -11,6 +11,7 @@
 #include <nccl_net.h>
 #include <nccl_ofi.h>
 #include <nccl_ofi_log.h>
+#include <nccl_ofi_param.h>
 #include "mpi.h"
 #include "config.h"
 #include <unistd.h>

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -80,6 +80,9 @@ void print_dev_props(int dev, ncclNetProperties_t *props)
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 12, 0))
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Grouped Receives: %d", props->name, props->maxRecvs);
+#endif
 }
 #endif
 

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -71,7 +71,7 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 }
 
 #if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
-void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+void print_dev_props(int dev, ncclNetProperties_t *props)
 {
         NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
         NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -62,6 +62,19 @@ void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
 	va_end(vargs);
 }
 
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 6, 4))
+void print_dev_props(int dev, ncclNetProperties_v3_t *props)
+{
+        NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Plugin Support: %d", props->name, props->ptrSupport);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %d", props->name, props->guid);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
+}
+#endif
+
 ncclNet_t *get_extNet(void)
 {
 	void *netPluginLib = NULL;


### PR DESCRIPTION
Add --disable-tests configure flag that excludes tests directory from build and bypasses check for mpicc.
Fail if mpicc is not in the path and if --with-mpi= is not specified.
