### PR TITLE
Bugfix: Correctly handle FI_EAGAIN return code when reposting a pending eager copy fails

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1574,7 +1574,14 @@ static ssize_t post_eager_copy(nccl_net_ofi_rdma_req_t *req);
 
 /*
  * Progress a request associated with recv
- * @param add_to_pending whether to add to pending reqs queue on EAGAIN
+ *
+ * Post request associated with a receive. If `add_to_pending` is true
+ * and request could not be posted due to FI_EAGAIN, add request to
+ * pending requests queue.
+ *
+ * @param add_to_pending	whether to add to pending reqs queue on EAGAIN
+ * @return 			0, if request is successfully posted or added to pending requests queue
+ *	   			negative errno, otherwise
  */
 static ssize_t receive_progress(nccl_net_ofi_rdma_req_t *req, bool add_to_pending)
 {
@@ -1603,6 +1610,8 @@ static ssize_t receive_progress(nccl_net_ofi_rdma_req_t *req, bool add_to_pendin
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to nccl_ofi_deque_insert_back: %d", ret);
 			return ret;
+		} else {
+			rc = 0;
 		}
 
 		NCCL_OFI_TRACE_PENDING_INSERT(req);


### PR DESCRIPTION
*Description of changes:*

This PR fixes a bug that occurred when `fi_read` returns `FI_EAGAIN` in the case where a pending eager copy request fails to get reposted. The error code has been returned wrongly even though the request is returned to the pending requests queue.

This PR consists of two commits. The first commit fixes the bug, the second commit refactors and simplifies the code which has been made possible by the bug fix commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
