### PR TITLE
cuda: Support versions of CUDA prior to 11.3

### DIFF
--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -14,8 +14,12 @@ cudaError_t (*nccl_net_ofi_cudaRuntimeGetVersion)(int *runtimeVersion) = NULL;
 cudaError_t (*nccl_net_ofi_cudaPointerGetAttributes)(struct cudaPointerAttributes* attributes, const void* ptr) = NULL;
 cudaError_t (*nccl_net_ofi_cudaGetDevice)(int* device) = NULL;
 cudaError_t (*nccl_net_ofi_cudaGetDeviceCount)(int* count) = NULL;
+#if CUDART_VERSION >= 11030
 cudaError_t (*nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites)(enum cudaFlushGPUDirectRDMAWritesTarget target,
 							   enum cudaFlushGPUDirectRDMAWritesScope scope) = NULL;
+#else
+void *nccl_net_ofi_cudaDeviceFlushGPUDirectRDMAWrites = NULL;
+#endif
 
 #define STRINGIFY(sym) # sym
 
@@ -45,7 +49,9 @@ nccl_net_ofi_cuda_init(void)
 	LOAD_SYM(cudaPointerGetAttributes);
 	LOAD_SYM(cudaGetDevice);
 	LOAD_SYM(cudaGetDeviceCount);
+#if CUDART_VERSION >= 11030
 	LOAD_SYM(cudaDeviceFlushGPUDirectRDMAWrites);
+#endif
 
 error:
 	return ret;


### PR DESCRIPTION
When we refactored the CUDA code to support dlopen/dlsym instead of directly linking against CUDA, I missed a place where the FlushGPU code needed protecting against old versions of CUDA.  This patch allows the plugin to build against all versions of CUDA 11.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
