### PR TITLE
Update version to 1.7.0rc2-aws

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.7.0rc1-aws], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.7.0rc2-aws], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
rc1 has escaped, make way for rc2


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
