### PR TITLE
Add support for FI_CONTEXT2

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ support the following features as defined in the
 [libfabric API documentation](https://github.com/ofiwg/libfabric/tree/master/man/).
 
 * Tagged messaging (`FI_TAGGED`, `FI_MSG`)
-* Data transfer context structures (`FI_CONTEXT`)
+* Data transfer context structures (`FI_CONTEXT`, `FI_CONTEXT2`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
 * Communication with remote endpoints (`FI_REMOTE_COMM`)

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -199,7 +199,7 @@ typedef struct nccl_net_ofi_sendrecv_req {
 	nccl_net_ofi_comm_t *comm;
 
 	/* Associated OFI Context */
-	struct fi_context ctx;
+	struct fi_context ctx[2];
 
 	/* Associated Device ID */
 	int dev_id;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -445,7 +445,7 @@ static void get_hints(struct fi_info *hints, int req_gdr)
 	 */
 	hints->caps |= FI_DIRECTED_RECV | FI_RMA | FI_WRITE | FI_REMOTE_WRITE;
 
-	hints->mode = FI_CONTEXT;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 
 	hints->ep_attr->type = FI_EP_RDM;
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -217,7 +217,7 @@ static inline void zero_nccl_ofi_req(nccl_net_ofi_sendrecv_req_t *req)
 {
 	req->comm = NULL;
 
-	memset(&req->ctx, 0, sizeof(struct fi_context));
+	memset(&req->ctx, 0, sizeof(req->ctx));
 
 	req->dev_id = -1;
 	req->size = 0;


### PR DESCRIPTION
Closes #204 

- Adds FI_CONTEXT2 to the list of data transfer context structures in the readme
- Changes the declaration of fi_context to become an array of two fi_context structs
- Adds FI_CONTEXT2 as a mode hint that is passed to the provider to infer support for FI_CONTEXT2
- Changes memset of ctx to extend for array of two ctxs, will still support initial behavior for fi_context


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
