### PR TITLE
rdma: do not use cq_entry.len in send completions, plus fix memory leak

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -59,12 +59,16 @@ typedef enum nccl_net_ofi_rdma_req_type {
 	NCCL_OFI_RDMA_SEND_CONN_RESP,
 } nccl_net_ofi_rdma_req_type_t;
 
-typedef enum nccl_ofi_rdma_msg_type {
+enum nccl_ofi_rdma_msg_type {
 	NCCL_OFI_RDMA_MSG_CONN,
 	NCCL_OFI_RDMA_MSG_CONN_RESP,
 	NCCL_OFI_RDMA_MSG_CTRL,
 	NCCL_OFI_RDMA_MSG_EAGER
-} nccl_ofi_rdma_msg_type_t;
+};
+/* This goes on the wire, so we want the datatype
+ * size to be fixed.
+ */
+typedef uint16_t nccl_ofi_rdma_msg_type_t;
 
 /*
  * @brief	Rdma memory registration handle
@@ -84,7 +88,7 @@ typedef struct nccl_net_ofi_rdma_mr_handle {
    destination buffer */
 typedef struct nccl_net_ofi_rdma_ctrl_msg {
 	/* Message type, must be NCCL_OFI_RDMA_MSG_CTRL */
-	uint16_t type;
+	nccl_ofi_rdma_msg_type_t type;
 
 	/* Message sequence number */
 	uint16_t msg_seq_num;
@@ -328,7 +332,7 @@ typedef struct nccl_ofi_rdma_connection_info {
 	/* Message type
 	 * either NCCL_OFI_RDMA_MSG_CONN or NCCL_OFI_RDMA_MSG_CONN_RESP
 	 */
-	uint16_t type;
+	nccl_ofi_rdma_msg_type_t type;
 
 	/* Number of rails */
 	uint16_t num_rails;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4975,7 +4975,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
 			      dev_id, ret);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto error;
 	}
 
 	/* Store remote address of first rail in communicator */
@@ -4991,7 +4992,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI request free list for dev %d rail %d",
 			      dev_id, rail_id);
-		return ret;
+		goto error;
 	}
 
 	/* Allocate and initialize connect message */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1154,11 +1154,12 @@ static int finish_connect(nccl_net_ofi_rdma_send_comm_t *s_comm);
  * 		connect messages (l_comm), connect response messages (s_comm),
  * 		RDMA control messages (s_comm), eager messages (r_comm).
  */
-static inline int handle_bounce_recv(nccl_ofi_rdma_msg_type_t msg_type, nccl_net_ofi_rdma_ep_t *ep, int rail_id,
-				     struct fi_cq_data_entry *cq_entry, nccl_net_ofi_rdma_req_t *bounce_req)
+static inline int handle_bounce_recv(nccl_net_ofi_rdma_ep_t *ep, int rail_id, struct fi_cq_data_entry *cq_entry,
+				     nccl_net_ofi_rdma_req_t *bounce_req, bool eager)
 {
 	int ret;
 	rdma_req_bounce_data_t *bounce_data = NULL;
+	nccl_net_ofi_rdma_bounce_fl_item_t *bounce_fl_item = NULL;
 	nccl_ofi_rdma_connection_info_t *conn_msg = NULL;
 	nccl_ofi_rdma_connection_info_t *conn_resp_msg = NULL;
 	nccl_net_ofi_rdma_ctrl_msg_t *ctrl_msg = NULL;
@@ -1177,13 +1178,16 @@ static inline int handle_bounce_recv(nccl_ofi_rdma_msg_type_t msg_type, nccl_net
 
 	bounce_data = get_bounce_data(bounce_req);
 	bounce_data->recv_len = cq_entry->len;
+	bounce_fl_item = bounce_data->bounce_fl_item;
+
+	nccl_ofi_rdma_msg_type_t msg_type = eager ? NCCL_OFI_RDMA_MSG_EAGER : *(uint16_t *)&bounce_fl_item->bounce_msg;
 
 	switch (msg_type) {
 	case NCCL_OFI_RDMA_MSG_CONN:
 		/* CONN receive completion */
 		assert(sizeof(nccl_ofi_rdma_connection_info_t) == cq_entry->len);
 
-		conn_msg = get_bounce_connection_msg(bounce_data->bounce_fl_item);
+		conn_msg = get_bounce_connection_msg(bounce_fl_item);
 		l_comm = get_listen_comm(ep, conn_msg->remote_comm_id);
 
 		assert(l_comm->req.comm->type == NCCL_NET_OFI_LISTEN_COMM);
@@ -1208,7 +1212,7 @@ static inline int handle_bounce_recv(nccl_ofi_rdma_msg_type_t msg_type, nccl_net
 		/* CONN_RESP receive completion */
 		assert(sizeof(nccl_ofi_rdma_connection_info_t) == cq_entry->len);
 
-		conn_resp_msg = get_bounce_connection_msg(bounce_data->bounce_fl_item);
+		conn_resp_msg = get_bounce_connection_msg(bounce_fl_item);
 		s_comm = get_send_comm(ep, conn_resp_msg->remote_comm_id);
 
 		assert(NULL != s_comm->conn_resp_req);
@@ -1239,7 +1243,7 @@ static inline int handle_bounce_recv(nccl_ofi_rdma_msg_type_t msg_type, nccl_net
 		/* CTRL receive completion */
 		assert(sizeof(nccl_net_ofi_rdma_ctrl_msg_t) == cq_entry->len);
 
-		ctrl_msg = get_bounce_ctrl_msg(bounce_data->bounce_fl_item);
+		ctrl_msg = get_bounce_ctrl_msg(bounce_fl_item);
 		s_comm = get_send_comm(ep, ctrl_msg->remote_comm_id);
 
 		NCCL_OFI_TRACE_SEND_CTRL_RECV(s_comm->base.base.dev_id, rail_id, s_comm, ctrl_msg->msg_seq_num);
@@ -1410,7 +1414,6 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 	uint64_t comp_idx = 0, comp_flags = 0;
 
 	rdma_req_send_data_t *send_data = NULL;
-	uint16_t *msg_type = NULL;
 
 	for (comp_idx = 0; comp_idx < num_cqes; comp_idx++) {
 		/* The context for these operations is req.
@@ -1452,17 +1455,9 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 			}
 		} else if (comp_flags & FI_RECV) {
 			/* Receive completions */
+			ret = handle_bounce_recv(ep, rail->rail_id, &cq_entry[comp_idx], req,
+						 comp_flags & FI_REMOTE_CQ_DATA);
 
-			if (!(comp_flags & FI_REMOTE_CQ_DATA)) {
-				/* CONN, CONN_RESP, or CTRL message */
-				msg_type = (uint16_t *)cq_entry[comp_idx].buf;
-				ret = handle_bounce_recv(*msg_type, ep, rail->rail_id, &cq_entry[comp_idx], req);
-
-			} else {
-				/* Eager message receive completion */
-				ret = handle_bounce_recv(NCCL_OFI_RDMA_MSG_EAGER, ep, rail->rail_id,
-							 &cq_entry[comp_idx], req);
-			}
 		} else if (comp_flags & FI_REMOTE_WRITE) {
 			/* Remote-initiated write is complete */
 			ret = handle_write_comp(&cq_entry[comp_idx], ep, rail->rail_id);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1180,7 +1180,8 @@ static inline int handle_bounce_recv(nccl_net_ofi_rdma_ep_t *ep, int rail_id, st
 	bounce_data->recv_len = cq_entry->len;
 	bounce_fl_item = bounce_data->bounce_fl_item;
 
-	nccl_ofi_rdma_msg_type_t msg_type = eager ? NCCL_OFI_RDMA_MSG_EAGER : *(uint16_t *)&bounce_fl_item->bounce_msg;
+	nccl_ofi_rdma_msg_type_t msg_type =
+		eager ? NCCL_OFI_RDMA_MSG_EAGER : *(nccl_ofi_rdma_msg_type_t *)&bounce_fl_item->bounce_msg;
 
 	switch (msg_type) {
 	case NCCL_OFI_RDMA_MSG_CONN:


### PR DESCRIPTION
This PR has 3 fix commits:

1. According to libfabric specs, the buf field in a recv completion entry
only applies when the receive buffer was posted with the `FI_MULTI_RECV` flag.
So we shouldn't use it, and rely on the bounce buffer address instead.

2. There were error cases when `create_send_comm` would return an error before freeing
the allocated resources first. This fixes the error path to avoid that.

3. A mostly aesthetic change. 
The message type is an enum that goes on the wire in conn/conn_resp/ctrl messages.
For this reason we want the datatype size to be fixed, so we can typedef
`nccl_ofi_rdma_msg_type_t` to `uint16_t` rather than explicitly assign the enum to a
`uint16_t`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
