### PR TITLE
Inline allocate_stack(..) and free_stack(..) in include/stack.h

### DIFF
--- a/include/stack.h
+++ b/include/stack.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef STACK_H_
@@ -17,7 +17,7 @@ extern "C" {
 /*
  * @brief	Allocate stack of free indexes
  */
-static stack_t *allocate_stack(size_t num_elems)
+static inline stack_t *allocate_stack(size_t num_elems)
 {
 	stack_t *stack = NULL;
 
@@ -38,7 +38,7 @@ exit:
  * @brief	Free given stack
  */
 
-void free_stack(stack_t *stack)
+inline void free_stack(stack_t *stack)
 {
 	if (!stack)
 		return;


### PR DESCRIPTION
Issue
Following error occurs if include/stack.h is included in multiple compilation units.

.libs/*.o: In function free_stack': src/../include/stack.h:43: multiple definition of free_stack'
.libs/nccl_ofi_net.o:src/Aws-ofi-nccl/src/../include/stack.h:43: first defined here

Solution
Add inline allocate_stack(..) and free_stack(..) in include/stack.h

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.