### PR TITLE
 freelist: remove <= comparison on the unsigned allocation_count 

### DIFF
--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -209,7 +209,7 @@ int nccl_ofi_freelist_add(nccl_ofi_freelist_t *freelist,
 		allocation_count = freelist->max_entry_count - freelist->num_allocated_entries;
 	}
 
-	if (allocation_count <= 0) {
+	if (allocation_count == 0) {
 		NCCL_OFI_WARN("freelist %p is full", freelist);
 		return -ENOMEM;
 	}


### PR DESCRIPTION
Assert that we do not exceed entry limit in the freelist, and remove `<=` comparison on the unsigned `allocation_count`

Closes #236

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
