### PR TITLE
freelist: Fix unit test initialization

### DIFF
--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -19,6 +19,10 @@ int regmr_simple(void *opaque, void *data, size_t size, void **handle)
 	simple_base = data;
 	simple_size = size;
 
+	if (size % system_page_size != 0) {
+		return ncclSystemError;
+	}
+
 	return ncclSuccess;
 }
 
@@ -47,6 +51,7 @@ int main(int argc, char *argv[])
 	int ret;
 	size_t i;
 
+	system_page_size = 4096;
 	ofi_log_function = logger;
 
 	/* initial size larger than max size */

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -366,6 +366,7 @@ int main(int argc, char *argv[])
 {
 	int ret = 0;
 	ofi_log_function = logger;
+	system_page_size = 4096;
 
 	ret = test_multiplexing_schedule() || test_threshold_scheduler();
 


### PR DESCRIPTION
The freelist and scheduler unit tests were recently broken by the change to freelist to allocate page-size boundary regions when growing.  Fix the unit tests by specifying the system page size (which is initialized during the core init function).

This is really a temporary fix, but we need to do some refactoring of the code base to better handle unit testing.  Until we do that, this works well enough.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
