### PR TITLE
.ci/aws: Increase timeout + minor edit

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -13,7 +13,7 @@ pipeline {
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: "90"))
-        timeout(time: 8, unit: 'HOURS')
+        timeout(time: 24, unit: 'HOURS')
     }
     environment {
         // AWS region where the cluster is created

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -55,7 +55,7 @@ pipeline {
                     def common = load ".ci/aws/common.groovy"
                     def stages = [:]
                     def nccl_version = "v2.20.5-1"
-                    def addl_args_pr = "--enable-live-log true --test-aws-ofi-nccl-pr $env.CHANGE_ID --test-nccl-version ${nccl_version}"
+                    def addl_args_pr = "--test-aws-ofi-nccl-pr $env.CHANGE_ID --test-nccl-version ${nccl_version}"
                     def config = ".ci/aws/aws_ofi_nccl_pr_ci.yaml"
                     def num_instances = 4
                     def p4d_lock_label = "p4d-1-4node"

--- a/.ci/aws/aws_ofi_nccl_pr_ci.yaml
+++ b/.ci/aws/aws_ofi_nccl_pr_ci.yaml
@@ -1,5 +1,6 @@
 general:
   timeout: 180
+  enable_live_log: true
 cluster:
   cluster_type: manual_cluster
 testing:


### PR DESCRIPTION
Stop AWS CI from timing out when under heavy load (24 hours should allow 12 PRs to be submitted at the same time without timing out).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
