### PR TITLE
dist generation fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -13,7 +13,7 @@ AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([config.h])
 AC_CONFIG_MACRO_DIRS([m4])
 
-AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects])
+AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects tar-pax])
 AM_SILENT_RULES([yes])
 
 dnl AX_CHECK_ENABLE_DEBUG must be called before AC_PROG_CC or

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -8,30 +8,35 @@ noinst_HEADERS = \
 	nccl_ofi.h \
 	nccl_ofi_api.h \
 	nccl_ofi_cuda.h \
-	nccl_ofi_sendrecv.h \
-	nccl_ofi_rdma.h \
-	nccl_ofi_scheduler.h \
-	nccl_ofi_topo.h \
-	nccl_ofi_msgbuff.h \
 	nccl_ofi_deque.h \
+	nccl_ofi_freelist.h \
 	nccl_ofi_idpool.h \
 	nccl_ofi_log.h \
-	nccl_ofi_freelist.h \
-	nccl_ofi_param.h \
-	nccl_ofi_tuner.h \
 	nccl_ofi_math.h \
 	nccl_ofi_memcheck.h \
+	nccl_ofi_memcheck_asan.h \
 	nccl_ofi_memcheck_nop.h \
+	nccl_ofi_memcheck_valgrind.h \
+	nccl_ofi_msgbuff.h \
+	nccl_ofi_param.h \
+	nccl_ofi_rdma.h \
+	nccl_ofi_sendrecv.h \
+	nccl_ofi_scheduler.h \
+	nccl_ofi_topo.h \
+	nccl_ofi_tuner.h \
 	tracepoint.h \
 	nccl-headers/net.h \
 	nccl-headers/error.h \
-	nccl-headers/nvidia/net.h \
 	nccl-headers/nvidia/err.h \
+	nccl-headers/nvidia/net.h \
+	nccl-headers/nvidia/net_device.h \
 	nccl-headers/nvidia/net_v2.h \
 	nccl-headers/nvidia/net_v3.h \
 	nccl-headers/nvidia/net_v4.h \
 	nccl-headers/nvidia/net_v5.h \
 	nccl-headers/nvidia/net_v6.h \
+	nccl-headers/nvidia/net_v7.h \
+	nccl-headers/nvidia/types.h \
 	nccl-headers/nvidia/tuner.h \
 	nccl-headers/neuron/net.h \
 	nccl-headers/neuron/error.h


### PR DESCRIPTION
Two fixes to the release dist generation. We were generating an empty dist even after fixing the UID issue.

With these changes:

```
<snip>

============================================================================
Testsuite summary for aws-ofi-nccl GitHub-dev
============================================================================
# TOTAL: 5
# PASS:  5
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================

<snip>


=========================================================
aws-ofi-nccl-GitHub-dev archives ready for distribution:
aws-ofi-nccl-GitHub-dev.tar.gz
=========================================================
```

These will be cherry-picked to the v1.8.x-aws branch once merged.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
