### PR TITLE
Add NVTX tracing support

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -71,6 +71,7 @@ CHECK_GCC_BUILTIN([__builtin_ffsll])
 # Checks for external packages
 CHECK_PKG_LIBFABRIC([], [AC_MSG_ERROR([NCCL OFI Plugin could not find a working Libfabric install.])])
 
+CHECK_PKG_NVTX()
 CHECK_PKG_LTTNG()
 
 have_device_interface=no

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -25,7 +25,8 @@ noinst_HEADERS = \
 	nccl_ofi_topo.h \
 	nccl_ofi_tuner.h \
 	nccl_ofi_ofiutils.h \
-	tracepoint.h \
+	nccl_ofi_tracepoint.h \
+	tracing_impl/lttng.h \
 	nccl-headers/net.h \
 	nccl-headers/error.h \
 	nccl-headers/nvidia/err.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -27,6 +27,7 @@ noinst_HEADERS = \
 	nccl_ofi_ofiutils.h \
 	nccl_ofi_tracepoint.h \
 	tracing_impl/lttng.h \
+	tracing_impl/nvtx.h \
 	nccl-headers/net.h \
 	nccl-headers/error.h \
 	nccl-headers/nvidia/err.h \

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+
+#ifndef NCCL_OFI_TRACEPOINT_H_
+#define NCCL_OFI_TRACEPOINT_H_
+
+#include "config.h"
+#include "tracing_impl/lttng.h"
+
+#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_RECV(dev, rail_id, comm, msg_seq_num) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num); \
+	} while (0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(dev, rail_id, size, comm, msg_seq_num, request) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(dev, rail_id, comm, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_complete, dev, rail_id, comm, msg_seq_num, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_FLUSH(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_INSERT(request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_REMOVE(request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_remove, request); \
+	} while(0)
+
+#endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -9,6 +9,24 @@
 #include "config.h"
 #include "tracing_impl/lttng.h"
 
+/***** SENDRECV PROTOCOL *****/
+#define NCCL_OFI_TRACE_SEND_SENDRECV(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
+} while (0)
+
+#define NCCL_OFI_TRACE_RECV_SENDRECV(dev, tag, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_FLUSH_SENDRECV(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+} while(0)
+
+/***** RDMA PROTOCL *****/
 #define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
 	} while(0)

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -7,6 +7,7 @@
 #define NCCL_OFI_TRACEPOINT_H_
 
 #include "config.h"
+#include "tracing_impl/nvtx.h"
 #include "tracing_impl/lttng.h"
 
 /***** SENDRECV PROTOCOL *****/
@@ -27,52 +28,89 @@
 } while(0)
 
 /***** RDMA PROTOCL *****/
+
 #define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
-	} while(0)
+	NCCL_OFI_TRACE_SEND_NVTX(dev, size, comm, msg_seq_num, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_SEND_END(request) do { \
+	NCCL_OFI_TRACE_SEND_END_NVTX(request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_SEND_START(dev, rail_id, size, comm, msg_seq_num, request) do { \
+	/* TODO: use a better (LTTNG) trace for eager send? */ \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
+	NCCL_OFI_TRACE_EAGER_SEND_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_SEND_COMPLETE(dev, rail_id, comm, msg_seq_num, request) do { \
+	NCCL_OFI_TRACE_EAGER_SEND_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request); \
+} while (0)
 
 #define NCCL_OFI_TRACE_SEND_CTRL_RECV(dev, rail_id, comm, msg_seq_num) do { \
-		lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num); \
-	} while (0)
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num); \
+	NCCL_OFI_TRACE_SEND_CTRL_RECV_NVTX(dev, rail_id, comm, msg_seq_num); \
+} while (0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_START(dev, rail_id, comm, req, msg_seq_num) do { \
+	NCCL_OFI_TRACE_SEND_CTRL_START_NVTX(dev, rail_id, comm, req, msg_seq_num); \
+} while (0);
+
+#define NCCL_OFI_TRACE_SEND_CTRL_END(dev, rail_id, comm, req, msg_seq_num) do { \
+	NCCL_OFI_TRACE_SEND_CTRL_END_NVTX(dev, rail_id, comm, req, msg_seq_num); \
+} while (0);
 
 #define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(dev, rail_id, size, comm, msg_seq_num, request) do { \
-		lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
-	} while(0)
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
+	NCCL_OFI_TRACE_SEND_WRITE_SEG_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(dev, rail_id, comm, msg_seq_num, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_complete, dev, rail_id, comm, msg_seq_num, request); \
-	} while(0)
+	NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
-	} while(0)
+	NCCL_OFI_TRACE_RECV_NVTX(dev, tag, size, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_RECV_END(request) do { \
+	NCCL_OFI_TRACE_RECV_END_NVTX(request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) do { \
-		lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request); \
-	} while(0)
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request); \
-	} while(0)
+	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) do { \
-		lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num); \
-	} while(0)
+	lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num); \
+	NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num); \
+} while(0)
 
 #define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
-	} while(0)
+} while(0)
 
 #define NCCL_OFI_TRACE_FLUSH(request, nccl_req) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
-	} while(0)
+	NCCL_OFI_TRACE_FLUSH_NVTX(request, nccl_req); \
+} while(0)
 
 #define NCCL_OFI_TRACE_PENDING_INSERT(request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request); \
-	} while(0)
+	NCCL_OFI_TRACE_PENDING_INSERT_NVTX(request); \
+} while(0)
 
 #define NCCL_OFI_TRACE_PENDING_REMOVE(request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_remove, request); \
-	} while(0)
+	NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(request); \
+} while(0)
 
 #endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
+
+#ifndef LTTNG_H_
+#define LTTNG_H_
+
+#if HAVE_LTTNG_UST
 
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
 #define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
-#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracepoint.h"
+#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracing_impl/lttng.h"
 
 /*
  * To add a tracepoint at the nccl_ofi_plugin layer:
@@ -28,9 +33,9 @@
  * tracing output, and arguments <arg1> and <arg2> with <name1> and
  * <name2> will appear in that trace as data.
  *
+ * Add a macro to the top level nccl_ofi_tracepoint.h
+ *
  */
-
-#if HAVE_LIBLTTNG_UST == 1
 
 /*
  * LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ must be included so that the tracepoints
@@ -64,8 +69,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -83,8 +88,9 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
     )
 )
-#define NCCL_OFI_TRACE_SEND_CTRL_RECV(dev, rail_id, comm, msg_seq_num) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num)
+
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -106,8 +112,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(dev, rail_id, size, comm, msg_seq_num, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -127,8 +133,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(dev, rail_id, comm, msg_seq_num, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_complete, dev, rail_id, comm, msg_seq_num, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -148,8 +154,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_RECV(dev, comm_id, size, request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm_id, size, request, nccl_req)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -161,8 +167,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -180,8 +186,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -199,8 +204,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
     )
 )
-#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -214,8 +218,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
     )
 )
-#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -229,8 +233,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_FLUSH(request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -242,8 +245,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_PENDING_INSERT(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -255,26 +257,13 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_PENDING_REMOVE(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_remove, request)
 
 #endif /* NCCL_OFI_TRACEPOINT_H */
 
 #include <lttng/tracepoint-event.h>
 
 #else
+#define lttng_ust_tracepoint(...)
+#endif
 
-#define NCCL_OFI_TRACE_SEND(...)
-#define NCCL_OFI_TRACE_SEND_CTRL_RECV(...)
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(...)
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(...)
-#define NCCL_OFI_TRACE_RECV(...)
-#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(...)
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(...)
-#define NCCL_OFI_TRACE_EAGER_RECV(...)
-#define NCCL_OFI_TRACE_FLUSH(...)
-#define NCCL_OFI_TRACE_PENDING_INSERT(...)
-#define NCCL_OFI_TRACE_PENDING_REMOVE(...)
-#define NCCL_OFI_TRACE_COMPLETIONS(...)
-
-#endif // HAVE_LIBLTTNG_UST
+#endif /* LTTNG_H_ */

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -1,0 +1,218 @@
+/*
+ * Copyright (c) 2022-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NVTX_H
+#define NVTX_H
+
+#if HAVE_NVTX_TRACING
+#include "nvToolsExt.h"
+
+#define NCCL_OFI_N_NVTX_DOMAIN_PER_COMM 8
+
+static inline void nvtx_mark_domain(nvtxDomainHandle_t domain, const char* name, uint32_t color)
+{
+	const nvtxEventAttributes_t eventAttrib = {
+		.version = NVTX_VERSION,
+		.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE,
+		.colorType = NVTX_COLOR_ARGB,
+		.color = color,
+		.messageType = NVTX_MESSAGE_TYPE_ASCII,
+		.message = { .ascii = name },
+	};
+	nvtxDomainMarkEx(domain, &eventAttrib);
+}
+
+static inline nvtxRangeId_t nvtx_start_domain(bool have_domain, nvtxDomainHandle_t domain, const char* name, uint32_t color) {
+	const nvtxEventAttributes_t eventAttrib = {
+		.version = NVTX_VERSION,
+		.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE,
+		.colorType = NVTX_COLOR_ARGB,
+		.color = color,
+		.messageType = NVTX_MESSAGE_TYPE_ASCII,
+		.message = { .ascii = name },
+	};
+	if (have_domain)
+		return nvtxDomainRangeStartEx(domain, &eventAttrib);
+	else
+		return nvtxRangeStartEx(&eventAttrib);
+}
+
+static inline nvtxRangeId_t nvtx_start(const char* name, uint32_t color) {
+	return nvtx_start_domain(false, 0, name, color);
+}
+
+static inline void nvtx_end_domain(nvtxDomainHandle_t domain, nvtxRangeId_t id) {
+	nvtxDomainRangeEnd(domain, id);
+}
+
+static inline void nvtx_end(nvtxRangeId_t id) {
+	nvtxRangeEnd(id);
+}
+
+#define NCCL_OFI_TRACE_SEND_NVTX(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_send_comm_t*)comm) \
+			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		get_send_data(request)->trace_id = nvtx_start_domain(true, handle, "Send", 0xeb9234); \
+	} \
+} while (0)
+
+#define NCCL_OFI_TRACE_SEND_END_NVTX(request) do { \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_send_comm_t*)(request->comm)) \
+			->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, get_send_data(request)->trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_SEND_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
+	} \
+} while (0)
+
+#define NCCL_OFI_TRACE_EAGER_SEND_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_RECV_NVTX(dev, rail_id, comm, msg_seq_num) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->base.base.ep->device))->nvtx_domain[rail_id]; \
+		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
+	} \
+} while (0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_START_NVTX(dev, rail_id, comm, req, msg_seq_num) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_recv_comm_t *)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		get_send_ctrl_data(req)->trace_id = nvtx_start_domain(true, handle, "Send_ctrl_start", 0x00ffff); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		get_send_ctrl_data(req)->trace_id = nvtx_start_domain(true, handle, "Send_ctrl_start", 0x00ffff); \
+	} \
+} while (0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_END_NVTX(dev, rail_id, comm, req, msg_seq_num) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_recv_comm_t *)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, get_send_ctrl_data(req)->trace_id); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		nvtx_end_domain(handle, get_send_ctrl_data(req)->trace_id);\
+	} \
+} while (0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(comm->ep->device))->nvtx_domain[rail_id]; \
+		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_RECV_NVTX(dev, tag, size, request, nccl_req) do { \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
+			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		get_recv_data(request)->trace_id = nvtx_start_domain(true, handle, "Recv", 0x34EB37); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_RECV_END_NVTX(request) do { \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
+			->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, get_recv_data(request)->trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request) do { \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm)->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(request->comm->ep->device))->nvtx_domain[rail_id]; \
+		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num) do { \
+	nvtx_mark_domain(NULL, "Eager_recv", 0x0000FF); \
+} while(0)
+
+#define NCCL_OFI_TRACE_FLUSH_NVTX(request, nccl_req) do { \
+	nvtx_mark_domain(NULL, "Flush", 0xA52A2A); \
+} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_INSERT_NVTX(request) do { \
+	nvtx_mark_domain(NULL, "Pending_insert", 0xFF8C00); \
+} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(request) do { \
+	nvtx_mark_domain(NULL, "Pending_remove", 0xFF8C00); \
+} while(0)
+
+#else
+
+#define NCCL_OFI_TRACE_SEND_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_END_NVTX(...)
+#define NCCL_OFI_TRACE_EAGER_SEND_START_NVTX(...)
+#define NCCL_OFI_TRACE_EAGER_SEND_COMPLETE_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_CTRL_RECV_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_CTRL_START_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_CTRL_END_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START_NVTX(...)
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(...)
+#define NCCL_OFI_TRACE_RECV_NVTX(...)
+#define NCCL_OFI_TRACE_RECV_END_NVTX(...)
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(...)
+#define NCCL_OFI_TRACE_EAGER_RECV_NVTX(...)
+#define NCCL_OFI_TRACE_FLUSH_NVTX(...)
+#define NCCL_OFI_TRACE_PENDING_INSERT_NVTX(...)
+#define NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(...)
+
+#endif
+
+#endif /* NVTX_H */

--- a/m4/check_pkg_lttng.m4
+++ b/m4/check_pkg_lttng.m4
@@ -35,7 +35,7 @@ AC_DEFUN([CHECK_PKG_LTTNG], [
          LIBS="${check_pkg_LIBS_save}"
          $2])
 
-  AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
+  AC_DEFINE_UNQUOTED([HAVE_LIBLTTNG_UST], [${check_pkg_found}], [Defined to 1 if lttng-ust is requested and available])
 
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])

--- a/m4/check_pkg_nvtx.m4
+++ b/m4/check_pkg_nvtx.m4
@@ -1,0 +1,69 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_PKG_NVTX], [
+  check_pkg_found=yes
+
+  check_pkg_CPPFLAGS_save="${CPPFLAGS}"
+  check_pkg_LDFLAGS_save="${LDFLAGS}"
+  check_pkg_LIBS_save="${LIBS}"
+
+  AC_ARG_WITH([nvtx],
+     [AS_HELP_STRING([--with-nvtx=DIR], [Enable tracing capability with NVTX @<:@default=no@:>@])])
+
+  AS_IF([test "${with_nvtx}" = "yes"],
+        [],
+        [test "${with_nvtx}" = "no"],
+        [check_pkg_found=no],
+        [AS_IF([test -d ${with_nvtx}/lib64], [check_pkg_libdir="lib64"], [check_pkg_libdir="lib"])
+         CPPFLAGS="-I${with_nvtx}/include ${CPPFLAGS}"
+         LDFLAGS="-L${with_nvtx}/${check_pkg_libdir} ${LDFLAGS}"])
+
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [AC_CHECK_LIB([nvToolsExt], [nvtxRangePop], [], [check_pkg_found=no])])
+
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [check_pkg_define=1
+         $1],
+        [check_pkg_define=0
+         CPPFLAGS="${check_pkg_CPPFLAGS_save}"
+         LDFLAGS="${check_pkg_LDFLAGS_save}"
+         LIBS="${check_pkg_LIBS_save}"
+         $2])
+
+  AC_DEFINE_UNQUOTED([HAVE_NVTX_TRACING], [${check_pkg_define}], [Defined to 1 if NVTX is available])
+
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [nvtx_trace_per_comm=1
+         nvtx_trace_per_dev=0
+
+         AC_ARG_ENABLE([nvtx_trace_per_comm],
+                       AS_HELP_STRING([--enable-nvtx-trace-per-comm], [Collect NVTX traces in a "per-communicator" view, which associates parent
+                        send/recv events with constituent events (segments, controls).]),
+                       AS_IF([test "${enableval}" = "yes"], [nvtx_trace_per_comm=1], [nvtx_trace_per_comm=0]),
+                       [])
+         AC_ARG_ENABLE([nvtx_trace_per_dev],
+                       AS_HELP_STRING([--enable-nvtx-trace-per-dev], [Collect NVTX traces in a "per-device" view, which associates sub-events with
+                        an EFA device, showing activity on each device.]),
+                       AS_IF([test "${enableval}" = "yes"], [nvtx_trace_per_dev=1], [nvtx_trace_per_dev=0]),
+                       [])
+
+         AC_DEFINE_UNQUOTED([NCCL_OFI_NVTX_TRACE_PER_COMM], [$nvtx_trace_per_comm], [Defined to 1 if NVTX traces are collected per-communicator])
+         AC_DEFINE_UNQUOTED([NCCL_OFI_NVTX_TRACE_PER_DEV], [$nvtx_trace_per_dev], [Defined to 1 if NVTX traces are collected per-device])
+
+         AS_IF([test "${nvtx_trace_per_comm}" -ne 0 -a "${nvtx_trace_per_dev}" -ne 0],
+               AC_MSG_ERROR([Error: setting both nvtx_trace_per_comm and nvtx_trace_per_dev is currently not supported]))
+
+        ], [])
+
+  AS_UNSET([check_pkg_found])
+  AS_UNSET([check_pkg_define])
+  AS_UNSET([check_pkg_libdir])
+  AS_UNSET([check_pkg_CPPFLAGS_save])
+  AS_UNSET([check_pkg_LDFLAGS_save])
+  AS_UNSET([check_pkg_LIBS_save])
+])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -17,7 +17,7 @@
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -17,7 +17,7 @@
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -18,7 +18,7 @@
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_math.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #include "nccl_ofi_scheduler.h"
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_memcheck.h"

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -94,7 +94,7 @@ static inline int process_completions(struct fi_cq_tagged_entry *cq_entry,
 		comp_flags = cq_entry[comp_idx].flags;
 		req = container_of(op_ctx, nccl_net_ofi_sendrecv_req_t, ctx);
 
-		NCCL_OFI_TRACE_COMPLETIONS(req, &req->ctx);
+		NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req, &req->ctx);
 
 		/* Determine if this is control message */
 		if (OFI_UNLIKELY(cq_entry[comp_idx].tag & control_bit_mask)) {
@@ -871,7 +871,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 			desc = fi_mr_desc(mr_handles[recv_n]);
 		}
 
-		NCCL_OFI_TRACE_RECV(dev_id, r_comm->tag, sizes[recv_n], req, base_req);
+		NCCL_OFI_TRACE_RECV_SENDRECV(dev_id, r_comm->tag, sizes[recv_n], req, base_req);
 
 		/*
 		 * TODO: Use NCCL provided tags when plugin supports grouped
@@ -1052,7 +1052,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		}
 	}
 
-	NCCL_OFI_TRACE_FLUSH(req, base_req);
+	NCCL_OFI_TRACE_FLUSH_SENDRECV(req, base_req);
 
 	/* Issue RDMA read */
 	do {
@@ -1654,7 +1654,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	if (mr_handle != NULL)
 		desc = fi_mr_desc(mr_handle);
 
-	NCCL_OFI_TRACE_SEND(req->dev_id, size, s_comm, 0, req, base_req);
+	NCCL_OFI_TRACE_SEND_SENDRECV(req->dev_id, size, s_comm, 0, req, base_req);
 
 	/*
 	 * Try sending data to remote EP; Return NULL request

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -20,7 +20,7 @@
 #include "nccl_ofi_sendrecv.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_ofiutils.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #include "nccl_ofi_math.h"
 
 


### PR DESCRIPTION
Add support for NVTX tracepoints (RDMA protocol only). Enabled at compile-time with `--with-nvtx`.

Re-vamped version of #363 from Nick.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.