### PR TITLE
dist: Add recent headers to Makefile.am

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,6 +17,8 @@ noinst_HEADERS = \
 	nccl_ofi_freelist.h \
 	nccl_ofi_param.h \
 	nccl_ofi_math.h \
+	nccl_ofi_memcheck.h \
+	nccl_ofi_memcheck_nop.h \
 	tracepoint.h \
 	nccl-headers/error.h \
 	nccl-headers/net.h \


### PR DESCRIPTION
A recent commit added new files that were not added to the relevant Makefile.am files, breaking "make dist".  Fix that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
