### PR TITLE
Add support for NCCL v2.13

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -3218,6 +3218,9 @@ const ncclNet_t NCCL_PLUGIN_SYMBOL = {
 	.accept = ofi_accept,
 #endif
 	.regMr = ofi_regMr,
+#if (NCCL_VERSION_CODE >= NCCL_VERSION(2, 13, 0)) /* Support NCCL v2.13 */
+	.regMrDmaBuf = NULL,
+#endif
 	.deregMr = ofi_deregMr,
 	.isend = ofi_isend,
 	.irecv = ofi_irecv,


### PR DESCRIPTION
*Issue #, if available:*

None.

*Description of changes:*

aws-ofi-nccl uses the latest plugin version in the NCCL installation `nccl_net.h`. The aws-ofi-nccl code currently supports the v5 interface, but will build as v6 with NCCL 2.13.x and later leaving the `regMrDmaBuf` field uninitialized. This has been benign since the C standard guarantees static objects are initialized to zero. But, it's a good example of why it's safer to make the plugin version explicit, rather than picking up the latest version from the NCCL header.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
