### PR TITLE
Rename HAVE_LTTNG HAVE_LIBLTTNG_UST to be consistent with configure.ac refactoring

### DIFF
--- a/include/tracepoint.h
+++ b/include/tracepoint.h
@@ -31,7 +31,7 @@
  */
 
 #include "config.h"
-#if HAVE_LTTNG == 1
+#if HAVE_LIBLTTNG_UST == 1
 
 /*
  * LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ must be included so that the tracepoints
@@ -132,4 +132,4 @@ LTTNG_UST_TRACEPOINT_EVENT(
 #define NCCL_OFI_TRACE_FLUSH(...)
 #define NCCL_OFI_TRACE_COMPLETIONS(...)
 
-#endif // HAVE_LTTNG
+#endif // HAVE_LIBLTTNG_UST

--- a/src/tracepoint.c
+++ b/src/tracepoint.c
@@ -3,7 +3,7 @@
  */
 
 #include <config.h>
-#if HAVE_LTTNG == 1
+#if HAVE_LIBLTTNG_UST == 1
 
 #define TRACEPOINT_CREATE_PROBES
 #define LTTNG_UST_TRACEPOINT_DEFINE
@@ -17,4 +17,4 @@
 
 #include <tracepoint.h>
 
-#endif // HAVE_LTTNG == 1
+#endif // HAVE_LIBLTTNG_UST == 1


### PR DESCRIPTION
Rename HAVE_LTTNG HAVE_LIBLTTNG_UST to be consistent with configure.ac refactoring

*Issue #, if available:*

*Description of changes:*
HAVE_LTTNG changed to HAVE_LIBLTTNG_UST with the configure.ac changes, so update it in the source as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
