### PR TITLE
Fix compilation, declare support_gdr as extern

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -90,7 +90,8 @@ extern int max_reqs;
 
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t {GDR_UNKNOWN, GDR_SUPPORTED, GDR_UNSUPPORTED};
-enum gdr_support_level_t support_gdr;
+extern enum gdr_support_level_t support_gdr;
+
 
 /* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
  * to flush data to the GPU. Note, CUDA flush support is not supported on all

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -19,6 +19,7 @@
 #endif
 
 #include "stack.h"
+#include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
 #include "tracepoint.h"
 #include "nccl_ofi_sendrecv.h"


### PR DESCRIPTION
support_gdr is a global variable which should declared as extern to prevent linking issues.  
Fix commit b9351fe28 ("Delay GDR detection to account for 1.18 API")



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
