### PR TITLE
tuner: consume base costs

### DIFF
--- a/include/nccl_ofi_tuner.h
+++ b/include/nccl_ofi_tuner.h
@@ -89,16 +89,19 @@ struct nccl_ofi_tuner_model_dims {
 	int num_nodes;
 };
 
+typedef float nccl_ofi_tuner_cost_table_t[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+
 struct nccl_ofi_tuner_context {
     struct nccl_ofi_tuner_model_dims dims;
 	struct nccl_ofi_tuner_model_params model_params;
 
-	float base_costs[NCCL_NUM_FUNCTIONS][NCCL_NUM_ALGORITHMS][NCCL_NUM_PROTOCOLS];
+	nccl_ofi_tuner_cost_table_t base_costs;
 };
 
 /* Modeling functions */
 void nccl_ofi_tuner_model_costs(struct nccl_ofi_tuner_context *ctx);
 float nccl_ofi_tuner_compute_cost(struct nccl_ofi_tuner_model_params *params, struct nccl_ofi_tuner_model_dims *dims,
+					  const nccl_ofi_tuner_cost_table_t *base_costs,
                                   ncclFunc_t func, int algo, int proto, int pipe_ops, size_t size);
 
 #endif /* NCCL_OFI_TUNER_H_ */

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -84,6 +84,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context, ncclFunc_t collType, si
 				continue;
 
 			cost = nccl_ofi_tuner_compute_cost(&nccl_ofi_tuner_ctx->model_params, &nccl_ofi_tuner_ctx->dims,
+							   &nccl_ofi_tuner_ctx->base_costs,
 							   collType, algo, proto, numPipeOps,  nBytes);
 			if (cost < 0)
 				continue;

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -73,7 +73,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 
 int test_multiplexing_schedule()
 {
-	nccl_net_ofi_schedule_t *schedule;
+	nccl_net_ofi_schedule_t *schedule = NULL;
 	nccl_net_ofi_schedule_t *ref_schedule = malloc(sizeof(nccl_net_ofi_schedule_t)
 						       + 3 * sizeof(nccl_net_ofi_xfer_info_t));
 	if (!ref_schedule) {


### PR DESCRIPTION
*Description of changes:*

Two commits:

```
96b109e tuner: include base costs
ddbbc9d test: nit: null-initialize test member
```

First one is tagging along, fixes a warning under gcc when building the unit tests.

Second commit:

```
AuthorDate: Thu Apr 25 12:11:23 2024 -0700
CommitDate: Thu Apr 25 17:42:57 2024 -0700

tuner: include base costs

on the original introduction of the tuner, base costs for the tuner were
copied directly from nccl, with notes on the need to eventually tune
them further for specifics of aws-ofi-nccl/aws. Ultimately, the base
latencies (tuned or not) were not included at all in the in our
calculations at all up until this patch. (note: the original point about
tuning these further is not represented in this patch.)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
