### PR TITLE
Add support for CUDA GDR flush

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,17 @@ The plugin allows to configure the following variables at run-time according to 
       <td>Integer</td>
       <td>x, to set x number of connections. Only overridden for greater than 0 values (Default: 0)</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_CUDA_FLUSH_ENABLE</code></td>
+      <td>When using GPUDirect use the cudaDeviceFlushGPUDirectRDMAWrites to
+      enforce data consistency at the receiving GPU. Requires CUDA 11.3 or
+      later. Note that this function only provides a GPU memory fence and
+      requires that data has already been delivered to GPU memory. Some
+      networks and PCIe configurations require an additional network-level
+      flush that is not provided by this option.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
 </table>
 
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -99,6 +99,16 @@ OFI_NCCL_PARAM_INT(gdr_flush_disable, "GDR_FLUSH_DISABLE", 0);
 OFI_NCCL_PARAM_INT(nic_dup_conns, "NIC_DUP_CONNS", 0);
 #endif
 
+/*
+ * When using GPUDirect use the cudaDeviceFlushGPUDirectRDMAWrites
+ * to enforce data consistency at the receiving GPU. Requires CUDA 11.3 or
+ * later. Note that this function only provides a GPU memory fence and requires
+ * that data has already been delivered to GPU memory. Some networks and
+ * PCIe configurations require an additional network-level flush that
+ * is not provided by this option.
+ */
+OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -50,6 +50,10 @@ bool local_mr = false;
 bool hmem_mr = false;
 /* Indicates if GPUDirect is supported by libfabric provider */
 bool support_gdr = true;
+/* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
+ * to flush data to the GPU. Note, CUDA flush support is not supported on all
+ * platforms and should be disabled by default */
+bool cuda_flush = false;
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -540,7 +544,9 @@ exit:
 static void get_hints(struct fi_info *hints, int request_gdr)
 {
 	if (request_gdr) {
-		hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_RMA | FI_READ | FI_REMOTE_COMM;
+		hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_REMOTE_COMM;
+		if (!cuda_flush)
+			hints->caps |= FI_RMA | FI_READ;
 		/*
 		 * Set MR mode bits to indicate that application allows
 		 * registration of both local and device memory buffers
@@ -1206,6 +1212,16 @@ static ncclResult_t ofi_init(ncclDebugLogger_t logFunction)
 	ofi_log_function = logFunction;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using " PACKAGE_STRING);
+
+	if (ofi_nccl_cuda_flush_enable()) {
+#if CUDART_VERSION < 11030
+		NCCL_OFI_WARN("CUDA flush requested, but CUDART_VERSION %ld < 11030", CUDART_VERSION)
+		cuda_flush = false;
+#else
+		NCCL_OFI_WARN("CUDA flush enabled");
+		cuda_flush = true;
+#endif
+	}
 
 	/*
 	 * Use a static pre-configured topology for supported EC2 platform types
@@ -2340,7 +2356,7 @@ static recvComm_t *prepare_recv_comm(listenComm_t *lComm, char *remote_ep_addr)
 	 * Setup flush resources if using GPUDirect RDMA unless user disables
 	 * flush operations
 	 */
-	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr && !cuda_flush) {
 		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
 		ret = alloc_and_reg_flush_buff(rComm);
 		if (OFI_UNLIKELY(ret != ncclSuccess)) {
@@ -2574,7 +2590,7 @@ static ncclResult_t ofi_accept(void *listenComm, void **recvComm)
 	rComm->remote_ep = remote_ep;
 	rComm->dev = dev;
 
-	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr && !cuda_flush) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Registering buffer for flush operations");
 		rComm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
 		rComm->flush_buff.host_buffer = mmap(NULL, page_size, PROT_READ | PROT_WRITE,
@@ -2966,6 +2982,22 @@ static ncclResult_t ofi_iflush(void* recvComm, void* buffer, int size,
 	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
 		goto exit;
 
+#if CUDART_VERSION >= 11030
+	if (cuda_flush) {
+		cudaError_t cuda_ret = cudaDeviceFlushGPUDirectRDMAWrites(
+						cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
+						cudaFlushGPUDirectRDMAWritesToOwner);
+
+		if (cuda_ret != cudaSuccess) {
+			ret = ncclUnhandledCudaError;
+			NCCL_OFI_WARN("Error performing CUDA GDR flush");
+			goto exit;
+		}
+
+		goto exit;
+	}
+#endif
+
 	/* Validate recvComm */
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		ret = ncclSystemError;
@@ -3178,7 +3210,7 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 
 	dev = rComm->dev;
 
-	if (!ofi_nccl_gdr_flush_disable() && support_gdr) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr && !cuda_flush) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;


### PR DESCRIPTION
Add support for implementing flush operations as a call to
cudaDeviceFlushGPUDirectRDMAWrites on CUDA 11.3 and later. User must enable
this by setting OFI_NCCL_CUDA_FLUSH_ENABLE.

Signed-off-by: James Dinan <jdinan@nvidia.com>
Signed-off-by: Rashika Kheria <rashika@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
