### PR TITLE
testing: Allow Neuron unit tests to build and run

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -70,8 +70,10 @@ have_device_interface=no
 CHECK_PKG_NEURON([AS_IF([test -n "${want_cuda}"],
                         [AC_MSG_ERROR([Cannot enable both CUDA and neuron.])],
                         [want_cuda=no])
-                  have_device_interface=neuon])
-CHECK_PKG_CUDA([have_device_interface=cuda])
+                  have_device_interface=neuon]
+                  AC_SUBST([OFI_NCCL_ARCHIVE], [nccom-net]))
+CHECK_PKG_CUDA([have_device_interface=cuda]
+               AC_SUBST([OFI_NCCL_ARCHIVE], [nccl-net]))
 
 AS_IF([test "${have_device_interface}" = "no"],
       [AC_MSG_ERROR([NCCL OFI Plugin requires either CUDA or Neuron runtime.])])

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -5,7 +5,7 @@
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
-LDADD = $(top_builddir)/src/libnccl-net.la
+LDADD = $(top_builddir)/src/lib$(OFI_NCCL_ARCHIVE).la
 
 noinst_HEADERS = test-common.h
 

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -6,9 +6,15 @@
 
 #include <stdint.h>
 
-#include "nccl-headers/error.h"
-#include "nccl-headers/net.h"
 #include "nccl_ofi_log.h"
+#include "nccl-headers/error.h"
+
+#if HAVE_NEURON
+#include "nccl-headers/net_neuron.h"
+#else
+#include "nccl-headers/net.h"
+#endif
+
 #include "test-common.h"
 #include "nccl_ofi_scheduler.h"
 


### PR DESCRIPTION
The unit tests themselves do not have any accelerator-specific constraint, we just needed some build config updates to link to the right archive.

Testing: `make check` with an `--enable-neuron` config runs to completion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
