### PR TITLE
Add ability to build with memcheck framework and undefined behavior sanitizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,22 @@ Use optional parameter `PATH` to point the build to a custom path
 where valgrind is installed. The memory access checkers ASAN and
 valgrind are mutually exclusive.
 
+In case plugin allocates a block of memory to store multiple
+structures, redzones are added between adjacent objects such that
+memory access checker can detect access out of the boundaries of these
+objects. The redzones are dedicated memory areas that are marked as
+not accessible by memory access checkers. The default size of redzones
+is 16 bytes in case memory access checks are enabled and 0
+otherwise. To control the size of redzones, use the following config
+option:
+
+```
+   MEMCHECK_REDZONE_SIZE=REDZONE_SIZE   Size of redzones in bytes
+```
+
+Redzones are required to be a multiple of 8 due to ASAN shadow-map
+granularity.
+
 LTTNG tracing is documented in the doc/tracing.md file.
 
 To enable LTTNG tracing, use the following configuration option:

--- a/README.md
+++ b/README.md
@@ -106,6 +106,11 @@ following config option:
    --enable-trace         Enable printing trace messages
 ```
 
+To enable UBSAN (Undefined Behaviour Sanitizer), use the following config option:
+
+```
+   --enable-ubsan         Enable undefined behaviour checks with UBSAN
+```
 
 LTTNG tracing is documented in the doc/tracing.md file.
 

--- a/README.md
+++ b/README.md
@@ -112,6 +112,38 @@ To enable UBSAN (Undefined Behaviour Sanitizer), use the following config option
    --enable-ubsan         Enable undefined behaviour checks with UBSAN
 ```
 
+To enable memory access checks with ASAN (disabled by default), use
+the following config option:
+
+```
+   --enable-asan           Enable ASAN memory access checks
+```
+
+In case plugin is configured with `--enable-asan` and the executable
+binary is not compiled and linked with ASAN support, it is required to
+preload the ASAN library, i.e., run the application with `export
+LD_PRELOAD=<path to libasan.so>`.
+
+In case plugin is configured with `--enable-asan` and the plugin is
+run within a CUDA application, environment variable `ASAN_OPTIONS`
+needs to include `protect_shadow_gap=0`. Otherwise, ASAN will crash on
+out-of-memory.
+NCCL currently has some memory leaks and ASAN reports memory leaks by
+default on process exit. To avoid warnings on such memory leaks, e.g.,
+only invalid memory accesses are of interest, add `detect_leaks=0` to
+`ASAN_OPTIONS`.
+
+To enable memory access checks with valgrind (disabled by default),
+use the following config option:
+
+```
+   -with-valgrind[=PATH]  Enable valgrind memory access checks
+```
+
+Use optional parameter `PATH` to point the build to a custom path
+where valgrind is installed. The memory access checkers ASAN and
+valgrind are mutually exclusive.
+
 LTTNG tracing is documented in the doc/tracing.md file.
 
 To enable LTTNG tracing, use the following configuration option:

--- a/configure.ac
+++ b/configure.ac
@@ -36,6 +36,8 @@ dnl bunch of debugging flags, so there's no ordering requirement
 dnl between this and AC_PROG_CC.
 AS_IF([test "${ax_enable_debug}" = "no"], [CFLAGS="${CFLAGS} -O3"])
 
+CHECK_ENABLE_SANITIZER()
+
 
 # Checks for header files
 AC_HEADER_STDBOOL

--- a/configure.ac
+++ b/configure.ac
@@ -85,6 +85,7 @@ CHECK_PKG_HWLOC([],
                        [AC_MSG_ERROR([HWLOC package required for CUDA builds])])])
 
 CHECK_PKG_VALGRIND()
+CHECK_VAR_REDZONE()
 
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])

--- a/configure.ac
+++ b/configure.ac
@@ -84,6 +84,8 @@ CHECK_PKG_HWLOC([],
                 [AS_IF([test "${have_device_interface}" = "cuda"],
                        [AC_MSG_ERROR([HWLOC package required for CUDA builds])])])
 
+CHECK_PKG_VALGRIND()
+
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
 
@@ -122,6 +124,9 @@ NCCL_OFI_PLATFORM="none"
 AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
 
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
+
+AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
+      [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
 
 AC_CONFIG_FILES([Makefile
                  include/Makefile

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -90,6 +90,9 @@ struct nccl_ofi_freelist_reginfo_t {
 };
 typedef struct nccl_ofi_freelist_reginfo_t nccl_ofi_freelist_reginfo_t;
 
+_Static_assert(offsetof(nccl_ofi_freelist_reginfo_t, elem) == 0,
+	       "elem is not the first member of the structure nccl_ofi_freelist_reginfo_t");
+
 /*
  * Freelist structure
  *

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2014-2023 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ */
+
+#ifndef NCCL_OFI_MEMCHECK_H
+#define NCCL_OFI_MEMCHECK_H
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include "nccl_ofi_math.h"
+
+/**
+ * Memory access tracing requires memory areas to be 8-byte aligned
+ * because ASAN shadow-memory granularity is 8 bytes.
+ */
+#define MEMCHECK_GRANULARITY (8)
+
+#if ENABLE_VALGRIND
+#include "nccl_ofi_memcheck_valgrind.h"
+#elif ENABLE_ASAN
+#include "nccl_ofi_memcheck_asan.h"
+#else
+#include "nccl_ofi_memcheck_nop.h"
+#endif
+
+/**
+ * @file
+ * This module defines the interface for providing hints about the
+ * expected state of a memory region.  This can be used to detect
+ * memory corruption with memory checkers like valgrind or ASAN.
+ *
+ * These functions will be compiled to nops when no memory checker is
+ * enabled at build time.
+ */
+
+/**
+ * Mark a memory area as having contents which are defined. This means
+ * the area can be read or written without any errors.
+ *
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_defined(void *data, size_t size);
+
+/**
+ * Mark a memory area as having an undefined content.  This can result
+ * in errors on read access before defined data is written to the
+ * memory.
+ *
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_undefined(void *data, size_t size);
+
+/**
+ * Mark a memory area as being invalid for read or write accesss.  Any
+ * access may result in a fault.
+ *
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
+
+/**
+ * Same as nccl_net_ofi_mem_defined() except that hint is applied to
+ * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ */
+static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
+{
+	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - p_prefix;
+	nccl_net_ofi_mem_defined(data - offset, size + offset);
+}
+
+/**
+ * Same as nccl_net_ofi_mem_undefined() except that hint is applied to
+ * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ */
+static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
+{
+	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - p_prefix;
+	nccl_net_ofi_mem_undefined(data - offset, size + offset);
+}
+
+/**
+ * Same as nccl_net_ofi_mem_noaccess() except that hint is applied to
+ * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ */
+static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
+{
+	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - p_prefix;
+	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
+}
+
+/**
+ * Create a memory allocator with a pool of managed memory.  Any
+ * access to the pool of memory prior to a
+ * nccl_net_ofi_mem_pool_alloc() may result in an error.  If
+ * book-keeping data must be stored in the memory region, it should
+ * first be marked as undefined via nccl_net_ofi_mem_undefined().
+ *
+ * @param handle
+ *   An opaque handle to identify the allocator.
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_create_mempool(void *handle, void *data, size_t size);
+
+/**
+ * Destroy a memory allocator.
+ *
+ * @param handler
+ *   The opaque handle used previously in nccl_net_ofi_mem_create_mempool().
+ */
+static inline void nccl_net_ofi_mem_destroy_mempool(void *handle);
+
+/**
+ * Indicate that an allocation has occured from a memory allocator.
+ * The memory area returned with have undefined semantics after this
+ * call.
+ *
+ * @param handle
+ *   The opaque handle used previously in nccl_net_ofi_mem_create_mempool().
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size_t size);
+
+/**
+ * Indicate that a deallocate has occured to a memory allocator.  The
+ * memory area will have noaccess semantics after this call.  If
+ * book-keeping structures need to be stored in this area, the
+ * specific area should be first marked as undefined via
+ * nccl_net_ofi_mem_undefined().
+ *
+ * @param handle
+ *   The opaque handle used previously in nccl_net_ofi_mem_create_mempool().
+ * @param data
+ *   A pointer to the beginning of the memory area. Must be
+ *   MEMCHECK_GRANULARITY-byte aligned.
+ * @param size
+ *   The size of the memory area.
+ */
+static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size);
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_MEMCHECK_H

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -26,6 +26,13 @@ extern "C" {
 #endif
 
 /**
+ * MEMCHECK_REDZONE_SIZE defines the size of redzones prefixing each
+ * entry. Redzones are required to be a multiple of 8 due to ASAN
+ * shadow-map granularity */
+_Static_assert(MEMCHECK_REDZONE_SIZE % MEMCHECK_GRANULARITY == 0,
+	       "Size of redzone is not a multiple of ASAN shadow-map granularity");
+
+/**
  * @file
  * This module defines the interface for providing hints about the
  * expected state of a memory region.  This can be used to detect
@@ -73,35 +80,35 @@ static inline void nccl_net_ofi_mem_undefined(void *data, size_t size);
 static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
 
 /**
- * Same as nccl_net_ofi_mem_defined() except that hint is applied to
- * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ * Same as nccl_net_ofi_mem_defined() except that guard is applied to
+ * memory region [NCCL_OFI_ROUND_DOWN(data, MEMCHECK_GRANULARITY), data + size).
  */
 static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 {
-	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - p_prefix;
+	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - aligned;
 	nccl_net_ofi_mem_defined(data - offset, size + offset);
 }
 
 /**
- * Same as nccl_net_ofi_mem_undefined() except that hint is applied to
- * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ * Same as nccl_net_ofi_mem_undefined() except that guard is applied to
+ * memory region [NCCL_OFI_ROUND_DOWN(data, MEMCHECK_GRANULARITY), data + size).
  */
 static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 {
-	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - p_prefix;
+	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - aligned;
 	nccl_net_ofi_mem_undefined(data - offset, size + offset);
 }
 
 /**
- * Same as nccl_net_ofi_mem_noaccess() except that hint is applied to
- * memory region [FLOOR(data, MEMCHECK_GRANULARITY), data + size).
+ * Same as nccl_net_ofi_mem_noaccess() except that guard is applied to
+ * memory region [NCCL_OFI_ROUND_DOWN(data, MEMCHECK_GRANULARITY), data + size).
  */
 static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
 {
-	void *p_prefix = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - p_prefix;
+	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = data - aligned;
 	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
 }
 

--- a/include/nccl_ofi_memcheck_asan.h
+++ b/include/nccl_ofi_memcheck_asan.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020-2023 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ */
+
+#ifndef NCCL_OFI_MEMCHECK_ASAN_H
+#define NCCL_OFI_MEMCHECK_ASAN_H
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <sanitizer/asan_interface.h>
+
+#if !defined(__SANITIZE_ADDRESS__)
+#error "memcheck-asan should not be compiled when ASAN is disabled"
+#endif
+
+static inline void nccl_net_ofi_mem_defined(void *data, size_t size)
+{
+	__asan_unpoison_memory_region(data, size);
+}
+
+static inline void nccl_net_ofi_mem_undefined(void *data, size_t size)
+{
+	/*
+	 * ASAN poison primitives do not support marking memory as inaccessible
+	 * to reads but as accessible to writes.
+	 *
+	 * Therefore, just unpoison memory for both reads & writes.
+	 */
+	nccl_net_ofi_mem_defined(data, size);
+}
+
+static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size)
+{
+	__asan_poison_memory_region(data, size);
+}
+
+static inline void nccl_net_ofi_mem_create_mempool(void *handle, void *data, size_t size)
+{
+	nccl_net_ofi_mem_noaccess(data, size);
+}
+
+static inline void nccl_net_ofi_mem_destroy_mempool(void *handle)
+{
+	/* Cannot posion without knowing mempool data and size */
+}
+
+static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size_t size)
+{
+	nccl_net_ofi_mem_undefined(data, size);
+}
+
+static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size)
+{
+	nccl_net_ofi_mem_noaccess(data, size);
+}
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_MEMCHECK_ASAN_H

--- a/include/nccl_ofi_memcheck_nop.h
+++ b/include/nccl_ofi_memcheck_nop.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014-2023 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ */
+
+#ifndef NCCL_OFI_MEMCHECK_NOP_H
+#define NCCL_OFI_MEMCHECK_NOP_H
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+/**
+ * @file This module provides empty implementations of the interface
+ * for providing hints about the expected state of a memory region.
+ *
+ * By including this module, calls to the interface will result in nops.
+ */
+
+static inline void nccl_net_ofi_mem_defined(void *data, size_t size)
+{
+}
+
+static inline void nccl_net_ofi_mem_undefined(void *data, size_t size)
+{
+}
+
+static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size)
+{
+}
+
+static inline void nccl_net_ofi_mem_create_mempool(void *handle, void *data, size_t size)
+{
+}
+
+static inline void nccl_net_ofi_mem_destroy_mempool(void *handle)
+{
+}
+
+static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size_t size)
+{
+}
+
+static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size)
+{
+}
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_MEMCHECK_NOP_H

--- a/include/nccl_ofi_memcheck_valgrind.h
+++ b/include/nccl_ofi_memcheck_valgrind.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014-2023 Amazon.com, Inc. or its affiliates.  All Rights Reserved.
+ */
+
+#ifndef NCCL_OFI_MEMCHECK_VALGRIND_H
+#define NCCL_OFI_MEMCHECK_VALGRIND_H
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <valgrind/valgrind.h>
+#include <valgrind/memcheck.h>
+
+static inline void nccl_net_ofi_mem_defined(void *data, size_t size)
+{
+	VALGRIND_MAKE_MEM_DEFINED(data, size);
+}
+
+static inline void nccl_net_ofi_mem_undefined(void *data, size_t size)
+{
+	VALGRIND_MAKE_MEM_UNDEFINED(data, size);
+}
+
+static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size)
+{
+	VALGRIND_MAKE_MEM_NOACCESS(data, size);
+}
+
+static inline void nccl_net_ofi_mem_create_mempool(void *handle, void *data, size_t size)
+{
+	nccl_net_ofi_mem_noaccess(data, size);
+	VALGRIND_CREATE_MEMPOOL(handle, 0, 0);
+}
+
+static inline void nccl_net_ofi_mem_destroy_mempool(void *handle)
+{
+	VALGRIND_DESTROY_MEMPOOL(handle);
+}
+
+static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size_t size)
+{
+	VALGRIND_MEMPOOL_ALLOC(handle, data, size);
+}
+
+static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size)
+{
+	VALGRIND_MEMPOOL_FREE(handle, data);
+}
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_MEMCHECK_VALGRIND_H

--- a/m4/check_enable_sanitizer.m4
+++ b/m4/check_enable_sanitizer.m4
@@ -1,0 +1,42 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2023      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_ENABLE_SANITIZER_HANDLER], [
+  AS_IF([test -n "${sanitizer_flags}"],
+        [CFLAGS="${sanitizer_flags} ${CFLAGS}"
+         LDFLAGS="${sanitizer_flags} ${LDFLAGS}"])
+])
+
+AC_DEFUN([CHECK_ENABLE_SANITIZE_EXPAND_SANITIZER], [
+  AC_ARG_ENABLE([$1], [AS_HELP_STRING([--enable-$1], [$2])])
+
+  AC_MSG_CHECKING([whether to enable $1])
+  AS_IF([test "${enable_$1}" = "yes"],
+        [sanitizer_flags="${sanitizer_flags} $3"
+         AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+  AS_IF([test "${enable_$1}" = "yes"],
+        [AC_MSG_CHECKING([if $1 works])
+         sanitizer_CFLAGS_save="${CFLAGS}"
+         CFLAGS="$3 ${CFLAGS}"
+         AC_LINK_IFELSE([AC_LANG_PROGRAM(
+                            [[]],
+                            [[int main(void) {
+                                return 0;
+                              }]])],
+                           [AC_MSG_RESULT([yes])],
+                           [AC_MSG_RESULT([no])
+                            AC_MSG_ERROR([Compiler and linker need to support flag $3])])
+         CFLAGS="${sanitizer_CFLAGS_save}"])
+])
+
+AC_DEFUN([CHECK_ENABLE_SANITIZER], [
+  CHECK_ENABLE_SANITIZE_EXPAND_SANITIZER([ubsan],
+       [Enable undefined behavior checks with UBSAN], [-fsanitize=undefined])
+  AC_CONFIG_COMMANDS_PRE([CHECK_ENABLE_SANITIZER_HANDLER])
+])

--- a/m4/check_enable_sanitizer.m4
+++ b/m4/check_enable_sanitizer.m4
@@ -38,5 +38,10 @@ AC_DEFUN([CHECK_ENABLE_SANITIZE_EXPAND_SANITIZER], [
 AC_DEFUN([CHECK_ENABLE_SANITIZER], [
   CHECK_ENABLE_SANITIZE_EXPAND_SANITIZER([ubsan],
        [Enable undefined behavior checks with UBSAN], [-fsanitize=undefined])
+  CHECK_ENABLE_SANITIZE_EXPAND_SANITIZER([asan],
+       [Enable address checking with ASAN], [-fsanitize=address])
   AC_CONFIG_COMMANDS_PRE([CHECK_ENABLE_SANITIZER_HANDLER])
+
+  AC_DEFINE_UNQUOTED([ENABLE_ASAN], [`test "${enable_asan}" = "yes" && echo 1 || echo 0`],
+                     [Defined to 1 if ASAN is enabled])
 ])

--- a/m4/check_pkg_valgrind.m4
+++ b/m4/check_pkg_valgrind.m4
@@ -1,0 +1,50 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2023      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_PKG_VALGRIND], [
+  valgrind_enabled=0
+
+  AC_ARG_WITH([valgrind],
+              [AS_HELP_STRING([--with-valgrind[=DIR]], [Enable address checking with valgrind])],
+              [AS_IF([test "${with_valgrind}" != "no"], [valgrind_enabled=1])])
+
+  AC_MSG_CHECKING([whether to enable valgrind])
+  AS_IF([test "${valgrind_enabled}" = "1"],
+        [AC_MSG_RESULT([yes])],
+        [AC_MSG_RESULT([no])])
+
+  AS_IF([test "${valgrind_enabled}" = "1" -a "${with_valgrind}" != "yes"],
+        [AS_IF([test -f ${with_valgrind}/valgrind/valgrind.h],
+               [CPPFLAGS="-I${with_valgrind} ${CPPFLAGS}"],
+               [test -f ${with_valgrind}/include/valgrind/valgrind.h],
+               [CPPFLAGS="-I${with_valgrind}/include ${CPPFLAGS}"],
+               [AC_MSG_ERROR(valgrind.h not found in ${with_valgrind})])])
+
+  AS_IF([test "${valgrind_enabled}" = "1"],
+        [AC_CHECK_HEADERS([valgrind/valgrind.h],
+                          [],
+                          [AC_MSG_ERROR([valgrind.h not found])])
+         # Valgrind API changed significantly with the introduction of
+         # version 3.2.0. Verify that memory checking macros introduced by
+         # version 3.2.0 are available.
+         AC_MSG_CHECKING([for VALGRIND_MAKE_MEM_NOACCESS])
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+                            [[
+                              #include "valgrind/memcheck.h"
+                            ]],
+                            [[#if !defined(VALGRIND_MAKE_MEM_NOACCESS)
+                              #error Failed not defined $define
+                              #endif
+                              int main(void) {
+                                return 0;
+                              }]])],
+                           [AC_MSG_RESULT([yes])],
+                           [AC_MSG_RESULT([no])
+                            AC_MSG_ERROR([Need valgrind version 3.2.0 or later.])])])
+
+  AC_DEFINE_UNQUOTED([ENABLE_VALGRIND], [${valgrind_enabled}], [Defined to 1 if valgrind is enabled])
+])

--- a/m4/check_var_redzone.m4
+++ b/m4/check_var_redzone.m4
@@ -1,0 +1,23 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2023      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_VAR_REDZONE], [
+  default_memcheck_redzone_size=16
+
+  AC_MSG_CHECKING([for MEMCHECK_REDZONE_SIZE])
+  AC_ARG_VAR(MEMCHECK_REDZONE_SIZE,
+             AS_HELP_STRING([Size of added redzones (in bytes). The default size is 16 bytes in case memory access checks are enabled and 0 otherwise. Is required to be a multiple of 8. @<:@default=16@:>@]))
+  AS_IF([test "${asan_enabled}" = "0" -a "${valgrind_enabled}" = "0"],[default_memcheck_redzone_size=0])
+  MEMCHECK_REDZONE_SIZE=${MEMCHECK_REDZONE_SIZE:=${default_memcheck_redzone_size}}
+  AC_MSG_RESULT(${MEMCHECK_REDZONE_SIZE})
+  AS_IF([test "$(( MEMCHECK_REDZONE_SIZE % 8 ))" != "0"],
+        [AC_MSG_ERROR([MEMCHECK_REDZONE_SIZE=${MEMCHECK_REDZONE_SIZE} is not a multiple of 8])])
+
+  AC_DEFINE_UNQUOTED([MEMCHECK_REDZONE_SIZE], [${MEMCHECK_REDZONE_SIZE}], [Defines size of added redzones (in bytes) in case ASAN or valgrind is enabled.])
+
+  AS_UNSET([default_memcheck_redzone_size])
+])

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -161,7 +161,7 @@ int main(int argc, char *argv[])
 		}
 
 		if (last_buff) {
-			if (last_buff - (char *)entry != 1024) {
+			if (last_buff - (char *)entry != 1024 + MEMCHECK_REDZONE_SIZE) {
 				NCCL_OFI_WARN("bad spacing %ul", (char *)entry - last_buff);
 				exit(1);
 			}


### PR DESCRIPTION
*Description of changes:*

* Add undefined behavior sanitizer (UBSAN) and memcheck frameworks (ASAN and Valgrind) as configure options.
* Add fine-grained memory access checks and redzones to freelist (in case memory checks are enabled)

This PR also fixes some memory leaks detected by the memcheck frameworks. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
