### PR TITLE
fix(build): tuner: prefer ncclInvalidArgument

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -21,7 +21,12 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 	 */
 	if (getenv("NCCL_ALGO") || getenv("NCCL_PROTO")) {
 		NCCL_OFI_WARN("The tuner plugin can not be loaded when explicitly choosing an algorithm or protocol with NCCL_ALGO/NCCL_PROTO");
-		return ncclInvalidUsage;
+		// FIXME: "ncclInvalidUsage should be returned when the error is
+		// most likely a user error" per nccl docs, which arguably makes
+		// it a better return code here than ncclInvalidArgument, but
+		// the former is currently not vended in ext-net headers, so
+		// we're returning ncclInvalidArgument instead.
+		return ncclInvalidArgument;
 	}
 
 	struct nccl_ofi_tuner_model_params params = {


### PR DESCRIPTION
ncclInvalidArgument is present both in neuron and nvidia whereas ncclInvalidUsage is only present in neuron headers. Callsite just wraps the value in ncclcheck and the meaning isn't meaningfully changed, so prefer the portable one.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
