### PR TITLE
ci(github): run CodeChecker on PRs

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -21,6 +21,8 @@ jobs:
           - neuron
       fail-fast: false
     steps:
+      - uses: actions/checkout@v4
+
       - name: Install Dependencies
         run: |
           sudo apt-get update -y
@@ -42,7 +44,6 @@ jobs:
           # Install Neuron Runtime
           sudo apt-get install aws-neuronx-runtime-lib -y
 
-      - uses: actions/checkout@v4
       - name: Install Libfabric
         run: |
           # We're just doing distchecks, so it is fine if we
@@ -88,3 +89,31 @@ jobs:
         with:
           name: ${{ matrix.cc }}-config.log
           path: config.log
+
+      - uses: actions/setup-python@v5
+        if: matrix.cc == 'clang'
+        with:
+          python-version: '3.9'
+
+      - name: Run CodeChecker
+        if: matrix.cc == 'clang'
+        uses: whisperity/codechecker-analysis-action@v1
+        id: codechecker
+        with:
+          # clean and rebuild so that compile_commands.json can be detected
+          build-command: "make clean && make"
+          ctu: true
+
+      - name: Save CodeChecker HTML output.
+        if: matrix.cc == 'clang'
+        uses: actions/upload-artifact@v4
+        with:
+          name: "CodeChecker Bug Reports for ${{ matrix.sdk }}"
+          path: ${{ steps.codechecker.outputs.result-html-dir }}/*.html
+
+      - name: CodeChecker Pass Or Fail?
+        if: matrix.cc == 'clang' && ${{ steps.codechecker.outputs.warnings-in-diff == 'true' }}
+        shell: bash
+        run: |
+          echo "::error title=Static Analyzers Failed::Analysed commit(s) caused static analysis warnings"
+          exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,6 +53,7 @@ opensource-codeofconduct@amazon.com with any additional questions or comments.
 ## Security issue notifications
 If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+We run [CodeChecker](https://codechecker.readthedocs.io/en/latest/) (LLVM/Clang Static Analysis) on every pull request.
 
 ## Licensing
 


### PR DESCRIPTION
extend distcheck workflow to run a second build under CodeChecker and report defects. Better configuration and fixes of reported defects will follow in a separate series, so for now, do not fail CI based on the existence of a report.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
