### PR TITLE
Return 0 when supplying default NIC props

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1245,7 +1245,7 @@ int nccl_net_ofi_info_properties(struct fi_info *nic_prov, int dev_id, int num_d
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
 			      "No NIC info for dev %d. Supplying default values for NIC properties.",
 			      dev_id);
-		ret = -ENOTSUP;
+		ret = 0;
 		goto exit;
 	}
 


### PR DESCRIPTION
This was incorrectly changed to -ENOTSUP, causing failure when using TCP provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.