### PR TITLE
Add parameter to align freelist entries

### DIFF
--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -121,6 +121,8 @@ struct nccl_ofi_freelist_t {
 	void *regmr_opaque;
 	size_t reginfo_offset;
 
+	size_t memcheck_redzone_size;
+
 	pthread_mutex_t lock;
 };
 typedef struct nccl_ofi_freelist_t nccl_ofi_freelist_t;
@@ -172,6 +174,7 @@ int nccl_ofi_freelist_init_mr(size_t entry_size,
 			      nccl_ofi_freelist_deregmr_fn deregmr_fn,
 			      void *regmr_opaque,
 			      size_t reginfo_offset,
+			      size_t entry_alignment,
 			      nccl_ofi_freelist_t **freelist_p);
 
 /*

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -87,9 +87,14 @@ typedef struct nccl_net_ofi_rdma_ctrl_fl_item {
 	nccl_net_ofi_rdma_ctrl_msg_t ctrl_msg;
 } nccl_net_ofi_rdma_ctrl_fl_item_t;
 
+/* For LL/LL128 protocols, bounce buffers (source of RDMA read operations) need to be 128B aligned */
+#define BOUNCE_BUFFER_ALIGNMENT 128
+
 /* Structure used to store bounce buffers in a free list */
 typedef struct nccl_net_ofi_rdma_bounce_fl_item {
 	nccl_ofi_freelist_reginfo_t fl_reginfo;
+#define PADDING_SIZE (BOUNCE_BUFFER_ALIGNMENT - (sizeof(nccl_ofi_freelist_reginfo_t) % BOUNCE_BUFFER_ALIGNMENT))
+	char padding[PADDING_SIZE];
 	char bounce_msg[];
 } nccl_net_ofi_rdma_bounce_fl_item_t;
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2018,6 +2018,7 @@ static inline nccl_net_ofi_rdma_req_t *alloc_bounce_req(nccl_net_ofi_rdma_ep_t *
 		req->free(req, false);
 		return NULL;
 	}
+	assert(NCCL_OFI_IS_PTR_ALIGNED(&bounce_fl_item->bounce_msg, BOUNCE_BUFFER_ALIGNMENT));
 
 	bounce_data->bounce_fl_item = bounce_fl_item;
 	bounce_data->buff_len = ep->bounce_buff_size;
@@ -3704,7 +3705,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 
 	ret = nccl_ofi_freelist_init_mr(sizeof(nccl_net_ofi_rdma_ctrl_fl_item_t), 8, 8,
 					NCCL_OFI_MAX_REQUESTS, freelist_regmr_host_fn,
-					freelist_deregmr_host_fn, ep, 0,
+					freelist_deregmr_host_fn, ep, 0, 1,
 					&r_comm->ctrl_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Call to freelist_init_mr failed: %d", ret);
@@ -4974,7 +4975,7 @@ static inline int init_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 	ret = nccl_ofi_freelist_init_mr(sizeof(nccl_net_ofi_rdma_bounce_fl_item_t) + ep->bounce_buff_size,
 					ofi_nccl_rdma_min_posted_bounce_buffers(), 16, 0,
 					freelist_regmr_host_fn, freelist_deregmr_host_fn,
-					ep, 0, &ep->bounce_buff_fl);
+					ep, 0, BOUNCE_BUFFER_ALIGNMENT, &ep->bounce_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init bounce_buff_fl");
 		if (nccl_ofi_freelist_fini(ep->bounce_buff_reqs_fl))

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -184,6 +184,7 @@ int main(int argc, char *argv[])
 					deregmr_simple,
 					(void *)0xdeadbeaf,
 					offsetof(struct random_freelisted_item, reginfo),
+					1,
 					&freelist);
 	if (ret != ncclSuccess) {
 		NCCL_OFI_WARN("freelist_init failed: %d", ret);


### PR DESCRIPTION
Since bounce buffers are the source of an RDMA read operation, we need
them to be 128B aligned for LL/LL128 protocols to work properly on local
reads.

Signed-off-by: Eric Raut <eraut@amazon.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.