### PR TITLE
Fix error code value message for de-register.

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2696,7 +2696,7 @@ static ncclResult_t ofi_deregMr(void *comm, void *mhandle)
 	if (OFI_UNLIKELY(rc != 0)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-			      fi_strerror(-rc));
+				rc, fi_strerror(-rc));
 	}
 
 exit:
@@ -3218,7 +3218,7 @@ static ncclResult_t ofi_closeRecv(void *recvComm)
 		if (OFI_UNLIKELY(rc != 0)) {
 			ret = ncclSystemError;
 			NCCL_OFI_WARN("Unable to de-register flush buffer. RC: %d, Error: %s",
-				      fi_strerror(-rc));
+					rc, fi_strerror(-rc));
 			goto exit;
 		}
 		if (munmap(rComm->flush_buff.host_buffer, sysconf(_SC_PAGESIZE))) {


### PR DESCRIPTION
In two cases, the error string expects two arguments, but the argument list
omits the numeric error code.

Signed-off-by: Ryan Hankins <rqh@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
