### PR TITLE
Compare env vars string parameters in case insensitive manner

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -1054,7 +1054,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 			      nccl_ofi_selected_protocol);
 	}
 
-	if (0 == strcmp(nccl_ofi_selected_protocol, "SENDRECV")) {
+	if (0 == strcasecmp(nccl_ofi_selected_protocol, "SENDRECV")) {
 		ret = nccl_net_ofi_sendrecv_init(ofi_info_list, ofi_ndevices,
 						 provide_own_mr_key,
 						 plugin_p);
@@ -1063,7 +1063,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 			ret = ncclInternalError;
 			goto exit;
 		}
-	} else if (0 == strcmp(nccl_ofi_selected_protocol, "RDMA")) {
+	} else if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
 		/* NCCL OFI topology */
 		nccl_ofi_topo_t *topo = NULL;
 

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -231,7 +231,7 @@ static int configure_nccl_proto(void)
 				      strerror(errno));
 			return -errno;
 		}
-	} else if (strcmp(getenv("NCCL_PROTO"), "simple") != 0) {
+	} else if (strcasecmp(getenv("NCCL_PROTO"), "simple") != 0) {
 		NCCL_OFI_WARN("NCCL_PROTO was set to \"LL/LL128\", but the Libfabric endpoint does not support 128 byte in-order aligned stores. This endpoint may corrupt data during communication");
 	}
 

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -479,7 +479,7 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	 * emulated writes are disabled.
 	 */
 
-	if (0 == strcmp("RDMA", nccl_ofi_selected_protocol) &&
+	if (0 == strcasecmp("RDMA", nccl_ofi_selected_protocol) &&
 	    ofi_nccl_disable_native_rdma_check() == 0) {
 		ret = validate_rdma_write(endpoint);
 		if (ret != 0) {
@@ -501,12 +501,12 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	 * was previously set and error if we can't set them the same
 	 * way later.
 	 */
-	if (0 == strcmp("SENDRECV", nccl_ofi_selected_protocol)) {
+	if (0 == strcasecmp("SENDRECV", nccl_ofi_selected_protocol)) {
 #if HAVE_DECL_FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES
 		optname = FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES;
 		optname_name = "FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES";
 #endif
-	} else if (0 == strcmp("RDMA", nccl_ofi_selected_protocol)) {
+	} else if (0 == strcasecmp("RDMA", nccl_ofi_selected_protocol)) {
 #if HAVE_DECL_FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES
 		optname = FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES;
 		optname_name = "FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES";
@@ -543,7 +543,7 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	 * the check when using the RDMA protocol.
 	 */
 	if ((NULL == getenv("NCCL_PROTO")) &&
-	    (0 == strcmp("RDMA", nccl_ofi_selected_protocol)) &&
+	    (0 == strcasecmp("RDMA", nccl_ofi_selected_protocol)) &&
 	    (0 == strcmp(get_platform_type(), "p5.48xlarge"))) {
 		if (!nccl_proto_configured) {
 			NCCL_OFI_INFO(NCCL_INIT, "Skipping NCCL_PROTO checks on P5 + RDMA");


### PR DESCRIPTION
The patch-series contains 2 commits.
The 1st commit fixes a false warning due to parsing NCCL_PROTO env var with case sensitivity.
The 2nd commit changes the parse of OFI_NCCL_PROTOCOL to be case insensitive to be more consistent with how NCCL parse string env vars.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
