### PR TITLE
Fix missing MPI or old Libfabric checks

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -84,12 +84,15 @@ CHECK_PKG_HWLOC([],
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
 
 AC_ARG_ENABLE([tests],
-   [AS_HELP_STRING([--disable-tests], [Disable build of test binaries])])
+   [AS_HELP_STRING([--disable-tests], [Disable build of functional test binaries])])
 AS_IF([test "${enable_tests}" != "no" -a "${enable_neuron}" = "yes"],
       [AC_MSG_WARN([Disabling tests due to Neuron configuration.])
        enable_tests=no],
       [test "${enable_tests}" = "yes" -a "${found_mpi}" = "no"],
-      [AC_MSG_ERROR([Tests requested, but MPI not found.  Aborting.])])
+      [AC_MSG_ERROR([Tests requested, but MPI not found.  Aborting.])],
+      [test "${found_mpi}" = "no"],
+      [AC_MSG_WARN([Disabling tests due to no MPI.])
+       enable_tests=no])
 AM_CONDITIONAL([ENABLE_TESTS], [test "$enable_tests" != "no"])
 
 # Enable output at the TRACE level for unit tests.

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -31,9 +31,26 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
   AS_IF([test "${check_pkg_found}" = "yes"],
         [AC_SEARCH_LIBS([fi_getinfo], [fabric], [], [check_pkg_found=no])])
 
-  AC_CHECK_HEADERS([rdma/fi_ext.h])
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [AC_MSG_CHECKING([for Libfabric 1.11.0 or later])
+	 AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+[[#include <rdma/fabric.h>
+]],
+[[#if !defined(FI_MAJOR_VERSION)
+#error "we cannot check the version -- sad panda"
+#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION(1,11))
+#error "version is too low -- nopes"
+#endif
+]])],
+                      [AC_MSG_RESULT([yes])],
+                      [AC_MSG_RESULT([no])
+                       check_pkg_found=no])])
 
-  AC_CHECK_DECLS([FI_OPT_CUDA_API_PERMITTED,
+  AS_IF([test "${check_pkg_found}" = "yes"],
+	[AC_CHECK_HEADERS([rdma/fi_ext.h])])
+
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [AC_CHECK_DECLS([FI_OPT_CUDA_API_PERMITTED,
                   FI_OPT_EFA_USE_DEVICE_RDMA,
                   FI_OPT_EFA_EMULATED_WRITE,
                   FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
@@ -42,7 +59,7 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
 [#include <rdma/fi_endpoint.h>
 #ifdef HAVE_RDMA_FI_EXT_H
 #include <rdma/fi_ext.h>
-#endif]])
+#endif]])])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [$1],


### PR DESCRIPTION
Add test for older Libfabric and fail configure with an obvious error message, rather than amorphous compile errors.

If MPI isn't found, disable the functional tests (if not explicitly enabled) rather than causing compile errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
