### PR TITLE
tuner model: do not use channels in bw computation

### DIFF
--- a/include/nccl_ofi_tuner.h
+++ b/include/nccl_ofi_tuner.h
@@ -10,6 +10,7 @@
  * The plugin interface lets us tune the number of channels as well, but that
  * can come later (once a proto+algo combination is chosen, we can compute the
  * cost with different channel count and optimize for it.
+ * NOTE: this parameter is not currently used by the model
  */
 OFI_NCCL_PARAM_INT(tuner_num_channels, "TUNER_NUM_CHANNELS", 8);
 


### PR DESCRIPTION
* Do not include channels in bw computation -- The current use of nChannels==8 suggests 8x the bw we actually have

* Divide ring bw by 2 (matching the bw computation for NVLSTree and Tree)

Needs perf testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
