### PR TITLE
tests: Do not build unit test programs unless necessary

### DIFF
--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -9,11 +9,13 @@ LDADD = $(top_builddir)/src/libnccl-net.la
 
 noinst_HEADERS = test-common.h
 
+if ENABLE_TESTS
 noinst_PROGRAMS = \
 	deque \
 	freelist \
 	msgbuff \
 	scheduler
+endif
 
 TESTS = $(noinst_PROGRAMS)
 


### PR DESCRIPTION
7026b4bc made it so that configure will disable tests for Neuron builds, but the unit test binaries were getting built anyway. We can get the tests to be more broadly applicable, but that needs some work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
