### PR TITLE
init: Free topology also when RDMA init fails

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1107,13 +1107,14 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 		}
 
 		ret = nccl_net_ofi_rdma_init(topo, provide_own_mr_key);
+
+		nccl_ofi_topo_free(topo);
+
 		if (ret != ncclSuccess) {
 			NCCL_OFI_WARN("Failed to initialize rdma protocol");
 			ret = ncclInternalError;
 			goto exit;
 		}
-
-		nccl_ofi_topo_free(topo);
 	} else {
 		NCCL_OFI_WARN("Unable to find plugin protocol %s", nccl_ofi_selected_protocol);
 		ret = ncclInternalError;


### PR DESCRIPTION
Topology should be freed regardless if RDMA init failed or succeed. As it's not needed after RDMA init call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.