### PR TITLE
Clean up a couple of coding nits in the rdma protocol

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5781,7 +5781,6 @@ int nccl_net_ofi_rdma_init(nccl_ofi_topo_t *topo,
 				    nccl_net_ofi_plugin_t **plugin_p)
 {
 	int ret = 0;
-	int dev_id = 0;
 	nccl_net_ofi_device_t **base_devs = NULL;
 	int num_rails = 0;
 	int num_devs = 0;
@@ -5812,14 +5811,13 @@ int nccl_net_ofi_rdma_init(nccl_ofi_topo_t *topo,
 
 	num_rails = topo->max_group_size;
 	if (num_rails > MAX_NUM_RAILS) {
-		NCCL_OFI_WARN("Unexpected number of rails of device %i. Maximum is %i but got %i",
-			      dev_id, MAX_NUM_RAILS, num_rails);
+		NCCL_OFI_WARN("Unexpected topo group size of %d (maximum %d)",
+			      num_rails, MAX_NUM_RAILS);
 		ret = ncclInternalError;
 		goto error;
 	}
 	if (num_rails < 1) {
-		NCCL_OFI_WARN("Unexpected number of rails of device %i. Expected at least one NIC but got %i",
-			      dev_id, num_rails);
+		NCCL_OFI_WARN("Unexpected group size %d", num_rails);
 		ret = ncclInternalError;
 		goto error;
 	}
@@ -5862,7 +5860,7 @@ int nccl_net_ofi_rdma_init(nccl_ofi_topo_t *topo,
 	}
 
 	/* Allocate and initialize nccl_net devices */
-	for (; dev_id != num_devs; ++dev_id) {
+	for (int dev_id = 0 ; dev_id != num_devs ; ++dev_id) {
 		/* Retrieve NIC info list from topology */
 		info_list = nccl_ofi_topo_next_info_list(&data_iter);
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -29,7 +29,7 @@ static const char *topo_file_template = "/tmp/aws-ofi-nccl-topo-XXXXXX";
 /* Stores path to NCCL topology file written by ofi plugin for later unlinking */
 static char *topo_file_unlink = NULL;
 /* Locks functions which access `topo_file_unlink` */
-static pthread_mutex_t topo_file_lock;
+static pthread_mutex_t topo_file_lock = PTHREAD_MUTEX_INITIALIZER;
 
 /* Maximum number of comms open simultaneously. Eventually this will be
    runtime-expandable */
@@ -5788,13 +5788,6 @@ int nccl_net_ofi_rdma_init(nccl_ofi_topo_t *topo,
 	struct fi_info *info_list = NULL;
 	size_t rr_threshold = ofi_nccl_round_robin_threshold();
 	nccl_net_ofi_plugin_t *plugin = NULL;
-
-	ret = pthread_mutex_init(&topo_file_lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
-		ret = ncclSystemError;
-		goto error;
-	}
 
 	if (ofi_nccl_eager_max_size() < 0 ||
 	    ofi_nccl_eager_max_size() > rr_threshold) {


### PR DESCRIPTION
Fix three nits in the rdma protocol:

1) use static initializer for the topo lock mutex
2) Fix some prints that printed a misleading device id
3) clean up scoping and confusing use of dev_id and num_rails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
