### PR TITLE
Add FI_LOCAL_COMM to requested OFI caps

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ support the following features as defined in the
 * Data transfer context structures (`FI_CONTEXT`, `FI_CONTEXT2`)
 * Reliable datagram endpoints (`FI_EP_RDM`)
 * Send after Send ordering semantics (`FI_ORDER_SAS`)
-* Communication with remote endpoints (`FI_REMOTE_COMM`)
+* Communication with local and remote endpoints (`FI_LOCAL_COMM` and `FI_REMOTE_COMM`)
 
 For GPUDirect RDMA support, it requires these additional features from libfabric
 providers. If these are not supported by any provider on system, plug-in turns off

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -381,7 +381,7 @@ static void filter_tcp_info_list(struct fi_info **info_list, int *num_infos)
 static void get_hints(struct fi_info *hints, int req_gdr)
 {
 	if (req_gdr) {
-		hints->caps = FI_TAGGED | FI_MSG | FI_HMEM | FI_REMOTE_COMM;
+		hints->caps = FI_TAGGED | FI_MSG | FI_HMEM;
 		if (!cuda_flush)
 			hints->caps |= FI_RMA | FI_READ;
 		/*
@@ -393,13 +393,15 @@ static void get_hints(struct fi_info *hints, int req_gdr)
 		hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
 	}
 	else {
-		hints->caps = FI_TAGGED | FI_MSG | FI_REMOTE_COMM;
+		hints->caps = FI_TAGGED | FI_MSG;
 		/*
 		 * Set MR mode bits to indicate that application allows
 		 * registration of both local memory buffers
 		 */
 		hints->domain_attr->mr_mode = FI_MR_LOCAL;
 	}
+
+	hints->caps |= FI_LOCAL_COMM | FI_REMOTE_COMM;
 
 	/*
 	 * Add capabilities needed for RDMA protcol:


### PR DESCRIPTION
This requests node-local communication capability from the OFI provider, which can be used for various reasons, including
* GDR detection
* Functional tests
* Platforms without NVLink
* When `NCCL_SHM_DISABLE=1`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
