### PR TITLE
Move rdma control channel traffic to its own endpoint

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -78,6 +78,8 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  * allocate a rdma memory registration handle with `num_rails' rails.
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
+	struct fid_mr *control_mr;
+
 	int num_rails;
 
 	/* Array of size `num_rails' */
@@ -341,6 +343,11 @@ typedef struct nccl_ofi_rdma_connection_info {
 	 * on the receiver side */
 	uint32_t remote_comm_id;
 
+	nccl_ofi_rdma_ep_name_t control_ep_name;
+
+	/* Number of rails */
+	int num_rails;
+
 	/* Array of `MAX_NUM_RAILS` `nccl_ofi_rdma_ep_name_t`
 	 * structs. The member `num_rails` indicates the number of
 	 * entries that are in use. */
@@ -401,6 +408,8 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	uint16_t next_msg_seq_num;
 
 	nccl_ofi_msgbuff_t *msgbuff;
+
+	nccl_net_ofi_rdma_send_comm_rail_t control_rail;
 
 	/* Number of rails */
 	int num_rails;
@@ -484,6 +493,9 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 #if HAVE_NVTX_TRACING
 	nvtxDomainHandle_t nvtx_domain[NCCL_OFI_N_NVTX_DOMAIN_PER_COMM];
 #endif
+
+	nccl_net_ofi_rdma_recv_comm_rail_t control_rail;
+
 
 	/* Number of rails */
 	int num_rails;
@@ -575,6 +587,8 @@ struct nccl_net_ofi_rdma_ep {
 
 	/* ID pool */
 	nccl_ofi_idpool_t *comm_idpool;
+
+	nccl_net_ofi_ep_rail_t control_rail;
 
 	/* Number of rails */
 	int num_rails;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -187,10 +187,6 @@ typedef struct {
 typedef struct {
 	/* Pointer to the allocated control buffer from freelist */
 	nccl_net_ofi_rdma_ctrl_fl_item_t *ctrl_fl_item;
-	/* Schedule used to transfer the control buffer. We save the
-	 * pointer to reference it when transferring the buffer over
-	 * network. */
-	nccl_net_ofi_schedule_t *ctrl_schedule;
 	/* Pointer to recv parent request */
 	nccl_net_ofi_rdma_req_t *recv_req;
 #if HAVE_NVTX_TRACING

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1826,12 +1826,6 @@ static inline int free_send_ctrl_req(nccl_net_ofi_rdma_req_t *req,
 		(nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 	rdma_req_send_ctrl_data_t *send_ctrl_data = get_send_ctrl_data(req);
 
-	if (send_ctrl_data->ctrl_schedule) {
-		nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)req->comm->ep->device;
-		nccl_net_ofi_release_schedule(device->scheduler, send_ctrl_data->ctrl_schedule);
-		send_ctrl_data->ctrl_schedule = NULL;
-	}
-
 	if (send_ctrl_data->ctrl_fl_item) {
 		nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 		nccl_ofi_freelist_entry_free(r_comm->ctrl_buff_fl, send_ctrl_data->ctrl_fl_item);
@@ -2626,7 +2620,6 @@ static inline int insert_send_ctrl_req(
 				nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle,
 				nccl_net_ofi_rdma_req_t *recv_req)
 {
-	nccl_net_ofi_scheduler_t *scheduler = device->scheduler;
 	nccl_net_ofi_rdma_req_t *send_ctrl_req = allocate_req(r_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(send_ctrl_req == NULL)) {
 		NCCL_OFI_WARN("Unable to get NCCL OFI send control request for device %d",
@@ -2643,18 +2636,6 @@ static inline int insert_send_ctrl_req(
 	rdma_req_send_ctrl_data_t *send_ctrl_data = get_send_ctrl_data(send_ctrl_req);
 	send_ctrl_data->recv_req = recv_req;
 	send_ctrl_data->ctrl_fl_item = NULL;
-	send_ctrl_data->ctrl_schedule = scheduler->get_schedule(scheduler,
-							   sizeof(nccl_net_ofi_rdma_ctrl_msg_t),
-							   device->num_rails);
-
-	if (OFI_UNLIKELY(!(send_ctrl_data->ctrl_schedule))) {
-		return -EINVAL;
-	} else if (OFI_UNLIKELY(send_ctrl_data->ctrl_schedule->num_xfer_infos != 1)) {
-		NCCL_OFI_WARN("Invalid schedule for outgoing control message (%zu bytes). Expected one rail, but got %zu",
-			      size,
-			      send_ctrl_data->ctrl_schedule->num_xfer_infos);
-		return -EINVAL;
-	}
 
 	/*
 	 * Allocate RDMA control buffer which transfers the RDMA write buffer
@@ -4184,16 +4165,11 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req_t *req)
 	assert(req->type == NCCL_OFI_RDMA_SEND_CTRL);
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 	rdma_req_send_ctrl_data_t *send_ctrl_data = get_send_ctrl_data(req);
-	nccl_net_ofi_schedule_t *schedule = send_ctrl_data->ctrl_schedule;
-
-	assert(schedule != NULL);
-
-	// Should be using a single rail for posting the control message
-	nccl_net_ofi_xfer_info_t *xfer_info = &schedule->rail_xfer_infos[0];
+	const int control_rail_id = 0;
 
 	// Get communicator rail information to xfer the req
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail;
-	comm_rail = get_recv_comm_rail(r_comm, xfer_info->rail_id);
+	comm_rail = get_recv_comm_rail(r_comm, control_rail_id);
 
 	nccl_net_ofi_rdma_ctrl_fl_item_t *ctrl_fl_item = send_ctrl_data->ctrl_fl_item;
 
@@ -4201,8 +4177,7 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req_t *req)
 	freelist_regmr_fn_handle_t * fl_handle = ctrl_fl_item->fl_reginfo.mr_handle;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = fl_handle->mr_handle;
 
-	assert(xfer_info->rail_id < mr_handle->num_rails);
-	void *desc = fi_mr_desc(mr_handle->mr[xfer_info->rail_id]);
+	void *desc = fi_mr_desc(mr_handle->mr[control_rail_id]);
 
 	NCCL_OFI_TRACE_SEND_CTRL_START(req->dev_id, xfer_info->rail_id, req->comm, req, req->msg_seq_num);
 	ssize_t rc = fi_send(comm_rail->local_ep, &ctrl_fl_item->ctrl_msg, sizeof(nccl_net_ofi_rdma_ctrl_msg_t), desc,


### PR DESCRIPTION
This is a series of cleanup patches that includes splitting some of the initialization of Libfabric between the send/recv and rdma transports, with the end goal of making it easier to move the control channel data from the data endpoint to its own endpoint (always on "NIC 0"), so that we can eventually increase the priority level of control messages over data messages (when Libfabric/rdma-core supports the service level feature through to the card). 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
