### PR TITLE
tuner: Prevent double-free of dangling global context

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -112,7 +112,12 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(ncclFunc_t collType, size_t nBytes,
 
 ncclResult_t nccl_ofi_tuner_destroy()
 {
+	pthread_mutex_lock(&nccl_ofi_tuner_ctx_lock);
 	free(nccl_ofi_tuner_ctx);
+	/* Prevent other threads from freeing a dangling global ctx */
+	nccl_ofi_tuner_ctx = NULL;
+	pthread_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
+
 	return ncclSuccess;
 }
 


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license. 
