### PR TITLE
Allocator for communicator ID and MR keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ tests/unit/msgbuff
 tests/unit/freelist
 tests/unit/deque
 tests/unit/scheduler
+tests/unit/idpool
 
 # http://www.gnu.org/software/automake
 .deps/

--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,9 @@ AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset funct
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
 
+# Check for GCC builtin functions
+CHECK_GCC_BUILTIN([__builtin_expect])
+CHECK_GCC_BUILTIN([__builtin_ffsll])
 
 # Checks for external packages
 CHECK_PKG_LIBFABRIC([], [AC_MSG_ERROR([NCCL OFI Plugin could not find a working Libfabric install.])])

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -14,6 +14,7 @@ noinst_HEADERS = \
 	nccl_ofi_topo.h \
 	nccl_ofi_msgbuff.h \
 	nccl_ofi_deque.h \
+	nccl_ofi_idpool.h \
 	nccl_ofi_log.h \
 	nccl_ofi_freelist.h \
 	nccl_ofi_param.h \

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -194,7 +194,7 @@ typedef struct nccl_ofi_connection_info {
 
 typedef struct nccl_net_ofi_conn_handle {
 	char ep_name[MAX_EP_ADDR];
-	uint64_t tag;
+	uint64_t comm_id;
 	/* Save temporary communicator state when creating send communicator */
 	save_comm_state_t state;
 } nccl_net_ofi_conn_handle_t;

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -1,0 +1,94 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_IDPOOL_H_
+#define NCCL_OFI_IDPOOL_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+
+#include <stdint.h>
+
+/*
+ * Pool of IDs, used to keep track of communicator IDs and MR keys.
+ */
+typedef struct nccl_ofi_idpool {
+	/* Size of the id pool (number of IDs) */
+	size_t size;
+
+	/* ID pool bit array. A bit set in the array indicates
+	   that the ID corresponding to its index is available.*/
+	uint64_t *ids;
+
+	/* Lock for concurrency */
+	pthread_mutex_t lock;
+} nccl_ofi_idpool_t;
+
+/*
+ * @brief	Initialize pool of IDs
+ *
+ * Allocates and initializes a nccl_ofi_idpool_t object, marking all
+ * IDs as available.
+ *
+ * @param	idpool_p
+ *		Return value with the ID pool pointer allocated
+ * @param	size
+ *		Size of the id pool (number of IDs)
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size);
+
+/*
+ * @brief	Allocate an ID
+ *
+ * Extract an available ID from the ID pool, mark the ID as
+ * unavailable in the pool, and return extracted ID. No-op in case
+ * no ID was available.
+ *
+ * This operation is locked by the ID pool's internal lock.
+ *
+ * @param	idpool
+ *		The ID pool
+ * @return	the extracted ID (zero-based) on success,
+ *		negative value on error
+ */
+int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool);
+
+/*
+ * @brief	Free an ID from the pool
+ *
+ * Return input ID into the pool.
+ *
+ * This operation is locked by the ID pool's internal lock.
+ *
+ * @param	idpool
+ *		The ID pool
+ * @param	id
+ *		The ID to release (zero-based)
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id);
+
+/*
+ * @brief	Release pool of IDs and free resources
+ *
+ * Releases a nccl_ofi_idpool_t object and frees allocated memory.
+ *
+ * @param	idpool_p
+ *		Pointer to the ID pool, it will be set to NULL on success
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_IDPOOL_H_

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -294,9 +294,9 @@ typedef struct nccl_ofi_rdma_ep_name {
  * connection information.
  */
 typedef struct nccl_ofi_rdma_connection_info {
-	/* A tag identitifer that uniquely identifies the comm on the sender
-	   side. The receiver must use this tag when sending messages to sender */
-	uint64_t local_tag;
+	/* A comm identitifer that uniquely identifies the comm on the sender
+	   side. The receiver must use this ID when sending messages to sender */
+	uint64_t local_comm_id;
 
 	/* Number of rails */
 	int num_rails;
@@ -338,10 +338,10 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	uint64_t num_inflight_reqs;
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
-	/* Tag provided by the local endpoint */
-	uint64_t local_tag;
-	/* Tag provided by remote endpoint */
-	uint64_t remote_tag;
+	/* Comm ID provided by the local endpoint */
+	uint64_t local_comm_id;
+	/* Comm ID provided by remote endpoint */
+	uint64_t remote_comm_id;
 
 	/* Request to receive connect response message to finalize
 	 * connection establishment */
@@ -416,10 +416,10 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	uint64_t num_inflight_reqs;
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
-	/* Tag provided by the local endpoint */
-	uint64_t local_tag;
-	/* Tag provided by remote endpoint */
-	uint64_t remote_tag;
+	/* Comm ID provided by the local endpoint */
+	uint64_t local_comm_id;
+	/* Comm ID provided by remote endpoint */
+	uint64_t remote_comm_id;
 
 	/* The flush buffer */
 	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
@@ -444,8 +444,8 @@ typedef struct nccl_net_ofi_rdma_listen_comm {
 	 * struct and its base struct. */
 	nccl_net_ofi_listen_comm_t base;
 
-	/* Tag provided by local endpoint */
-	uint64_t tag;
+	/* Comm ID provided by local endpoint */
+	uint64_t comm_id;
 	struct fid_ep *leader_local_ep;
 
 	/* Communicator created while accept routine is executed */
@@ -514,8 +514,8 @@ struct nccl_net_ofi_rdma_ep {
 	 * and its base struct. */
 	nccl_net_ofi_ep_t base;
 
-	/* Current available tag ID */
-	uint64_t tag;
+	/* ID pool */
+	nccl_ofi_idpool_t *comm_idpool;
 
 	/* Number of rails */
 	int num_rails;
@@ -618,8 +618,8 @@ typedef struct nccl_net_ofi_rdma_device {
 	/* Pointer to provider name of first NIC */
 	char *prov_name;
 
-	/* Maximum supported tag ID */
-	uint64_t max_tag;
+	/* Maximum number of supported communicator IDs */
+	uint64_t num_comm_ids;
 
 	/* Memory registration key pool */
 	nccl_ofi_idpool_t key_pool;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -20,6 +20,7 @@ extern "C" {
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_deque.h"
 #include "nccl_ofi_freelist.h"
+#include "nccl_ofi_idpool.h"
 
 /* Maximum number of rails supported. This defines the size of
  * messages exchanged during connection establishment (linear
@@ -621,7 +622,7 @@ typedef struct nccl_net_ofi_rdma_device {
 	uint64_t max_tag;
 
 	/* Memory registration key pool */
-	nccl_ofi_mr_keypool_t key_pool;
+	nccl_ofi_idpool_t key_pool;
 } nccl_net_ofi_rdma_device_t;
 
 /*

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -15,6 +15,7 @@ extern "C" {
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_log.h"
+#include "nccl_ofi_idpool.h"
 
 typedef enum nccl_net_ofi_sendrecv_req_state {
 	NCCL_OFI_SENDRECV_REQ_CREATED = 0,
@@ -189,7 +190,7 @@ typedef struct nccl_net_ofi_sendrecv_device {
 	struct fid_domain *domain;
 
 	/* Memory registration key pool */
-	nccl_ofi_mr_keypool_t key_pool;
+	nccl_ofi_idpool_t key_pool;
 } nccl_net_ofi_sendrecv_device_t;
 	
 typedef struct nccl_net_ofi_sendrecv_req {

--- a/m4/check_gcc_builtin.m4
+++ b/m4/check_gcc_builtin.m4
@@ -1,0 +1,23 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_GCC_BUILTIN], [
+  result="no"
+
+  AC_MSG_CHECKING([if $1 is available])
+  AC_LINK_IFELSE([AC_LANG_PROGRAM([], [
+    m4_case([$1],
+      [__builtin_ffs], [$1(0)],
+      [__builtin_ffsl], [$1(0)],
+      [__builtin_ffsll], [$1(0)],
+      [__builtin_expect], [$1(0, 0)]),
+      [exit(1)]
+      ])], [result=yes], [result=no])
+
+  AC_MSG_RESULT([${result}])
+  AS_IF([test "${result}" = "no"], [AC_MSG_ERROR([$1 not available])], [])
+])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ sources = \
 	nccl_ofi_msgbuff.c \
 	nccl_ofi_freelist.c \
 	nccl_ofi_deque.c \
+	nccl_ofi_idpool.c \
 	tracepoint.c
 
 if WANT_PLATFORM_AWS

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "nccl_ofi.h"
+#include "nccl_ofi_idpool.h"
+#include "nccl_ofi_math.h"
+
+/*
+ * @brief	Initialize pool of IDs
+ *
+ * Allocates and initializes a nccl_ofi_idpool_t object, marking all
+ * IDs as available.
+ *
+ * @param	idpool_p
+ *		Return value with the ID pool pointer allocated
+ * @param	size
+ *		Size of the id pool (number of IDs)
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size)
+{
+	int ret = 0;
+
+	assert(NULL != idpool);
+
+	if (0 == size) {
+		/* Empty or unused pool */
+		idpool->ids = NULL;
+		idpool->size = 0;
+		return ret;
+	}
+
+	/* Scale pool size to number of 64-bit uints (rounded up) */
+	size_t num_long_elements = NCCL_OFI_ROUND_UP(size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
+
+	/* Allocate memory for the pool */
+	idpool->ids = malloc(sizeof(uint64_t) * num_long_elements);
+
+	/* Return in case of allocation error */
+	if (NULL == idpool->ids) {
+		NCCL_OFI_WARN("Unable to allocate ID pool");
+		return -ENOMEM;
+	}
+
+	/* Set all IDs to be available */
+	memset(idpool->ids, 0xff, size / 8);
+	if (size % 8) {
+		idpool->ids[num_long_elements - 1] = (1ULL << (size % (sizeof(uint64_t) * 8))) - 1;
+	}
+
+	/* Initialize mutex */
+	ret = pthread_mutex_init(&idpool->lock, NULL);
+	if (OFI_UNLIKELY(ret)) {
+		NCCL_OFI_WARN("Unable to initialize mutex");
+		free(idpool->ids);
+		idpool->ids = NULL;
+		return ret;
+	}
+
+	idpool->size = size;
+
+	return ret;
+}
+
+/*
+ * @brief	Allocate an ID
+ *
+ * Extract an available ID from the ID pool, mark the ID as
+ * unavailable in the pool, and return extracted ID. No-op in case
+ * no ID was available.
+ *
+ * This operation is locked by the ID pool's internal lock.
+ *
+ * @param	idpool
+ *		The ID pool
+ * @return	the extracted ID (zero-based) on success,
+ *		negative value on error
+ */
+int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
+{
+	assert(NULL != idpool);
+
+	if (0 == idpool->size) {
+		NCCL_OFI_WARN("Cannot allocate an ID from a 0-sized pool");
+		return -ENOMEM;
+	}
+
+	if (OFI_UNLIKELY(NULL == idpool->ids)) {
+		NCCL_OFI_WARN("Invalid call to nccl_ofi_allocate_id with uninitialized pool");
+		return -EINVAL;
+	}
+
+	/* Scale pool size to number of 64-bit uints (rounded up) */
+	size_t num_long_elements = NCCL_OFI_ROUND_UP(idpool->size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
+
+	pthread_mutex_lock(&idpool->lock);
+
+	int entry_index = 0;
+	int id = -1;
+	for (size_t i = 0; i < num_long_elements; i++) {
+		entry_index = __builtin_ffsll(idpool->ids[i]);
+		if (0 != entry_index) {
+			/* Found one available ID */
+
+			/* Set to 0 bit at entry_index - 1 */
+			idpool->ids[i] &= ~(1ULL << (entry_index - 1));
+
+			/* Store the ID we found */
+			id = (int)((i * sizeof(uint64_t) * 8) + entry_index - 1);
+			break;
+		}
+	}
+
+	pthread_mutex_unlock(&idpool->lock);
+
+	if (-1 == id || id >= idpool->size) {
+		NCCL_OFI_WARN("No IDs available (max: %lu)", idpool->size);
+		return -ENOMEM;
+	}
+
+	return id;
+}
+
+/*
+ * @brief	Free an ID from the pool
+ *
+ * Return input ID into the pool.
+ *
+ * This operation is locked by the ID pool's internal lock.
+ *
+ * @param	idpool
+ *		The ID pool
+ * @param	id
+ *		The ID to release (zero-based)
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
+{
+	assert(NULL != idpool);
+	assert(id >= 0);
+
+	if (0 == idpool->size) {
+		NCCL_OFI_WARN("Cannot free an ID from a 0-sized pool");
+		return -EINVAL;
+	}
+
+	if (OFI_UNLIKELY(NULL == idpool->ids)) {
+		NCCL_OFI_WARN("Invalid call to nccl_ofi_free_id with uninitialized pool");
+		return -EINVAL;
+	}
+
+	if (OFI_UNLIKELY(id >= idpool->size)) {
+		NCCL_OFI_WARN("ID value %lu out of range (max: %lu)", id, idpool->size);
+		return -EINVAL;
+	}
+
+	pthread_mutex_lock(&idpool->lock);
+
+	size_t i = id / (sizeof(uint64_t) * 8);
+	size_t entry_index = id % (sizeof(uint64_t) * 8);
+
+	/* Check if bit is 1 already */
+	if (idpool->ids[i] & (1ULL << entry_index)) {
+		NCCL_OFI_WARN("Attempted to free an ID that's not in use (%lu)", id);
+
+		pthread_mutex_unlock(&idpool->lock);
+		return -ENOTSUP;
+	}
+
+	/* Set bit to 1, making the ID available */
+	idpool->ids[i] |= 1ULL << (entry_index);
+
+	pthread_mutex_unlock(&idpool->lock);
+
+	return 0;
+}
+
+/*
+ * @brief	Release pool of IDs and free resources
+ *
+ * Releases a nccl_ofi_idpool_t object and frees allocated memory.
+ *
+ * @param	idpool_p
+ *		Pointer to the ID pool, it will be set to NULL on success
+ * @return	0 on success
+ *		non-zero on error
+ */
+int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool)
+{
+	int ret = 0;
+
+	assert(NULL != idpool);
+
+	if (0 == idpool->size && NULL == idpool->ids) {
+		/* Empty or unused pool, no-op */
+		return ret;
+	}
+
+	/* Destroy mutex */
+	ret = pthread_mutex_destroy(&idpool->lock);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Unable to destroy mutex");
+	}
+
+	free(idpool->ids);
+	idpool->ids = NULL;
+	idpool->size = 0;
+
+	return ret;
+}

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1393,7 +1393,7 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 		goto exit;
 	}
 
-	base_ep->release_ep(base_ep);
+	ret = base_ep->release_ep(base_ep);
 	free(listen_comm);
  exit:
 	return ret;
@@ -1473,7 +1473,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	local_ep_name = get_local_address(ep->ofi_ep);
 
 	memcpy(handle->ep_name, local_ep_name, MAX_EP_ADDR);
-	handle->tag = tag;
+	handle->comm_id = tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
 	num_addrs = fi_av_insert(ep->av, (void *)local_ep_name, 1,
@@ -1722,7 +1722,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 
 	/* Get tag and remote name from handle */
 	memcpy(&remote_ep_addr, handle->ep_name, MAX_EP_ADDR);
-	memcpy(&tag, &handle->tag, sizeof(tag));
+	memcpy(&tag, &handle->comm_id, sizeof(tag));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
 			      device->base.dev_id);
@@ -2067,7 +2067,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 	pthread_mutex_lock(&device->ep_lock);
 
 	/* Obtain thread-local sendrecv endpoint. Allocate and
-	 * initialize endpoint if neccessary. */
+	 * initialize endpoint if necessary. */
 	nccl_net_ofi_sendrecv_ep_t *ep = pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -13,7 +13,8 @@ noinst_PROGRAMS = \
 	deque \
 	freelist \
 	msgbuff \
-	scheduler
+	scheduler \
+	idpool
 
 TESTS = $(noinst_PROGRAMS)
 

--- a/tests/unit/idpool.c
+++ b/tests/unit/idpool.c
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+
+#include "test-common.h"
+#include "nccl_ofi_idpool.h"
+#include "nccl_ofi_math.h"
+
+int main(int argc, char *argv[]) {
+
+	ofi_log_function = logger;
+	int ret = 0;
+	(void) ret; // Avoid unused-variable warning
+	size_t sizes[] = {0, 5, 63, 64, 65, 127, 128, 129, 255};
+
+	for (int t = 0; t < sizeof(sizes) / sizeof(size_t); t++) {
+		size_t size = sizes[t];
+
+		/* Scale pool size to number of 64-bit uints (rounded up) */
+		size_t num_long_elements = NCCL_OFI_ROUND_UP(size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
+
+		nccl_ofi_idpool_t *idpool = malloc(sizeof(nccl_ofi_idpool_t));
+		assert(NULL != idpool);
+
+		/* Test nccl_ofi_idpool_init */
+		ret = nccl_ofi_idpool_init(idpool, size);
+		assert(0 == ret);
+		assert(idpool->size == size);
+
+		/* Test that all bits are set */
+		for (int i = 0; i < num_long_elements; i++) {
+			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
+				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
+			} else {
+				assert(0xffffffffffffffff == idpool->ids[i]);
+			}
+		}
+
+		/* Test nccl_ofi_allocate_id */
+		int id = 0;
+		(void) id; // Avoid unused-variable warning
+		for (uint64_t i = 0; i < size; i++) {
+			id = nccl_ofi_idpool_allocate_id(idpool);
+			assert(id == i);
+		}
+		id = nccl_ofi_idpool_allocate_id(idpool);
+		assert(-ENOMEM == id);
+
+		/* Test freeing and reallocating IDs */
+		if (size) {
+			int holes[] = {(int)(size/3), (int)(size/2)}; // Must be in increasing order
+
+			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+				if (0 == i || holes[i] != holes[i-1]) {
+					ret = nccl_ofi_idpool_free_id(idpool, holes[i]);
+					assert(0 == ret);
+				}
+			}
+
+			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+				if (0 == i || holes[i] != holes[i-1]) {
+					id = nccl_ofi_idpool_allocate_id(idpool);
+					assert(id == holes[i]);
+				}
+			}
+		}
+
+		/* Test nccl_ofi_free_id */
+		ret = nccl_ofi_idpool_free_id(idpool, (int)size);
+		assert(-EINVAL == ret);
+
+		for (int i = 0; i < size; i++) {
+			ret = nccl_ofi_idpool_free_id(idpool, i);
+			assert(0 == ret);
+		}
+
+		if (size) {
+			ret = nccl_ofi_idpool_free_id(idpool, 0);
+			assert(-ENOTSUP == ret);
+		}
+
+		/* Test that all bits are set */
+		for (int i = 0; i < num_long_elements; i++) {
+			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
+				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
+			} else {
+				assert(0xffffffffffffffff == idpool->ids[i]);
+			}
+		}
+
+		/* Test nccl_ofi_idpool_fini */
+		ret = nccl_ofi_idpool_fini(idpool);
+		assert(0 == ret);
+		/* nccl_ofi_idpool_fini is a no-op if the pool is
+		   0-sized or uninitialized */
+		ret = nccl_ofi_idpool_fini(idpool);
+		assert(0 == ret);
+
+		free(idpool);
+		idpool = NULL;
+	}
+
+	printf("Test completed successfully!\n");
+
+	return 0;
+}


### PR DESCRIPTION
*Issue:*

The communicator ID, which is used as tag for tagged operations and is carried in the immediate value in WRITE operations, is always incremented and never reused.
This can be a problem especially for the RDMA protocol, which has only 12 bits for the communicator ID, so there is a possibility that we run out of IDs.

*Description of changes:*

This PR makes changes to the way the RDMA protocol selects the communicator ID.
With these changes the ID is picked from a pool belonging to the endpoint and returned to the pool once the communicator is closed.
The pool keeps track of the used IDs by keeping a bit array and using a find-first-set operation to pick an available ID.

Also, with these changes the recv communicator ID in the RDMA protocol is no longer the same as the listen communicator ID, which means that more than one connect call can be sent to the same listen communicator.

The same approach is not used for the sendrecv protocol for now, as the sendrecv protocol has more bits per communicator ID, and implementing this same approach would require an additional "connect response" message to send the recv communicator ID to the sender.

Using the same ID pool structure, this also  changes the way we deal with MR keys, replacing the array of booleans to
keep track of used/available keys with a bit array.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

