### PR TITLE
Backport getopt optlen initialization fix

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -28,6 +28,7 @@ Bug Fixes:
 * Fix allocation of free lists to avoid accidently registering user
   data, which can cause corruption on fork() with older Linux kernels.
 * Fix memory leak with registered bounce buffers.
+* Fix improper usage of optlen in call to fi\_getopt().
 * Numerous memory cleanup fixes.
 
 Testing:

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -172,10 +172,10 @@ static ncclResult_t validate_rdma_write(struct fid_ep *ep)
 	int ret = ncclSuccess;
 #if HAVE_DECL_FI_OPT_EFA_EMULATED_WRITE
 	bool optval;
-	size_t optlen = 0;
+	size_t optlen = sizeof(optval);
 
 	ret = fi_getopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_EFA_EMULATED_WRITE, &optval, &optlen);
-	if(ret != 0 || optlen != sizeof(bool)) {
+	if(ret != 0 || optlen != sizeof(optval)) {
 		NCCL_OFI_WARN("Couldn't get FI_OPT_EFA_EMULATED_WRITE. optlen: %lu, RC: %d, ERROR: %s",
 			      optlen, ret, fi_strerror(-ret));
 		ret = ncclSystemError;


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
