### PR TITLE
Only include fi_ext.h when needed

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -17,7 +17,6 @@ extern "C" {
 #include <rdma/fi_cm.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_rma.h>
-#include <rdma/fi_ext.h>
 #if HAVE_NEURON
 #include "nccl-headers/net_neuron.h"
 #else

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -30,14 +30,19 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [check_pkg_found=no])])
-  
+
+  AC_CHECK_HEADERS([rdma/fi_ext.h])
+
   AC_CHECK_DECLS([FI_OPT_CUDA_API_PERMITTED,
                   FI_OPT_EFA_USE_DEVICE_RDMA,
                   FI_OPT_EFA_EMULATED_WRITE,
                   FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
                   FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES],
-                  [], [], [[#include <rdma/fi_endpoint.h>
-                            #include <rdma/fi_ext.h>]])
+                  [], [], [AC_INCLUDES_DEFAULT
+[#include <rdma/fi_endpoint.h>
+#ifdef HAVE_RDMA_FI_EXT_H
+#include <rdma/fi_ext.h>
+#endif]])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [$1],

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -12,6 +12,9 @@
 #include <string.h>
 #include <unistd.h>
 #include <inttypes.h>
+#ifdef HAVE_RDMA_FI_EXT_H
+#include <rdma/fi_ext.h>
+#endif
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_log.h"


### PR DESCRIPTION
fi_ext.h was introduced in Libfabric 1.13.0, so is not available in some versions of Libfabric that are supported by the plugin. All the features we use in fi_ext.h are already protected by compatibility checks, so only include fi_ext.h where it is needed and when available.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit e16fe06b8f2f06ef5da0f593453558acaa31be64)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
