### PR TITLE
Cleanup NCCL resource limit handling

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -68,14 +68,20 @@ extern "C" {
  */
 #define NCCL_OFI_MAX_REQUESTS	(128)
 
+/*
+ * Number of send requests that can be active at any given time.  In
+ * the case of supporting NCCL_OFI_MAX_RECVS grouped receives for each
+ * receive request, which means the number of send requests that must
+ * be supported is actually larger than the number of receive
+ * requests.
+ */
+#define NCCL_OFI_MAX_SEND_REQUESTS (NCCL_OFI_MAX_REQUESTS * NCCL_OFI_MAX_RECVS)
+
 /* Maximum length of directory path */
 #define PATH_MAX	4096
 
 /* Flush read size (bytes) */
 #define NCCL_OFI_FLUSH_SIZE	4
-
-// Maximum numbers of requests supported by plugin
-extern int max_reqs;
 
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t {GDR_UNKNOWN, GDR_SUPPORTED, GDR_UNSUPPORTED};

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -58,9 +58,6 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 // can be sent over the network
 ncclResult_t nccl_net_ofi_init_v3(ncclDebugLogger_t logFunction)
 {
-#ifdef NCCL_NET_MAX_REQUESTS_V3
-	max_reqs = NCCL_NET_MAX_REQUESTS_V3;
-#endif
 	int ret = nccl_net_ofi_init(logFunction);
 
 	return nccl_net_ofi_retval_translate(ret);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -52,16 +52,6 @@ int nic_dup_conns = 0;
    read in the polling loop without protection of a lock. */
 size_t cq_read_count = 1;
 
-/*
- * Maximum numbers of requests supported per communicator by
- * plugin. Since NCCL Net v5, one NCCL request can correspond to
- * multiple network requests with `n` identifier passed to
- * irecv(). Therefore, the total number of requests that plugin should
- * support is product of number of NCCL requests and maximum number of
- * recvs supported by plugin.
- */
-int max_reqs = NCCL_OFI_MAX_REQUESTS * NCCL_OFI_MAX_RECVS;
-
 const char *provider_filter = NULL;
 
 /* Indicates if memory registration of local buffers is required */

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1190,7 +1190,7 @@ static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 	 * to be always 1.
 	 */
 	props->port_number = 1;
-	props->max_communicators = nic_prov->domain_attr->ep_cnt;
+	props->max_communicators = 0;
 	props->guid = dev_id;
 
 	props->latency = net_latency >= .0 ? net_latency : .0;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -669,6 +669,9 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 	 * reails have the same speed. */
 	if (ret == 0) {
 		props->port_speed *= device->num_rails;
+		_Static_assert(NUM_TAG_VALUE_BITS < 31,
+			       "NUM_TAG_VALUE_BITS must be less than 31 so max_communicators fits in an integer");
+		props->max_communicators = (1 << NUM_TAG_VALUE_BITS);
 	}
 	return ret;
 }

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3136,11 +3136,11 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto exit;
 	}
 
-	/* Support only max_reqs inflight reqs. */
-	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == max_reqs)) {
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight reqs. */
+	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
 		ret = -ENOSPC;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_REQUESTS);
 		goto error;
 	}
 
@@ -3502,10 +3502,10 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	data = buffers[flush_n];
 
 	/* Support only max_requests inflight requests. */
-	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == max_reqs)) {
+	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
 		ret = ncclSystemError;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_REQUESTS);
 		goto exit;
 	}
 
@@ -3674,9 +3674,10 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	}
 
 	/* Allocate request freelist */
-	/* Maximum freelist entries is 4*max_reqs because each receive request
+	/* Maximum freelist entries is 4*NCCL_OFI_MAX_REQUESTS because each receive request
 	   can have associated reqs for send_ctrl, recv_segms, and eager_copy */
-	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t), 16, 16, 4 * max_reqs, &r_comm->nccl_ofi_reqs_fl);
+	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t), 16, 16,
+				     4 * NCCL_OFI_MAX_REQUESTS, &r_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 				  dev_id);
@@ -4689,11 +4690,11 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		goto error;
 	}
 
-	/* Support only max_reqs inflight requests. */
-	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == max_reqs)) {
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
+	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == NCCL_OFI_MAX_SEND_REQUESTS)) {
 		ret = ncclInternalError;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_SEND_REQUESTS);
 		goto error;
 	}
 
@@ -5132,7 +5133,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->num_init_rails = 1;
 
 	/* Allocate request free list */
-	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t), 16, 16, max_reqs, &ret_s_comm->nccl_ofi_reqs_fl);
+	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t), 16, 16,
+				     NCCL_OFI_MAX_SEND_REQUESTS, &ret_s_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI request free list for dev %d rail %d",
 			      dev_id, rail_id);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -798,11 +798,11 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto exit;
 	}
 
-	/* Support only max_reqs inflight reqs. */
-	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == max_reqs)) {
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight reqs. */
+	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_REQUESTS);
 		goto error;
 	}
 
@@ -986,10 +986,10 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	data = buffers[flush_n];
 
 	/* Support only max_requests inflight requests. */
-	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == max_reqs)) {
+	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
 		ret = -ENOSPC;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_REQUESTS);
 		goto exit;
 	}
 
@@ -1192,7 +1192,8 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 
 	/* Pre-allocated buffers for data path */
 
-	ret = nccl_ofi_freelist_init(req_size, 16, 16, max_reqs, &r_comm->nccl_ofi_reqs_fl);
+	ret = nccl_ofi_freelist_init(req_size, 16, 16, NCCL_OFI_MAX_REQUESTS,
+				     &r_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 			      dev_id);
@@ -1564,11 +1565,11 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		goto exit;
 	}
 
-	/* Support only max_reqs inflight requests. */
-	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == max_reqs)) {
+	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
+	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == NCCL_OFI_MAX_SEND_REQUESTS)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
-			      max_reqs);
+			      NCCL_OFI_MAX_SEND_REQUESTS);
 		goto error;
 	}
 
@@ -1774,7 +1775,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 		(0 == memcmp(ret_s_comm->conn_info->ep_name, remote_ep_addr, ret_s_comm->conn_info->ep_namelen)) ? 1 : 0;
 
 	/* Pre-allocated buffers for data path */
-	ret = nccl_ofi_freelist_init(req_size, 16, 16, max_reqs, &ret_s_comm->nccl_ofi_reqs_fl);
+	ret = nccl_ofi_freelist_init(req_size, 16, 16, NCCL_OFI_MAX_SEND_REQUESTS,
+				     &ret_s_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 			      device->base.dev_id);


### PR DESCRIPTION
Clean up two NCCL resource limits we weren't handling properly.  First, our handling of multirecv and max outstanding requests was a mess, so follow NCCL's guidance, with the exception that we'll continue to support 128 outstanding instead of the most recent limit of 32.  If NCCL wants to give us more data, we'll take it.

Second, we were using entirely the wrong value for the max number of communicators.  That value is independent of the number of endpoints the domain supports and entirely dependent on tag space.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
