### PR TITLE
tuner: Fix nccl_ofi_tuner lib build

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,6 +36,7 @@ if WANT_PLATFORM_AWS
   # NCCL tuner plugin
   lib_LTLIBRARIES += libnccl-ofi-tuner.la
   tuner_sources = \
+	nccl_ofi_api.c \
 	tuner/nccl_ofi_model.c \
 	tuner/nccl_ofi_tuner.c
   libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)


### PR DESCRIPTION
With my testing so far, I was explicitly preloading libnccl-net.so. This meant `ofi_log_function`, which was declared and allocated in nccl_ofi_api.c,  was available for the tuner to hook into NCCL's logger and reuse our logging macros. Folks who were relying on the right LD paths to be set — so that a dlopen() of  libnccl-net.so from NCCL would find the right library — ran into issues with missing `ofi_log_function` symbol (even when the network plugin was opened and loaded). I would have expected both cases to behave the same. Until I understand the difference, fixing the tuner sources to explicitly include nccl_ofi_api.c.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
