### PR TITLE
RDMA protocol fixes for non-EFA providers

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -628,8 +628,9 @@ typedef struct nccl_net_ofi_rdma_device {
  * @brief	Initialize plugin with rdma protocol structures
  */
 int nccl_net_ofi_rdma_init(nccl_ofi_topo_t *topo,
-			   bool provide_own_mr_key,
-			   nccl_net_ofi_plugin_t **plugin_p);
+                           struct fi_info *ofi_info_list, int num_infos,
+                           bool use_topo, bool provide_own_mr_key,
+                           nccl_net_ofi_plugin_t **plugin_p);
 
 #ifdef _cplusplus
 } // End extern "C"


### PR DESCRIPTION
1. Fall back to info list of topology information is not available
2. Do not use tag field from completion queue events

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.