### PR TITLE
Only set EFA-specific latency when EFA in use

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -17,14 +17,15 @@
 #include <stack.h>
 #include <nccl_ofi_param.h>
 #ifdef EFA_NIC_DUP
-#define EFA_PROVIDER_NAME "efa"
-#define IS_EFA_PROVIDER(NAME) (strcmp((NAME), EFA_PROVIDER_NAME)==0)
 #include <ctype.h>
 #endif
 #if HAVE_CUDA
 #include <cuda_runtime.h>
 #endif
 #include "tracepoint.h"
+
+#define EFA_PROVIDER_NAME "efa"
+#define IS_EFA_PROVIDER(NAME) (strcmp((NAME), EFA_PROVIDER_NAME)==0)
 
 struct ec2_platform_topology {
 	const char* name;
@@ -1632,18 +1633,20 @@ static ncclResult_t set_nic_props_default(int dev, struct fi_info *nic_prov,
 	props->maxComms = nic_prov->domain_attr->ep_cnt;
 	props->guid = dev;
 
-	/*
-	 * Sets intranode latency for EFA networks.
-	 *
-	 * This value is chosen by measuring all reduce latency for
-	 * different NCCL algorithms and using that to calculate intra node
-	 * latency based on NCCL's tuning algorithm.
-	 *
-	 * A few different values around this value were tried to see which
-	 * chose the correct algorithm (tree or ring) most times across
-	 * different message and cluster sizes.
-	 */
-	props->latency = 150;
+	if (IS_EFA_PROVIDER(nic_prov->fabric_attr->prov_name)) {
+		/*
+		 * Sets intranode latency for EFA networks.
+		 *
+		 * This value is chosen by measuring all reduce latency for
+		 * different NCCL algorithms and using that to calculate intra node
+		 * latency based on NCCL's tuning algorithm.
+		 *
+		 * A few different values around this value were tried to see which
+		 * chose the correct algorithm (tree or ring) most times across
+		 * different message and cluster sizes.
+		 */
+		props->latency = 150;
+	}
 
 	/*
 	 * Maximum number of grouped receives. Currently, we set it to 1 to


### PR DESCRIPTION
A previous commit (d087749) in the aws branch set the latency property unconditionally, making it unsuitable for moving to the master branch. This patch adjusts the previous commit to only set the latency property when the EFA provider is in use, allowing us to pull both changes into the master branch.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
