### PR TITLE
[v1.6.x] v1.6.1 - set next release candidate version

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.6.0], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.6.1], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Set next release candidate version as v1.6.1 for v1.6.x branch.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
