### PR TITLE
Add ofi_nccl_cuda.h to dist tarball

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -6,6 +6,7 @@
 
 noinst_HEADERS = \
 	nccl_ofi.h \
+	nccl_ofi_cuda.h \
 	nccl_ofi_sendrecv.h \
 	nccl_ofi_rdma.h \
 	nccl_ofi_scheduler.h \


### PR DESCRIPTION
When we added ofi_nccl_cuda.{c,h}, forgot to update the makefile to include the headers.  This fixes "make dist".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
