### PR TITLE
Update README for disable tests.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+By default, tests are built.  To disable building tests, use the following
+config option:
+
+```
+   --disable-tests        Disable build of tests.
+```
+
 ### Plugin Configurations
 
 The plugin allows to configure the following variables at run-time according to your environment.


### PR DESCRIPTION
The new config option --disable-tests allows skipping the tests directory when
building.  Include documentation of that option in the README.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
