### PR TITLE
Add -lm to library list for plugins

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -62,6 +62,7 @@ AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset funct
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
 AC_SEARCH_LIBS([pthread_getspecific], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
+AC_SEARCH_LIBS([log2], [m], [], [AC_MSG_ERROR([NCCL OFI Plugin requires the log2 library function.])])
 
 # Check for GCC builtin functions
 CHECK_GCC_BUILTIN([__builtin_expect])


### PR DESCRIPTION
The tuner uses the log2 function that is defined in libm, but we were relying on someone else to pull in libm, which is technically wrong.  Checking for what library provides libm fixes this issue, with the side effect of adding a -lm to the link line for the libnccl-net plugin.  This is not strictly needed, but linkers also will do the right thing most of the time and not actually include that dependency in the list of libraries that must be loaded for the plugin.  So this is a lot less configure code compared to each plugin having its own LIBS list, for the same outcome.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
