### PR TITLE
build: Introduce flag to build with UBSAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+To enable UBSAN (Undefined Behaviour Sanitizer), use the following config option:
+
+```
+   --enable-ubsan         Enable undefined behaviour checks with UBSAN
+```
+
 
 LTTNG tracing is documented in the doc/tracing.md file.
 

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,9 @@ dnl bunch of debugging flags, so there's no ordering requirement
 dnl between this and AC_PROG_CC.
 AS_IF([test "${ax_enable_debug}" = "no"], [CFLAGS="${CFLAGS} -O3"])
 
+# Check for UBSAN
+CHECK_ENABLE_UBSAN()
+
 
 # Checks for header files
 AC_HEADER_STDBOOL

--- a/m4/check_enable_ubsan.m4
+++ b/m4/check_enable_ubsan.m4
@@ -1,0 +1,33 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2023      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_ENABLE_UBSAN], [
+  ubsan_flag=-fsanitize=undefined
+
+  AC_ARG_ENABLE([ubsan],
+                [AS_HELP_STRING([--enable-ubsan], [Enable undefined behaviour checks with UBSAN])])
+
+  AC_MSG_CHECKING([whether to enable UBSAN (Undefined Behaviour Sanitizer)])
+  AS_IF([test "${enable_ubsan}" = "yes"],
+        [CPPFLAGS="${ubsan_flag} ${CPPFLAGS}"
+         LDFLAGS="${ubsan_flag} ${LDFLAGS}"
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+  # Ensure that compiler and linker support UBSAN
+  AS_IF([test "${enable_ubsan}" = "yes"],
+        [AC_MSG_CHECKING([for support of UBSAN])
+         AC_LINK_IFELSE([AC_LANG_PROGRAM(
+                            [[]],
+                            [[int main(void) {
+                                return 0;
+                              }]])],
+                           [AC_MSG_RESULT([yes])],
+                           [AC_MSG_RESULT([no])
+                            AC_MSG_ERROR([Compiler and linker need to support flag ${ubsan_flag}])])])
+  AS_UNSET([ubsan_flag])
+])


### PR DESCRIPTION
UBSAN (Undefined Behavior Sanitizer) is a useful tool to catch code usage that results in undefined behavior.

Such as array subscript out of bounds (where the bounds can be statically determined), bitwise shifts that are out of bounds for their data type, dereferencing misaligned or null pointers, signed integer overflow and etc.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
