### PR TITLE
Print Libfabric version as INFO when plugin starts

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -834,6 +834,11 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
 
+	/* Print Libfabric version */
+	uint32_t fab_version = fi_version();
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using Libfabric version %u.%u", FI_MAJOR(fab_version),
+			FI_MINOR(fab_version));
+
 	system_page_size = sysconf(_SC_PAGESIZE);
 	if (OFI_UNLIKELY(system_page_size == -1)) {
 		NCCL_OFI_WARN("Failed to get system page size (%d %s)", errno, strerror(errno));


### PR DESCRIPTION
The Libfabric version is often useful when debugging.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
