### PR TITLE
rdma: (fix) do not use cq_entry.len in send completions

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1433,7 +1433,7 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 
 			if (req->type == NCCL_OFI_RDMA_SEND_CONN || req->type == NCCL_OFI_RDMA_SEND_CONN_RESP) {
 				/* CONN or CONN_RESP send completion */
-				ret = inc_req_completion(req, cq_entry[comp_idx].len, 1);
+				ret = inc_req_completion(req, sizeof(nccl_ofi_rdma_connection_info_t), 1);
 
 			} else if (req->type == NCCL_OFI_RDMA_SEND_CTRL) {
 				/* CTRL message send completion */


### PR DESCRIPTION
According to libfabric specs, the len field in a completion entry only applies to completed receive operations. We were using it for send completions as well, which is currently working in the EFA provider, but there is no guarantee that this will be true in the future and for other providers. This PR is fixing this issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
