### PR TITLE
Avoid topology update if NCCL_TOPO_FILE is already set

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -223,8 +223,15 @@ ncclResult_t platform_init(void)
 		}
 	}
 
-	if (platform_data && platform_data->topology) {
-		/* Update topology */
+	/*
+	 * Update topology if platform topology is available and 
+	 * environment variable NCCL_TOPO_FILE is not set.
+	 */
+	if (getenv("NCCL_TOPO_FILE")) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "Running on %s platform, NCCL_TOPO_FILE environment variable is already set to %s",
+			      platform_type, getenv("NCCL_TOPO_FILE"));
+	} else if (platform_data && platform_data->topology) {
 		char topology_path[PATH_MAX];
 
 		rc = snprintf(topology_path, sizeof(topology_path), "%s/%s",


### PR DESCRIPTION
Signed-off-by: Michael Axtmann <axtmannm@amazon.com>

*Description of changes:*
Environment variable NCCL_TOPO_FILE is only set by plugin if variable undefined. This allows users to provide their own topology files to NCCL even though plugin would like to provide a topology file as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
