### PR TITLE
fix(tuner): remove spurious deref from context arg

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -163,7 +163,7 @@ static ncclResult_t nccl_ofi_tuner_get_coll_info_v1(ncclFunc_t collType, size_t 
 						    int nvlsSupport, int numPipeOps, int *algorithm, int *protocol,
 						    int *nChannels)
 {
-	return nccl_ofi_tuner_get_coll_info(&nccl_ofi_tuner_ctx_internal, collType, nBytes,
+	return nccl_ofi_tuner_get_coll_info(nccl_ofi_tuner_ctx_internal, collType, nBytes,
 					    collNetSupport, nvlsSupport, numPipeOps, algorithm,
 					    protocol, nChannels);
 }


### PR DESCRIPTION
The context parameter to `nccl_ofi_tuner_get_coll_info` had an erroneous dereference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
