### PR TITLE
nccl_ofi_tuner: Tuner component for aws-ofi-nccl

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -17,6 +17,7 @@ noinst_HEADERS = \
 	nccl_ofi_log.h \
 	nccl_ofi_freelist.h \
 	nccl_ofi_param.h \
+	nccl_ofi_tuner.h \
 	nccl_ofi_math.h \
 	nccl_ofi_memcheck.h \
 	nccl_ofi_memcheck_nop.h \
@@ -30,5 +31,6 @@ noinst_HEADERS = \
 	nccl-headers/nvidia/net_v4.h \
 	nccl-headers/nvidia/net_v5.h \
 	nccl-headers/nvidia/net_v6.h \
+	nccl-headers/nvidia/tuner.h \
 	nccl-headers/neuron/net.h \
 	nccl-headers/neuron/error.h

--- a/include/nccl-headers/nvidia/tuner.h
+++ b/include/nccl-headers/nvidia/tuner.h
@@ -1,0 +1,73 @@
+/*************************************************************************
+ * Copyright (c) 2023, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023, Meta Platforms, Inc. and affiliates.
+ *
+ * See LICENSE.txt for license information
+ ************************************************************************/
+
+#ifndef NCCL_TUNER_H_
+#define NCCL_TUNER_H_
+
+#include "nccl-headers/net.h"
+#include "nccl-headers/error.h"
+
+#define NCCL_NUM_FUNCTIONS 5 // Send/Recv not included for now
+typedef enum { ncclFuncBroadcast, ncclFuncReduce, ncclFuncAllGather, ncclFuncReduceScatter, ncclFuncAllReduce, ncclFuncSendRecv, ncclFuncSend, ncclFuncRecv, ncclNumFuncs} ncclFunc_t;
+
+#define NCCL_NUM_ALGORITHMS 6 // Tree/Ring/CollNet*
+#define NCCL_ALGO_UNDEF -1
+#define NCCL_ALGO_TREE 0
+#define NCCL_ALGO_RING 1
+#define NCCL_ALGO_COLLNET_DIRECT 2
+#define NCCL_ALGO_COLLNET_CHAIN 3
+#define NCCL_ALGO_NVLS 4
+#define NCCL_ALGO_NVLS_TREE 5
+
+#define NCCL_NUM_PROTOCOLS 3 // Simple/LL/LL128
+#define NCCL_PROTO_UNDEF -1
+#define NCCL_PROTO_LL 0
+#define NCCL_PROTO_LL128 1
+#define NCCL_PROTO_SIMPLE 2
+
+// API to be implemented by external tuner
+typedef struct {
+  // Name of the tuner
+  const char* name;
+
+  // Initializes tuner states.
+  // nRanks: number of ranks in current communicator. Each communicator initialize its own tuner.
+  // nNodes: number of nodes in current communicator.
+  // logFunction: a logFunction can be useful to integrate logging together with NCCL core.
+  ncclResult_t (*init)(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction);
+
+  // Gets info (algo, protocol, number of ctas and threads) for a given collective.
+  // Inputs:
+  //   - collType: collective type , e.g., allreduce, allgather…
+  //   - nBytes: collective size in bytes
+  //   - collNetSupport: whether collnet supports this type
+  //   - nvlsSupport: whether nvlink sharp supports this time
+  //   - numPipeOps: number of operations in the group
+  //
+  // Outputs:
+  //   - algorithm: selected algorithm to be used for the given collective
+  //   - protocol: selected protocol to be used for the given collective
+  //   - nChannels: number of channels (hence SMs) to be used.
+  //
+  // If getCollInfo() does not return ncclSuccess, NCCL will fall back to the
+  // default tuning for the given collective.
+  // Also, the plugin is allowed to not set any output, or set only the
+  // algorithm and protocol, but not only the algorithm or only the protocol.
+  // Unset fields will be set automatically by NCCL.
+  ncclResult_t (*getCollInfo)(ncclFunc_t collType, size_t nBytes,
+                              int collNetSupport, int nvlsSupport, int numPipeOps,
+                              int *algorithm, int *protocol, int* nChannels);
+
+  // Terminates the plugin and cleans up any resources that the plugin allocated.
+  ncclResult_t (*destroy)();
+} ncclTuner_v1_t;
+
+typedef ncclTuner_v1_t ncclTuner_t;
+
+#define NCCL_TUNER_PLUGIN_SYMBOL "ncclTunerPlugin_v1"
+
+#endif

--- a/include/nccl_ofi_tuner.h
+++ b/include/nccl_ofi_tuner.h
@@ -1,0 +1,106 @@
+#ifndef NCCL_OFI_TUNER_H_
+#define NCCL_OFI_TUNER_H_
+
+#include <linux/limits.h>
+#include <float.h>
+#include "nccl-headers/nvidia/tuner.h"
+#include "nccl_ofi_param.h"
+
+/*
+ * The plugin interface lets us tune the number of channels as well, but that
+ * can come later (once a proto+algo combination is chosen, we can compute the
+ * cost with different channel count and optimize for it.
+ */
+OFI_NCCL_PARAM_INT(tuner_num_channels, "TUNER_NUM_CHANNELS", 8);
+
+/*
+ * Latency in µsecs. Note, this is currently different from the network plugin's param for
+ * net latency by design. When we merge with the platform_data values, we will
+ * need to do some additional testing on the base case where a tuner is not
+ * loaded to make sure the same defaykts make sense across both paths, and
+ * combine the parameters. This parameter is meant for internal testing only and
+ * is not meant to be documented for users.
+ */
+OFI_NCCL_PARAM_INT(tuner_net_latency, "TUNER_NET_LATENCY", 20);
+
+/*
+ * With EFA, we expect a ~2µsec cost in the device and ~1µsec cost to write that
+ * completion up to the host stack.
+ */
+OFI_NCCL_PARAM_INT(tuner_net_comp_overhead, "TUNER_NET_COMP_OVERHEAD", 3);
+
+/* EFA unidirectional network bandwidth */
+#define NCCL_OFI_TUNER_INTERNODE_BW	(12.5 * 1024 * 1024 * 1024 * 1e-6) /* per rail */
+#define NCCL_OFI_TUNER_NET_NUM_RAILS	(4) /* Available to each GPU */
+
+/*
+ * For Hopper GPUs on P5, all intranode communication goes over NVLink, so use
+ * the bandwidth for SM90 architecture in NCCL (SM90_NVLINK_BW).
+ *
+ * This is unidirectional bandwidth per NVLink (900GB/s bidirectional on the
+ * platform, with 18 NVLinks in total. NCCL considers a 20% protocol overhead,
+ * leaving 20GB/s bandwidth per link).
+ *
+ * TODO: When extending to P4/other platforms, include these values in
+ * platform_data and fetch from it for the tuner. Value as defined in Bytes/µsec.
+ */
+#define NCCL_OFI_TUNER_INTRANODE_BW	(20.0 * 1024 * 1024 * 1024 * 1e-6)
+
+/*
+ * NCCL's algo-specific latencies for intra-node cases with NVLink.
+ * The values are directly taken from NCCL (hwLat[])). Values in µsecs.
+ */
+static const float nccl_nvlink_lat[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS] = {
+	{ .6, 1.25,  28 }, /* Tree (LL, LL128, Simple) */
+	{ .6,  1.9, 3.4 }, /* Ring (LL, LL128, Simple) */
+	{  0,    0, 3.7 }, /* Collnet Direct - Unused */
+	{  0,    0, 2.8 }, /* Collnet Chain - Unused */
+	{  0,    0,  23 }, /* NVLS (Simple only) */
+	{  0,    0,  23 }  /* NVLS Tree (Simple only)*/
+};
+
+/*
+ * Base algorithm latencies from NCCL (baseLat[]). For Trees and Rings, NCCL
+ * has empirically derived costs to the algorithms that are otherwise not
+ * captured in the intranode/internode portion of cost computation. This is
+ * considered the base latency, which nccl_ofi_tuner is applying as well. This
+ * can be computed better once we are able to model the pipelining, but adding
+ * these base latencies seem to pick better switchpoints. Values in µsecs.
+ */
+static const float nccl_base_lat[NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS] = {
+	{  6.8, 14.0,    0 }, /* Tree */
+	{  6.6, 14.0,  8.4 }, /* Ring */
+	{    0,    0,    0 }, /* Collnet Direct */
+	{    0,    0,    0 }, /* Collnet Chain */
+	{    0,    0,    0 }, /* NVLS */
+	{    0,    0,    0 }  /* NVLS Tree */
+};
+
+struct nccl_ofi_tuner_model_params {
+	float net_lat;
+	float internode_bw;
+	float intranode_bw;
+	int num_rails;
+};
+
+struct nccl_ofi_tuner_context {
+	/* communicator size */
+	int num_ranks;
+	int num_nodes;
+
+	struct nccl_ofi_tuner_model_params model_params;
+
+	float base_costs[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+};
+
+/*
+ * Global context, allocated at _init(). This is allocated and initialized once
+ * per process.
+ */
+struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx;
+
+/* Modeling functions */
+void nccl_ofi_tuner_model_costs();
+float nccl_ofi_tuner_compute_cost(ncclFunc_t func, int algo, int proto, int pipe_ops, size_t size);
+
+#endif /* NCCL_OFI_TUNER_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -31,4 +31,13 @@ else
   sources += nccl_ofi_cuda.c \
 	nccl_ofi_interface_nvidia.c
   libnccl_net_la_SOURCES = $(sources)
+
+if WANT_PLATFORM_AWS
+  # NCCL tuner plugin
+  lib_LTLIBRARIES += libnccl-ofi-tuner.la
+  tuner_sources = \
+	tuner/nccl_ofi_model.c \
+	tuner/nccl_ofi_tuner.c
+  libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)
+endif
 endif

--- a/src/tuner/nccl_ofi_model.c
+++ b/src/tuner/nccl_ofi_model.c
@@ -1,0 +1,111 @@
+#include <stdlib.h>
+#include <math.h>
+#include "nccl-headers/nvidia/tuner.h"
+#include "nccl_ofi_tuner.h"
+#include "nccl_ofi_log.h"
+#include "nccl_ofi_math.h"
+
+float nccl_ofi_tuner_compute_base_cost(ncclFunc_t func, int algo, int proto)
+{
+	/*
+	 * Just passing up the NCCL base latencies for now. These costs could be
+	 * computed too, but that can come as a follow up.
+	 */
+	return nccl_base_lat[algo][proto];
+}
+
+float nccl_ofi_tuner_compute_cost(ncclFunc_t func, int algo, int proto, int pipe_ops, size_t size)
+{
+	struct nccl_ofi_tuner_model_params *params = &nccl_ofi_tuner_ctx->model_params;
+	float cost = -1;
+	float latency = 0;
+	float bw = 0;
+	float p2p_lat = 0;
+	float net_lat = 0;
+	int num_steps = 0;
+	int num_internode_steps = 0;
+
+	/*
+	 * There is more involved than the NET_COMP_OVERHEAD itself for the
+	 * simple protocol, including overheads from libfabric and NCCL's proxy
+	 * thread itself in processing a completion handed to the host by the
+	 * device. Costs associated with out-of-order completions that could
+	 * stall the pipeline should be captured here as well.
+	 */
+	net_lat = (proto == NCCL_PROTO_SIMPLE)
+		    ? params->net_lat + ofi_nccl_tuner_net_comp_overhead()
+		    : params->net_lat;
+
+	p2p_lat = nccl_nvlink_lat[algo][proto];
+
+	switch(func) {
+	case ncclFuncAllReduce:
+		switch(algo) {
+		case NCCL_ALGO_RING:
+			num_steps = 2 * (nccl_ofi_tuner_ctx->num_ranks - 1);
+			num_internode_steps = 2 * nccl_ofi_tuner_ctx->num_nodes;
+			latency = (num_internode_steps * net_lat)
+				  + (num_steps - num_internode_steps) * p2p_lat;
+			bw = params->internode_bw * params->num_rails * ofi_nccl_tuner_num_channels();
+			break;
+
+		case NCCL_ALGO_NVLS_TREE:
+			latency = 2 * (p2p_lat + (log2(nccl_ofi_tuner_ctx->num_nodes) * net_lat));
+			bw = NCCL_OFI_MIN(params->intranode_bw, (params->internode_bw * params->num_rails) / 2)
+			     * ofi_nccl_tuner_num_channels();
+			break;
+
+		case NCCL_ALGO_TREE:
+			latency = ((2 * ((nccl_ofi_tuner_ctx->num_ranks / nccl_ofi_tuner_ctx->num_nodes) - 1) * p2p_lat)
+				   + (2 * log2(nccl_ofi_tuner_ctx->num_nodes) * net_lat));
+			bw = (params->internode_bw * params->num_rails * ofi_nccl_tuner_num_channels()) / 2;
+			break;
+
+		default:
+			NCCL_OFI_WARN("Algorithm %d for collective %d  without a model.", algo, func);
+			return -1;
+		}
+		break;
+
+	default:
+		NCCL_OFI_WARN("Unsupported collective %d, fallback to NCCL's selection.", func);
+		return -1;
+	}
+
+	/* Penalize the low-latency protocol bandwidths for their overhead */
+	if (proto == NCCL_PROTO_LL)
+		/* 8B total with 4B data and 4B flags, so take a 50% hit */
+		bw *= 0.5;
+	else if (proto == NCCL_PROTO_LL128)
+		/* 120B data and 8B flags */
+		bw *= 0.9375;
+
+	/*
+	 * Simplest hockney based: t = (⍺ + βm).
+	 * When extending to LogGP or other models, implement separate cost
+	 * functions and pick with a model config env rather than overwriting
+	 * this one cost function.
+	 */
+	cost = (latency * pipe_ops) + size / bw;
+
+	return cost;
+}
+
+
+/*
+ * Compute the base costs for each of the algorithms at plugin initialization
+ * time using only the comm size.
+ */
+void nccl_ofi_tuner_model_costs()
+{
+	ncclFunc_t func;
+	int algo, proto = 0;
+	for (func = 0; func < NCCL_NUM_FUNCTIONS; func++) {
+		for (algo = 0; algo < NCCL_NUM_ALGORITHMS; algo++) {
+			for(proto = 0; proto < NCCL_NUM_PROTOCOLS; proto++) {
+				nccl_ofi_tuner_ctx->base_costs[func][algo][proto] = 
+					nccl_ofi_tuner_compute_base_cost(func, algo, proto);
+			}
+		}
+	}
+}

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -1,0 +1,123 @@
+#include <stdlib.h>
+#include <pthread.h>
+#include "nccl-headers/nvidia/tuner.h"
+#include "nccl_ofi_tuner.h"
+#include "nccl_ofi_log.h"
+
+pthread_mutex_t nccl_ofi_tuner_ctx_lock = PTHREAD_MUTEX_INITIALIZER;
+
+ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction)
+{
+	ofi_log_function = logFunction;
+
+	/*
+	 * NCCL parses these variables and applies user filters inside its
+	 * current tuner logic. Ideally, this should be done regardless of the
+	 * use of NCCL's internal tuner or an external tuner plugin. For the
+	 * time being, given the external tuner is an opt-in, detect if a user
+	 * has set one of them and bail when an external tuner is loaded.
+	 */
+	if (getenv("NCCL_ALGO") || getenv("NCCL_PROTO")) {
+		NCCL_OFI_WARN("The tuner plugin can not be loaded when explicitly choosing an algorithm or protocol with NCCL_ALGO/NCCL_PROTO");
+		return ncclInvalidUsage;
+	}
+
+	struct nccl_ofi_tuner_model_params params = {
+		.net_lat = ofi_nccl_tuner_net_latency(),
+		.internode_bw = NCCL_OFI_TUNER_INTERNODE_BW,
+		.intranode_bw = NCCL_OFI_TUNER_INTRANODE_BW,
+		.num_rails = NCCL_OFI_TUNER_NET_NUM_RAILS
+	};
+
+	/*
+	 * The tuner API is missing a mechanism to pass around context after
+	 * initialization. For now, init a plugin-lobal context once.
+	 */ 
+	pthread_mutex_lock(&nccl_ofi_tuner_ctx_lock);
+	if (!nccl_ofi_tuner_ctx) {
+		nccl_ofi_tuner_ctx = calloc(1, sizeof(struct nccl_ofi_tuner_context));
+		if (!nccl_ofi_tuner_ctx) {
+			NCCL_OFI_WARN("Context allocation failed.");
+			return ncclInternalError;
+		}
+
+		nccl_ofi_tuner_ctx->num_ranks = nRanks;
+		nccl_ofi_tuner_ctx->num_nodes = nNodes;
+		nccl_ofi_tuner_ctx->model_params = params;
+
+		/*
+		 * Build cost model to use from nccl_ofi_tuner_get_coll_info.
+		 */
+		nccl_ofi_tuner_model_costs();
+	}
+	pthread_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
+
+	NCCL_OFI_TRACE(NCCL_TUNING, "Tuner init: comm with %ld ranks and %ld nodes.", nRanks, nNodes);
+	return ncclSuccess;
+}
+
+ncclResult_t nccl_ofi_tuner_get_coll_info(ncclFunc_t collType, size_t nBytes,
+				  int collNetSupport, int nvlsSupport, int numPipeOps,
+				  int *algorithm, int *protocol, int* nChannels)
+{
+	float cost = 0;
+	float lowest = FLT_MAX;
+	int algo, proto = 0;
+
+	/* Skip runs smaller than 2 nodes and fallback to NCCL's internal tunings */
+	if (nccl_ofi_tuner_ctx->num_nodes <= 2)
+		return ncclSuccess;
+
+	/*
+	 * Ideally, this should just be a lookup and not be in-flight math
+	 * We do not want divs in the hot path, but working with the API we've
+	 * got now. 
+	 */
+	for (algo = 0; algo < NCCL_NUM_ALGORITHMS; algo++) {
+		/* No CollNet on AWS today */
+		if (algo == NCCL_ALGO_COLLNET_DIRECT || algo == NCCL_ALGO_COLLNET_CHAIN)
+			continue;
+
+		/* Skip NCCL_ALGO_NVLS used only for single-node jobs */
+		if (algo == NCCL_ALGO_NVLS)
+			continue;
+
+		if (!nvlsSupport && (algo == NCCL_ALGO_NVLS_TREE))
+			continue;
+
+		for (proto = 0; proto < NCCL_NUM_PROTOCOLS; proto++) {
+			/* This is not a supported combination in NCCL */
+			if (algo == NCCL_ALGO_NVLS_TREE && proto != NCCL_PROTO_SIMPLE)
+				continue;
+
+			cost = nccl_ofi_tuner_compute_cost(collType, algo, proto, numPipeOps,  nBytes);
+			if (cost < 0)
+				continue;
+
+			NCCL_OFI_TRACE(NCCL_TUNING, "Computed cost for algo %d proto %d pipe %d: cost %.8f µsecs.", algo, proto, numPipeOps, cost);
+			if (cost < lowest) {
+				*algorithm = algo;
+				*protocol = proto;
+				lowest = cost;
+			}
+		}
+	}
+
+	NCCL_OFI_TRACE(NCCL_TUNING, "Choosing algo %d proto %d with cost %.8f µsecs for coll %d size %ld.",
+				    *algorithm, *protocol, lowest, collType, nBytes);
+	return ncclSuccess;
+}
+
+ncclResult_t nccl_ofi_tuner_destroy()
+{
+	free(nccl_ofi_tuner_ctx);
+	return ncclSuccess;
+}
+
+
+const ncclTuner_v1_t ncclTunerPlugin_v1 = {
+  .name = "nccl_ofi_tuner",
+  .init = nccl_ofi_tuner_init,
+  .getCollInfo = nccl_ofi_tuner_get_coll_info,
+  .destroy = nccl_ofi_tuner_destroy
+};


### PR DESCRIPTION
This commit introduces a custom tuner plugin for NCCL that bypasses the cost function used by NCCL today. The existing cost function is a combination of empirically derived costs, lat/bw reported by network plugins, and other coefficients that are unexplainable. These defaults seem to work well for IB, but not for EFA. The tuner is currently built and used only when running on AWS.

In this initial implementation, a simple Hockney model is used as a starting point, and only AllReduce is supported. Once we prove out the viability of the tuner plugin in selecting algorithm switch points, we can extend this to LogGP-based models to account for protocol specifics used in the aws-ofi-nccl plugin (such as the eager->rendezvous switch and the cost of control message exhange).

At the time of this commit, NCCL explicitly dlopen()s the tuner plugin with a path provided to NCCL_TUNER_PLUGIN, but that will change in the future to automatically pick up a tune from the network plugin install path (v2.21 likely). NCCL should also look for the tuner symbols with dlsym() implicitly if the environment variable is not set, but that's a separate discussion to be had with the NCCL team.

Note that nccl-headers/tuner.h had to be slightly modified to remove redundancy with definitions in nccl-headers/net.h and nccl-headers/error.h. There are still some duplicate definitions, but in the interest of keeping the header from NCCL as close to the upstream version as possible, this commit does not refactor the common definitions for reuse.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
