### PR TITLE
Switch to untagged send/recv and remove SAS ordering requirement in the RDMA protocol

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -191,6 +191,9 @@ typedef struct nccl_ofi_connection_info {
 	uint64_t connect_to_self;
 	nccl_net_ofi_req_t* req;
 } nccl_ofi_connection_info_t;
+/* Since this is a message on the wire, check that it has the expected size */
+_Static_assert(sizeof(nccl_ofi_connection_info_t) == 80,
+	       "Wrong size for SENDRECV connect message");
 
 typedef struct nccl_net_ofi_conn_handle {
 	char ep_name[MAX_EP_ADDR];

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -194,7 +194,7 @@ typedef struct nccl_ofi_connection_info {
 
 typedef struct nccl_net_ofi_conn_handle {
 	char ep_name[MAX_EP_ADDR];
-	uint64_t comm_id;
+	uint32_t comm_id;
 	/* Save temporary communicator state when creating send communicator */
 	save_comm_state_t state;
 } nccl_net_ofi_conn_handle_t;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -298,7 +298,7 @@ typedef struct nccl_ofi_rdma_ep_name {
 typedef struct nccl_ofi_rdma_connection_info {
 	/* A comm identitifer that uniquely identifies the comm on the sender
 	   side. The receiver must use this ID when sending messages to sender */
-	uint64_t local_comm_id;
+	uint32_t local_comm_id;
 
 	/* Number of rails */
 	int num_rails;
@@ -341,9 +341,9 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
 	/* Comm ID provided by the local endpoint */
-	uint64_t local_comm_id;
+	uint32_t local_comm_id;
 	/* Comm ID provided by remote endpoint */
-	uint64_t remote_comm_id;
+	uint32_t remote_comm_id;
 
 	/* Request to receive connect response message to finalize
 	 * connection establishment */
@@ -419,9 +419,9 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
 	/* Comm ID provided by the local endpoint */
-	uint64_t local_comm_id;
+	uint32_t local_comm_id;
 	/* Comm ID provided by remote endpoint */
-	uint64_t remote_comm_id;
+	uint32_t remote_comm_id;
 
 	/* The flush buffer */
 	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
@@ -447,7 +447,7 @@ typedef struct nccl_net_ofi_rdma_listen_comm {
 	nccl_net_ofi_listen_comm_t base;
 
 	/* Comm ID provided by local endpoint */
-	uint64_t comm_id;
+	uint32_t comm_id;
 	struct fid_ep *leader_local_ep;
 
 	/* Communicator created while accept routine is executed */
@@ -623,7 +623,7 @@ typedef struct nccl_net_ofi_rdma_device {
 	char *prov_name;
 
 	/* Maximum number of supported communicator IDs */
-	uint64_t num_comm_ids;
+	uint32_t num_comm_ids;
 
 	/* Memory registration key pool */
 	nccl_ofi_idpool_t key_pool;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -98,6 +98,9 @@ typedef struct nccl_net_ofi_rdma_ctrl_msg {
 	uint64_t buff_len;
 	uint64_t buff_mr_key[MAX_NUM_RAILS];
 } nccl_net_ofi_rdma_ctrl_msg_t;
+/* Since this is a message on the wire, check that it has the expected size */
+_Static_assert(sizeof(nccl_net_ofi_rdma_ctrl_msg_t) == 56,
+	       "Wrong size for RDMA Control message");
 
 /* Structure used to store control messages in a free list */
 typedef struct nccl_net_ofi_rdma_ctrl_fl_item {
@@ -334,6 +337,9 @@ typedef struct nccl_ofi_rdma_connection_info {
 	 * entries that are in use. */
 	nccl_ofi_rdma_ep_name_t ep_names[MAX_NUM_RAILS];
 } nccl_ofi_rdma_connection_info_t;
+/* Since this is a message on the wire, check that it has the expected size */
+_Static_assert(sizeof(nccl_ofi_rdma_connection_info_t) == 236,
+	       "Wrong size for RDMA connect message");
 
 /*
  * @brief	Send communicator rail

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -60,6 +60,13 @@ typedef enum nccl_net_ofi_rdma_req_type {
 	NCCL_OFI_RDMA_SEND_CONN_RESP,
 } nccl_net_ofi_rdma_req_type_t;
 
+typedef enum nccl_ofi_rdma_msg_type {
+	NCCL_OFI_RDMA_MSG_CONN,
+	NCCL_OFI_RDMA_MSG_CONN_RESP,
+	NCCL_OFI_RDMA_MSG_CTRL,
+	NCCL_OFI_RDMA_MSG_EAGER
+} nccl_ofi_rdma_msg_type_t;
+
 /*
  * @brief	Rdma memory registration handle
 
@@ -77,6 +84,16 @@ typedef struct nccl_net_ofi_rdma_mr_handle {
 /* Contents of ctrl message sent from receiver to sender to advertise
    destination buffer */
 typedef struct nccl_net_ofi_rdma_ctrl_msg {
+	/* Message type, must be NCCL_OFI_RDMA_MSG_CTRL */
+	uint16_t type;
+
+	/* Message sequence number */
+	uint16_t msg_seq_num;
+
+	/* A comm identitifer that uniquely identifies the comm
+	 * on the receiver side */
+	uint32_t remote_comm_id;
+
 	uint64_t buff_addr;
 	uint64_t buff_len;
 	uint64_t buff_mr_key[MAX_NUM_RAILS];
@@ -296,12 +313,21 @@ typedef struct nccl_ofi_rdma_ep_name {
  * connection information.
  */
 typedef struct nccl_ofi_rdma_connection_info {
+	/* Message type
+	 * either NCCL_OFI_RDMA_MSG_CONN or NCCL_OFI_RDMA_MSG_CONN_RESP
+	 */
+	uint16_t type;
+
+	/* Number of rails */
+	uint16_t num_rails;
+
 	/* A comm identitifer that uniquely identifies the comm on the sender
 	   side. The receiver must use this ID when sending messages to sender */
 	uint32_t local_comm_id;
 
-	/* Number of rails */
-	int num_rails;
+	/* A comm identitifer that uniquely identifies the comm
+	 * on the receiver side */
+	uint32_t remote_comm_id;
 
 	/* Array of `MAX_NUM_RAILS` `nccl_ofi_rdma_ep_name_t`
 	 * structs. The member `num_rails` indicates the number of
@@ -342,6 +368,7 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 
 	/* Comm ID provided by the local endpoint */
 	uint32_t local_comm_id;
+
 	/* Comm ID provided by remote endpoint */
 	uint32_t remote_comm_id;
 
@@ -420,6 +447,7 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 
 	/* Comm ID provided by the local endpoint */
 	uint32_t local_comm_id;
+
 	/* Comm ID provided by remote endpoint */
 	uint32_t remote_comm_id;
 

--- a/include/tracepoint.h
+++ b/include/tracepoint.h
@@ -136,21 +136,21 @@ LTTNG_UST_TRACEPOINT_EVENT(
     Recv,
     LTTNG_UST_TP_ARGS(
             int, dev,
-            int, tag,
+            int, comm_id,
             int, size,
             void *, request,
             void *, nccl_req
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer(int, tag, tag)
+            lttng_ust_field_integer(int, comm_id, comm_id)
             lttng_ust_field_integer(int, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req)
+#define NCCL_OFI_TRACE_RECV(dev, comm_id, size, request, nccl_req) \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm_id, size, request, nccl_req)
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -259,7 +259,12 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 		goto error;
 	}
 
-	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	if (info->caps & FI_TAGGED) {
+		cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	} else {
+		cq_attr.format = FI_CQ_FORMAT_DATA;
+	}
+
 	ret = fi_cq_open(domain, &cq_attr, cq, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3877,12 +3877,13 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		ret = -EINVAL;
 	}
 
- exit:
-
+ exit:;
 	/* Close receive communicator in case listen operation failed */
-	ret = close_listen_recv_comm(l_comm);
-
-	return ret;
+	int close_ret = close_listen_recv_comm(l_comm);
+	if (close_ret) {
+		NCCL_OFI_WARN("Failed to close listen communicator");
+	}
+	return ret ? ret : close_ret;
 }
 
 static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
@@ -5992,7 +5993,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 
 	goto exit;
 
- error:;
+ error:
 	if (base_devs) {
 		for (nccl_net_ofi_device_t **base_dev = base_devs; base_dev != base_devs + num_devs; ++base_dev) {
 			nccl_net_ofi_rdma_device_t *device =

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5743,8 +5743,8 @@ static void get_hints(struct fi_info *hints)
 
 	hints->mode = 0;
 
-	hints->tx_attr->msg_order = FI_ORDER_SAS;
-	hints->rx_attr->msg_order = FI_ORDER_SAS;
+	hints->tx_attr->msg_order = FI_ORDER_NONE;
+	hints->rx_attr->msg_order = FI_ORDER_NONE;
 
 	hints->ep_attr->type = FI_EP_RDM;
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3518,8 +3518,7 @@ static inline nccl_net_ofi_rdma_recv_comm_t *calloc_rdma_recv_comm(int num_rails
  * @return	Receive communicator object, on success
  * 		NULL, on error
  */
-static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen_comm_t *l_comm,
-							nccl_net_ofi_rdma_device_t *device,
+static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device_t *device,
 							nccl_net_ofi_rdma_ep_t *ep,
 							nccl_ofi_rdma_connection_info_t *conn_msg)
 {
@@ -3875,7 +3874,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		/* Prepare receive communicator object for the received peer connection */
-		r_comm = prepare_recv_comm(l_comm, device, ep, conn_msg);
+		r_comm = prepare_recv_comm(device, ep, conn_msg);
 		if (OFI_UNLIKELY(r_comm == NULL)) {
 			ret = -EINVAL;
 			goto exit;
@@ -5192,7 +5191,7 @@ static int post_send_conn(nccl_net_ofi_rdma_send_comm_t *s_comm,
  *
  * The connect functionality is split into two steps. This function
  * implements the first step in a nonblocking manner. The first step
- * performs (a) create send comminicator with only the first
+ * performs (a) create send communicator with only the first
  * communicator rail being initalized, (b) post send operation to send
  * connect message to remote, containing local endpoint addresses, (c)
  * wait until message is delivered, (d) post receive operation to

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1478,7 +1478,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	local_ep_name = get_local_address(ep->ofi_ep);
 
 	memcpy(handle->ep_name, local_ep_name, MAX_EP_ADDR);
-	handle->comm_id = tag;
+	handle->comm_id = (uint32_t)tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
 	num_addrs = fi_av_insert(ep->av, (void *)local_ep_name, 1,
@@ -1727,7 +1727,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 
 	/* Get tag and remote name from handle */
 	memcpy(&remote_ep_addr, handle->ep_name, MAX_EP_ADDR);
-	memcpy(&tag, &handle->comm_id, sizeof(tag));
+	memcpy(&tag, &handle->comm_id, sizeof(handle->comm_id));
 	if (tag < 1 || tag > max_tag) {
 		NCCL_OFI_WARN("Received an invalid tag %lu for device %d", tag,
 			      device->base.dev_id);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2105,9 +2105,8 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 	}
 
 	if (ep->ref_cnt == 0) {
-		ret = nccl_ofi_ofiutils_init_connection(selected_api_version, device->info,
-							device->domain, &ep->ofi_ep, &ep->av,
-							&ep->cq);
+		ret = nccl_ofi_ofiutils_init_connection(selected_api_version, device->info, device->domain, &ep->ofi_ep,
+							&ep->av, &ep->cq);
 		if (ret != 0) {
 			goto unlock;
 		}


### PR DESCRIPTION
Switching to using untagged send/recv operations in the RDMA protocol. Tags were used for connection request and response, while control messages and eager messages used tag 0. The data previously present in the tag has been moved to the message itself. 
In addition, the control message is now using send() instead of senddata(), and the data is carried directly in the message.

Switching to untagged ops means that libfabric won't pre-select the message provided to the recv, so all SENDs are received into bounce buffers now.

This PR also removes the Send-After-Send ordering requirement from libfabric.
~~The only case where out-of-order sends can be a problem is if a receiver sends a connect response followed by a control message, and they arrive in the opposite order on the sender side. To deal with this rare case, we add a list of control messages in the send communicator to store those early control messages, and process them after the connect response is received.~~

This also fixes a bug in the accept() error path, that caused accept() to return "success" even in case of errors.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
