### PR TITLE
Increase default round robin threshold to 256 KiB

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -175,7 +175,7 @@ OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
 /*
  * Maximum size of a message in bytes before message is multiplexed
  */
-OFI_NCCL_PARAM_INT(round_robin_threshold, "ROUND_ROBIN_THRESHOLD", 8192);
+OFI_NCCL_PARAM_INT(round_robin_threshold, "ROUND_ROBIN_THRESHOLD", (256 * 1024));
 
 /*
  * Minimum bounce buffers posted per endpoint. The plugin will attempt to post


### PR DESCRIPTION
empirical testing on P5 indicates that throughput is generally improved with a larger round robin threshold, although some sizes of larger messages for reduce-scatter and allgather were worse at 512 KiB.  So set the threshold to 256 KiB, which offers good improvements across the board, with no regression points.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
