### PR TITLE
MR: Set minimal access permissions for each MR based on its usage

### DIFF
--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -49,7 +49,8 @@ struct nccl_ofi_freelist_block_t {
  * Note that the freelist lock will be held during this function.  The
  * caller must avoid a deadlock situation with this behavior.
  */
-typedef int (*nccl_ofi_freelist_regmr_fn)(void *opaque, void *data, size_t size,
+typedef int (*nccl_ofi_freelist_regmr_fn)(void *opaque,
+					  void *data, size_t size, uint64_t access,
 					  void **handle);
 
 /*
@@ -100,6 +101,7 @@ struct nccl_ofi_freelist_t {
 	bool have_reginfo;
 	nccl_ofi_freelist_regmr_fn regmr_fn;
 	nccl_ofi_freelist_deregmr_fn deregmr_fn;
+	uint64_t mr_access;
 	void *regmr_opaque;
 	size_t reginfo_offset;
 
@@ -152,6 +154,7 @@ int nccl_ofi_freelist_init_mr(size_t entry_size,
 			      size_t max_entry_count,
 			      nccl_ofi_freelist_regmr_fn regmr_fn,
 			      nccl_ofi_freelist_deregmr_fn deregmr_fn,
+			      uint64_t mr_access,
 			      void *regmr_opaque,
 			      size_t reginfo_offset,
 			      nccl_ofi_freelist_t **freelist_p);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -489,15 +489,19 @@ static ncclResult_t register_mr_buffers(struct fid_domain *domain, struct fid_ep
 	/* Initialize MR attributes */
 	mr_attr.mr_iov = &iov;
 	mr_attr.iov_count = 1;
+
+	/* Communication buffer is used as a message source/target */
 	mr_attr.access = FI_SEND | FI_RECV;
 
 	switch (type) {
 	case NCCL_PTR_HOST:
+		/* Host buffer is used as a RMA read target on GPU flush */
 		mr_attr.access |= FI_READ;
 		mr_attr.iface = FI_HMEM_SYSTEM;
 		break;
 #if HAVE_CUDA
 	case NCCL_PTR_CUDA:
+		/* CUDA buffer is used as a RMA read source on GPU flush */
 		mr_attr.access |= FI_REMOTE_READ;
 		mr_attr.iface = FI_HMEM_CUDA;
 
@@ -510,7 +514,6 @@ static ncclResult_t register_mr_buffers(struct fid_domain *domain, struct fid_ep
 #endif
 #if HAVE_NEURON
 	case NCCL_PTR_NEURON:
-		mr_attr.access |= FI_REMOTE_READ;
 		mr_attr.iface = FI_HMEM_NEURON;
 		/*
 		 * Store a sentinel; libfabric requires this to be initialized Libfabric


### PR DESCRIPTION
This PR is composed of 2 commits.
The 1st commit fixes a bug in MR access permissions setting for RMA reads. It is a minimal change to the functions initializing the MR attributes that just fixes the issue.
The 2nd commit change the codebase such that the various MR users determines the specific MR access permissions they require rather than setting the MR permission overly permissive for all possible use cases. This is less error prone (As the bug fixed in 1st commit) and provides some protection on mistakenly confusing MR handles, as that would lead to MR access permission failure rather than potentially a memory corruption issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
