### PR TITLE
configure: Require hwloc for both Neuron and CUDA builds.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -72,7 +72,7 @@ have_device_interface=no
 CHECK_PKG_NEURON([AS_IF([test -n "${want_cuda}"],
                         [AC_MSG_ERROR([Cannot enable both CUDA and neuron.])],
                         [want_cuda=no])
-                  have_device_interface=neuon]
+                  have_device_interface=neuron]
                   AC_SUBST([OFI_NCCL_ARCHIVE], [nccom-net]))
 CHECK_PKG_CUDA([have_device_interface=cuda]
                AC_SUBST([OFI_NCCL_ARCHIVE], [nccl-net]))
@@ -81,8 +81,7 @@ AS_IF([test "${have_device_interface}" = "no"],
       [AC_MSG_ERROR([NCCL OFI Plugin requires either CUDA or Neuron runtime.])])
 
 CHECK_PKG_HWLOC([],
-                [AS_IF([test "${have_device_interface}" = "cuda"],
-                       [AC_MSG_ERROR([HWLOC package required for CUDA builds])])])
+		[AC_MSG_ERROR([Could not find the hwloc library. Use --with-hwloc to provide the path to non-standard hwloc installation.])])
 
 CHECK_PKG_VALGRIND()
 CHECK_VAR_REDZONE()


### PR DESCRIPTION
On systems without hwloc, configuration with `--enable-neuron`  completes successfully even if CHECK_PKG_HWLOC fails to find hwloc's devel library. The build later fails during compilation. This commit fixes the issue by requiring hwloc for any device build. This also fixes a typo in an unused value.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
