### PR TITLE
rdma: support NCCL multi-recv interface

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -59,7 +59,8 @@ extern "C" {
 #define MIN_TAG_BITS_FOR_RING_ID	(32 + 1)
 
 /* Maximum number of grouped receives */
-#define NCCL_OFI_MAX_RECVS	1
+#define NCCL_OFI_MAX_RECVS	8
+#define NCCL_OFI_MAX_RECVS_SENDRECV	1
 
 /*
  * This defines a higher value than maximum inflight requests supported by NCCL

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -68,6 +68,10 @@ typedef struct {
 	// Type of element
 	nccl_ofi_msgbuff_elemtype_t type;
 	void *elem;
+	// Multi-recv information
+	uint16_t multi_recv_size;
+	uint16_t multi_recv_start;
+	int multi_recv_tag;
 } nccl_ofi_msgbuff_elem_t;
 
 typedef struct {
@@ -110,8 +114,13 @@ bool nccl_ofi_msgbuff_destroy(nccl_ofi_msgbuff_t *msgbuff);
  *  NCCL_OFI_MSGBUFF_ERROR, other error
  */
 nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
+		uint16_t msg_index, uint16_t multi_recv_start, uint16_t multi_recv_size, int multi_recv_tag,
+		void *elem, nccl_ofi_msgbuff_elemtype_t type,
 		nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert_ctrl_multirecv(nccl_ofi_msgbuff_t *msgbuff,
+	uint16_t msg_base_index, uint16_t multi_recv_size, int *tags, void *elem,
+	nccl_ofi_msgbuff_elemtype_t type, nccl_ofi_msgbuff_status_t *msg_idx_status);
 
 /**
  * Replace an existing message element
@@ -126,8 +135,9 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
  *  NCCL_OFI_MSGBUFF_ERROR, other error
  */
 nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status);
+		uint16_t msg_index, uint16_t multi_recv_start, uint16_t multi_recv_size,
+		int multi_recv_tag, void *elem, nccl_ofi_msgbuff_elemtype_t type,
+		nccl_ofi_msgbuff_status_t *msg_idx_status, bool *multi_send_ready);
 
 /**
  * Retrieve message with given index
@@ -142,6 +152,12 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
  *  NCCL_OFI_MSGBUFF_ERROR, other error
  */
 nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
+		uint16_t msg_index, uint16_t multi_recv_start, uint16_t multi_recv_size,
+		int multi_recv_tag, void **elem, nccl_ofi_msgbuff_elemtype_t *type,
+		nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+/* As above, but with no tag */
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve_notag(nccl_ofi_msgbuff_t *msgbuff,
 		uint16_t msg_index, void **elem, nccl_ofi_msgbuff_elemtype_t *type,
 		nccl_ofi_msgbuff_status_t *msg_idx_status);
 
@@ -156,7 +172,8 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
  *  NCCL_OFI_MSGBUFF_ERROR, other error
  */
 nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, nccl_ofi_msgbuff_status_t *msg_idx_status);
+		uint16_t msg_index, uint16_t multi_recv_start, uint16_t multi_recv_size,
+		int multi_recv_tag, nccl_ofi_msgbuff_status_t *msg_idx_status);
 
 #ifdef _cplusplus
 } // End extern "C"

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -345,6 +345,12 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	/* Comm ID provided by remote endpoint */
 	uint64_t remote_comm_id;
 
+	/* Request to send connect message */
+	nccl_net_ofi_rdma_req_t *send_conn_req;
+
+	/* Indicates if connect message was delivered (and req freed) */
+	bool connect_msg_delivered;
+
 	/* Request to receive connect response message to finalize
 	 * connection establishment */
 	nccl_net_ofi_rdma_req_t *conn_resp_req;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -331,7 +331,7 @@ static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 	 * impacted with this feature as NCCL doesn't aggregate receives from
 	 * same source.
 	 */
-	props->max_group_receives = NCCL_OFI_MAX_RECVS;
+	props->max_group_receives = NCCL_OFI_MAX_RECVS_SENDRECV;
 
 	if (support_gdr == GDR_SUPPORTED) {
 		props->hmem_support = true;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -597,6 +597,9 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 	struct fi_info *info = device->device_rails[0].info;
 	int ret =  nccl_net_ofi_info_properties(info, dev_id, base_dev->plugin->num_devs, props);
 
+	/* Multi-recv adjustment */
+	props->max_group_receives = NCCL_OFI_MAX_RECVS;
+
 	/* Scale speed by the total number of rails. Assume that all
 	 * reails have the same speed. */
 	if (ret == 0) {

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
 
 	/* For grouped recvs */
 	int tag = 1;
-	int nrecv = NCCL_OFI_MAX_RECVS;
+	int nrecv = 1;
 	int *sizes = (int *)malloc(sizeof(int)*nrecv);
 	int *tags = (int *)malloc(sizeof(int)*nrecv);
 	int recv_n;

--- a/tests/functional/ring.c
+++ b/tests/functional/ring.c
@@ -39,7 +39,7 @@ int main(int argc, char *argv[])
 
 	/* For grouped receives */
 	int tag = 1;
-	int nrecv = NCCL_OFI_MAX_RECVS;
+	int nrecv = 1;
 	int *sizes = (int *)malloc(sizeof(int)*nrecv);
 	int *tags = (int *)malloc(sizeof(int)*nrecv);
 	int recv_n;

--- a/tests/unit/msgbuff.c
+++ b/tests/unit/msgbuff.c
@@ -26,17 +26,17 @@ int main(int argc, char *argv[])
 
 	/** Test insert new **/
 	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_insert(msgbuff, i, &buff_store[i], type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+		if (nccl_ofi_msgbuff_insert(msgbuff, i, i, 1, 0, &buff_store[i], type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
 			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert failed when non-full");
 			return 1;
 		}
 	}
-	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz, buff_sz, 1, 0, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_UNAVAILABLE) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return unavailable when full");
 		return 1;
 	}
-	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz-1, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz-1, buff_sz-1, 1, 0, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_INPROGRESS) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return inprogress on duplicate insert");
 		return 1;
@@ -45,7 +45,7 @@ int main(int argc, char *argv[])
 	/** Test retrieve **/
 	uint16_t *result;
 	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_retrieve(msgbuff, i, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+		if (nccl_ofi_msgbuff_retrieve(msgbuff, i, i, 1, 0, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
 			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve failed on valid index");
 			return 1;
 		}
@@ -54,12 +54,13 @@ int main(int argc, char *argv[])
 			return 1;
 		}
 	}
-	if (nccl_ofi_msgbuff_retrieve(msgbuff, buff_sz, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_retrieve(msgbuff, buff_sz, buff_sz, 1, 0, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return notstarted");
 		return 1;
 	}
-	if (nccl_ofi_msgbuff_retrieve(msgbuff, UINT16_C(0) - UINT16_C(1), (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_retrieve(msgbuff, UINT16_C(0) - UINT16_C(1), UINT16_C(0) - UINT16_C(1), 1, 0,
+				(void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_COMPLETED) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return completed");
 		return 1;
@@ -67,17 +68,17 @@ int main(int argc, char *argv[])
 
 	/** Test complete **/
 	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_complete(msgbuff, i, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+		if (nccl_ofi_msgbuff_complete(msgbuff, i, i, 1, 0, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
 			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete failed");
 			return 1;
 		}
 	}
-	if (nccl_ofi_msgbuff_complete(msgbuff, buff_sz, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_complete(msgbuff, buff_sz, buff_sz, 1, 0, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return notstarted");
 		return 1;
 	}
-	if (nccl_ofi_msgbuff_complete(msgbuff, 0, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+	if (nccl_ofi_msgbuff_complete(msgbuff, 0, 0, 1, 0, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 			stat != NCCL_OFI_MSGBUFF_COMPLETED) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return completed");
 		return 1;


### PR DESCRIPTION
The multi-recv interface allows aggregating up to 8 receive requests in a single request. The changes include msgbuff changes to be tag-aware.

* Temporarily disables eager; it will be re-enabled in a future commit.
* Makes `connect()` blocking; we need to better understand why this is necessary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
