### PR TITLE
tuner: Fix missing config.h include

### DIFF
--- a/include/nccl-headers/error.h
+++ b/include/nccl-headers/error.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)      2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef NCCL_HEADERS_ERROR_H
@@ -7,8 +7,10 @@
 
 #if HAVE_CUDA
 #include "nccl-headers/nvidia/err.h"
-#else
+#elif HAVE_NEURON
 #include "nccl-headers/neuron/error.h"
+#else
+#error "Neither CUDA nor Neuron support is available"
 #endif
 
 #endif

--- a/include/nccl-headers/net.h
+++ b/include/nccl-headers/net.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (c)      2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2023-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
 #ifndef NCCL_HEADERS_NET_H
@@ -7,8 +7,10 @@
 
 #if HAVE_CUDA
 #include "nccl-headers/nvidia/net.h"
-#else
+#elif HAVE_NEURON
 #include "nccl-headers/neuron/net.h"
+#else
+#error "Neither CUDA nor Neuron support is available"
 #endif
 
 #endif

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-#include "config.h"
-
 #include <rdma/fabric.h>
 
 #include "nccl_ofi.h"

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-#include "config.h"
-
 #include <rdma/fabric.h>
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"

--- a/include/tracepoint.h
+++ b/include/tracepoint.h
@@ -30,7 +30,6 @@
  *
  */
 
-#include "config.h"
 #if HAVE_LIBLTTNG_UST == 1
 
 /*

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -2,6 +2,8 @@
  * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
+#include "config.h"
+
 #include "nccl_ofi.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_math.h"

--- a/src/tuner/nccl_ofi_model.c
+++ b/src/tuner/nccl_ofi_model.c
@@ -1,5 +1,8 @@
+#include "config.h"
+
 #include <stdlib.h>
 #include <math.h>
+
 #include "nccl-headers/nvidia/tuner.h"
 #include "nccl_ofi_tuner.h"
 #include "nccl_ofi_log.h"

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -1,5 +1,8 @@
+#include "config.h"
+
 #include <stdlib.h>
 #include <pthread.h>
+
 #include "nccl-headers/nvidia/tuner.h"
 #include "nccl_ofi_tuner.h"
 #include "nccl_ofi_log.h"


### PR DESCRIPTION
Without this, we were incorrectly including neuron headers instead of CUDA ones when HAVE_CUDA was not defined. Also fail compilation if neither definition was found rather than having a fall-through case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
