### PR TITLE
Disable Libfabric < 1.18.0 when using EFA

### DIFF
--- a/m4/ax_platform_aws.m4
+++ b/m4/ax_platform_aws.m4
@@ -19,5 +19,19 @@ AC_DEFUN([AX_CHECK_PLATFORM_AWS],[
   AC_MSG_RESULT([${want_platform_aws}])
 
   AM_CONDITIONAL([WANT_PLATFORM_AWS], [test "${want_platform_aws}" = "yes"])
-  AS_IF([test "${want_platform_aws}" = "yes"], [NCCL_OFI_PLATFORM="AWS"])
+  AS_IF([test "${want_platform_aws}" = "yes"],
+        [NCCL_OFI_PLATFORM="AWS"
+         AC_MSG_CHECKING([for Libfabric 1.18.0 or later])
+         AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
+[[#include <rdma/fabric.h>
+]],
+[[#if !defined(FI_MAJOR_VERSION)
+#error "we cannot check the version -- sad panda"
+#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION(1,18))
+#error "version is too low -- nopes"
+#endif
+]])],
+             [AC_MSG_RESULT([yes])],
+             [AC_MSG_RESULT([no])
+	      AC_MSG_ERROR([On AWS platforms, Libfabric 1.18.0 or later is required])])])])
 ])


### PR DESCRIPTION
Libfabric prior to 1.18.0 did not have a way to disable CUDA calls, relying on a bunch of side-channel ways that were provider specific. Most providers don't make CUDA calls, although the shm utility provider does use CUDA.  Since EFA uses the shm provider, this could go sideways. Rather than try to deal with all the side channel corner cases to disable CUDA, just require Libfabric 1.18.0 or later when using the EFA provider or building on AWS.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
