### PR TITLE
bugfix: Fixes a compilation failure on newer compilers

### DIFF
--- a/include/nccl_ofi_tuner.h
+++ b/include/nccl_ofi_tuner.h
@@ -97,7 +97,7 @@ struct nccl_ofi_tuner_context {
  * Global context, allocated at _init(). This is allocated and initialized once
  * per process.
  */
-struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx;
+extern struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx;
 
 /* Modeling functions */
 void nccl_ofi_tuner_model_costs();

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -4,6 +4,7 @@
 #include "nccl_ofi_tuner.h"
 #include "nccl_ofi_log.h"
 
+struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx;
 pthread_mutex_t nccl_ofi_tuner_ctx_lock = PTHREAD_MUTEX_INITIALIZER;
 
 ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction)


### PR DESCRIPTION
GCC-10+/clang defaults to using -fno-common, which no longer allows the linker to resolve tentative definitions of same variable. Adding the extern keyword to `nccl_ofi_tuner_ctx` in the header so the storage is allocated once for the tentative definition in source instead.

Ref: https://gcc.gnu.org/gcc-10/porting_to.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
