### PR TITLE
Build plugins as DSOs intead of shared libraries.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,6 +61,7 @@ AC_FUNC_MALLOC
 AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset function.])])
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
+AC_SEARCH_LIBS([pthread_getspecific], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
 
 # Check for GCC builtin functions
 CHECK_GCC_BUILTIN([__builtin_expect])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -6,6 +6,9 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include -DXML_DIR=\"${pkgdatadir}/xml\"
 
+#
+# net plugin
+#
 sources = \
 	nccl_ofi_api.c \
 	nccl_ofi_net.c \
@@ -25,15 +28,36 @@ sources += platform-aws.c
 endif
 
 if ENABLE_NEURON
-  lib_LTLIBRARIES = libnccom-net.la
   sources += nccl_ofi_interface_neuron.c
-  libnccom_net_la_SOURCES = $(sources)
 else
-  lib_LTLIBRARIES = libnccl-net.la
   sources += nccl_ofi_cuda.c \
 	nccl_ofi_interface_nvidia.c
-  libnccl_net_la_SOURCES = $(sources)
+endif
 
+# Build an internal-only library that can be used by unit tests as
+# well as the actual nccl_net.so / nccom_net.so libraries.  This saves
+# us writing dlopen() handlers for simple unit tests.
+noinst_LTLIBRARIES = libinternal_net_plugin.la
+libinternal_net_plugin_la_SOURCES = $(sources)
+libinternal_net_plugin_la_LDFLAGS = -avoid-version
+
+if ENABLE_NEURON
+  lib_LTLIBRARIES = libnccom-net.la
+  libnccom_net_la_SOURCES =
+  libnccom_net_la_LIBADD = libinternal_net_plugin.la
+  libnccom_net_la_LDFLAGS = -module -avoid-version
+else
+  lib_LTLIBRARIES = libnccl-net.la
+  libnccl_net_la_SOURCES =
+  libnccl_net_la_LIBADD = libinternal_net_plugin.la
+  libnccl_net_la_LDFLAGS = -module -avoid-version
+endif
+
+
+#
+# Tuner
+#
+if HAVE_CUDA
 if WANT_PLATFORM_AWS
   # NCCL tuner plugin
   lib_LTLIBRARIES += libnccl-ofi-tuner.la
@@ -41,5 +65,6 @@ if WANT_PLATFORM_AWS
 	tuner/nccl_ofi_model.c \
 	tuner/nccl_ofi_tuner.c
   libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)
+  libnccl_ofi_tuner_la_LDFLAGS = -module -avoid-version
 endif
 endif

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -7,7 +7,7 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include $(MPI_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
-LDADD = $(top_builddir)/src/libnccl-net.la $(MPI_LIBS) $(CUDA_LIBS)
+LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
 CC = $(MPICC)
 
 noinst_HEADERS = test-common.h
@@ -25,4 +25,4 @@ cuda_check_SOURCES = cuda_check.c
 # Override the LDADD for this check to avoid the -lcudart used by the
 # other tests, since the purpose of this test is to make sure we
 # didn't leak direct cuda dependencies into the plugin.
-cuda_check_LDADD = $(top_builddir)/src/libnccl-net.la
+cuda_check_LDADD = $(top_builddir)/src/libinternal_net_plugin.la

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -5,7 +5,7 @@
 #
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
-LDADD = $(top_builddir)/src/lib$(OFI_NCCL_ARCHIVE).la
+LDADD = $(top_builddir)/src/libinternal_net_plugin.la
 
 noinst_HEADERS = test-common.h
 


### PR DESCRIPTION
Build the plugins (tuner and net) as DSOs instead of shared libraries  by adding the `-module -avoid-version` flags to the library LDFLAGS.

Fix up a couple of issues that fall out of that change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
