### PR TITLE
Remove Amazon Linux 1 reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ and operating system bypass.
 ## Requirements
 
 The plug-in currently supports the following distributions:
-* Amazon Linux
 * Amazon Linux 2
 * Redhat Enterprise Linux 7 and 8
 * Ubuntu 18.04 and 20.04 LTS


### PR DESCRIPTION
AL1 is dead.  Let's not claim support for it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
