### PR TITLE
Temporarily disable NLVS on AWS platforms

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -377,6 +377,22 @@ ncclResult_t platform_init(void)
 			goto exit;
 		}
 	}
+
+	/* Disable NVLS topology discovery.  There's a bug with EFA
+	 * and NCCL 2.17/2.18 that is still under investigation that
+	 * causes random failures due to memory corruption during
+	 * initialization.  For now, skip that code.  We need to come
+	 * back to this when the bug is fixed.
+	 */
+	if (getenv("NCCL_NVLS_ENABLE") == NULL) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Disabling NVLS support when using Libfabric on AWS.");
+		rc = setenv("NCCL_NVLS_ENABLE", "0", 1);
+		if (rc != 0) {
+			NCCL_OFI_WARN("Unable to set NCCL_NVLS_ENABLE");
+			ret = ncclSystemError;
+			goto exit;
+		}
+	}
 #endif
 
 	/*


### PR DESCRIPTION
During topology discovery, the NVLS detection code and AWS don't see eye to eye and cause memory corruption.  The investigation of the issue is on-going, but for now, disable NVLS to avoid memory corruption.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
