### PR TITLE
Add LTTNG Tracing to the plugin, including instructions and configuration option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,15 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+
+LTTNG tracing is documented in the doc/tracing.md file.
+
+To enable LTTNG tracing, use the following configuration option:
+
+```
+  --with-lttng=PATH       Path to LTTNG installation
+```
+
 By default, tests are built.  To disable building tests, use the following
 config option:
 

--- a/configure.ac
+++ b/configure.ac
@@ -74,6 +74,22 @@ AS_IF([test "x${enable_trace}" = "xyes" ],
        AC_MSG_RESULT(no)])
 AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 if aws-ofi-nccl was configured with --enable-trace, 0 otherwise])
 
+dnl Check for LTTNG tracing capability
+AC_ARG_WITH([lttng],
+    AS_HELP_STRING([--with-lttng=DIR],
+           [Enable tracing capability with LTTNG @<:@default=no@:>@]))
+AS_IF([test -n "$with_lttng"],
+      [
+       AC_CHECK_LIB(lttng-ust,lttng_ust_probe_register, [], AC_MSG_ERROR("lttng-ust not found"))
+       AS_IF([test -d $withval/lib64], [lttng_libdir="lib64"], [lttng_libdir="lib"])
+       LDFLAGS="-L$withval/$lttng_libdir $LDFLAGS"
+       AC_DEFINE(HAVE_LTTNG, 1, [Build with LTTNG tracing])
+      ],
+      [
+       AC_DEFINE(HAVE_LTTNG, 0, [Build without LTTNG tracing])
+      ]
+)
+
 # Checks for header files.
 AC_CHECK_HEADERS([limits.h stdlib.h string.h unistd.h rdma/fabric.h], [],[
 	AC_MSG_ERROR([unable to find required headers])

--- a/doc/tracing.md
+++ b/doc/tracing.md
@@ -1,0 +1,27 @@
+Tracing using LTTNG
+
+NCCL_OFI_TRACE_SEND, NCCL_OFI_TRACE_RECV and NCCL_OFI_TRACE_FLUSH trace requests with the provided
+arguments plus the request and context.  The context address (&req->ctx) is used to correlate traces
+with libfabric from fi_tsend(), fi_recv() or fi_read() to fi_cq_read() in process_completions().
+The plugin request address (req) is used to associate requests between NCCL calls to the plugin.
+The NCCL request address (request) is used to associate calls from NCCL to the plugin.
+
+To trace aws-ofi-nccl using LTTNG Tracing:
+1. Install the LTTNG libraries and dependencies as documented at https://lttng.org/docs/v2.13/#doc-building-from-source
+2. Configure aws-ofi-nccl as normal, but with the addition of the --with-lttng=<prefix> flag to ./configure.  Use as
+   <prefix> the location you chose in the previous step for LTTNG.  For example,
+   --with-lttng=/usr/local
+3. Start the LTTNG session daemon.
+   lttng-sessiond --daemonize
+4. Enable up to 1 Gigabyte of tracing in a memory ring as a single tracing channel.
+   lttng enable-channel --userspace --overwrite --subbuf-size=1M --num-subbuf=1024 efa
+5. Enable all tracepoints on the channel you configured.
+   lttng enable-event --userspace -a --channel=efa
+6. Start tracing
+   lttng start
+7. Run your test.  Traces should be recorded.
+8. Destroy the tracing that was enabled.
+   lttng destroy
+9. To read and print the traces LTTNG recorded, install the babelfish2 utility.
+10. Print the traces.
+    babelfish2 ~/lttng-traces

--- a/include/tracepoint.h
+++ b/include/tracepoint.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#undef LTTNG_UST_TRACEPOINT_PROVIDER
+#define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
+
+#undef LTTNG_UST_TRACEPOINT_INCLUDE
+#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracepoint.h"
+
+/*
+ * To add a tracepoint at the nccl_ofi_plugin layer:
+ * Add a definition of LTTNG_UST_TRACEPOINT_EVENT.
+ * LTTNG_UST_TRACEPOINT_EVENT(
+ *      nccl_ofi_plugin,
+ *      <NewTracepointName>,
+ *      LTTNG_UST_TP_ARGS(
+ *          <type1>, <arg1>,
+ *          <type2>, <arg2>
+ *      ),
+ *      LTTNG_UST_TP_FIELDS(
+ *          lttng_ust_field_integer(<type1>, name1, <arg1>)
+ *          lttng_ust_field_integer(<type2>, name2, <arg2>)
+ *      )
+ * )
+ *
+ * <NewTracepointName> will appear as the tracepoint name in the
+ * tracing output, and arguments <arg1> and <arg2> with <name1> and
+ * <name2> will appear in that trace as data.
+ *
+ */
+
+#include "config.h"
+#if HAVE_LTTNG == 1
+
+/*
+ * LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ must be included so that the tracepoints
+ * can be defined and compiled from tracepoint.c, and so they can be referenced
+ * from any other files.
+ *
+ */
+
+#if !defined(NCCL_OFI_TRACEPOINT_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define NCCL_OFI_TRACEPOINT_H
+
+#include <lttng/tracepoint.h>
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Send,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, size,
+            void *, request,
+            void **, nccl_req,
+            void *, ctx
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+            lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
+    )
+)
+#define NCCL_OFI_TRACE_SEND(dev, size, request, nccl_req,ctx) \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, request, nccl_req,ctx)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Recv,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, tag,
+            int, size,
+            void *, request,
+            void **, nccl_req,
+            void *, ctx
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, tag, tag)
+            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+            lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
+    )
+)
+#define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req,ctx) \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req,ctx)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    ProcessCompletions,
+    LTTNG_UST_TP_ARGS(
+            void *, request,
+            void *, ctx
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
+    )
+)
+#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Flush,
+    LTTNG_UST_TP_ARGS(
+            void *, request,
+            void **, nccl_req,
+            void *, ctx
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+            lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
+    )
+)
+#define NCCL_OFI_TRACE_FLUSH(request,nccl_req,ctx) \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req,ctx)
+
+#endif /* NCCL_OFI_TRACEPOINT_H */
+
+#include <lttng/tracepoint-event.h>
+
+#else
+
+#define NCCL_OFI_TRACE_SEND(...)
+#define NCCL_OFI_TRACE_RECV(...)
+#define NCCL_OFI_TRACE_FLUSH(...)
+#define NCCL_OFI_TRACE_COMPLETIONS(...)
+
+#endif // HAVE_LTTNG

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -12,8 +12,8 @@ endif HAVE_CUDA
 
 if ENABLE_NEURON
   lib_LTLIBRARIES = libnccom-net.la
-  libnccom_net_la_SOURCES = nccl_ofi_net.c
+  libnccom_net_la_SOURCES = nccl_ofi_net.c tracepoint.c
 else
   lib_LTLIBRARIES = libnccl-net.la
-  libnccl_net_la_SOURCES = nccl_ofi_net.c
+  libnccl_net_la_SOURCES = nccl_ofi_net.c tracepoint.c
 endif

--- a/src/tracepoint.c
+++ b/src/tracepoint.c
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include <config.h>
+#if HAVE_LTTNG == 1
+
+#define TRACEPOINT_CREATE_PROBES
+#define LTTNG_UST_TRACEPOINT_DEFINE
+
+/*
+ * tracepoint.c creates the lttng probes, from those created in tracepoint.h.  The probes are created
+ * only if TRACEPOINT_CREATE_PROBES is set before the definitions of those probes, so tracepoint.h must
+ * be included once after that definition.
+ *
+ */
+
+#include <tracepoint.h>
+
+#endif // HAVE_LTTNG == 1


### PR DESCRIPTION
Add LTTNG Tracing to the plugin, including instructions and configuration option.

Signed-off-by: Ryan Hankins <rqh@amazon.com>

*Description of changes:*

LTTNG Tracing can be enabled at compile time as described in the included documentation

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
