### PR TITLE
Fix error "undefined reference to `free_stack'" while linking

### DIFF
--- a/include/stack.h
+++ b/include/stack.h
@@ -38,7 +38,7 @@ exit:
  * @brief	Free given stack
  */
 
-inline void free_stack(stack_t *stack)
+static inline void free_stack(stack_t *stack)
 {
 	if (!stack)
 		return;


### PR DESCRIPTION
*Issue:*
Linking fails with error "undefined reference to `free_stack'" when the code is compiled without optimizations, e.g., without "-O3" in configure.ac.

*Description of changes:*
Add static keyword to function free_stack(..) in include/stack.h


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
