### PR TITLE
Separate the domain, and abstract access to the domain.

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -131,6 +131,15 @@ extern bool virt_addr_mr;
  */
 extern const char *nccl_ofi_selected_protocol;
 
+/*
+ * Determine whether to allocate the domain per process or per
+ * thread.
+ * 0: allocate domain per process
+ * 1: allocate domain per thread
+ */
+
+extern int domain_per_thread;
+
 /* Internode network latency reported to NCCL. */
 extern float net_latency;
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -139,6 +139,17 @@ OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
 OFI_NCCL_PARAM_STR(protocol, "PROTOCOL", NULL);
 
 /*
+ * Override the platform default for domain allocation, with
+ * respect to the process or thread.
+ *
+ * -1 (unset default): use the platform-specific configuration.
+ * 0: Allocate one domain per process
+ * 1: Allocate one domain per thread
+ */
+
+OFI_NCCL_PARAM_INT(domain_per_thread, "DOMAIN_PER_THREAD", -1);
+
+/*
  * When enabled and RDMA communication protocol is used, write NCCL
  * topology file and set environment variable `NCCL_TOPO_FILE`. By
  * default, OFI plugin writes the NCCL topology file to a unique

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -517,6 +517,9 @@ struct nccl_net_ofi_ep_rail {
 	/* Completion Queue handle */
 	struct fid_cq *cq;
 
+	/* Access domain handles */
+	struct fid_domain *domain;
+
 	/*
 	 * Bounce buffer management
 	 */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -110,6 +110,9 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Endpoint handle to communicate to */
 	struct fid_ep *ofi_ep;
 
+	/* Access Domain handle */
+	struct fid_domain *domain;
+
 	/* Address vector handle */
 	struct fid_av *av;
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -60,6 +60,9 @@ bool virt_addr_mr = false;
 /* Selected communication protocol. */
 const char *nccl_ofi_selected_protocol = "SENDRECV";
 
+/* Allocate one domain per process (0) or per thread (1) */
+int domain_per_thread = 0;
+
 /* Internode network latency. */
 float net_latency = .0;
 

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -543,6 +543,7 @@ int platform_init(const char **provider_filter)
 	if (domain_per_thread == -1) {
 		domain_per_thread = platform_data->domain_per_thread;
 	}
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Creating one domain per %s", domain_per_thread ? "process" : "thread");
 
 exit:
 	return ret;

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -29,6 +29,7 @@ struct ec2_platform_data {
 	bool gdr_required;
 	bool net_flush_required;
 	const char *default_protocol;
+	int domain_per_thread;
 } platform_data_map[] = {
 	{
 		.name = "p4d.24xlarge",
@@ -38,6 +39,7 @@ struct ec2_platform_data {
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
+		.domain_per_thread = 0,
 	},
 	{
 		.name = "p4de.24xlarge",
@@ -47,6 +49,7 @@ struct ec2_platform_data {
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
+		.domain_per_thread = 0,
 	},
 	{
 		.name = "p3dn.24xlarge",
@@ -56,6 +59,7 @@ struct ec2_platform_data {
 		.gdr_required = false,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
+		.domain_per_thread = 0,
 	},
 	{
 		.name = "p5.48xlarge",
@@ -65,6 +69,7 @@ struct ec2_platform_data {
 		.gdr_required = true,
 		.net_flush_required = false,
 		.default_protocol = "RDMA",
+		.domain_per_thread = 0,
 	},
 	{
 		.name = "g5.48xlarge",
@@ -72,7 +77,22 @@ struct ec2_platform_data {
 		.gdr_required = false,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
+		.domain_per_thread = 0,
 	},
+	{
+		.name = "trn1.32xlarge",
+		.default_protocol = "SENDRECV",
+		.gdr_required = true,
+		.net_flush_required = true,
+		.domain_per_thread = 1,
+	},
+	{
+		.name = "trn1n.32xlarge",
+		.default_protocol = "SENDRECV",
+		.gdr_required = true,
+		.net_flush_required = true,
+		.domain_per_thread = 1,
+	}
 };
 
 /*
@@ -517,6 +537,11 @@ int platform_init(const char **provider_filter)
 
 	if (select_efa && ofi_nccl_protocol() == NULL && platform_data) {
 		nccl_ofi_selected_protocol = platform_data->default_protocol;
+	}
+
+	domain_per_thread = ofi_nccl_domain_per_thread();
+	if (domain_per_thread == -1) {
+		domain_per_thread = platform_data->domain_per_thread;
 	}
 
 exit:


### PR DESCRIPTION
On Neuron, create the domain in the endpoint structure.  On P-series, keep it in the device structure.  This is because, on Neuron, we lock when accessing the domain, so retaining separate domains per thread and per endpoint reduces contention

Create an accessor method, get_domain(), that abstractly accesses the endpoint by protocol and architecture.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
