### PR TITLE
Force allocation of registered memory to be page-aligned

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -138,6 +138,9 @@ extern const char *nccl_ofi_selected_protocol;
 /* Internode network latency reported to NCCL. */
 extern float net_latency;
 
+/* Size of system memory pages */
+extern long system_page_size;
+
 struct nccl_net_ofi_plugin;
 struct nccl_net_ofi_device;
 struct nccl_net_ofi_ep;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -562,6 +562,37 @@ ncclResult_t nccl_net_ofi_free_mr_key(nccl_ofi_mr_keypool_t *key_pool, uint64_t 
 uint64_t nccl_net_ofi_allocate_mr_key(nccl_ofi_mr_keypool_t *key_pool);
 
 /*
+ * @brief	Allocate memory region for memory registration
+ *
+ * This function allocates memory that covers full page aligned.
+ *
+ * Internally allocated memory that is registered is required to cover
+ * full memory pages. For more information, see functions
+ * `register_internal_mr_buffers()` and `reg_internal_mr_ep()`.
+ *
+ * To free deallocate the memory region, function
+ * nccl_net_ofi_dealloc_mr_buffer() must be used.
+ *
+ * @param	size
+ *		Size of the memory region. Must be a multiple of system memory page size.
+ * @return	Pointer to memory region. Memory region is aligned to system memory page size.
+ * @return	0, on success
+ *		error, on others
+ */
+int nccl_net_ofi_alloc_mr_buffer(size_t size, void **ptr);
+
+/*
+ * @brief	Deallocate memory region allocated by function nccl_net_ofi_alloc_mr_buffer()
+ *
+ * @return	Pointer to memory region
+ * @param	size
+ *		Size of the memory region
+ * @return	0, on success
+ *		error, on others
+ */
+int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
+
+/*
  * @brief	Free libfabric NIC info list.
  *
  * Frees each node of the list. No operation if list is NULL.

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -34,6 +34,7 @@ struct nccl_ofi_freelist_elem_t {
 struct nccl_ofi_freelist_block_t {
 	struct nccl_ofi_freelist_block_t *next;
 	void *memory;
+	size_t memory_size;
 	void *mr_handle;
 };
 

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -49,6 +49,14 @@ struct nccl_ofi_freelist_block_t {
  *
  * Note that the freelist lock will be held during this function.  The
  * caller must avoid a deadlock situation with this behavior.
+ *
+ * The registered memory region must cover full memory pages. For more
+ * information, see function reg_internal_mr_ep().
+ *
+ * @param	data
+ *		Pointer to MR. MR must be aligned to system memory page size.
+ * @param	size
+ *		Size of MR. Size must be a multiple of system memory page size.
  */
 typedef int (*nccl_ofi_freelist_regmr_fn)(void *opaque, void *data, size_t size,
 					  void **handle);

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -32,6 +32,22 @@ extern "C" {
  */
 #define NCCL_OFI_IS_POWER_OF_TWO(x) ((x) && (((x) & ((x) - 1)) == 0))
 
+/*
+ * @brief	Round value down to be a multiple of alignment
+ *
+ * @param	y
+ *		Must be a power of two
+ */
+#define NCCL_OFI_ROUND_DOWN(x, y) ((x) & (~((y) - 1)))
+
+/*
+ * @brief	Round value up to be a multiple of alignment
+ *
+ * @param	y
+ *		Must be a power of two
+ */
+#define NCCL_OFI_ROUND_UP(x, y) NCCL_OFI_ROUND_DOWN((x) + ((y) - 1), (y))
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -15,43 +15,17 @@ extern "C" {
 /*
  * @brief	Returns the ceil of x/y.
  */
-static inline size_t nccl_ofi_div_ceil(size_t x, size_t y)
-{
-	assert(y != 0);
-	return x == 0 ? 0 : 1 + ((x - 1) / y);
-}
+#define NCCL_OFI_DIV_CEIL(x, y) ((x) == 0 ? 0 : 1 + (((x) - 1) / (y)))
 
 /*
  * @brief	Max of two int values
  */
-static inline int nccl_ofi_max_int(int x, int y)
-{
-	return (x < y ? y : x);
-}
+#define NCCL_OFI_MAX(x, y) ((x) < (y) ? (y) : (x))
 
 /*
  * @brief	Min of two int values
  */
-static inline int nccl_ofi_min_int(int x, int y)
-{
-	return (x < y ? x : y);
-}
-
-/*
- * @brief	Max of two size_t values
- */
-static inline size_t nccl_ofi_max_size_t(size_t x, size_t y)
-{
-	return (x < y ? y : x);
-}
-
-/*
- * @brief	Min of two size_t values
- */
-static inline size_t nccl_ofi_min_size_t(size_t x, size_t y)
-{
-	return (x < y ? x : y);
-}
+#define  NCCL_OFI_MIN(x, y) ((x) < (y) ? (x) : (y))
 
 #ifdef _cplusplus
 } // End extern "C"

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -11,6 +11,7 @@ extern "C" {
 
 #include <assert.h>
 #include <stddef.h>
+#include <stdint.h>
 
 /*
  * @brief	Returns the ceil of x/y.
@@ -31,6 +32,22 @@ extern "C" {
  * @brief	Returns true if and only if size_t value is a power of two
  */
 #define NCCL_OFI_IS_POWER_OF_TWO(x) ((x) && (((x) & ((x) - 1)) == 0))
+
+/*
+ * @brief	Return true if and only if `x` is a multiple of `a`
+ *
+ * @param	a
+ *		Must be a power of two
+ */
+#define NCCL_OFI_IS_ALIGNED(x, a) (((x) & ((typeof(x))(a) - 1)) == 0)
+
+/*
+ * @brief	Return true if and only if pointer `p` is `a`-byte aligned
+ *
+ * @param	a
+ *		Must be a power of two
+ */
+#define NCCL_OFI_IS_PTR_ALIGNED(p, a) NCCL_OFI_IS_ALIGNED((uintptr_t)(p), (uintptr_t)(a))
 
 /*
  * @brief	Round value down to be a multiple of alignment

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -27,6 +27,11 @@ extern "C" {
  */
 #define  NCCL_OFI_MIN(x, y) ((x) < (y) ? (x) : (y))
 
+/*
+ * @brief	Returns true if and only if size_t value is a power of two
+ */
+#define NCCL_OFI_IS_POWER_OF_TWO(x) ((x) && (((x) & ((x) - 1)) == 0))
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -32,7 +32,7 @@ static int freelist_init_internal(size_t entry_size,
 		return -ENOMEM;
 	}
 
-	freelist->entry_size = ROUND_UP(nccl_ofi_max_size_t(entry_size, sizeof(struct nccl_ofi_freelist_elem_t)), 8);
+	freelist->entry_size = ROUND_UP(NCCL_OFI_MAX(entry_size, sizeof(struct nccl_ofi_freelist_elem_t)), 8);
 	freelist->num_allocated_entries = 0;
 	freelist->max_entry_count = max_entry_count;
 	freelist->increase_entry_count = increase_entry_count;

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -10,8 +10,6 @@
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_math.h"
 
-#define ROUND_UP(x, y) (((x) + (y)-1)  & (~((y)-1)) )
-
 static int freelist_init_internal(size_t entry_size,
 				  size_t initial_entry_count,
 				  size_t increase_entry_count,
@@ -32,7 +30,7 @@ static int freelist_init_internal(size_t entry_size,
 		return -ENOMEM;
 	}
 
-	freelist->entry_size = ROUND_UP(NCCL_OFI_MAX(entry_size, sizeof(struct nccl_ofi_freelist_elem_t)), 8);
+	freelist->entry_size = NCCL_OFI_ROUND_UP(NCCL_OFI_MAX(entry_size, sizeof(struct nccl_ofi_freelist_elem_t)), 8);
 	freelist->num_allocated_entries = 0;
 	freelist->max_entry_count = max_entry_count;
 	freelist->increase_entry_count = increase_entry_count;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4895,10 +4895,10 @@ static inline int init_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 
 	for (int rail_id = 0; rail_id < ep->num_rails; ++rail_id) {
 		nccl_net_ofi_ep_rail_t *rail = get_rail(ep, rail_id);
-		rail->min_bounce_posted = nccl_ofi_div_ceil(
+		rail->min_bounce_posted = NCCL_OFI_DIV_CEIL(
 			ofi_nccl_rdma_min_posted_bounce_buffers(), ep->num_rails
 		);
-		rail->max_bounce_posted = nccl_ofi_div_ceil(
+		rail->max_bounce_posted = NCCL_OFI_DIV_CEIL(
 			ofi_nccl_rdma_max_posted_bounce_buffers(), ep->num_rails
 		);
 		ret = pthread_mutex_init(&rail->bounce_mutex, NULL);
@@ -5554,7 +5554,7 @@ static ncclResult_t get_ep(nccl_net_ofi_device_t *base_dev,
 		/* Initialize reference count */
 		ep->ref_cnt = 0;
 
-		ep->bounce_buff_size = nccl_ofi_max_size_t(sizeof(nccl_net_ofi_rdma_ctrl_msg_t),
+		ep->bounce_buff_size = NCCL_OFI_MAX(sizeof(nccl_net_ofi_rdma_ctrl_msg_t),
 			eager_max_size);
 
 		/* Store endpoint in thread-local variable */

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -35,11 +35,11 @@ void nccl_net_ofi_set_multiplexing_schedule(size_t size, int num_rails,
 
 	if (OFI_UNLIKELY(num_rails == 0)) return;
 
-	max_stripe_size = nccl_ofi_div_ceil(nccl_ofi_div_ceil(size, num_rails), align) * align;
+	max_stripe_size = NCCL_OFI_DIV_CEIL(NCCL_OFI_DIV_CEIL(size, num_rails), align) * align;
 
 	/* Compute stripes and assign to rails */
 	for (int rail_id = 0; rail_id != num_rails && left > 0; ++rail_id) {
-		size_t stripe_size = nccl_ofi_min_size_t(left, max_stripe_size);
+		size_t stripe_size = NCCL_OFI_MIN(left, max_stripe_size);
 
 		schedule->rail_xfer_infos[rail_id].rail_id = rail_id;
 		schedule->rail_xfer_infos[rail_id].offset = offset;

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -776,7 +776,7 @@ static ncclResult_t create_groups_from_info_list(nccl_ofi_topo_t *topo,
 	int group_idx = 0;
 
 	/* Adjust number of groups if input list does not provide enough members */
-	num_groups = nccl_ofi_min_int(num_groups, num_infos);
+	num_groups = NCCL_OFI_MIN(num_groups, num_infos);
 	/* Number of groups with one additional member. Handles the
 	 * case where list size is not a multiple of number of
 	 * groups */
@@ -825,7 +825,7 @@ static ncclResult_t create_groups_from_info_list(nccl_ofi_topo_t *topo,
 		user_data->gpu_group_node = gpu_group_node;
 
 		/* Track maximum group size */
-		topo->max_group_size = nccl_ofi_max_int(topo->max_group_size, group_size);
+		topo->max_group_size = NCCL_OFI_MAX(topo->max_group_size, group_size);
 
 		/* Cut list into two lists after group size list elements */
 		struct fi_info *end = user_data->info_list;
@@ -1197,8 +1197,8 @@ static int get_pci_device_min_speed(hwloc_obj_t node, bool is_nic, size_t *speed
 		return ret;
 	}
 
-	*speed_idx = nccl_ofi_min_size_t(device_speed_idx, port_speed_idx);
-	*width = nccl_ofi_min_size_t(device_width, port_width);
+	*speed_idx = NCCL_OFI_MIN(device_speed_idx, port_speed_idx);
+	*width = NCCL_OFI_MIN(device_width, port_width);
 
 	return 0;
 }


### PR DESCRIPTION
Change freelist to allocate memory in a page-aligned fashion, to work around zeroing out in the child on a fork.  Since this is the second time we've had this issue, also force a check so that internal allocations are page aligned.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
