### PR TITLE
Dynamically load cuda dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tests/unit/*.trs
 tests/functional/nccl_connection
 tests/functional/nccl_message_transfer
 tests/functional/ring
+tests/functional/cuda_check
 tests/unit/msgbuff
 tests/unit/freelist
 tests/unit/deque
@@ -60,4 +61,3 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
-

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -553,21 +553,6 @@ ncclResult_t nccl_net_ofi_reg_mr_dma_buf_send_comm(nccl_net_ofi_send_comm_t *sen
  */
 ncclResult_t nccl_net_ofi_free_mr_key(nccl_ofi_mr_keypool_t *key_pool, uint64_t key);
 
-#if HAVE_CUDA
-/*
- * @brief	Gets the CUDA device associated with the buffer
- *
- * @param	data
- *		Pointer to CUDA buffer.
- *
- * @return	Valid CUDA device ID on success
- *		-1 on error
- * @return	0 on success
- *		non-zero on error
- */
-ncclResult_t nccl_net_ofi_get_cuda_device(void *data, int *dev_id);
-#endif
-
 /*
  * @brief	Allocate a memory registration key
  */

--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_CUDA_H_
+#define NCCL_OFI_CUDA_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <cuda_runtime.h>
+
+int nccl_net_ofi_cuda_init(void);
+
+/*
+ * @brief	Gets the CUDA device associated with the buffer
+ *
+ * @param	data
+ *		Pointer to CUDA buffer.
+ *
+ * @return	Valid CUDA device ID on success
+ *		-1 on error
+ * @return	0 on success
+ *		non-zero on error
+ */
+ncclResult_t nccl_net_ofi_get_cuda_device(void *data, int *dev_id);
+
+extern cudaError_t (*nccl_net_ofi_cudaRuntimeGetVersion)(int *runtimeVersion);
+
+extern cudaError_t (*nccl_net_ofi_cudaPointerGetAttributes)(struct cudaPointerAttributes* attributes, const void* ptr);
+
+extern cudaError_t (*nccl_net_ofi_cudaGetDevice)(int* device);
+extern cudaError_t (*nccl_net_ofi_cudaGetDeviceCount)(int* count);
+
+#if CUDART_VERSION >= 11030
+extern cudaError_t (*nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites)(enum cudaFlushGPUDirectRDMAWritesTarget target,
+								      enum cudaFlushGPUDirectRDMAWritesScope scope);
+#else
+extern void *nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites;
+#endif
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_H_

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -22,25 +22,33 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [test "${with_cuda}" = "no"],
         [check_pkg_found=no],
         [AS_IF([test -d ${with_cuda}/lib64], [check_pkg_libdir="lib64"], [check_pkg_libdir="lib"])
+
+         CUDA_LDFLAGS="-L${with_cuda}/${check_pkg_libdir}"
+
          CPPFLAGS="-I${with_cuda}/include ${CPPFLAGS}"
-         LDFLAGS="-L${with_cuda}/${check_pkg_libdir} ${LDFLAGS}"])
+         LDFLAGS="${CUDA_LDFLAGS} ${LDFLAGS}"])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [AC_CHECK_HEADERS([cuda_runtime.h], [], [check_pkg_found=no])])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
-        [AC_SEARCH_LIBS([cudaPointerGetAttributes], [cudart], [], [check_pkg_found=no])])
+        [AC_SEARCH_LIBS([cudaHostAlloc], [cudart], [CUDA_LIBS="-lcudart"], [check_pkg_found=no])])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [check_pkg_define=1
          $1],
         [check_pkg_define=0
          CPPFLAGS="${check_pkg_CPPFLAGS_save}"
-         LDFLAGS="${check_pkg_LDFLAGS_save}"
-         LIBS="${check_pkg_LIBS_save}"
          $2])
 
   AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
+  AM_CONDITIONAL([HAVE_CUDA], [test "${check_pkg_found}" = "yes"])
+
+  AC_SUBST([CUDA_LDFLAGS])
+  AC_SUBST([CUDA_LIBS])
+
+  LDFLAGS="${check_pkg_LDFLAGS_save}"
+  LIBS="${check_pkg_LIBS_save}"
 
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -17,6 +17,10 @@ sources = \
 	nccl_ofi_deque.c \
 	tracepoint.c
 
+if HAVE_CUDA
+sources += nccl_ofi_cuda.c
+endif
+
 if WANT_PLATFORM_AWS
 sources += platform-aws.c
 endif

--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <dlfcn.h>
+
+#include "nccl_ofi.h"
+#include "nccl_ofi_cuda.h"
+
+cudaError_t (*nccl_net_ofi_cudaRuntimeGetVersion)(int *runtimeVersion) = NULL;
+cudaError_t (*nccl_net_ofi_cudaPointerGetAttributes)(struct cudaPointerAttributes* attributes, const void* ptr) = NULL;
+cudaError_t (*nccl_net_ofi_cudaGetDevice)(int* device) = NULL;
+cudaError_t (*nccl_net_ofi_cudaGetDeviceCount)(int* count) = NULL;
+cudaError_t (*nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites)(enum cudaFlushGPUDirectRDMAWritesTarget target,
+							   enum cudaFlushGPUDirectRDMAWritesScope scope) = NULL;
+
+#define STRINGIFY(sym) # sym
+
+#define LOAD_SYM(sym)							\
+	nccl_net_ofi_ ## sym = dlsym(cudart_lib, STRINGIFY(sym));	\
+	if (nccl_net_ofi_ ## sym == NULL) {				\
+		NCCL_OFI_WARN("Failed to load symbol " STRINGIFY(sym)); \
+		ret = -ENOTSUP;						\
+		goto error;						\
+	}								\
+
+int
+nccl_net_ofi_cuda_init(void)
+{
+	int ret = 0;
+	void *cudart_lib = NULL;
+
+	(void) dlerror(); /* Clear any previous errors */
+	cudart_lib = dlopen("libcudart.so", RTLD_NOW);
+	if (cudart_lib == NULL) {
+		NCCL_OFI_WARN("Failed to find CUDA Runtime library: %s", dlerror());
+		ret = -ENOTSUP;
+		goto error;
+	}
+
+	LOAD_SYM(cudaRuntimeGetVersion);
+	LOAD_SYM(cudaPointerGetAttributes);
+	LOAD_SYM(cudaGetDevice);
+	LOAD_SYM(cudaGetDeviceCount);
+	LOAD_SYM(cudaDeviceFlushGPUDirectRDMAWrites);
+
+error:
+	return ret;
+}
+
+
+ncclResult_t nccl_net_ofi_get_cuda_device(void *data, int *dev_id)
+{
+	ncclResult_t ret = ncclSuccess;
+	int cuda_device = -1;
+	struct cudaPointerAttributes attr;
+	cudaError_t cuda_ret = nccl_net_ofi_cudaPointerGetAttributes(&attr, data);
+
+	if (cuda_ret != cudaSuccess) {
+		ret = ncclUnhandledCudaError;
+		NCCL_OFI_WARN("Invalid buffer pointer provided");
+		goto exit;
+	}
+
+	if (attr.type == cudaMemoryTypeDevice) {
+		cuda_device = attr.device;
+	} else {
+		ret = ncclInternalError;
+		NCCL_OFI_WARN("Invalid type of buffer provided. Only device memory is expected for NCCL_PTR_CUDA type");
+	}
+
+ exit:
+	*dev_id = cuda_device;
+	return ret;
+}
+

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -10,12 +10,12 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <stdlib.h>
-#if HAVE_CUDA
-#include <cuda_runtime.h>
-#endif
 
 #include "nccl-headers/error.h"
 #include "nccl_ofi.h"
+#if HAVE_CUDA
+#include "nccl_ofi_cuda.h"
+#endif
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_math.h"
@@ -3361,7 +3361,7 @@ static ncclResult_t flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buf
 
 #if CUDART_VERSION >= 11030
 	if (cuda_flush) {
-		cudaError_t cuda_ret = cudaDeviceFlushGPUDirectRDMAWrites(
+		cudaError_t cuda_ret = nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites(
 			cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
 			cudaFlushGPUDirectRDMAWritesToOwner);
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -8,11 +8,11 @@
 #include <stdio.h>
 #include <sys/mman.h>
 #include <unistd.h>
-#if HAVE_CUDA
-#include <cuda_runtime.h>
-#endif
 
 #include "nccl_ofi.h"
+#if HAVE_CUDA
+#include "nccl_ofi_cuda.h"
+#endif
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_sendrecv.h"
 #include "nccl_ofi_freelist.h"
@@ -885,7 +885,7 @@ static ncclResult_t flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buf
 
 #if CUDART_VERSION >= 11030
 	if (cuda_flush) {
-		cudaError_t cuda_ret = cudaDeviceFlushGPUDirectRDMAWrites(
+		cudaError_t cuda_ret = nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites(
 			cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
 			cudaFlushGPUDirectRDMAWritesToOwner);
 

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -6,16 +6,22 @@
 
 
 AM_CPPFLAGS = -I$(top_srcdir)/include $(MPI_CPPFLAGS)
-AM_LDFLAGS = $(MPI_LDFLAGS)
-LDADD = $(top_builddir)/src/libnccl-net.la $(MPI_LIBS) -lcudart
+AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
+LDADD = $(top_builddir)/src/libnccl-net.la $(MPI_LIBS) $(CUDA_LIBS)
 CC = $(MPICC)
 
 noinst_HEADERS = test-common.h
 
 if ENABLE_TESTS
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring
+bin_PROGRAMS = nccl_connection nccl_message_transfer ring cuda_check
 endif
 
 nccl_connection_SOURCES = nccl_connection.c
 nccl_message_transfer_SOURCES = nccl_message_transfer.c
 ring_SOURCES = ring.c
+
+cuda_check_SOURCES = cuda_check.c
+# Override the LDADD for this check to avoid the -lcudart used by the
+# other tests, since the purpose of this test is to make sure we
+# didn't leak direct cuda dependencies into the plugin.
+cuda_check_LDADD = $(top_builddir)/src/libnccl-net.la

--- a/tests/functional/cuda_check.c
+++ b/tests/functional/cuda_check.c
@@ -1,0 +1,23 @@
+/*
+ * Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+/*
+ * This test is the only functional test that does not directly link
+ * against libcudart.  Its purpose is to ensure that that the build
+ * will fail if a direct cuda call is made from the plugin.
+ */
+
+#include "config.h"
+
+#include "nccl-headers/net.h"
+
+void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
+	    int line, const char *fmt, ...)
+{
+}
+
+int main(int argc, char* argv[])
+{
+	return nccl_net_ofi_init(logger);
+}


### PR DESCRIPTION
CUDA 12 changed the libcudart major version number, but did not break the API of any of the interface functions that we use.  Rather than force everyone to build multiple versions of the plugin for moving between CUDA 11 and CUDA 12, dynamically load the libcudart.so dependency and reference the few CUDA symbols we use via function pointers.

Tested the functional tests and megatron-lm successfully.  Also added a direct call to a CUDA function in the plugin to verify that the new cuda_check test will throw a link-time error in that case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
