### PR TITLE
Skip NVLS version check if NCCL *.so not found

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -283,8 +283,8 @@ static int configure_ep_inorder(struct fid_ep *ep, int optname, const char* optn
 
 int configure_nvls_option(void)
 {
-	/* Disable NVLS topology discovery.  There's a bug with EFA
-	 * and NCCL version 2.18.3 and earlier on platforms with
+	/* Disable NVLS topology discovery for older NCCL versions. There's a
+	 * bug with EFA and NCCL version 2.18.3 and earlier on platforms with
 	 * NVLink Switch support.  We selectively disable NVLS support
 	 * to avoid the bug, which was fixed in 2.18.5.
 	 */
@@ -296,7 +296,9 @@ int configure_nvls_option(void)
 	if (getenv("NCCL_NVLS_ENABLE") == NULL) {
 		nccl_get_version = dlsym(RTLD_DEFAULT, "ncclGetVersion");
 		if (nccl_get_version == NULL) {
-			NCCL_OFI_WARN("Could not find ncclGetVersion symbol");
+			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			    "Could not find ncclGetVersion symbol; skipping NVLS NCCL version check");
+			return 0;
 		} else {
 			nccl_ret = nccl_get_version(&version);
 			if (nccl_ret != ncclSuccess) {


### PR DESCRIPTION
Some environments (e.g., pytorch) statically link NCCL. In these environments our current logic for checking NCCL version doesn't work, and we ended up erroneously disabling NVLS even when using a new enough NCCL version.

So, skip the version check if we can't load the NCCL dynamic library

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
