### PR TITLE
fix: Close the libfabric domain before closing the fabric

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5819,9 +5819,15 @@ static void release_device_ofi_resources(nccl_net_ofi_rdma_device_t *device)
 	nccl_net_ofi_rdma_device_rail_t *end = device->device_rails + device->num_rails;
 
 	for (; begin != end; ++begin) {
-		if (begin->info) fi_freeinfo(begin->info);
-		if (begin->fabric) fi_close(&begin->fabric->fid);
-		if (begin->domain) fi_close(&begin->domain->fid);
+		if (begin->domain) {
+			fi_close(&begin->domain->fid);
+		}
+		if (begin->fabric) {
+			fi_close(&begin->fabric->fid);
+		}
+		if (begin->info) {
+			fi_freeinfo(begin->info);
+		}
 	}
 }
 


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
