### PR TITLE
Move the tuner's selecting debug print to INFO level

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -97,7 +97,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context, ncclFunc_t collType, si
 		}
 	}
 
-	NCCL_OFI_TRACE(NCCL_TUNING, "Choosing algo %d proto %d with cost %.8f µsecs for coll %d size %ld.",
+	NCCL_OFI_INFO(NCCL_TUNING, "Choosing algo %d proto %d with cost %.8f µsecs for coll %d size %ld.",
 				    *algorithm, *protocol, lowest, collType, nBytes);
 	return ncclSuccess;
 }


### PR DESCRIPTION
This is a useful print to debug issues with algorithm selection at scale without having to rebuild the plugin. While the actual costs calculated are more developer-focused and can stay under TRACE, the final choice should be available to INFO when the TUNING debug subsystem is enabled.

NCCL 2.20 moved their algo/proto selection print from a TRACE to INFO for this reason as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
