### PR TITLE
Make master work with EFA provider again

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -622,7 +622,7 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 		 * registration of both local and device memory buffers
 		 * and can support the endpoint memory registration model
 		 */
-		hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ENDPOINT;
+		hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM | FI_MR_ENDPOINT;
 		hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
 	}
 	else {


### PR DESCRIPTION
Two changes to adjust the behavior around memory registration to work with the EFA provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
