### PR TITLE
Fix error-case memory handling in freelist and RDMA protocol

### DIFF
--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -174,7 +174,6 @@ int nccl_ofi_freelist_add(nccl_ofi_freelist_t *freelist,
 	block = (struct nccl_ofi_freelist_block_t*)(buffer + (freelist->entry_size * allocation_count));
 	block->memory = buffer;
 	block->next = freelist->blocks;
-	freelist->blocks = block;
 
 	if (freelist->regmr_fn) {
 		ret = freelist->regmr_fn(freelist->regmr_opaque, block->memory,
@@ -188,6 +187,8 @@ int nccl_ofi_freelist_add(nccl_ofi_freelist_t *freelist,
 	} else {
 		block->mr_handle = NULL;
 	}
+
+	freelist->blocks = block;
 
 	for (size_t i = 0 ; i < allocation_count ; ++i) {
 		struct nccl_ofi_freelist_elem_t *entry;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1986,7 +1986,9 @@ static inline ncclResult_t free_bounce_req(nccl_net_ofi_rdma_req_t *req,
 	rdma_req_bounce_data_t *bounce_data = get_bounce_data(req);
 	nccl_net_ofi_rdma_ep_t *ep = bounce_data->ep;
 	/* Free buffer */
-	nccl_ofi_freelist_entry_free(ep->bounce_buff_fl, bounce_data->bounce_fl_item);
+	if (bounce_data->bounce_fl_item) {
+		nccl_ofi_freelist_entry_free(ep->bounce_buff_fl, bounce_data->bounce_fl_item);
+	}
 	return free_base_req(NULL, ep->bounce_buff_reqs_fl, req, false);
 }
 


### PR DESCRIPTION
1. If memory allocation fails, don't leave a dangling pointer in the freelist.
2. Check for non-NULL pointer before freeing `bounce_fl_item`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
