### PR TITLE
Backport 2 cleanups from master

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3488,7 +3488,7 @@ static ncclResult_t flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buf
 static inline nccl_net_ofi_rdma_recv_comm_t *calloc_rdma_recv_comm(int num_rails)
 {
 	return calloc(1, sizeof(nccl_net_ofi_rdma_recv_comm_t)
-		      + num_rails * sizeof(nccl_net_ofi_rdma_recv_comm_t));
+		      + num_rails * sizeof(nccl_net_ofi_rdma_recv_comm_rail_t));
 }
 
 /*
@@ -4852,7 +4852,7 @@ static void prepare_send_connect_message(nccl_net_ofi_rdma_ep_t *ep,
 static inline nccl_net_ofi_rdma_send_comm_t *calloc_rdma_send_comm(int num_rails)
 {
 	return calloc(1, sizeof(nccl_net_ofi_rdma_send_comm_t)
-		      + num_rails * sizeof(nccl_net_ofi_rdma_send_comm_t));
+		      + num_rails * sizeof(nccl_net_ofi_rdma_send_comm_rail_t));
 }
 
 /*

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -706,6 +706,7 @@ static inline nccl_net_ofi_sendrecv_req_t *allocate_req(nccl_ofi_freelist_t *fl)
 	}
 
 	req->base.test = test;
+	req->state = NCCL_OFI_SENDRECV_REQ_CREATED;
 
  exit:
 	return req;


### PR DESCRIPTION
Backport both the fix to allocate the right rail size in the rdma transport and to properly initialize state in the sendrecv transport for the v1.7.x branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
