### PR TITLE
Request FI_THREAD_SAFE from the provider

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -638,6 +638,8 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
+	hints->domain_attr->threading = FI_THREAD_SAFE;
+
 	/* Set progress mode to unspec to use the provider's default mode. */
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
 	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;


### PR DESCRIPTION
*Issue #, if available:*

None

*Description of changes:*

Reqest `FI_THREAD_SAFE` threading support from the libfabric provider. This is required for multithreaded NCCL usage models (e.g. running NCCL perf tests with `-t ##`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
