### PR TITLE
HMEM copy overrides using GDRCopy

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -76,6 +76,19 @@ CHECK_PKG_CUDA([have_device_interface=cuda])
 AS_IF([test "${have_device_interface}" = "no"],
       [AC_MSG_ERROR([NCCL OFI Plugin requires either CUDA or Neuron runtime.])])
 
+AC_ARG_WITH([gdrcopy],
+            AC_HELP_STRING([--with-gdrcopy=PATH], [Path to non-standard GDRCopy installation]),
+            [AS_IF([test "$withval" = "yes"], [],
+                   [AS_IF([test -d $withval/lib64], [gdrcopy_libdir="lib64"], [gdrcopy_libdir="lib"])
+                    CFLAGS="-I$withval/include $CFLAGS"
+                    LDFLAGS="-L$withval/$gdrcopy_libdir $LDFLAGS"])
+             AC_DEFINE([HAVE_GDRCOPY], [1], [Build support for GDRCopy])
+             AC_CHECK_HEADERS([gdrapi.h], [], [AC_MSG_ERROR([unable to find GDRCopy headers])])
+             AC_CHECK_LIB([gdrapi], [gdr_open], [], [AC_MSG_ERROR([GDRCopy library not found])])],
+            [])
+
+AM_CONDITIONAL([HAVE_GDRCOPY], [test "x$with_gdrcopy" != "x"])
+
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -272,6 +272,13 @@ typedef struct nccl_ofi_handle {
 	save_comm_state_t state;
 } nccl_ofi_handle_t;
 
+typedef struct nccl_ofi_mr_handle {
+	void *addr;
+	size_t size;
+	int type;
+	struct fid_mr *fi_handle;
+} nccl_ofi_mr_handle_t;
+
 _Static_assert(sizeof(nccl_ofi_handle_t) <= NCCL_NET_HANDLE_MAXSIZE, "Size of OFI Handle is too large");
 
 /*

--- a/include/nccl_ofi_hcopy.h
+++ b/include/nccl_ofi_hcopy.h
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include <gdrapi.h>
+
+typedef struct {
+	void *ptr;
+	size_t length;
+	void *base_ptr;
+	gdr_info_t info;
+	gdr_mh_t mhandle;
+	int refs;
+} nccl_ofi_hcopy_buf_handle_t;
+
+extern gdr_t gdr_desc;
+
+int nccl_ofi_hcopy_register(void *addr, size_t length);
+int nccl_ofi_hcopy_unregister(void *addr);
+void nccl_ofi_hcopy_unregister_all();
+nccl_ofi_hcopy_buf_handle_t *nccl_ofi_get_hcopy_buffer_handle(void *addr, size_t len);

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -5,6 +5,7 @@
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -DXML_DIR=\"${pkgdatadir}/xml\"
+AM_LDFLAGS  =
 
 sources = \
 	nccl_ofi_net.c \
@@ -21,8 +22,13 @@ endif
 
 if ENABLE_NEURON
   lib_LTLIBRARIES = libnccom-net.la
-  libnccom_net_la_SOURCES = $(sources)
+  libnccl_net_la_SOURCES = $(sources)
 else
   lib_LTLIBRARIES = libnccl-net.la
   libnccl_net_la_SOURCES = $(sources)
+endif
+
+if HAVE_GDRCOPY
+AM_LDFLAGS += -lgdrapi
+libnccl_net_la_SOURCES += hcopy.c
 endif

--- a/src/hcopy.c
+++ b/src/hcopy.c
@@ -1,0 +1,299 @@
+/*
+ * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <limits.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <nccl_ofi.h>
+#include <nccl_ofi_log.h>
+#include <nccl_ofi_hcopy.h>
+
+#include <cuda.h>
+#include <cuda_runtime.h>
+#include <gdrapi.h>
+
+#define NCCL_OFI_INITIAL_REG_ARRAY_SIZE 128
+
+static size_t registered_buffer_array_used = 0;
+static size_t registered_buffer_array_size = 0;
+static nccl_ofi_hcopy_buf_handle_t **registered_buffers = NULL;
+
+int nccl_ofi_hcopy_register(void *addr, size_t length) {
+	nccl_ofi_hcopy_buf_handle_t *handle = NULL;
+	size_t i;
+	int status = 0, ret;
+	struct cudaPointerAttributes attr;
+
+	status = cudaPointerGetAttributes(&attr, addr);
+
+	if (status != cudaSuccess) {
+		/* clear CUDA error string. */
+		cudaGetLastError();
+		NCCL_OFI_WARN("Unable to query pointer attributes.");
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	if (attr.type == cudaMemoryTypeManaged) {
+		NCCL_OFI_WARN("Unable to register managed memory (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+	else if (attr.type == cudaMemoryTypeHost) {
+		NCCL_OFI_WARN("Unable to register host memory (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+	else if (attr.type == cudaMemoryTypeUnregistered) {
+		NCCL_OFI_WARN("Unable to register unregistered memory type (0x%p)", addr);
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	handle = (nccl_ofi_hcopy_buf_handle_t *)calloc(1, sizeof(nccl_ofi_hcopy_buf_handle_t));
+	if (handle == NULL) {
+		NCCL_OFI_WARN("Unable to allocate registered buffer handle.");
+		status = ncclSystemError;
+		goto out_error;
+	}
+
+	NCCL_OFI_TRACE(NCCL_NET, "Registering (0x%p - 0x%p) length=%zu", addr, (char*)addr + length, length);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	if (registered_buffer_array_used == registered_buffer_array_size) {
+		size_t new_array_size = registered_buffer_array_size ?
+			registered_buffer_array_size * 2 :
+			NCCL_OFI_INITIAL_REG_ARRAY_SIZE;
+		void *new_buf;
+
+		assert(new_array_size < (SIZE_MAX / sizeof(nccl_ofi_hcopy_buf_handle_t)));
+		new_buf = realloc(registered_buffers, new_array_size * sizeof(nccl_ofi_hcopy_buf_handle_t *));
+		if (new_buf == NULL) {
+			NCCL_OFI_WARN("Unable to resize the registered buffer array.");
+			status = ncclSystemError;
+			goto out_unlock;
+		}
+		registered_buffers = (nccl_ofi_hcopy_buf_handle_t **)new_buf;
+		registered_buffer_array_size = new_array_size;
+	}
+
+	for (i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+		if (addr > tmp_handle->ptr) {
+			void *max_addr;
+			max_addr = (void *)((char *)tmp_handle->ptr + tmp_handle->length);
+			if (addr < max_addr) {
+				NCCL_OFI_WARN("Unable to register overlapping memory regions.\n");
+				status = ncclSystemError;
+				goto out_unlock;
+			}
+			continue;
+		} else if (addr == tmp_handle->ptr) {
+			if (length != tmp_handle->length) {
+				NCCL_OFI_WARN("Unable to register overlapping memory regions.");
+				status = ncclSystemError;
+			} else {
+				tmp_handle->refs++;
+				NCCL_OFI_TRACE(NCCL_NET, "Added ref to existing registration (0x%p, %zu, %d).",
+						addr, length, tmp_handle->refs);
+				status = 0;
+			}
+			goto out_unlock;
+		} else {
+			/* addr < tmp_handle->ptr */
+			break;
+		}
+	}
+
+	handle->ptr = addr;
+	handle->length = length;
+	handle->refs = 1;
+
+	ret = gdr_pin_buffer(gdr_desc, (unsigned long) addr, length, 0, 0, &handle->mhandle);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_pin_buffer (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+	ret = gdr_map(gdr_desc, handle->mhandle, &handle->base_ptr, length);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_map (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+	ret = gdr_get_info(gdr_desc, handle->mhandle, &handle->info);
+	if (ret) {
+		NCCL_OFI_WARN("Error in gdr_get_info (%d)", ret);
+		status = ncclSystemError;
+		goto out_unlock;
+	}
+
+	assert(i < registered_buffer_array_size);
+	if (i < registered_buffer_array_used) {
+		memmove(&registered_buffers[i + 1],
+				&registered_buffers[i],
+				sizeof(nccl_ofi_hcopy_buf_handle_t *) * (registered_buffer_array_used - i));
+	}
+	registered_buffers[i] = handle;
+	registered_buffer_array_used++;
+
+out_unlock:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+out_error:
+	if (status) free(handle);
+	return status;
+}
+
+int nccl_ofi_hcopy_unregister(void *addr) {
+	size_t i, ret;
+	int status = 0;
+
+	NCCL_OFI_TRACE(NCCL_NET, "Unregistering 0x%p", addr);
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	for (i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+		if (addr > tmp_handle->ptr) {
+			continue;
+		} else if (addr == tmp_handle->ptr) {
+			tmp_handle->refs--;
+			if (tmp_handle->refs > 0) {
+				NCCL_OFI_TRACE(NCCL_NET, "Released ref to registration (0x%p, %d).",
+						addr, tmp_handle->refs);
+				goto out_unlock;
+			}
+			if ((i + 1) < registered_buffer_array_used) {
+				memmove(&registered_buffers[i],
+						&registered_buffers[i + 1],
+						sizeof(nccl_ofi_hcopy_buf_handle_t *) * (registered_buffer_array_used - i));
+			}
+
+			ret = gdr_unmap(gdr_desc, tmp_handle->mhandle, tmp_handle->base_ptr, tmp_handle->length);
+			if (ret) {
+				NCCL_OFI_WARN("Error in gdr_unmap (%d)", ret);
+				status = ncclSystemError;
+				break;
+			}
+
+			ret = gdr_unpin_buffer(gdr_desc, tmp_handle->mhandle);
+			if (ret) {
+				NCCL_OFI_WARN("Error in gdr_unpin_buffer (%d)", ret);
+				status = ncclSystemError;
+				break;
+			}
+
+			free(tmp_handle);
+			registered_buffer_array_used--;
+			break;
+			/* addr < tmp_handle->ptr*/
+		} else {
+			NCCL_OFI_WARN("Could not unmap (0x%p)", addr);
+			//status = ncclSystemError;
+			break;
+		}
+	}
+
+out_unlock:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	return status;
+}
+
+void nccl_ofi_hcopy_unregister_all() {
+	int ret;
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	for (size_t i = 0; i < registered_buffer_array_used; i++) {
+		nccl_ofi_hcopy_buf_handle_t *tmp_handle = registered_buffers[i];
+
+		ret = gdr_unmap(gdr_desc, tmp_handle->mhandle, tmp_handle->base_ptr, tmp_handle->length);
+		if (ret) {
+			NCCL_OFI_WARN("Error in gdr_unmap (%d)", ret);
+		}
+
+		ret = gdr_unpin_buffer(gdr_desc, tmp_handle->mhandle);
+		if (ret) {
+			NCCL_OFI_WARN("Error in gdr_unpin_buffer (%d)", ret);
+		}
+
+		free(registered_buffers[i]);
+	}
+
+	registered_buffer_array_used = 0;
+
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	return;
+}
+
+nccl_ofi_hcopy_buf_handle_t *nccl_ofi_get_hcopy_buffer_handle(void *addr, size_t len) {
+	nccl_ofi_hcopy_buf_handle_t *tmp_handle;
+	size_t min, max, mid;
+	nccl_ofi_hcopy_buf_handle_t *ret_handle = NULL;
+
+	pthread_mutex_lock(&nccl_ofi_lock);
+
+	if (registered_buffer_array_used == 0) {
+		goto out;
+	}
+
+	min = 0;
+	max = registered_buffer_array_used;
+	do {
+		mid = (max - min) / 2 + min;
+		/* We have gone past the end of the loop. */
+		if (mid >= registered_buffer_array_used) {
+			break;
+		}
+		tmp_handle = registered_buffers[mid];
+		if (addr > tmp_handle->ptr) {
+			void *max_addr = (void *)((char *)tmp_handle->ptr + tmp_handle->length);
+			size_t max_len = (size_t)((char *)max_addr - (char *)addr);
+			if (addr < max_addr) {
+				if (len > max_len) {
+					NCCL_OFI_WARN("Requested range exceeds registered buffer length (0x%p, %zu) > (0x%p, %zu).",
+							addr, len, tmp_handle->ptr, tmp_handle->length);
+					ret_handle = NULL;
+				} else {
+					ret_handle = tmp_handle;
+				}
+				goto out;
+			}
+			min = mid + 1;
+		} else if (addr == tmp_handle->ptr) {
+			if (len > tmp_handle->length) {
+				NCCL_OFI_WARN("Requested range exceeds registered buffer length (0x%p, %zu) > (0x%p, %zu).",
+						addr, len, tmp_handle->ptr, tmp_handle->length);
+				ret_handle = NULL;
+			} else {
+				ret_handle = tmp_handle;
+			}
+			goto out;
+		} else {
+			if (mid == 0) {
+				break;
+			}
+			max = mid - 1;
+		}
+	} while (max >= min);
+
+out:
+	pthread_mutex_unlock(&nccl_ofi_lock);
+
+	if (ret_handle == NULL) {
+		NCCL_OFI_WARN("Unable to find a reference to the requested buffer address.");
+	}
+	return ret_handle;
+}

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -23,6 +23,12 @@
 #define EFA_PROVIDER_NAME "efa"
 #define IS_EFA_PROVIDER(NAME) (strcmp((NAME), EFA_PROVIDER_NAME)==0)
 
+#include <nccl_ofi_hcopy.h>
+
+#if HAVE_GDRCOPY
+#include <gdrapi.h>
+#endif
+
 /* NICs info list for a provider */
 struct fi_info* ofi_info_list = NULL;
 /* Number of NICs */
@@ -79,6 +85,10 @@ ncclDebugLogger_t ofi_log_function = NULL;
 int max_requests = NCCL_OFI_MAX_REQUESTS * NCCL_OFI_MAX_RECVS;
 
 const char *provider_filter = NULL;
+
+#if HAVE_GDRCOPY
+gdr_t gdr_desc = NULL;
+#endif
 
 /* Table indicating allocation state of MR keys */
 static size_t num_mr_keys = 0;
@@ -868,6 +878,109 @@ static struct fi_info *get_nic_info(int dev, struct fi_info *nic_info_list)
 	return nic_info;
 }
 
+#if HAVE_GDRCOPY
+static ssize_t copy_from_hmem(void *dest, size_t size, enum fi_hmem_iface iface,
+		uint64_t device, const struct iovec *hmem_iov,
+		size_t hmem_iov_count, uint64_t hmem_iov_offset)
+{
+	char *dest_ptr = (char*) dest;
+	ssize_t size_cpy = 0;
+	int ret;
+
+	assert(hmem_iov_offset < hmem_iov_count);
+
+	for (size_t i = hmem_iov_offset; i < hmem_iov_count; i++) {
+		if (size_cpy + hmem_iov[i].iov_len > size)
+			break;
+
+		switch (iface) {
+			case FI_HMEM_CUDA:
+				nccl_ofi_hcopy_buf_handle_t *buf_hdl =
+					nccl_ofi_get_hcopy_buffer_handle(hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+
+				if (NULL == buf_hdl) {
+					NCCL_OFI_WARN("Could not locate GDRCopy registration for 0x%p len=%zu",
+							hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+
+				ptrdiff_t offset = (uint64_t)hmem_iov[i].iov_base - buf_hdl->info.va;
+				ret = gdr_copy_from_mapping(buf_hdl->mhandle, dest_ptr,
+						(char *)buf_hdl->base_ptr + offset, hmem_iov[i].iov_len);
+				if (ret) {
+					NCCL_OFI_WARN("Error in gdr_copy_from_mapping (%d)", ret);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+				break;
+			case FI_HMEM_SYSTEM:
+				memcpy(dest_ptr, hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+				break;
+			default:
+				return -FI_EINVAL;
+		}
+
+		dest_ptr += hmem_iov[i].iov_len;
+		size_cpy += hmem_iov[i].iov_len;
+	}
+
+out:
+	return size_cpy;
+}
+
+static ssize_t copy_to_hmem(enum fi_hmem_iface iface, uint64_t device,
+		const struct iovec *hmem_iov, size_t hmem_iov_count,
+		uint64_t hmem_iov_offset, const void *src, size_t size)
+{
+	char *src_ptr = (char*) src;
+	ssize_t size_cpy = 0;
+	int ret;
+
+	assert(hmem_iov_offset < hmem_iov_count);
+
+	for (size_t i = hmem_iov_offset; i < hmem_iov_count; i++) {
+		if (size_cpy + hmem_iov[i].iov_len > size)
+			break;
+
+		switch (iface) {
+			case FI_HMEM_CUDA:
+				nccl_ofi_hcopy_buf_handle_t *buf_hdl =
+					nccl_ofi_get_hcopy_buffer_handle(hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+
+				if (NULL == buf_hdl) {
+					NCCL_OFI_WARN("Could not locate GDRCopy registration for 0x%p len=%zu",
+							hmem_iov[i].iov_base, hmem_iov[i].iov_len);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+
+				ptrdiff_t offset = (uint64_t)hmem_iov[i].iov_base - buf_hdl->info.va;
+				ret = gdr_copy_to_mapping(buf_hdl->mhandle,
+						(char *)buf_hdl->base_ptr + offset, src_ptr, hmem_iov[i].iov_len);
+				if (ret) {
+					NCCL_OFI_WARN("Error in gdr_copy_to_mapping (%d)", ret);
+					size_cpy = -FI_EOTHER;
+					goto out;
+				}
+				break;
+			case FI_HMEM_SYSTEM:
+				memcpy(hmem_iov[i].iov_base, src_ptr, hmem_iov[i].iov_len);
+				break;
+			default:
+				return -FI_EINVAL;
+		}
+
+		src_ptr  += hmem_iov[i].iov_len;
+		size_cpy += hmem_iov[i].iov_len;
+	}
+
+out:
+	return size_cpy;
+}
+#endif /* HAVE_GDRCOPY */
+
+
 /*
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric, domain, endpoint, CQ and AV.
@@ -920,6 +1033,25 @@ static ncclResult_t create_nccl_ofi_component(struct fi_info *prov,
 		ret = ncclSystemError;
 		goto error;
 	}
+
+#if HAVE_GDRCOPY
+	struct fi_hmem_override_ops hmem_ops;
+
+	hmem_ops.size = sizeof(struct fi_hmem_override_ops);
+	hmem_ops.copy_from_hmem_iov = copy_from_hmem;
+	hmem_ops.copy_to_hmem_iov   = copy_to_hmem;
+
+	ret = fi_set_ops(&(nccl_ofi_comp->domain->fid),
+			FI_SET_OPS_HMEM_OVERRIDE,
+			0, &hmem_ops, NULL);
+
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't override HMEM ops. RC: %d, ERROR: %s",
+			     ret, fi_strerror(-ret));
+		ret = ncclSystemError;
+		goto error;
+	}
+#endif
 
 	/* Create transport level communication endpoint(s) */
 	ret = fi_endpoint(nccl_ofi_comp->domain, prov, &(nccl_ofi_comp->ep), NULL);
@@ -985,6 +1117,7 @@ error:
 		fi_close((fid_t)nccl_ofi_comp->av);
 	if (nccl_ofi_comp->cq)
 		fi_close((fid_t)nccl_ofi_comp->cq);
+
 exit:
 	return ret;
 }
@@ -1466,6 +1599,15 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 	/* Store the cq_read_count parameter value in a global
 	   variable to avoid the lookup overhead during execution. */
 	cq_read_count = ofi_nccl_cq_read_count();
+
+#if HAVE_GDRCOPY
+	gdr_desc = gdr_open();
+	if (!gdr_desc) {
+		NCCL_OFI_WARN("GDRCopy initialization failed.");
+		ret = ncclSystemError;
+		goto exit;
+	}
+#endif
 
 exit:
 	if (ret != ncclSuccess) {
@@ -2476,7 +2618,7 @@ ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, int size, int type,
 #endif
 			      void **mhandle)
 {
-	struct fid_mr *mr_handle = NULL;
+	nccl_ofi_mr_handle_t *mr_handle = NULL;
 	ncclResult_t ret = ncclSuccess;
 
 	ofiComm_t *ofi_comm = (ofiComm_t *)comm;
@@ -2504,7 +2646,41 @@ ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, int size, int type,
 		goto exit;
 	};
 
-	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle);
+	mr_handle = malloc(sizeof(nccl_ofi_mr_handle_t));
+	if (mr_handle == NULL) {
+		NCCL_OFI_WARN("Unable to allocate MR handle");
+		ret = ncclSystemError;
+		goto exit;
+	}
+	mr_handle->addr = data;
+	mr_handle->size = size;
+	mr_handle->type = type;
+	mr_handle->fi_handle = NULL;
+
+	ret = register_mr_buffers(ofi_comm, data, size, type, &mr_handle->fi_handle);
+
+	if (ret) {
+		NCCL_OFI_WARN("register_mr_buffers failed (%d)", ret);
+		ret = ncclSystemError;
+		goto exit;
+	}
+
+#if HAVE_GDRCOPY
+	if (type == NCCL_PTR_CUDA) {
+		ret = nccl_ofi_hcopy_register(data, size);
+		if (ret) {
+			NCCL_OFI_WARN("nccl_ofi_hcopy_register failed (%d)", ret);
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
+	/* No OFI registration and no GDR registration */
+	else
+#endif
+	if (mr_handle->fi_handle == NULL) {
+		free(mr_handle);
+		mr_handle = NULL;
+	}
 
 exit:
 	*mhandle = (void *)mr_handle;
@@ -2515,7 +2691,7 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 {
 	ncclResult_t ret = ncclSuccess;
 	int rc;
-	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
+	nccl_ofi_mr_handle_t *mr_handle = (nccl_ofi_mr_handle_t *)mhandle;
 
 	/* Validate Comm */
 	if (OFI_UNLIKELY(comm == NULL)) {
@@ -2529,8 +2705,19 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 		goto exit;
 	}
 
+#if HAVE_GDRCOPY
+	if (mr_handle->type == NCCL_PTR_CUDA) {
+		ret = nccl_ofi_hcopy_unregister(mr_handle->addr);
+		if (ret) {
+			NCCL_OFI_WARN("nccl_ofi_hcopy_unregister failed (%d)", ret);
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
+#endif
+
 	if (!prov_key_mr) {
-		uint64_t key = fi_mr_key(mr_handle);
+		uint64_t key = fi_mr_key(mr_handle->fi_handle);
 		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			ret = ncclSystemError;
 			NCCL_OFI_WARN("Error retrieving MR key, leaking key");
@@ -2542,12 +2729,18 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 		}
 	}
 
-	rc = fi_close((fid_t)mr_handle);
-	if (OFI_UNLIKELY(rc != 0)) {
-		ret = ncclSystemError;
-		NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-				rc, fi_strerror(-rc));
+	if (OFI_LIKELY(mr_handle->fi_handle != NULL)) {
+		rc = fi_close((fid_t)mr_handle->fi_handle);
+		if (OFI_UNLIKELY(rc != 0)) {
+			ret = ncclSystemError;
+			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+				      rc, fi_strerror(-rc));
+		}
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Null MR handle provided. Skipping deregisteration.");
 	}
+
+	free(mr_handle);
 
 exit:
 	return ret;
@@ -2637,7 +2830,7 @@ ncclResult_t nccl_net_ofi_isend(void *sendComm, void* data, int size,
 	req->dev = sComm->dev;
 	req->direction = NCCL_OFI_SEND;
 
-	if (mhandle != NULL)
+	if (mhandle != NULL && ((nccl_ofi_mr_handle_t*)mhandle)->fi_handle != NULL)
 		desc = fi_mr_desc(mhandle);
 
 	NCCL_OFI_TRACE_SEND(req->dev, size, req, request, &req->ctx);
@@ -2736,10 +2929,11 @@ ncclResult_t nccl_net_ofi_irecv(void* recvComm, int n, void** buffers, int* size
 	/* Currently, plugin doesn't support grouped receives */
 	assert(n <= NCCL_OFI_MAX_RECVS);
 	for (int recv_n = 0; recv_n < n; recv_n++) {
+		nccl_ofi_mr_handle_t **mr_handles = (nccl_ofi_mr_handle_t**) mhandles;
 		void *desc = NULL;
 
-		if (mhandles[recv_n] != NULL) {
-			desc = fi_mr_desc(mhandles[recv_n]);
+		if (mr_handles[recv_n] && mr_handles[recv_n]->fi_handle != NULL) {
+			desc = fi_mr_desc(mr_handles[recv_n]->fi_handle);
 		}
 
         NCCL_OFI_TRACE_RECV(rComm->dev, rComm->tag, sizes[recv_n], req, request, &req->ctx);
@@ -2889,8 +3083,9 @@ ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* siz
 		goto exit;
 	}
 
-	if (mhandles && mhandles[flush_n])
-		mr_handle = (struct fid_mr *)mhandles[flush_n];
+	nccl_ofi_mr_handle_t **mr_handles = (nccl_ofi_mr_handle_t**) mhandles;
+	if (mr_handles && mr_handles[flush_n]->fi_handle)
+		mr_handle = mr_handles[flush_n]->fi_handle;
 
 	data = buffers[flush_n];
 


### PR DESCRIPTION
@rashikakheria I'd like to add a new branch called `v1.6.0-hcopy` to make the HMEM copy overrides using GDRCopy available to users of aws-ofi-nccl. This patch overrides the `copy_from_hmem_iov` and `copy_to_hmem_iov` to directly use GDRCopy. This can be helpful with providers that don't have GDRCopy support or have some issue in GDRCopy support that needs to be worked around.

Could you please push a branch called `v1.6.0-hcopy` at the same location as the `v1.6.0` tag? Once the branch has been created, we can change the base branch of this PR to that branch instead of `v1.6.x`.

Thanks!