### PR TITLE
Skip setting environment variables on Neuron

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -96,6 +96,10 @@ extern int max_requests;
  * rings to use the connections
  */
 extern int nic_dup_conns;
+/* only allow providers in the comma-separated list provider_filter.
+   Default is no filter.  Used by platform files; users can get the
+   same behavior by setting FI_PROVIDER directly. */
+extern const char *provider_filter;
 
 typedef enum nccl_ofi_req_state {
 	NCCL_OFI_REQ_CREATED = 0,

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -161,13 +161,8 @@ ncclResult_t platform_init(void)
 	 * behaviors we want).
 	 */
 	if (!getenv("FI_PROVIDER")) {
-		NCCL_OFI_INFO(NCCL_INIT, "Setting FI_PROVIDER to \"efa\"");
-		rc = setenv("FI_PROVIDER", "efa", 0);
-		if (rc) {
-			NCCL_OFI_WARN("Error setting FI_PROVIDER environment variable: %d", rc);
-			ret = ncclSystemError;
-			goto exit;
-		}
+		NCCL_OFI_INFO(NCCL_INIT, "Setting provider_filter to efa");
+		provider_filter = "efa";
 	}
 
 	/* Use the simple protocol whenever we're not sure the


### PR DESCRIPTION
Two changes with the goal of skipping setting environment variables on Neuron.  The first uses local filtering instead of `FI_PROVIDER` for selecting the efa provider.  The second removes two configuration settings (NCCL_PROTO and fork save) that the Neuron team has asked us to avoid setting, in order to avoid calling setenv().

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
