### PR TITLE
Add static topology file for platform g5.48xlarge

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -51,6 +51,10 @@ struct ec2_platform_data {
 		.default_dup_conns = 0,
 		.latency = 75.0,
 	},
+	{
+		.name = "g5.48xlarge",
+		.topology = "g5.48xl-topo.xml",
+	},
 };
 
 /*

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -5,4 +5,4 @@
 #
 
 xmldir = ${pkgdatadir}/xml
-dist_xml_DATA = p4d-24xl-topo.xml p4de-24xl-topo.xml p5.48xl-topo.xml
+dist_xml_DATA = g5.48xl-topo.xml p4d-24xl-topo.xml p4de-24xl-topo.xml p5.48xl-topo.xml

--- a/topology/g5.48xl-topo.xml
+++ b/topology/g5.48xl-topo.xml
@@ -1,0 +1,25 @@
+<!--
+Copyright (c) 2023, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `g5.48xlarge` platform type.
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `g5.48xlarge`.
+
+Note: The PCI IDs of PCI switches and NICs needs to match the PCI IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0">
+    <pci busid="0000:00:16.0"/>
+    <pci busid="0000:00:17.0"/>
+    <pci busid="0000:00:18.0"/>
+    <pci busid="0000:00:19.0"/>
+  </cpu>
+  <cpu numaid="1">
+    <pci busid="0000:00:1a.0"/>
+    <pci busid="0000:00:1b.0"/>
+    <pci busid="0000:00:1c.0"/>
+    <pci busid="0000:00:1d.0"/>
+  </cpu>
+</system>


### PR DESCRIPTION
G5.48xlarge has two NUMA nodes, so we have to provide GPU/NUMA mapping for optimal performance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
