### PR TITLE
Remove unneeded compatibility init

### DIFF
--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -16,7 +16,6 @@ extern "C" {
 struct nccl_ofi_properties;
 
 ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction);
-ncclResult_t nccl_net_ofi_init_v3(ncclDebugLogger_t logFunction);
 ncclResult_t nccl_net_ofi_devices(int *ndev);
 ncclResult_t nccl_net_ofi_get_properties(int dev, struct nccl_ofi_properties *ofi_properties);
 ncclResult_t nccl_net_ofi_listen(int dev, void *handle, void **listenComm);

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -54,16 +54,6 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 }
 
 
-// To handle the difference in maximum number of requests that
-// can be sent over the network
-ncclResult_t nccl_net_ofi_init_v3(ncclDebugLogger_t logFunction)
-{
-	int ret = nccl_net_ofi_init(logFunction);
-
-	return nccl_net_ofi_retval_translate(ret);
-}
-
-
 ncclResult_t nccl_net_ofi_devices(int *num_devices)
 {
 	/* Validate plugin */

--- a/src/nccl_ofi_interface_nvidia.c
+++ b/src/nccl_ofi_interface_nvidia.c
@@ -132,7 +132,7 @@ static ncclResult_t accept_v7(void* listenComm, void** recvComm,
 
 const ncclNet_v2_t ncclNetPlugin_v2 = {
 	.name = "AWS Libfabric",
-	.init = nccl_net_ofi_init_v3,
+	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
 	.pciPath = pciPath_v2,
 	.ptrSupport = ptrSupport_v2,
@@ -152,7 +152,7 @@ const ncclNet_v2_t ncclNetPlugin_v2 = {
 
 const ncclNet_v3_t ncclNetPlugin_v3 = {
 	.name = "AWS Libfabric",
-	.init = nccl_net_ofi_init_v3,
+	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
 	.getProperties = getProperties_v4,
 	.listen = nccl_net_ofi_listen_v4,


### PR DESCRIPTION
Finish cleanup from db64dbe and remove the init_v3 function.  Since we no longer try to match our request count to exactly what NCCL will use (which is good, since NCCL doesn't really obey that anyway), there's no point in an init_v3 function and we can remove it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
