### PR TITLE
static analyzer fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ m4/ltoptions.m4
 m4/ltsugar.m4
 m4/ltversion.m4
 m4/lt~obsolete.m4
+
+.idea/

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -529,7 +529,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
  * Set required behavior flags (and print debugging information) for
  * local_mr, virt_addr_mr, and endpoint_mr.
  */
-int nccl_net_ofi_query_provider_capabilities(struct fi_info *selected_provider,
+int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);
 
 /* Declare a platform-specific initialization hook that can be

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -269,7 +269,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
 	nccl_net_ofi_ep_t *base_ep = NULL;
 	if (ofi_handle->state.stage == COMM_CREATE_START) {
 		/* Retrieve and validate device */
-		nccl_net_ofi_device_t *base_dev = base_dev = plugin->devs[dev_id];
+		nccl_net_ofi_device_t *base_dev = plugin->devs[dev_id];
 		if (OFI_UNLIKELY(base_dev == NULL)) {
 			NCCL_OFI_WARN("Error accessing device. Device #%i has not been initialized.", dev_id);
 			return ncclInternalError;

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -491,7 +491,7 @@ error:
 
 ncclResult_t nccl_net_ofi_accept_v4(void* listenComm, void** recvComm)
 {
-	ncclResult_t ret;
+	ncclResult_t ret = ncclInvalidArgument;
 
 	while (*recvComm == NULL) {
 		ret = nccl_net_ofi_accept(listenComm, recvComm);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -499,7 +499,7 @@ int nccl_net_ofi_reg_mr_dma_buf_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 }
 
 
-int nccl_net_ofi_query_provider_capabilities(struct fi_info *selected_provider,
+int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers)
 {
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s (found %d nics)",

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -166,6 +166,7 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 	int rc = 0;
 	struct fi_info *providers = NULL, *prov = NULL, *last_prov;
 	char *selected_prov_name = NULL;
+	*num_prov_infos = 0;
 
 	rc = fi_getinfo(required_version, NULL, NULL, 0ULL, hints, &providers);
 	if (rc != 0)
@@ -173,6 +174,9 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 
 	if (!providers)
 		goto error;
+	if (!num_prov_infos) {
+		goto error;
+	}
 
 	/* Pick a provider name to use.  If there is a prov_include
 	 * provided, use the first provider which matches the list,
@@ -201,7 +205,6 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 	prov = providers;
 	providers = NULL;
 	last_prov = NULL;
-	*num_prov_infos = 0;
 	while (prov) {
 		struct fi_info *prov_next = prov->next;
 		prov->next = NULL;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5873,7 +5873,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	base_devs = calloc(num_devs, sizeof(nccl_net_ofi_rdma_device_t *));
+	base_devs = calloc(num_devs, sizeof(nccl_net_ofi_device_t *));
 	if (!base_devs) {
 		NCCL_OFI_WARN("Unable to allocate "
 			      "nccl_net_ofi_rdma_device_t pointer array");

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2400,7 +2400,7 @@ found:
 		goto exit;
 	}
 
-	base_devs = malloc(num_providers * sizeof(nccl_net_ofi_sendrecv_device_t *));
+	base_devs = malloc(num_providers * sizeof(nccl_net_ofi_device_t *));
 	if (!base_devs) {
 		NCCL_OFI_WARN("Unable to allocate "
 			      "nccl_net_ofi_sendrecv_device_t pointer array");

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -1300,9 +1300,13 @@ static int write_pci_tag(FILE *file, int indent,
 			 "<pci "
 			 "busid=\"%04x:%02x:%02x.%01x\" "
 			 "link_speed=\"%s GT/s PCIe/s\" "
-			 "link_width=\"%ld\"/>\n",
-			 indent, "",
-			 pcidev->domain, pcidev->bus, pcidev->dev, pcidev->func,
+			 "link_width=\"%zu\"/>\n",
+			 indent,
+			 "",
+			 pcidev->domain,
+			 pcidev->bus,
+			 pcidev->dev,
+			 pcidev->func,
 			 pcie_gen[speed_idx],
 			 width);
 

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -599,11 +599,15 @@ nccl_ofi_topo_t *nccl_ofi_topo_create(struct fi_info *info_list)
  */
 static int mark_topo_nodes_with_ofi_info_subtree(nccl_ofi_topo_t *topo)
 {
+	int status;
 	nccl_ofi_topo_data_t *data = NULL;
 
 	/* Iterate over user data that stores libfabric NIC info structs */
 	nccl_ofi_topo_data_iterator_t data_iter;
-	nccl_ofi_topo_set_to_begin(topo, &data_iter);
+	if ((status = nccl_ofi_topo_set_to_begin(topo, &data_iter)) < 0) {
+		return status;
+	}
+
 	while ((data = nccl_ofi_get_user_data(&data_iter))) {
 		nccl_ofi_inc_user_data_iter(&data_iter);
 		if (!data->info_list) {

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -91,12 +91,14 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 0;
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -112,12 +114,14 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 0;
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -129,6 +133,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -138,6 +143,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -149,6 +155,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -158,6 +165,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -169,6 +177,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -178,6 +187,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -193,12 +203,14 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 0;
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -210,6 +222,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 2;
@@ -222,6 +235,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -233,6 +247,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 2;
@@ -245,6 +260,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -256,6 +272,7 @@ int test_multiplexing_schedule()
 	ret = create_multiplexed(size, num_rails, align, &schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to create multiplexed schedule");
+		free(ref_schedule);
 		return ret;
 	}
 	ref_schedule->num_xfer_infos = 3;
@@ -271,6 +288,7 @@ int test_multiplexing_schedule()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	free(schedule);
@@ -291,6 +309,7 @@ int test_threshold_scheduler()
 	nccl_net_ofi_scheduler_t *scheduler;
 	if (nccl_net_ofi_threshold_scheduler_init(num_rails, rr_threshold, &scheduler)) {
 		NCCL_OFI_WARN("Failed to initialize threshold scheduler");
+		free(ref_schedule);
 		return -1;
 	}
 
@@ -298,6 +317,7 @@ int test_threshold_scheduler()
 	schedule = scheduler->get_schedule(scheduler, rr_threshold + 1, num_rails);
 	if (!schedule) {
 		NCCL_OFI_WARN("Failed to get schedule");
+		free(ref_schedule);
 		return -1;
 	}
 	ref_schedule->num_xfer_infos = 2;
@@ -310,6 +330,7 @@ int test_threshold_scheduler()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	nccl_net_ofi_release_schedule(scheduler, schedule);
@@ -318,6 +339,7 @@ int test_threshold_scheduler()
 	schedule = scheduler->get_schedule(scheduler, rr_threshold, num_rails);
 	if (!schedule) {
 		NCCL_OFI_WARN("Failed to get schedule");
+		free(ref_schedule);
 		return -1;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -327,6 +349,7 @@ int test_threshold_scheduler()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	nccl_net_ofi_release_schedule(scheduler, schedule);
@@ -334,6 +357,7 @@ int test_threshold_scheduler()
 	schedule = scheduler->get_schedule(scheduler, rr_threshold, num_rails);
 	if (!schedule) {
 		NCCL_OFI_WARN("Failed to get schedule");
+		free(ref_schedule);
 		return -1;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -343,6 +367,7 @@ int test_threshold_scheduler()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	nccl_net_ofi_release_schedule(scheduler, schedule);
@@ -350,6 +375,7 @@ int test_threshold_scheduler()
 	schedule = scheduler->get_schedule(scheduler, rr_threshold, num_rails);
 	if (!schedule) {
 		NCCL_OFI_WARN("Failed to get schedule");
+		free(ref_schedule);
 		return -1;
 	}
 	ref_schedule->num_xfer_infos = 1;
@@ -359,6 +385,7 @@ int test_threshold_scheduler()
 	ret = verify_schedule(schedule, ref_schedule);
 	if (ret) {
 		NCCL_OFI_WARN("Verification failed");
+		free(ref_schedule);
 		return ret;
 	}
 	nccl_net_ofi_release_schedule(scheduler, schedule);


### PR DESCRIPTION
*Description of changes:*

```
a15e2c7 nit: silence clangsa warnings on pointer mismatch
ff22381 nit: remove extraneous assignment to self
7ae42c7 nit: test: unit: fix early-return leaks
2eacffd fix: net: strlen(NULL) is UB
9e79a7f fix: net: get_provider: always set return count
1cc9939 fix: topo: dont ignore errno
fe829de fix: api: initialize ofi_accept return value
```

Fixes various reports found in [clang-static-analyzer/CodeChecker reporting](https://github.com/aws-nslick/aws-ofi-nccl/actions/runs/8002290167). Others remain.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
