### PR TITLE
Initialize send/recv request state

### DIFF
--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -706,6 +706,7 @@ static inline nccl_net_ofi_sendrecv_req_t *allocate_req(nccl_ofi_freelist_t *fl)
 	}
 
 	req->base.test = test;
+	req->state = NCCL_OFI_SENDRECV_REQ_CREATED;
 
  exit:
 	return req;


### PR DESCRIPTION
While the return path resets the request state to REQ_CREATED, the allocation path does not.  This means that there is an uninitialized variable usage the first time a request is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
