### PR TITLE
Merge missing changes from master to aws branch

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -175,6 +175,13 @@ typedef struct listenComm {
 	void *buffer;
 } listenComm_t;
 
+typedef struct nccl_ofi_connection_info {
+	char ep_name[MAX_EP_ADDR];
+	uint64_t ep_namelen;
+	uint64_t connect_to_self;
+	nccl_ofi_req_t* req;
+} nccl_ofi_connection_info_t;
+
 typedef struct comm {
     baseOfiComm_t baseComm;
     int dev;
@@ -186,9 +193,7 @@ typedef struct comm {
     free_list_t *nccl_ofi_reqs_fl;
 
     union {
-        struct {
-            free_list_t *pending_reqs_fl;
-        }; // sendComm_t
+        nccl_ofi_connection_info_t *connection_info; /* sendComm_t */
         struct {
             flush_buffer_t flush_buff;
         }; // recvComm_t

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -109,6 +109,12 @@ OFI_NCCL_PARAM_INT(nic_dup_conns, "NIC_DUP_CONNS", 0);
  */
 OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
 
+/*
+ * Specify the memory registration key size in bytes when using a libfabric
+ * provider that supports application-selected memory registration keys.
+ */
+OFI_NCCL_PARAM_INT(mr_key_size, "MR_KEY_SIZE", 2);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2060,6 +2060,30 @@ static inline int create_sendComm(int dev, nccl_ofi_handle_t *ofi_handle, nccl_o
 	sComm->dev = dev;
 	sComm->baseComm.ofi_comp = nccl_ofi_comp;
 
+	sComm->connection_info = calloc(1, sizeof(nccl_ofi_connection_info_t));
+	if (!sComm->connection_info) {
+		return -1;
+	}
+
+	sComm->connection_info->ep_namelen = sizeof(sComm->connection_info->ep_name);
+	sComm->connection_info->req = NULL;
+
+	ret = fi_getname(&(sComm->baseComm.ofi_comp->ep->fid),
+			 (void *)sComm->connection_info->ep_name,
+			 &sComm->connection_info->ep_namelen);
+	if (ret == -FI_ETOOSMALL) {
+		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+			      sComm->connection_info->ep_namelen, MAX_EP_ADDR);
+		return -1;
+	} else if (ret != 0) {
+		NCCL_OFI_WARN("Call to fi_getname() failed with RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		return -1;
+	}
+
+	sComm->connection_info->connect_to_self =
+		(0 == memcmp(sComm->connection_info->ep_name, remote_ep_addr, sComm->connection_info->ep_namelen)) ? 1 : 0;
+
 	/* Pre-allocated buffers for data path */
 	ret = allocate_ofi_fl(&sComm->nccl_ofi_reqs_fl, max_requests, req_size);
 	if (OFI_UNLIKELY(ret != ncclSuccess)) {
@@ -2114,23 +2138,20 @@ static ssize_t send_connect_message(sendComm_t *sComm, nccl_ofi_req_t *req)
 {
 	ssize_t rc = 0;
 	int ret = ncclSuccess;
-	char *local_ep_addr = NULL;
 	uint64_t max_tag = sComm->baseComm.ofi_comp->max_tag;
 
-	/* Get local EP address to transfer in the connect message */
-	local_ep_addr = get_local_address(sComm->dev, sComm->baseComm.ofi_comp);
-	if (local_ep_addr == NULL) {
-		return -1;
-	}
+	/* If connecting to self, pass along the send req so that the
+	   accept side can clean up the request */
+	sComm->connection_info->req = (sComm->connection_info->connect_to_self == 1) ? req : NULL;
 
 	/*
 	 * TODO: replace it with API of FI_INJECT type when most of
 	 * providers can support it, so that need for completion check
 	 * can be lifted.
 	 */
-	rc = fi_tsend(sComm->local_ep, (void *)local_ep_addr,
-			MAX_EP_ADDR, NULL, sComm->remote_ep,
-			sComm->tag | (max_tag + 1), &req->ctx);
+	rc = fi_tsend(sComm->local_ep, (void *)sComm->connection_info,
+		      sizeof(*sComm->connection_info), NULL, sComm->remote_ep,
+		      sComm->tag | (max_tag + 1), &req->ctx);
 	if (rc == -FI_EAGAIN) {
 		/*
 		 * Process completions so that you have enough
@@ -2241,6 +2262,14 @@ ncclResult_t nccl_net_ofi_connect(int dev, void *handle, void **sendComm)
 			comm_state->stage = COMM_REQ_PENDING_COMP;
 
 		case COMM_REQ_PENDING_COMP:
+			if (sComm->connection_info->connect_to_self == 1) {
+				NCCL_OFI_TRACE(NCCL_NET, "Connect to self; short circuit cleanup");
+				/* short cut to avoid rendezvous
+				   deadlock in GDR detection */
+				comm_state->stage = COMM_CONNECTED;
+				break;
+			}
+
 			/* Progress our engine to get completions */
 			ret = nccl_ofi_progress(sComm->baseComm.ofi_comp);
 			if (OFI_UNLIKELY(ret != ncclSuccess)) {
@@ -2312,7 +2341,7 @@ static nccl_ofi_req_t *prepare_recv_conn(listenComm_t *lComm)
  * 		-FI_EAGAIN, on lack of provider resources to post receive request
  * 		error, others
  */
-static ssize_t post_recv_conn(listenComm_t *lComm, nccl_ofi_t *nccl_ofi_comp, char **buffer,
+static ssize_t post_recv_conn(listenComm_t *lComm, nccl_ofi_t *nccl_ofi_comp, void *buffer,
 			      size_t size, nccl_ofi_req_t *req)
 {
 	ssize_t rc = 0;
@@ -2329,7 +2358,7 @@ static ssize_t post_recv_conn(listenComm_t *lComm, nccl_ofi_t *nccl_ofi_comp, ch
 	max_tag = nccl_ofi_comp->max_tag;
 
 	/* Post a buffer for receiving connection requests */
-	rc = fi_trecv(lComm->local_ep, (void *)*buffer, size,
+	rc = fi_trecv(lComm->local_ep, buffer, size,
 		      NULL, FI_ADDR_UNSPEC, lComm->tag | (max_tag + 1),
 		      0, &req->ctx);
 	if (rc == -FI_EAGAIN) {
@@ -2497,7 +2526,7 @@ ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm)
 	nccl_ofi_req_t *req = comm_state->req;
 
 	/* Extract peer address from listen communicator's buffer */
-	char *remote_ep_addr = lComm->buffer;
+	nccl_ofi_connection_info_t *conn_info = lComm->buffer;
 
 	nccl_ofi_t *nccl_ofi_comp = lComm->baseComm.ofi_comp;
 	if (nccl_ofi_comp == NULL) {
@@ -2544,18 +2573,21 @@ ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm)
 		case COMM_RECV_CONN:
 
 			/* Allocate memory for peer address for the first time ONLY */
-			if (remote_ep_addr == NULL)
-				remote_ep_addr = (char *)calloc(MAX_EP_ADDR, sizeof(char));
+			if (conn_info == NULL) {
+				conn_info = calloc(1, sizeof(nccl_ofi_connection_info_t));
+			}
 
 			/* Post a receive message to receive peer connections */
-			rc = post_recv_conn(lComm, nccl_ofi_comp, &remote_ep_addr, MAX_EP_ADDR, req);
+			rc = post_recv_conn(lComm, nccl_ofi_comp, conn_info, sizeof(nccl_ofi_connection_info_t), req);
 			if (rc == -FI_EAGAIN) {
 				/* Save recv request and buffer address for retry */
 				comm_state->req = req;
-				lComm->buffer = remote_ep_addr;
+				lComm->buffer = conn_info;
 				return ncclSuccess;
 			} else if (rc != 0) {
 				free(req);
+				free(conn_info);
+				lComm->buffer = NULL;
 				put_nccl_ofi_comp(nccl_ofi_comp, dev);
 				return ncclSystemError;
 			}
@@ -2575,8 +2607,16 @@ ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm)
 			if (lComm->accepted != true) {
 				/* Save recv request and buffer to retest completion */
 				comm_state->req = req;
-				lComm->buffer = remote_ep_addr;
+				lComm->buffer = conn_info;
 				return ncclSuccess;
+			}
+
+			if (conn_info->connect_to_self) {
+				NCCL_OFI_TRACE(NCCL_NET, "Accept from self; cleaning up");
+				if (conn_info->req->state != NCCL_OFI_REQ_COMPLETED) {
+					lComm->buffer = conn_info;
+					return ncclSuccess;
+				}
 			}
 
 			/* Done processing the request so free it */
@@ -2595,11 +2635,13 @@ ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm)
 	}
 
 	/* Prepare receive communicator object for the received peer connection */
-	rComm = prepare_recv_comm(lComm, remote_ep_addr);
+	rComm = prepare_recv_comm(lComm, conn_info->ep_name);
 	if (OFI_UNLIKELY(rComm == NULL)) {
 		put_nccl_ofi_comp(nccl_ofi_comp, dev);
 		return ncclSystemError;
 	}
+
+	free(conn_info);
 
 	comm_state->comm = rComm;
 	*recvComm = rComm;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -709,6 +709,8 @@ static void get_hints(struct fi_info *hints, int request_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
+	hints->domain_attr->threading = FI_THREAD_SAFE;
+
 	/* Set progress mode to unspec to use the provider's default mode. */
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
 	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -165,9 +165,9 @@ static const char *nccl_ofi_req_state_str(nccl_ofi_req_state_t state)
 	}
 }
 
-static const char *nccl_ofi_req_direction_str(nccl_ofi_req_state_t state)
+static const char *nccl_ofi_req_direction_str(nccl_ofi_req_direction_t direction)
 {
-	switch(state) {
+	switch(direction) {
 	case NCCL_OFI_SEND:
 		return "SEND";
 	case NCCL_OFI_RECV:

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1461,6 +1461,9 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		local_mr = true;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
+			       ofi_info_list->fabric_attr->prov_name);
 	}
 
 	/* Check if provider requires heterogeneous memory registration */
@@ -1468,6 +1471,9 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of device buffers",
 			       ofi_info_list->fabric_attr->prov_name);
 		hmem_mr = true;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of device buffers",
+			       ofi_info_list->fabric_attr->prov_name);
 	}
 
 exit:
@@ -2781,7 +2787,8 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	recvComm_t *rComm = (recvComm_t *)recvComm;
 	nccl_ofi_req_t *req = NULL;
 	ssize_t rc = 0;
-	uint64_t cuda_key;
+	uint64_t cuda_key = 0ULL;
+	void* desc = NULL;
 	struct fid_mr *mr_handle = NULL;
 	void *data = NULL;
 
@@ -2838,12 +2845,6 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	if (mhandles && mhandles[flush_n])
 		mr_handle = (struct fid_mr *)mhandles[flush_n];
 
-	if (OFI_UNLIKELY(mr_handle == NULL)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Invalid memory registration handle provided");
-		goto exit;
-	}
-
 	data = buffers[flush_n];
 
 	/* Support only max_requests inflight requests. */
@@ -2867,12 +2868,15 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
-	/* Extract remote key */
-	cuda_key = fi_mr_key(mr_handle);
-	if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Memory registration may not have completed.");
-		goto error;
+	if (mr_handle != NULL) {
+		/* Extract remote key */
+		desc = fi_mr_desc(mr_handle);
+		cuda_key = fi_mr_key(mr_handle);
+		if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
+			ret = ncclSystemError;
+			NCCL_OFI_WARN("Memory registration may not have completed.");
+			goto error;
+		}
 	}
 
 	NCCL_OFI_TRACE_FLUSH(req, request, &req->ctx);
@@ -2881,7 +2885,7 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	do {
 		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
-			     fi_mr_desc(rComm->flush_buff.mr_handle),
+			     desc,
 			     rComm->local_ep_addr, (uint64_t)data,
 			     cuda_key, &req->ctx);
 		if (rc == 0) {
@@ -2956,12 +2960,14 @@ ncclResult_t nccl_net_ofi_closeRecv(void *recvComm)
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = (struct fid_mr *)rComm->flush_buff.mr_handle;
-		rc = fi_close((fid_t)mr_handle);
-		if (OFI_UNLIKELY(rc != 0)) {
-			ret = ncclSystemError;
-			NCCL_OFI_WARN("Unable to de-register flush buffer. RC: %d, Error: %s",
-					rc, fi_strerror(-rc));
-			goto exit;
+		if (mr_handle) {
+			rc = fi_close((fid_t)mr_handle);
+			if (OFI_UNLIKELY(rc != 0)) {
+				ret = ncclSystemError;
+				NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+					      fi_strerror(-rc));
+				goto exit;
+			}
 		}
 		if (munmap(rComm->flush_buff.host_buffer, sysconf(_SC_PAGESIZE))) {
 			NCCL_OFI_WARN("Unable to unmap flush buffer (%d %s)", errno, strerror(errno));

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -2788,9 +2788,9 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	nccl_ofi_req_t *req = NULL;
 	ssize_t rc = 0;
 	uint64_t cuda_key = 0ULL;
-	void* desc = NULL;
 	struct fid_mr *mr_handle = NULL;
 	void *data = NULL;
+	void *flush_mr_desc = NULL;
 
 	if (ofi_nccl_gdr_flush_disable() || !support_gdr)
 		goto exit;
@@ -2868,9 +2868,14 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	req->dev = rComm->dev;
 	req->direction = NCCL_OFI_RECV;
 
+	if (rComm->flush_buff.mr_handle != NULL) {
+		/* Not checking for NULL flush_mr_desc as fi_mr_desc()
+		 * returns valid descriptors by valid handles */
+		flush_mr_desc = fi_mr_desc(rComm->flush_buff.mr_handle);
+	}
+
 	if (mr_handle != NULL) {
 		/* Extract remote key */
-		desc = fi_mr_desc(mr_handle);
 		cuda_key = fi_mr_key(mr_handle);
 		if (OFI_UNLIKELY(cuda_key == FI_KEY_NOTAVAIL)) {
 			ret = ncclSystemError;
@@ -2885,7 +2890,7 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 	do {
 		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
-			     desc,
+			     flush_mr_desc,
 			     rComm->local_ep_addr, (uint64_t)data,
 			     cuda_key, &req->ctx);
 		if (rc == 0) {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -56,6 +56,8 @@ int ofi_ndevices = -1;
 __thread nccl_ofi_t **nccl_ofi_component = NULL;
 /* Indicates if memory registration of local buffers is required */
 bool local_mr = false;
+/* Indicates if remote virtual addressing is used */
+bool virt_addr_mr = false;
 /* Indicates if memory registration of device buffers is required */
 bool hmem_mr = false;
 /* Indicates if GPUDirect is supported by libfabric provider */
@@ -1463,6 +1465,16 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 		local_mr = true;
 	} else {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
+			       ofi_info_list->fabric_attr->prov_name);
+	}
+
+	/* Check if provider uses remote virtual addressing */
+	if (ofi_info_list->domain_attr->mr_mode & FI_MR_VIRT_ADDR) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s uses remote virtual addressing",
+			       ofi_info_list->fabric_attr->prov_name);
+		virt_addr_mr = true;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not use remote virtual addressing",
 			       ofi_info_list->fabric_attr->prov_name);
 	}
 
@@ -2891,7 +2903,8 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 		rc = fi_read(rComm->local_ep, rComm->flush_buff.host_buffer,
 			     rComm->flush_buff.size,
 			     flush_mr_desc,
-			     rComm->local_ep_addr, (uint64_t)data,
+			     rComm->local_ep_addr,
+			     (uint64_t)(virt_addr_mr ? data : 0),
 			     cuda_key, &req->ctx);
 		if (rc == 0) {
 			break;

--- a/tests/test-common.h
+++ b/tests/test-common.h
@@ -142,7 +142,7 @@ ncclResult_t deallocate_buffer(void *buf, int buffer_type)
 		break;
 	default:
 		NCCL_OFI_WARN("Unidentified buffer type: %d", buffer_type);
-		return cudaErrorInvalidValue;
+		return ncclInvalidArgument;
 	}
 
 	return ncclSuccess;


### PR DESCRIPTION
This PR merges all non-doc fixes from the master branch to the aws branch.  Changes include:

134db8b Request FI_MR_HMEM by default
c38b5ba Use provider key mode when not using RMA
a9a8af6 Request FI_THREAD_SAFE from the provider
1506f3c Extend fi_read to support additional MR modes
8889dd2 Add support for 0-based MR addressing mode
02d5d6e Fix a couple type mismatches
b2ab25b Allow ofi_iflush without memory registration if provider does not request it
2ec1382 Fix crash in case if underlying fabric is GDR capable but does not require memory registering.

Additionally, 05cf55a (Fix deadlock in case if underlying provider uses rendezvous mode) was reimplemented, as the original patch was implemented only for the blocking connect path and it was simpler to re-implement than to try to cherry-pick.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
