### PR TITLE
Fix build compatibility issues

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -28,7 +28,7 @@ NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS=
 
 # Checks for programs
 AC_PROG_CC
-AC_PROG_CC_STDC
+m4_version_prereq([2.70], [], [AC_PROG_CC_STDC])
 AC_C_INLINE
 
 dnl ac_check_enable_debug will make sure AC_PROG_CC doesn't add a

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   check_pkg_LIBS_save="${LIBS}"
 
   AC_ARG_WITH([cuda],
-     [AC_HELP_STRING([--with-cuda=PATH], [Path to non-standard CUDA installation])])
+     [AS_HELP_STRING([--with-cuda=PATH], [Path to non-standard CUDA installation])])
 
   AS_IF([test -n "${with_cuda}"], [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-cuda=${with_cuda}"])
 

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
   check_pkg_LIBS_save="${LIBS}"
 
   AC_ARG_WITH([libfabric],
-     [AC_HELP_STRING([--with-libfabric=PATH], [Path to non-standard libfabric installation])])
+     [AS_HELP_STRING([--with-libfabric=PATH], [Path to non-standard libfabric installation])])
 
   AS_IF([test -n "${with_libfabric}"], [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-libfabric=${with_libfabric}"])
 

--- a/m4/check_pkg_mpi.m4
+++ b/m4/check_pkg_mpi.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
   check_pkg_LIBS_save="${LIBS}"
 
   AC_ARG_WITH([mpi],
-     [AC_HELP_STRING([--with-mpi=PATH], [Path to non-standard MPI installation])])
+     [AS_HELP_STRING([--with-mpi=PATH], [Path to non-standard MPI installation])])
 
   AS_IF([test -n "${with_mpi}"], [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-mpi=${with_mpi}"])
 

--- a/tests/nccl_message_transfer.c
+++ b/tests/nccl_message_transfer.c
@@ -38,7 +38,8 @@ int main(int argc, char* argv[])
 	int nrecv = NCCL_OFI_MAX_RECVS;
 	int *sizes = (int *)malloc(sizeof(int)*nrecv);
 	int *tags = (int *)malloc(sizeof(int)*nrecv);
-	for (int recv_n = 0; recv_n < nrecv; recv_n++) {
+	int recv_n;
+	for (recv_n = 0; recv_n < nrecv; recv_n++) {
 		sizes[recv_n] = RECV_SIZE;
 		tags[recv_n] = tag;
 	}

--- a/tests/ring.c
+++ b/tests/ring.c
@@ -38,8 +38,9 @@ int main(int argc, char *argv[])
 	int nrecv = NCCL_OFI_MAX_RECVS;
 	int *sizes = (int *)malloc(sizeof(int)*nrecv);
 	int *tags = (int *)malloc(sizeof(int)*nrecv);
+	int recv_n;
 
-	for (int recv_n = 0; recv_n < nrecv; recv_n++) {
+	for (recv_n = 0; recv_n < nrecv; recv_n++) {
 		sizes[recv_n] = RECV_SIZE;
 		tags[recv_n] = tag;
 	}


### PR DESCRIPTION
Two semi-related portability changes.

First, in response to https://github.com/aws/aws-ofi-nccl/issues/183, remove the use of C99 in the tests, which use mpicc instead of $CC, making it difficult to use AC_PROG_CC / AC_PROG_CC_STDC to set the C version to C99 or later.

Second, fix issues found while testing when using Autoconf 2.70 or later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
