### PR TITLE
[freelist] Fix invalid free in error handling

### DIFF
--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -182,7 +182,7 @@ int nccl_ofi_freelist_add(nccl_ofi_freelist_t *freelist,
 					 &block->mr_handle);
 		if (ret != 0) {
 			NCCL_OFI_WARN("freelist extension registration failed: %d", ret);
-			free(block);
+			free(block->memory);
 			return ret;
 		}
 	} else {


### PR DESCRIPTION
In an error condition (memory registration failed) freelist frees the wrong pointer. We shouldn't be hitting this in normal conditions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
