### PR TITLE
Backports for 1.7.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,12 +287,12 @@ git clone https://github.com/NVIDIA/nccl-tests.git
 2. Build the tests
 ```
 cd  nccl-tests/
-make NCCL_HOME=~/nccl/build/
+make MPI=1 MPI_HOME=/path/to/mpi CUDA_HOME=/path/to/cuda NCCL_HOME=/path/to/nccl
 ```
 
 3. Run perf tests
 ```
-NCCL_DEBUG=INFO build/all_reduce_perf -b 8 -f 2 -e 32M -c 1
+NCCL_DEBUG=INFO mpirun -np 2 build/all_reduce_perf -b 8 -f 2 -e 32M -c 1 -g 1
 ```
 
 If you installed the AWS libfabric plugin in a custom prefix, ensure

--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -14,6 +14,27 @@ release) was only available in one of the two variants, we note that
 in the release notes.
 
 
+# v1.7.3-aws release notes
+This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
+or later and supports [NCCL v2.18.5-1](https://github.com/NVIDIA/nccl/releases/tag/v2.18.3-1) while
+maintaining backward compatibility with older NCCL versions ([NCCL v2.4.8](https://github.com/NVIDIA/nccl/releases/tag/v2.4.8-1) and later).
+It was tested with Libfabric versions up to
+[Libfabric v1.18.1](https://github.com/ofiwg/libfabric/releases/tag/v1.18.1).
+
+New Features:
+
+Bug Fixes:
+* Add support for g5.48xlarge instance types.
+* Fix a block in use leak in the freelist implementation.
+* For NCCL 2.18.5 or later, don't disable NVLS support.
+* Fix bug in handling retry error issues from Libfabric in the RDMA
+  transport (P5 instance types).
+
+Testing:
+The plugin has been tested with following libfabric providers using unit tests
+bundled in the source code and [nccl-tests](https://github.com/NVIDIA/nccl-tests) test suite:
+* efa
+
 # v1.7.2-aws release notes
 This release requires [Libfabric v1.11.0](https://github.com/ofiwg/libfabric/releases/tag/v1.11.0)
 or later and supports [NCCL v2.18.3-1](https://github.com/NVIDIA/nccl/releases/tag/v2.18.3-1) while

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -178,6 +178,8 @@ int nccl_ofi_freelist_fini(nccl_ofi_freelist_t *freelist)
 
 	pthread_mutex_destroy(&freelist->lock);
 
+	free(freelist);
+
 	return 0;
 }
 

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -199,7 +199,7 @@ int nccl_ofi_freelist_add(nccl_ofi_freelist_t *freelist,
 		allocation_count = freelist->max_entry_count - freelist->num_allocated_entries;
 	}
 
-	if (allocation_count <= 0) {
+	if (allocation_count == 0) {
 		NCCL_OFI_WARN("freelist %p is full", freelist);
 		return -ENOMEM;
 	}

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1574,7 +1574,14 @@ static ssize_t post_eager_copy(nccl_net_ofi_rdma_req_t *req);
 
 /*
  * Progress a request associated with recv
- * @param add_to_pending whether to add to pending reqs queue on EAGAIN
+ *
+ * Post request associated with a receive. If `add_to_pending` is true
+ * and request could not be posted due to FI_EAGAIN, add request to
+ * pending requests queue.
+ *
+ * @param add_to_pending	whether to add to pending reqs queue on EAGAIN
+ * @return 			0, if request is successfully posted or added to pending requests queue
+ *	   			negative errno, otherwise
  */
 static ssize_t receive_progress(nccl_net_ofi_rdma_req_t *req, bool add_to_pending)
 {
@@ -1603,6 +1610,8 @@ static ssize_t receive_progress(nccl_net_ofi_rdma_req_t *req, bool add_to_pendin
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to nccl_ofi_deque_insert_back: %d", ret);
 			return ret;
+		} else {
+			rc = 0;
 		}
 
 		NCCL_OFI_TRACE_PENDING_INSERT(req);

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -51,6 +51,10 @@ struct ec2_platform_data {
 		.default_dup_conns = 0,
 		.latency = 75.0,
 	},
+	{
+		.name = "g5.48xlarge",
+		.topology = "g5.48xl-topo.xml",
+	},
 };
 
 /*

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -19,7 +19,6 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
 
 struct ec2_platform_data {
 	const char* name;

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -168,6 +168,11 @@ int main(int argc, char *argv[])
 		}
 		last_buff = entry;
 	}
+	ret = nccl_ofi_freelist_fini(freelist);
+	if (ret != ncclSuccess) {
+		NCCL_OFI_WARN("freelist_fini failed: %d", ret);
+		exit(1);
+	}
 
 	/* and now with registrations... */
 	simple_base = NULL;

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -273,6 +273,8 @@ int test_multiplexing_schedule()
 	}
 	free(schedule);
 
+	free(ref_schedule);
+
 	return 0;
 }
 
@@ -358,6 +360,12 @@ int test_threshold_scheduler()
 		return ret;
 	}
 	nccl_net_ofi_release_schedule(scheduler, schedule);
+
+	ret = scheduler->fini(scheduler);
+	if (ret) {
+		NCCL_OFI_WARN("Failed to destroy threshold scheduler");
+	}
+	free(ref_schedule);
 
 	return 0;
 }

--- a/topology/Makefile.am
+++ b/topology/Makefile.am
@@ -5,4 +5,4 @@
 #
 
 xmldir = ${pkgdatadir}/xml
-dist_xml_DATA = p4d-24xl-topo.xml p4de-24xl-topo.xml p5.48xl-topo.xml
+dist_xml_DATA = g5.48xl-topo.xml p4d-24xl-topo.xml p4de-24xl-topo.xml p5.48xl-topo.xml

--- a/topology/g5.48xl-topo.xml
+++ b/topology/g5.48xl-topo.xml
@@ -1,0 +1,25 @@
+<!--
+Copyright (c) 2023, Amazon.com, Inc. or its affiliates. All rights reserved.
+See LICENSE.txt for license information
+
+Static pre-configured topology for `g5.48xlarge` platform type.
+This topology is ingested into NCCL using `NCCL_TOPO_FILE` environment
+variable when the underlying system is detected as `g5.48xlarge`.
+
+Note: The PCI IDs of PCI switches and NICs needs to match the PCI IDs on the
+virtual machine.
+-->
+<system version="1">
+  <cpu numaid="0">
+    <pci busid="0000:00:16.0"/>
+    <pci busid="0000:00:17.0"/>
+    <pci busid="0000:00:18.0"/>
+    <pci busid="0000:00:19.0"/>
+  </cpu>
+  <cpu numaid="1">
+    <pci busid="0000:00:1a.0"/>
+    <pci busid="0000:00:1b.0"/>
+    <pci busid="0000:00:1c.0"/>
+    <pci busid="0000:00:1d.0"/>
+  </cpu>
+</system>


### PR DESCRIPTION
Backport the following PRs and update RELEASENOTES for the 1.7.3 release.

* https://github.com/aws/aws-ofi-nccl/pull/256
* https://github.com/aws/aws-ofi-nccl/pull/257
* https://github.com/aws/aws-ofi-nccl/pull/262
* https://github.com/aws/aws-ofi-nccl/pull/267
* https://github.com/aws/aws-ofi-nccl/pull/268
* https://github.com/aws/aws-ofi-nccl/pull/270

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
