### PR TITLE
neuron: Fixes missing definition of nccl_ofi_properties_t

### DIFF
--- a/src/nccl_ofi_interface_neuron.c
+++ b/src/nccl_ofi_interface_neuron.c
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 
 static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)


### PR DESCRIPTION
a128996 recently introduced an abstraction to handle property differences across the API versions and removing the versioned definitions from the core code. This commit fixes the missing definition for neuron builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
