### PR TITLE
Fail if GDR support is disabled on supported instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,14 @@ The plugin allows to configure the following variables at run-time according to 
       <td>Any non-negative integer, though must be <= ROUND_ROBIN_THRESHOLD. Defaults to 8KiB.
       </td>
    </tr>
+   <tr>
+      <td><code>OFI_NCCL_DISABLE_GDR_REQUIRED_CHECK</code></td>
+      <td>Disable the check for required GDR support on EC2 instances. When this check
+      is disabled, the plugin can be used without GDR support even on platforms
+      that support GDR (P4d and later). By default, the plugin performs the check.</td>
+      <td>Boolean</td>
+      <td>0/1 (Default: 0)</td>
+   </tr>
 </table>
 
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -166,6 +166,13 @@ OFI_NCCL_PARAM_STR(topo_file_template, "TOPO_FILE_TEMPLATE", NULL);
 OFI_NCCL_PARAM_INT(disable_native_rdma_check, "DISABLE_NATIVE_RDMA_CHECK", 0);
 
 /*
+ * Disable the check for required GDR support on EC2 instances. When this check
+ * is disabled, the plugin can be used without GDR support even on platforms
+ * that support GDR (P4d and later). By default, the plugin performs the check.
+ */
+OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
+
+/*
  * Maximum size of a message in bytes before message is multiplexed
  */
 OFI_NCCL_PARAM_INT(round_robin_threshold, "ROUND_ROBIN_THRESHOLD", 8192);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -696,7 +696,7 @@ int nccl_ofi_init_connection(struct fi_info *info, struct fid_domain *domain,
 				NCCL_OFI_WARN("GDR support reported to NCCL but then couldn't be configured on an endpoint.  Cannot continue.");
 				goto error;
 			} else {
-				NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Could not disable CUDA API usage for HMEM, disabling GDR");
+				NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Could not disable CUDA API usage for HMEM, disabling GDR");
 				/* If we can't disable CUDA, then we don't really
 				 * have GDR, so disable GDR  support from the NCCL
 				 * point of view.


### PR DESCRIPTION
Running without GDR on P4+ instances is not currently supported, so fail in this case.

Also, warn if setting `FI_OPT_CUDA_API_PERMITTED=false` fails, forcing fallback to non-GDR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
