### PR TITLE
HMEM Copy Callbacks and Extended MR Support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -57,6 +57,16 @@ AC_ARG_WITH([mpi],
              LDFLAGS="-L$withval/$mpi_libdir $LDFLAGS"],
             [])
 
+AC_ARG_WITH([gdrcopy],
+            AC_HELP_STRING([--with-gdrcopy=PATH], [Path to non-standard GDRCopy installation]),
+            [AS_IF([test -d $withval/lib64], [gdrcopy_libdir="lib64"], [gdrcopy_libdir="lib"])
+             CFLAGS="-I$withval/include $CFLAGS"
+             LDFLAGS="-L$withval/$gdrcopy_libdir $LDFLAGS"
+             AC_DEFINE([HAVE_GDRCOPY], [1], [Build support for GDRCopy])],
+            [])
+
+AM_CONDITIONAL([HAVE_GDRCOPY], [test "x$with_gdrcopy" != "x"])
+
 AC_ARG_ENABLE([tests], [AS_HELP_STRING([--disable-tests],
       [Disable build of test binaries])], [enable_tests], [])
 AM_CONDITIONAL([ENABLE_TESTS], [test "x$enable_tests" != "xno"])

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -69,6 +69,12 @@ extern "C" {
 /* Flush read size (bytes) */
 #define NCCL_OFI_FLUSH_SIZE	4
 
+/* Maxiumum registration key value when not using FI_MR_PROV_KEY */
+#define NCCL_OFI_MAX_MR_KEY	256
+
+/* Registration key size when not using FI_MR_PROV_KEY */
+#define NCCL_OFI_MR_KEY_BYTES	1
+
 /* NCCL OFI lock for concurrency */
 extern pthread_mutex_t nccl_ofi_lock;
 /* Logger Function */

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -70,9 +70,9 @@ extern "C" {
 #define NCCL_OFI_FLUSH_SIZE	4
 
 /* NCCL OFI lock for concurrency */
-pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
+extern pthread_mutex_t nccl_ofi_lock;
 /* Logger Function */
-ncclDebugLogger_t ofi_log_function = NULL;
+extern ncclDebugLogger_t ofi_log_function;
 
 typedef enum nccl_ofi_req_state {
 	NCCL_OFI_REQ_CREATED = 0,
@@ -238,6 +238,13 @@ typedef struct nccl_ofi_handle {
 	save_comm_state_t state;
 #endif
 } nccl_ofi_handle_t;
+
+typedef struct nccl_ofi_mr_handle {
+	void *addr;
+	size_t size;
+	int type;
+	struct fid_mr *fi_handle;
+} nccl_ofi_mr_handle_t;
 
 _Static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 

--- a/include/nccl_ofi_hcopy.h
+++ b/include/nccl_ofi_hcopy.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include <gdrapi.h>
+
+typedef struct {
+	void *ptr;
+	size_t length;
+	void *base_ptr;
+	gdr_info_t info;
+	gdr_mh_t mhandle;
+	int refs;
+} nccl_ofi_hcopy_buf_handle_t;
+
+extern gdr_t gdr_desc;
+
+int nccl_ofi_hcopy_register(void *addr, size_t length);
+int nccl_ofi_hcopy_unregister(void *addr);
+void nccl_ofi_hcopy_unregister_all();
+nccl_ofi_hcopy_buf_handle_t *nccl_ofi_get_hcopy_buffer_handle(void *addr, size_t len);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -10,3 +10,8 @@ AM_LDFLAGS = -lcudart
 
 lib_LTLIBRARIES = libnccl-net.la
 libnccl_net_la_SOURCES = nccl_ofi_net.c
+
+if HAVE_GDRCOPY
+AM_LDFLAGS += -lgdrapi
+libnccl_net_la_SOURCES += hcopy.c
+endif

--- a/src/hcopy.c
+++ b/src/hcopy.c
@@ -1,0 +1,300 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <nccl_ofi.h>
+#include <nccl_ofi_log.h>
+#include <nccl_ofi_hcopy.h>
+#include <nccl.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <gdrapi.h>
+
+#define NCCL_OFI_INITIAL_REG_ARRAY_SIZE 128
+
+static size_t registered_buffer_array_used = 0;
+static size_t registered_buffer_array_size = 0;
+static nccl_ofi_hcopy_buf_handle_t **registered_buffers = NULL;
+
+int nccl_ofi_hcopy_register(void *addr, size_t length) {
+	nccl_ofi_hcopy_buf_handle_t *handle = NULL;
+	size_t i;
+	int status = 0, ret;
+	struct cudaPointerAttributes attr;
+
+	status = cudaPointerGetAttributes(&attr, addr);
+
+	if (status != cudaSuccess) {
+		/* clear CUDA error string. */
+		cudaGetLastError();
+		NCCL_OFI_WARN("Unable to query pointer attributes.");
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	if (attr.type == cudaMemoryTypeManaged) {
+		NCCL_OFI_WARN("Unable to register managed memory (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+	else if (attr.type == cudaMemoryTypeHost) {
+		NCCL_OFI_WARN("Unable to register host memory (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+	else if (attr.type == cudaMemoryTypeUnregistered) {
+		NCCL_OFI_WARN("Unable to register unregistered memory type (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	handle = (nccl_ofi_hcopy_buf_handle_t *)calloc(1, sizeof(nccl_ofi_hcopy_buf_handle_t));
+	if (handle == NULL) {
+		NCCL_OFI_WARN("Unable to allocate registered buffer handle.");
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	NCCL_OFI_TRACE(NCCL_NET, "Registering (0x%p - 0x%p) length=%zu", addr, (char*)addr + length, length);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	if (registered_buffer_array_used == registered_buffer_array_size) {
+		size_t new_array_size = registered_buffer_array_size ?
+			registered_buffer_array_size * 2 :
+			NCCL_OFI_INITIAL_REG_ARRAY_SIZE;
+		void *new_buf;
+
+		assert(new_array_size < (SIZE_MAX / sizeof(nccl_ofi_hcopy_buf_handle_t)));
+		new_buf = realloc(registered_buffers, new_array_size * sizeof(nccl_ofi_hcopy_buf_handle_t *));
+		if (new_buf == NULL) {
+			NCCL_OFI_WARN("Unable to resize the registered buffer array.");
+			status = ncclSystemError;
+			goto out_unlock;
+		}
+		registered_buffers = (nccl_ofi_hcopy_buf_handle_t **)new_buf;
+		registered_buffer_array_size = new_array_size;
+	}
+
+	for (i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+		if (addr > tmp_handle->ptr) {
+			void *max_addr;
+			max_addr = (void *)((char *)tmp_handle->ptr + tmp_handle->length);
+			if (addr < max_addr) {
+				NCCL_OFI_WARN("Unable to register overlapping memory regions.\n");
+				status = ncclSystemError;
+				goto out_unlock;
+			}
+			continue;
+		} else if (addr == tmp_handle->ptr) {
+			if (length != tmp_handle->length) {
+				NCCL_OFI_WARN("Unable to register overlapping memory regions.");
+				status = ncclSystemError;
+			} else {
+				tmp_handle->refs++;
+				NCCL_OFI_TRACE(NCCL_NET, "Added ref to existing registration (0x%p, %zu, %d).",
+						addr, length, tmp_handle->refs);
+				status = 0;
+			}
+			goto out_unlock;
+		} else {
+			/* addr < tmp_handle->ptr */
+			break;
+		}
+	}
+
+	handle->ptr = addr;
+	handle->length = length;
+	handle->refs = 1;
+
+	ret = gdr_pin_buffer(gdr_desc, (unsigned long) addr, length, 0, 0, &handle->mhandle);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_pin_buffer (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+	ret = gdr_map(gdr_desc, handle->mhandle, &handle->base_ptr, length);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_map (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+	ret = gdr_get_info(gdr_desc, handle->mhandle, &handle->info);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_get_info (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+
+	assert(i < registered_buffer_array_size);
+	if (i < registered_buffer_array_used) {
+		memmove(&registered_buffers[i + 1],
+				&registered_buffers[i],
+				sizeof(nccl_ofi_hcopy_buf_handle_t *) * (registered_buffer_array_used - i));
+	}
+	registered_buffers[i] = handle;
+	registered_buffer_array_used++;
+
+out_unlock:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+out_error:
+	if (status) free(handle);
+	return status;
+}
+
+int nccl_ofi_hcopy_unregister(void *addr) {
+	size_t i, ret;
+	int status = 0;
+
+	NCCL_OFI_TRACE(NCCL_NET, "Unregistering 0x%p", addr);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	for (i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+		if (addr > tmp_handle->ptr) {
+			continue;
+		} else if (addr == tmp_handle->ptr) {
+			tmp_handle->refs--;
+			if (tmp_handle->refs > 0) {
+				NCCL_OFI_TRACE(NCCL_NET, "Released ref to registration (0x%p, %d).",
+						addr, tmp_handle->refs);
+				goto out_unlock;
+			}
+			if ((i + 1) < registered_buffer_array_used) {
+				memmove(&registered_buffers[i],
+						&registered_buffers[i + 1],
+						sizeof(nccl_ofi_hcopy_buf_handle_t *) * (registered_buffer_array_used - i));
+			}
+
+			ret = gdr_unmap(gdr_desc, tmp_handle->mhandle, tmp_handle->base_ptr, tmp_handle->length);
+			if (ret) {
+				NCCL_OFI_WARN("Error in gdr_unmap (%d)", ret);
+				status = ncclSystemError;
+				break;
+			}
+
+			ret = gdr_unpin_buffer(gdr_desc, tmp_handle->mhandle);
+			if (ret) {
+				NCCL_OFI_WARN("Error in gdr_unpin_buffer (%d)", ret);
+				status = ncclSystemError;
+				break;
+			}
+
+			free(tmp_handle);
+			registered_buffer_array_used--;
+			break;
+			/* addr < tmp_handle->ptr*/
+		} else {
+			NCCL_OFI_WARN("Could not unmap (0x%p)", addr);
+			//status = ncclSystemError;
+			break;
+		}
+	}
+
+out_unlock:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	return status;
+}
+
+void nccl_ofi_hcopy_unregister_all() {
+	int ret;
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	for (size_t i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+
+		ret = gdr_unmap(gdr_desc, tmp_handle->mhandle, tmp_handle->base_ptr, tmp_handle->length);
+		if (ret) {
+			NCCL_OFI_WARN("Error in gdr_unmap (%d)", ret);
+		}
+
+		ret = gdr_unpin_buffer(gdr_desc, tmp_handle->mhandle);
+		if (ret) {
+			NCCL_OFI_WARN("Error in gdr_unpin_buffer (%d)", ret);
+		}
+
+		free(registered_buffers[i]);
+	}
+
+	registered_buffer_array_used = 0;
+
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	return;
+}
+
+nccl_ofi_hcopy_buf_handle_t *nccl_ofi_get_hcopy_buffer_handle(void *addr, size_t len) {
+	nccl_ofi_hcopy_buf_handle_t *tmp_handle;
+	size_t min, max, mid;
+	nccl_ofi_hcopy_buf_handle_t *ret_handle = NULL;
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	if (registered_buffer_array_used == 0) {
+		goto out;
+	}
+
+	min = 0;
+	max = registered_buffer_array_used;
+	do {
+		mid = (max - min) / 2 + min;
+		/* We have gone past the end of the loop. */
+		if (mid >= registered_buffer_array_used) {
+			break;
+		}
+		tmp_handle = registered_buffers[mid];
+		if (addr > tmp_handle->ptr) {
+			void *max_addr = (void *)((char *)tmp_handle->ptr + tmp_handle->length);
+			size_t max_len = (size_t)((char *)max_addr - (char *)addr);
+			if (addr < max_addr) {
+				if (len > max_len) {
+					NCCL_OFI_WARN("Requested range exceeds registered buffer length (0x%p, %zu) > (0x%p, %zu).",
+							addr, len, tmp_handle->ptr, tmp_handle->length);
+					ret_handle = NULL;
+				} else {
+					ret_handle = tmp_handle;
+				}
+				goto out;
+			}
+			min = mid + 1;
+		} else if (addr == tmp_handle->ptr) {
+			if (len > tmp_handle->length) {
+				NCCL_OFI_WARN("Requested range exceeds registered buffer length (0x%p, %zu) > (0x%p, %zu).",
+						addr, len, tmp_handle->ptr, tmp_handle->length);
+				ret_handle = NULL;
+			} else {
+				ret_handle = tmp_handle;
+			}
+			goto out;
+		} else {
+			if (mid == 0) {
+				break;
+			}
+			max = mid - 1;
+		}
+	} while (max >= min);
+
+out:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	if (ret_handle == NULL) {
+		NCCL_OFI_WARN("Unable to find a reference to the requested buffer address.");
+	}
+	return ret_handle;
+}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -13,6 +13,16 @@
 #include <sys/mman.h>
 #include <stack.h>
 #include <nccl_ofi_param.h>
+#include <nccl_ofi_hcopy.h>
+
+#if HAVE_GDRCOPY
+#include <gdrapi.h>
+#endif
+
+/* NCCL OFI lock for concurrency */
+pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
+/* Logger Function */
+ncclDebugLogger_t ofi_log_function = NULL;
 
 static uint32_t libversion = 0;
 /* NICs info list for a provider */
@@ -31,6 +41,10 @@ bool support_gdr = true;
  * to flush data to the GPU. Note, CUDA flush support is not supported on all
  * platforms and should be disabled by default */
 bool cuda_flush = false;
+
+#if HAVE_GDRCOPY
+gdr_t gdr_desc = NULL;
+#endif
 
 /*
  * @brief	Allocates free list for NCCL OFI requests
@@ -702,6 +716,109 @@ static struct fi_info *get_nic_info(int dev, struct fi_info *nic_info_list)
 	return nic_info;
 }
 
+#if HAVE_GDRCOPY
+static ssize_t copy_from_hmem(void *dest, size_t size, enum fi_hmem_iface iface,
+		uint64_t device, const struct iovec *hmem_iov,
+		size_t hmem_iov_count, uint64_t hmem_iov_offset)
+{
+	char *dest_ptr = (char*) dest;
+	ssize_t size_cpy = 0;
+	int ret;
+
+	assert(hmem_iov_offset < hmem_iov_count);
+
+	for (size_t i = hmem_iov_offset; i < hmem_iov_count; i++) {
+		if (size_cpy + hmem_iov[i].iov_len > size)
+			break;
+
+		switch (iface) {
+			case FI_HMEM_CUDA:
+				nccl_ofi_hcopy_buf_handle_t *buf_hdl =
+					nccl_ofi_get_hcopy_buffer_handle(hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+
+				if (NULL == buf_hdl) {
+					NCCL_OFI_WARN("Could not locate GDRCopy registration for 0x%p len=%zu",
+							hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+
+				ptrdiff_t offset = (uint64_t)hmem_iov[i].iov_base - buf_hdl->info.va;
+				ret = gdr_copy_from_mapping(buf_hdl->mhandle, dest_ptr,
+						(char *)buf_hdl->base_ptr + offset, hmem_iov[i].iov_len);
+				if (ret) {
+					NCCL_OFI_WARN("Error in gdr_copy_from_mapping (%d)", ret);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+				break;
+			case FI_HMEM_SYSTEM:
+				memcpy(dest_ptr, hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+				break;
+			default:
+				return -FI_EINVAL;
+		}
+
+		dest_ptr += hmem_iov[i].iov_len;
+		size_cpy += hmem_iov[i].iov_len;
+	}
+
+out:
+	return size_cpy;
+}
+
+static ssize_t copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
+		const struct iovec *hmem_iov, size_t hmem_iov_count,
+		uint64_t hmem_iov_offset, const void *src, size_t size)
+{
+	char *src_ptr = (char*) src;
+	ssize_t size_cpy = 0;
+	int ret;
+
+	assert(hmem_iov_offset < hmem_iov_count);
+
+	for (size_t i = hmem_iov_offset; i < hmem_iov_count; i++) {
+		if (size_cpy + hmem_iov[i].iov_len > size)
+			break;
+
+		switch (iface) {
+			case FI_HMEM_CUDA:
+				nccl_ofi_hcopy_buf_handle_t *buf_hdl =
+					nccl_ofi_get_hcopy_buffer_handle(hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+
+				if (NULL == buf_hdl) {
+					NCCL_OFI_WARN("Could not locate GDRCopy registration for 0x%p len=%zu",
+							hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+
+				ptrdiff_t offset = (uint64_t)hmem_iov[i].iov_base - buf_hdl->info.va;
+				ret = gdr_copy_to_mapping(buf_hdl->mhandle,
+						(char *)buf_hdl->base_ptr + offset, src_ptr, hmem_iov[i].iov_len);
+				if (ret) {
+					NCCL_OFI_WARN("Error in gdr_copy_to_mapping (%d)", ret);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+				break;
+			case FI_HMEM_SYSTEM:
+				memcpy(hmem_iov[i].iov_base, src_ptr, hmem_iov[i].iov_len);
+				break;
+			default:
+				return -FI_EINVAL;
+		}
+
+		src_ptr  += hmem_iov[i].iov_len;
+		size_cpy += hmem_iov[i].iov_len;
+	}
+
+out:
+	return size_cpy;
+}
+#endif /* HAVE_GDRCOPY */
+
+
 /*
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric, domain, endpoint, CQ and AV.
@@ -754,6 +871,32 @@ static ncclResult_t create_nccl_ofi_component(struct fi_info *prov,
 		ret = ncclSystemError;
 		goto error;
 	}
+
+#if HAVE_GDRCOPY
+	struct fi_hmem_override_ops hmem_ops;
+
+	hmem_ops.size = sizeof(struct fi_hmem_override_ops);
+	hmem_ops.copy_from_hmem_iov = copy_from_hmem;
+	hmem_ops.copy_to_hmem_iov   = copy_to_hmem;
+
+	ret = fi_set_ops(&(nccl_ofi_comp->domain->fid),
+			FI_SET_OPS_HMEM_OVERRIDE,
+			0, &hmem_ops, NULL);
+
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't override HMEM ops. RC: %d, ERROR: %s",
+			     ret, fi_strerror(-ret));
+		ret = ncclSystemError;
+		goto error;
+	}
+
+	gdr_desc = gdr_open();
+	if (!gdr_desc) {
+		NCCL_OFI_WARN("GDRCopy initialization failed.");
+		ret = ncclSystemError;
+		goto error;
+	}
+#endif
 
 	/* Create transport level communication endpoint(s) */
 	ret = fi_endpoint(nccl_ofi_comp->domain, prov, &(nccl_ofi_comp->ep), NULL);
@@ -819,6 +962,11 @@ error:
 		fi_close((fid_t)nccl_ofi_comp->av);
 	if (nccl_ofi_comp->cq)
 		fi_close((fid_t)nccl_ofi_comp->cq);
+#if HAVE_GDRCOPY
+	if (gdr_desc)
+		gdr_close(gdr_desc);
+#endif
+
 exit:
 	return ret;
 }
@@ -884,6 +1032,10 @@ void release_nccl_ofi_component(int dev)
 		fi_close((fid_t)nccl_ofi_comp->domain);
 	if (nccl_ofi_comp->fabric)
 		fi_close((fid_t)nccl_ofi_comp->fabric);
+#if HAVE_GDRCOPY
+	if (gdr_desc)
+		gdr_close(gdr_desc);
+#endif
 
 	free(nccl_ofi_comp);
 	nccl_ofi_component[dev] = NULL;
@@ -2426,7 +2578,7 @@ exit:
 static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 			      void **mhandle)
 {
-	struct fid_mr *mr_handle = NULL;
+	nccl_ofi_mr_handle_t *mr_handle = NULL;
 	ncclResult_t ret = ncclSuccess;
 
 	ofiComm_t *ofi_comm = (ofiComm_t *)comm;
@@ -2445,7 +2597,41 @@ static ncclResult_t ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	}
 
-	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle);
+	mr_handle = malloc(sizeof(nccl_ofi_mr_handle_t));
+	if (mr_handle == NULL) {
+		NCCL_OFI_WARN("Unable to allocate MR handle");
+		ret = ncclSystemError;
+		goto exit;
+	}
+	mr_handle->addr = data;
+	mr_handle->size = size;
+	mr_handle->type = type;
+	mr_handle->fi_handle = NULL;
+
+	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle->fi_handle);
+
+	if (ret) {
+		NCCL_OFI_WARN("register_mr_buffers failed (%d)", ret);
+		ret = ncclSystemError;
+		goto exit;
+	}
+
+#if HAVE_GDRCOPY
+	if (type == NCCL_PTR_CUDA) {
+		ret = nccl_ofi_hcopy_register(data, size);
+		if (ret) {
+			NCCL_OFI_WARN("nccl_ofi_hcopy_register failed (%d)", ret);
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
+	/* No OFI registration and no GDR registration */
+	else
+#endif
+	if (mr_handle->fi_handle == NULL) {
+		free(mr_handle);
+		mr_handle = NULL;
+	}
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -2456,7 +2642,7 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 {
 	ncclResult_t ret = ncclSuccess;
 	int rc;
-	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
+	nccl_ofi_mr_handle_t *mr_handle = (nccl_ofi_mr_handle_t *)mhandle;
 
 	/* Validate Comm */
 	if (OFI_UNLIKELY(comm == NULL)) {
@@ -2470,12 +2656,29 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 		goto exit;
 	}
 
-	rc = fi_close((fid_t)mr_handle);
-	if (OFI_UNLIKELY(rc != 0)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-			      fi_strerror(-rc));
+	if (OFI_LIKELY(mr_handle->mr_handle != NULL)) {
+		rc = fi_close((struct fid*)mr_handle->fi_handle);
+		if (OFI_UNLIKELY(rc != 0)) {
+			ret = ncclSystemError;
+			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+				      rc, fi_strerror(-rc));
+		}
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Null MR handle provided. Skipping deregisteration.");
+        }
+
+#if HAVE_GDRCOPY
+	if (mr_handle->type == NCCL_PTR_CUDA) {
+		ret = nccl_ofi_hcopy_unregister(mr_handle->addr);
+		if (ret) {
+			NCCL_OFI_WARN("nccl_ofi_hcopy_register failed (%d)", ret);
+			ret = ncclSystemError;
+			goto exit;
+		}
 	}
+#endif
+
+	free(mr_handle);
 
 exit:
 	return ret;
@@ -2542,8 +2745,8 @@ static ncclResult_t ofi_isend(void *sendComm, void* data, int size,
 	if (OFI_UNLIKELY(ret != 0))
 		goto error;
 
-	if (mhandle != NULL)
-		desc = fi_mr_desc(mhandle);
+	if (mhandle != NULL && ((nccl_ofi_mr_handle_t*)mhandle)->fi_handle != NULL)
+		desc = fi_mr_desc(((nccl_ofi_mr_handle_t*)mhandle)->fi_handle);
 	/*
 	 * Try sending data to remote EP; Return NULL request
 	 * if not able to send.
@@ -2634,10 +2837,11 @@ static ncclResult_t ofi_irecv(void* recvComm, void* buffer, int size,
 	/* Currently, plugin doesn't support grouped receives */
 	assert(n == 1);
 	for (int recv_n = 0; recv_n < n; recv_n++) {
+		nccl_ofi_mr_handle_t **mr_handles = (nccl_ofi_mr_handle_t**) mhandles;
 		void *desc = NULL;
 
-		if (mhandles[recv_n] != NULL) {
-			desc = fi_mr_desc(mhandles[recv_n]);
+		if (mr_handles[recv_n] && mr_handles[recv_n]->fi_handle != NULL) {
+			desc = fi_mr_desc(mr_handles[recv_n]->fi_handle);
 		}
 
 		/*
@@ -2663,8 +2867,8 @@ static ncclResult_t ofi_irecv(void* recvComm, void* buffer, int size,
 	}
 #else
 	void *desc = NULL;
-	if (mhandle != NULL)
-		desc = fi_mr_desc(mhandle);
+	if (mhandle != NULL && ((nccl_ofi_mr_handle_t*)mhandle)->fi_handle != NULL)
+		desc = fi_mr_desc(((nccl_ofi_mr_handle_t*)mhandle)->fi_handle);
 
 	/* Try posting buffer to local EP */
 	rc = fi_trecv(rComm->local_ep, buffer, size,
@@ -2809,8 +3013,9 @@ static ncclResult_t ofi_iflush(void* recvComm, void* buffer, int size,
 		goto exit;
 	}
 
-	if (mhandles && mhandles[flush_n])
-		mr_handle = (struct fid_mr *)mhandles[flush_n];
+	nccl_ofi_mr_handle_t **mr_handles = (nccl_ofi_mr_handle_t**) mhandles;
+	if (mr_handles && mr_handles[flush_n]->fi_handle)
+		mr_handle = mr_handles[flush_n]->fi_handle;
 
 	data = buffers[flush_n];
 #else
@@ -2823,7 +3028,7 @@ static ncclResult_t ofi_iflush(void* recvComm, void* buffer, int size,
 		goto exit;
 	}
 
-	mr_handle = (struct fid_mr *)mhandle;
+	mr_handle = ((nccl_ofi_mr_handle_t*)mhandle)->fi_handle;
 
 	data = buffer;
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2798,7 +2798,7 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		ret = nccl_ofi_hcopy_unregister(mr_handle->addr);
 		if (ret) {
-			NCCL_OFI_WARN("nccl_ofi_hcopy_register failed (%d)", ret);
+			NCCL_OFI_WARN("nccl_ofi_hcopy_unregister failed (%d)", ret);
 			ret = ncclSystemError;
 			goto exit;
 		}


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

This PR adds HMEM copy callbacks that use GDRCopy to perform memory copies. This allows aws-ofi-nccl to support providers that copy data between device and host buffers from using `cudaMemcpy`. Because NCCL kernels are running on the GPU, submitting memcpy work to CUDA can (and usually does) result in a deadlock. GDRCopy can be used for such copies without introducing the risk of a deadlock. This change required the introduction of a GDRCopy buffer registration management layer (called hcopy) and a refactor of the MR handle in aws-ofi-nccl so that it can hold both the OFI and GDRCopy registration information for the buffer. GDRCopy callbacks are enabled at compile time by configuring with `--with-gdrcopy=...`.

The PR also extends the OFI memory registration modes supported by aws-ofi-nccl to include `FI_MR_ENDPOINT`, `!FI_MR_PROV_KEY`, and `!FI_MR_VIRT_ADDR`. Supporting application-specified registration keys required the addition of a key allocator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
