### PR TITLE
Don't install cuda_check test

### DIFF
--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -13,7 +13,8 @@ CC = $(MPICC)
 noinst_HEADERS = test-common.h
 
 if ENABLE_TESTS
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring cuda_check
+bin_PROGRAMS = nccl_connection nccl_message_transfer ring
+noinst_PROGRAMS = cuda_check
 endif
 
 nccl_connection_SOURCES = nccl_connection.c


### PR DESCRIPTION
The cuda_check functional test is really a link test, to make sure that we did not leak cuda symbols into the plugin.  It doesn't make sense for users to run it, so don't install it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
