### PR TITLE
Make TRACE logs compile-time disabled

### DIFF
--- a/include/nccl_ofi_log.h
+++ b/include/nccl_ofi_log.h
@@ -24,11 +24,14 @@ extern ncclDebugLogger_t ofi_log_function;
 	__PRETTY_FUNCTION__, __LINE__, "NET/OFI " fmt,		\
 	##__VA_ARGS__)
 
+#if OFI_NCCL_TRACE
 #define NCCL_OFI_TRACE(flags, fmt, ...)				\
 	(*ofi_log_function)(NCCL_LOG_TRACE, flags,		\
 	__PRETTY_FUNCTION__, __LINE__, "NET/OFI " fmt,		\
 	##__VA_ARGS__)
-
+#else
+#define NCCL_OFI_TRACE(flags, fmt, ...)
+#endif
 
 #ifdef _cplusplus
 } // End extern "C"

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5542,7 +5542,6 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 		NCCL_OFI_WARN("Invalid device provided");
 		goto exit;
 	}
-	int dev_id = device->base.dev_id;
 
 	/* Obtain lock */
 	pthread_mutex_lock(&device->ep_lock);
@@ -5598,7 +5597,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 
 		NCCL_OFI_TRACE(NCCL_NET, "RDMA endpoint %p for dev #%d is created",
 			       ep,
-			       dev_id);
+			       device->base.dev_id);
 
 	}
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2061,7 +2061,6 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 		NCCL_OFI_WARN("Invalid device provided");
 		goto exit;
 	}
-	int dev_id = device->base.dev_id;
 
 	/* Obtain lock */
 	pthread_mutex_lock(&device->ep_lock);
@@ -2096,7 +2095,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 
 		NCCL_OFI_TRACE(NCCL_NET, "Sendrecv endpoint %p for dev #%d is created",
 			       ep,
-			       dev_id);
+			       device->base.dev_id);
 
 	}
 


### PR DESCRIPTION
Following the same pattern as NCCL, don't evaluate all the TRACE prints in the plugin unless enabled at configure time.  The configure flag already exists, and was used in the (non-performance) tests, but was not used in the code itself.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
