### PR TITLE
Extend range of communicator IDs for the RDMA protocol

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -37,7 +37,7 @@ static pthread_mutex_t topo_file_lock = PTHREAD_MUTEX_INITIALIZER;
 /*
  * @brief	Number of bits used for the communicator ID
  */
-#define NUM_COMM_ID_BITS           ((uint64_t)12)
+#define NUM_COMM_ID_BITS           ((uint64_t)18)
 
 /* Maximum number of comms open simultaneously. Eventually this will be
    runtime-expandable */
@@ -51,13 +51,13 @@ static pthread_mutex_t topo_file_lock = PTHREAD_MUTEX_INITIALIZER;
  * communicator ID, and the message sequence number (msg_seq_num).
  * The data is encoded as follows:
  *
- * | 4-bit segment count | 12-bit comm ID | 16-bit msg_seq_num |
+ * | 4-bit segment count | 18-bit comm ID | 10-bit msg_seq_num |
  *
  * - Segment count: number of RDMA writes that will be delivered as part of this message
  * - Comm ID: the ID for this communicator
  * - Message sequence number: message identifier
  */
-#define NUM_MSG_SEQ_NUM_BITS ((uint64_t) 16)
+#define NUM_MSG_SEQ_NUM_BITS       ((uint64_t)10)
 
 /*
  * @brief	Number of bits used for number of segments value

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3070,7 +3070,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	/* Return request to NCCL */
 	*base_req = (nccl_net_ofi_req_t *)req;
 	/* Increment next_msg_seq_num for next call */
-	++(r_comm->next_msg_seq_num);
+	r_comm->next_msg_seq_num = (r_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
 
 	goto exit;
 
@@ -3531,7 +3531,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 	}
 
 	/* Allocate message buffer */
-	r_comm->msgbuff = nccl_ofi_msgbuff_init(NCCL_OFI_RDMA_MSGBUFF_SIZE);
+	r_comm->msgbuff = nccl_ofi_msgbuff_init(NCCL_OFI_RDMA_MSGBUFF_SIZE, NUM_MSG_SEQ_NUM_BITS);
 	if (!r_comm->msgbuff) {
 		NCCL_OFI_WARN("Failed to allocate and initialize message buffer");
 		free(r_comm);
@@ -4612,7 +4612,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	/* Return request to NCCL */
 	*base_req = &req->base;
 	/* Increment next_msg_seq_num for next call */
-	++(s_comm->next_msg_seq_num);
+	s_comm->next_msg_seq_num = (s_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
 
 	goto exit;
 
@@ -4961,7 +4961,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 				     &ret_s_comm->conn_msg);
 
 	/* Allocate message buffer */
-	ret_s_comm->msgbuff = nccl_ofi_msgbuff_init(NCCL_OFI_RDMA_MSGBUFF_SIZE);
+	ret_s_comm->msgbuff = nccl_ofi_msgbuff_init(NCCL_OFI_RDMA_MSGBUFF_SIZE, NUM_MSG_SEQ_NUM_BITS);
 	if (!ret_s_comm->msgbuff) {
 		NCCL_OFI_WARN("Failed to allocate and initialize message buffer");
 		ret = -ENOMEM;

--- a/tests/unit/msgbuff.c
+++ b/tests/unit/msgbuff.c
@@ -2,91 +2,127 @@
  * Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#include "config.h"
-
 #include <stdio.h>
 
-#include "test-common.h"
+#include "config.h"
+
 #include "nccl_ofi_msgbuff.h"
+
+#include "test-common.h"
 
 int main(int argc, char *argv[])
 {
 	ofi_log_function = logger;
-	const uint16_t buff_sz = 4;
-	uint16_t buff_store[4] = {0, 1, 2, 3};
+	const uint16_t max_inprogress = 4;
+	const uint16_t num_msg_seq_num_bits = 4;
+	const uint16_t field_size = 1 << num_msg_seq_num_bits;
+	uint16_t *result;
+
+	uint16_t *buff_store;
+	buff_store = calloc(max_inprogress, sizeof(uint16_t));
+	if (!buff_store) {
+		NCCL_OFI_WARN("Memory allocation failed");
+		return 1;
+	}
+
+	for (uint16_t i = 0; i < max_inprogress; ++i) {
+		buff_store[i] = i;
+	}
 
 	nccl_ofi_msgbuff_t *msgbuff;
-	if (!(msgbuff = nccl_ofi_msgbuff_init(buff_sz))) {
+	if (!(msgbuff = nccl_ofi_msgbuff_init(max_inprogress, num_msg_seq_num_bits))) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_init failed");
 		return 1;
 	}
 
 	nccl_ofi_msgbuff_status_t stat;
 	nccl_ofi_msgbuff_elemtype_t type = NCCL_OFI_MSGBUFF_REQ;
+	uint16_t msg_seq_num = 0;
+	uint16_t last_completed = (1 << num_msg_seq_num_bits) - 1;
 
-	/** Test insert new **/
-	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_insert(msgbuff, i, &buff_store[i], type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert failed when non-full");
-			return 1;
+	for (int rounds = 0; rounds < 4; rounds++) {
+		/** Test insert new **/
+		for (uint16_t i = 0; i < max_inprogress; ++i) {
+			if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + i) % field_size, &buff_store[i], type,
+						    &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+				NCCL_OFI_WARN("nccl_ofi_msgbuff_insert failed when non-full");
+				return 1;
+			}
 		}
-	}
-	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_UNAVAILABLE) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return unavailable when full");
-		return 1;
-	}
-	if (nccl_ofi_msgbuff_insert(msgbuff, buff_sz-1, NULL, type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_INPROGRESS) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return inprogress on duplicate insert");
-		return 1;
-	}
 
-	/** Test retrieve **/
-	uint16_t *result;
-	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_retrieve(msgbuff, i, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve failed on valid index");
+		if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + max_inprogress) % field_size, NULL, type, &stat) !=
+			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_UNAVAILABLE) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return unavailable when full");
 			return 1;
 		}
-		if (*result != buff_store[i]) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve returned incorrect value");
-			return 1;
-		}
-	}
-	if (nccl_ofi_msgbuff_retrieve(msgbuff, buff_sz, (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return notstarted");
-		return 1;
-	}
-	if (nccl_ofi_msgbuff_retrieve(msgbuff, UINT16_C(0) - UINT16_C(1), (void**)&result, &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_COMPLETED) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return completed");
-		return 1;
-	}
 
-	/** Test complete **/
-	for (uint16_t i = 0; i < buff_sz; ++i) {
-		if (nccl_ofi_msgbuff_complete(msgbuff, i, &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete failed");
+		if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + max_inprogress - 1) % field_size, NULL, type,
+					    &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_INPROGRESS) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return inprogress on duplicate insert");
 			return 1;
 		}
-	}
-	if (nccl_ofi_msgbuff_complete(msgbuff, buff_sz, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return notstarted");
-		return 1;
-	}
-	if (nccl_ofi_msgbuff_complete(msgbuff, 0, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
-			stat != NCCL_OFI_MSGBUFF_COMPLETED) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return completed");
-		return 1;
+
+		/** Test retrieve **/
+		for (uint16_t i = 0; i < max_inprogress; ++i) {
+			if (nccl_ofi_msgbuff_retrieve(msgbuff, (msg_seq_num + i) % field_size, (void **)&result, &type,
+						      &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+				NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve failed on valid index");
+				return 1;
+			}
+			if (*result != buff_store[i]) {
+				NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve returned incorrect value");
+				return 1;
+			}
+		}
+
+		if (nccl_ofi_msgbuff_retrieve(msgbuff, (msg_seq_num + max_inprogress) % field_size, (void **)&result,
+					      &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return notstarted");
+			return 1;
+		}
+
+		if (nccl_ofi_msgbuff_retrieve(msgbuff, last_completed, (void **)&result, &type, &stat) !=
+			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_COMPLETED) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return completed");
+			return 1;
+		}
+
+		/** Test complete **/
+		for (uint16_t i = 0; i < max_inprogress; ++i) {
+			if (nccl_ofi_msgbuff_complete(msgbuff, (msg_seq_num + i) % field_size, &stat) !=
+			    NCCL_OFI_MSGBUFF_SUCCESS) {
+				NCCL_OFI_WARN("nccl_ofi_msgbuff_complete failed");
+				return 1;
+			}
+		}
+
+		if (nccl_ofi_msgbuff_complete(msgbuff, (msg_seq_num + max_inprogress) % field_size, &stat) !=
+			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return notstarted");
+			return 1;
+		}
+
+		if (nccl_ofi_msgbuff_complete(msgbuff, msg_seq_num, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		    stat != NCCL_OFI_MSGBUFF_COMPLETED) {
+			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return completed");
+			return 1;
+		}
+
+		last_completed = (msg_seq_num + max_inprogress - 1) % field_size;
+		msg_seq_num = (msg_seq_num + max_inprogress) % field_size;
 	}
 
 	if (!nccl_ofi_msgbuff_destroy(msgbuff)) {
 		NCCL_OFI_WARN("nccl_ofi_msgbuff_destroy failed");
 		return 1;
 	}
+
+	free(buff_store);
 
 	/** Success! **/
 	return 0;


### PR DESCRIPTION
*Issue #*

The RDMA protocol is currently using 12 bits for the communicator ID, limiting the number of communicators to 4K, which can be hit in large deployments.

*Description of changes:*

This PR is hanging the number of bits used for the communicator ID from 12 to 18 to reduce
the chance of running out of comm IDs. To fit the comm ID in the immediate data,
the message sequence number has been reduced from 16 bits to 10, which is still
more than enough since usually the number of inflight messages is not that high.
The msg_seq_num space can be further reduced if needed.

With the 16 bits msg_seq_num the msgbuff relied on the wraparound of 16 bits integers,
so to reduce the number of bits of msg_seq_num we need to make the wrapping around
explicit and implement a subtraction to deal with the wraparound case. This makes
the msgbuff more generic, as it can now support any msg_seq_num space and any
number of inflight messages (not only powers of 2).

The msgbuff unit test has also been extended to test the case when message sequence numbers wrap around.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
