### PR TITLE
Fix log message for OFI_NCCL_DOMAIN_PER_THREAD setting.

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -543,7 +543,7 @@ int platform_init(const char **provider_filter)
 	if (domain_per_thread == -1) {
 		domain_per_thread = platform_data->domain_per_thread;
 	}
-	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Creating one domain per %s", domain_per_thread ? "process" : "thread");
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Creating one domain per %s", domain_per_thread ? "thread" : "process");
 
 exit:
 	return ret;


### PR DESCRIPTION
The OFI_NCCL_DOMAIN_PER_THREAD variable and platform setting determines  whether the domain is created per process or per thread, but the associated print message reverses the output.  Correct that, so that the correct relationship is printed in the logs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
