### PR TITLE
More cherry-picks for 1.9.x-aws 

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -72,10 +72,12 @@ jobs:
           then
             ./configure --with-libfabric=$PWD/libfabric/install \
                         --with-cuda=/usr/local/cuda/ \
+                        --enable-platform-aws \
                         CC=${{ matrix.cc }}
           else
             ./configure --with-libfabric=$PWD/libfabric/install \
                         --enable-neuron \
+                        --enable-platform-aws \
                         CC=${{ matrix.cc }}
           fi
           make -j $(nproc)

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -40,5 +40,7 @@ noinst_HEADERS = \
 	nccl-headers/nvidia/net_v8.h \
 	nccl-headers/nvidia/types.h \
 	nccl-headers/nvidia/tuner.h \
+	nccl-headers/nvidia/tuner_v1.h \
+	nccl-headers/nvidia/tuner_v2.h \
 	nccl-headers/neuron/net.h \
 	nccl-headers/neuron/error.h

--- a/m4/ax_platform_aws.m4
+++ b/m4/ax_platform_aws.m4
@@ -33,5 +33,5 @@ AC_DEFUN([AX_CHECK_PLATFORM_AWS],[
 ]])],
              [AC_MSG_RESULT([yes])],
              [AC_MSG_RESULT([no])
-	      AC_MSG_ERROR([On AWS platforms, Libfabric 1.18.0 or later is required])])])])
-])
+	      AC_MSG_ERROR([On AWS platforms, Libfabric 1.18.0 or later is required])])
+        NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --enable-platform-aws=${enable_platform_aws}"])])


### PR DESCRIPTION
b93bfbd build: Add headers that were missing in the distribution
c467d39 ci: Add --enable-platform-aws to Github distcheck action
306a4ad m4: Pass enable-aws-platform config to distcheck's config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
