### PR TITLE
Fixes to error path in tests

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4693,9 +4693,9 @@ static int blocked_send_close(nccl_net_ofi_send_comm_t *send_comm)
 	}
 
 	// TODO: We might want to use READ_ONCE to read variable `connected'
+	int ret = 0;
 	while (!s_comm->connected) {
 		__compiler_barrier();
-		int ret = 0;
 		/* Progress our engine to get completions. If the
 		 * connect response message has arrived, the
 		 * connection establishment will be finalized. */
@@ -4704,9 +4704,10 @@ static int blocked_send_close(nccl_net_ofi_send_comm_t *send_comm)
 			return ret;
 		}
 	}
-	send_close(s_comm);
 
-	return 0;
+	ret = send_close(s_comm);
+
+	return ret;
 }
 
 /*

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -345,30 +345,35 @@ int main(int argc, char* argv[])
 	MPI_Finalize();
 	NCCL_OFI_INFO(NCCL_NET, "Test completed successfully for rank %d", rank);
 
-exit:
+exit:;
+
+	ncclResult_t close_res = ncclSuccess;
 
 	/* Deallocate buffers */
 	for (int idx = 0; idx < NUM_REQUESTS; idx++) {
 		if (send_buf[idx]) {
-			res = deallocate_buffer(send_buf[idx], buffer_type);
-			if (res != ncclSuccess) {
-				NCCL_OFI_WARN("Send buffer deallocation failure: %d", res);
+			close_res = deallocate_buffer(send_buf[idx], buffer_type);
+			if (close_res != ncclSuccess) {
+				NCCL_OFI_WARN("Send buffer deallocation failure: %d", close_res);
+				res = res ? res : close_res;
 			}
 			send_buf[idx] = NULL;
 		}
 		if (recv_buf[idx]) {
-			res = deallocate_buffer(recv_buf[idx], buffer_type);
-			if (res != ncclSuccess) {
-				NCCL_OFI_WARN("Recv buffer deallocation failure: %d", res);
+			close_res = deallocate_buffer(recv_buf[idx], buffer_type);
+			if (close_res != ncclSuccess) {
+				NCCL_OFI_WARN("Recv buffer deallocation failure: %d", close_res);
+				res = res ? res : close_res;
 			}
 			recv_buf[idx] = NULL;
 		}
 	}
 
 	if (expected_buf) {
-		res = deallocate_buffer(expected_buf, NCCL_PTR_HOST);
-		if (res != ncclSuccess) {
-			NCCL_OFI_WARN("Expected buffer deallocation failure: %d", res);
+		close_res = deallocate_buffer(expected_buf, NCCL_PTR_HOST);
+		if (close_res != ncclSuccess) {
+			NCCL_OFI_WARN("Expected buffer deallocation failure: %d", close_res);
+			res = res ? res : close_res;
 		}
 		expected_buf = NULL;
 	}

--- a/tests/functional/ring.c
+++ b/tests/functional/ring.c
@@ -305,29 +305,35 @@ int main(int argc, char *argv[])
 
 	NCCL_OFI_INFO(NCCL_NET, "Test completed successfully for rank %d", rank);
 
-exit:
+exit:;
+
+	ncclResult_t close_res = ncclSuccess;
+
 	/* Deallocate buffers */
 	for (int idx = 0; idx < NUM_REQUESTS; idx++) {
 		if (send_buf[idx]) {
-			res = deallocate_buffer(send_buf[idx], buffer_type);
-			if (res != ncclSuccess) {
-				NCCL_OFI_WARN("Send buffer deallocation failure: %d", res);
+			close_res = deallocate_buffer(send_buf[idx], buffer_type);
+			if (close_res != ncclSuccess) {
+				NCCL_OFI_WARN("Send buffer deallocation failure: %d", close_res);
+				res = res ? res : close_res;
 			}
 			send_buf[idx] = NULL;
 		}
 		if (recv_buf[idx]) {
-			res = deallocate_buffer(recv_buf[idx], buffer_type);
-			if (res != ncclSuccess) {
-				NCCL_OFI_WARN("Recv buffer deallocation failure: %d", res);
+			close_res = deallocate_buffer(recv_buf[idx], buffer_type);
+			if (close_res != ncclSuccess) {
+				NCCL_OFI_WARN("Recv buffer deallocation failure: %d", close_res);
+				res = res ? res : close_res;
 			}
 			recv_buf[idx] = NULL;
 		}
 	}
 
 	if (expected_buf) {
-		res = deallocate_buffer(expected_buf, NCCL_PTR_HOST);
-		if (res != ncclSuccess) {
-			NCCL_OFI_WARN("Expected buffer deallocation failure: %d", res);
+		close_res = deallocate_buffer(expected_buf, NCCL_PTR_HOST);
+		if (close_res != ncclSuccess) {
+			NCCL_OFI_WARN("Expected buffer deallocation failure: %d", close_res);
+			res = res ? res : close_res;
 		}
 		expected_buf = NULL;
 	}


### PR DESCRIPTION
nccl_message_transfer and ring tests are overwriting in the cleanup the error value
returned from previous calls. This is making the tests quite worthless,
because if a function fails the returned error will be overwritten by the
deallocate_buffer call, so if the deallocation is successful, the tests
succeeds. This PR fixes that by using a different variable for the
return values in the cleanup and makes the test fail if either a function
call fails, or the cleanup fails, or both.

While testing this, I also noticed that we were ignoring the return value of 
send_close(), so I am also fixing that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
