### PR TITLE
Reduce count for fi_cq_read()

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,16 @@ The plugin allows to configure the following variables at run-time according to 
       <td>Boolean</td>
       <td>0/1 (Default: 0)</td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_CQ_READ_COUNT</code></td>
+      <td>Adjust the maximum number of completion entries that will
+	  be read in a single Libfabric polling loop.  In general, users
+	  should not have to adjust this value.  An array of completion
+	  queue entry structures is created on the stack, so large (over
+      16-32) values of this parameter may cause stack overflows.</td>
+      <td>Integer</td>
+      <td>Default: 4</td>
+   </tr>
 </table>
 
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -280,9 +280,6 @@ struct nccl_ofi {
 	/* Maximum supported tag ID */
 	uint64_t max_tag;
 
-	/* Count of CQEs to read from CQ */
-	uint64_t num_cqes;
-
 	/* Provider name */
 	char *prov_name;
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -109,6 +109,12 @@ OFI_NCCL_PARAM_INT(nic_dup_conns, "NIC_DUP_CONNS", 0);
  */
 OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
 
+/*
+ * Maximum number of cq entries to read in a single call to
+ * fi_cq_read.
+ */
+OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -65,6 +65,12 @@ bool support_gdr = true;
  * platforms and should be disabled by default */
 bool cuda_flush = false;
 
+/* number of cq entries to read in a single call to fi_cq_read.
+   This variable will be updated during init (hence, can not be
+   const), but will not change during execution.  Therefore, it may be
+   read in the polling loop without protection of a lock. */
+static size_t cq_read_count = 1;
+
 // NCCL OFI lock for concurrency
 pthread_mutex_t nccl_ofi_lock = PTHREAD_MUTEX_INITIALIZER;
 // Logger Function
@@ -932,7 +938,6 @@ static ncclResult_t create_nccl_ofi_comp_for_dev(int dev, struct fi_info *nic_in
 
 	/* Initialise tag and num_cqes */
 	nccl_ofi_component[dev]->tag = 0;
-	nccl_ofi_component[dev]->num_cqes = max_requests;
 	nccl_ofi_component[dev]->prov_name = prov->fabric_attr->prov_name;
 
 	ret = create_nccl_ofi_component(prov, nccl_ofi_component[dev]);
@@ -1114,18 +1119,17 @@ static ncclResult_t ofi_process_cq(nccl_ofi_t *nccl_ofi_comp)
 	ssize_t rc = 0;
 	ncclResult_t ret = ncclSuccess;
 	struct fi_cq_err_entry err_buffer = { 0 };
-	uint64_t cqe_burst = nccl_ofi_comp->num_cqes;
-	struct fi_cq_tagged_entry cqe_tagged_buffers[cqe_burst];
+	struct fi_cq_tagged_entry cqe_tagged_buffers[cq_read_count];
 	nccl_ofi_req_t *req = NULL;
 	struct fid_cq *cq = nccl_ofi_comp->cq;
 	uint64_t control_bit_mask = nccl_ofi_comp->max_tag + 1;
 
 	while (true) {
 		/* Receive completions for the given endpoint */
-		rc = fi_cq_read(cq, &cqe_tagged_buffers[0], cqe_burst);
+		rc = fi_cq_read(cq, cqe_tagged_buffers, cq_read_count);
 		if (rc > 0) {
 			ret = process_completions(
-					&cqe_tagged_buffers[0], rc,
+					cqe_tagged_buffers, rc,
 					control_bit_mask);
 			if (OFI_UNLIKELY(ret != 0))
 				goto exit;
@@ -1469,6 +1473,10 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 			       ofi_info_list->fabric_attr->prov_name);
 		hmem_mr = true;
 	}
+
+	/* Store the cq_read_count parameter value in a global
+	   variable to avoid the lookup overhead during execution. */
+	cq_read_count = ofi_nccl_cq_read_count();
 
 exit:
 	if (ret != ncclSuccess) {


### PR DESCRIPTION
The number of completion queue entries we read in one call to fi_cq_read() should be based on performance parameters that are independent of the maximum number of in flight requests, so remove the coupling between the two.  In practice, this number should be tuned based on experimentation, but 4 is a good starting number.

The previous implementation could cause stack overflows, due to the large array being built every time to ofi_process_cq, so this patch fixes an immediate pain point.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
