### PR TITLE
tuner: Use a separate logger for tuner

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -36,7 +36,6 @@ if WANT_PLATFORM_AWS
   # NCCL tuner plugin
   lib_LTLIBRARIES += libnccl-ofi-tuner.la
   tuner_sources = \
-	nccl_ofi_api.c \
 	tuner/nccl_ofi_model.c \
 	tuner/nccl_ofi_tuner.c
   libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -6,6 +6,7 @@
 
 struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx;
 pthread_mutex_t nccl_ofi_tuner_ctx_lock = PTHREAD_MUTEX_INITIALIZER;
+ncclDebugLogger_t ofi_log_function = NULL;
 
 ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t logFunction)
 {


### PR DESCRIPTION
NCCL dlopen()s ext-net plugins and tuner plugins with `RTLD_LOCAL`, so the symbols from loading libnccl-net.so is not available to the tuner by default. Declaring a separate logger for the tuner while being able to reuse the logging macros addresses this issue without having to add in the entirety of nccl_ofi_api.c objects into the tuner.

This properly addresses the issue that was patched with 64482e8.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
