### PR TITLE
Update master branch version to v1.6.1-dev

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.5.0], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.6.1-dev], [rashika@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
To avoid confusion from release branch version(v1.6.0) and master development branch version, 
We are going to use "dev" suffix.

So, now, v1.6.0 released. so master branch version will be "v1.6.1-dev".


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
