### PR TITLE
Fix recent regressions in ring functional test

### DIFF
--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -19,7 +19,7 @@ _Static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
 
 /* nccl_net_ofi plugin */
 nccl_net_ofi_plugin_t *plugin = NULL;
-ncclDebugLogger_t ofi_log_function;
+ncclDebugLogger_t ofi_log_function = NULL;
 
 
 static ncclResult_t nccl_net_ofi_retval_translate(int retval)

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -52,8 +52,6 @@ int nic_dup_conns = 0;
    read in the polling loop without protection of a lock. */
 size_t cq_read_count = 1;
 
-// Logger Function
-ncclDebugLogger_t ofi_log_function = NULL;
 /*
  * Maximum numbers of requests supported per communicator by
  * plugin. Since NCCL Net v5, one NCCL request can correspond to

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1213,7 +1213,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm_t *r_comm,
 	if (mb_res == NCCL_OFI_MSGBUFF_SUCCESS) {
 		/* Inserted! In this case receiver has not yet called recv() for this message, so
 		   return success and initiate eager read when sender calls send(). */
-		return -ENOSPC;
+		return 0;
 	}
 	if (mb_res != NCCL_OFI_MSGBUFF_INVALID_IDX) {
 		NCCL_OFI_WARN("Unexpected message insert result (%d) (eager recv)", (int)mb_res);
@@ -3121,6 +3121,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	if (ret == -EAGAIN) {
 		/* Network is still busy. Return NULL to NCCL. */
 		*base_req = NULL;
+		ret = 0;
 		goto error;
 	} else if (ret != 0) {
 		goto error;
@@ -4683,6 +4684,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	if (ret == -EAGAIN) {
 		/* Network is still busy. Return NULL to NCCL. */
 		*base_req = NULL;
+		ret = 0;
 		goto error;
 	} else if (ret != 0) {
 		goto error;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1094,7 +1094,7 @@ static inline int handle_ctrl_recv(nccl_net_ofi_rdma_send_comm_t *s_comm,
 
 	if (mb_res != NCCL_OFI_MSGBUFF_INVALID_IDX || stat != NCCL_OFI_MSGBUFF_INPROGRESS) {
 		NCCL_OFI_WARN("Unexpected message insert result (%d) (ctrl recv)", (int)mb_res);
-		return -ENOSPC;
+		return -EINVAL;
 	}
 
 	// Already a req entry here


### PR DESCRIPTION
* Remove ofi_log_function from nccl_ofi_net.c. This resolves a multiple definition compiler error.
* Fix return values, we were erroneously returning errors in non-error situations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
