### PR TITLE
Shortcut parameter lookup to avoid lock

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -399,7 +399,7 @@ exit:
 	return ret;
 }
 
-static int in_list(char *item, char *list)
+static int in_list(const char *item, const char *list)
 {
 	int ret = 0;
 	char *token = NULL;
@@ -438,7 +438,7 @@ exit:
 static bool match_prov_info(char *name, uint32_t addr_format,
 			    uint64_t mem_tag_format, uint64_t expected_mem_tag_format)
 {
-	char *tcp_if_exclude_list = ofi_nccl_exclude_tcp_if();
+	const char *tcp_if_exclude_list = ofi_nccl_exclude_tcp_if();
 
 	if (in_list(name, tcp_if_exclude_list)) {
 		return true;


### PR DESCRIPTION
The parameter lookup code always took a lock, which is really slow in the common case.  The flush parameter is used in the critical path, so this is not an awesome behavior.  This patch uses an initialized variable to signal whether or not the full lookup path is required.

While testing, I found that we didn't actually error check the integer converstion properly or the strdup properly, so this patch also fixes those two issues.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
