### PR TITLE
Refactor the platform-aws code

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -19,7 +19,6 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
 
 struct ec2_platform_data {
 	const char* name;


### PR DESCRIPTION
Series of changes to clean up some code duplication and unnecessary global variable usage in the platform-aws file.  Also fix a couple bugs in using Libfabric APIs and handling edge cases around Libfabric versions.

Refs #241 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
