### PR TITLE
.ci/aws: Compile aws-ofi-nccl in debug

### DIFF
--- a/.ci/aws/aws_ofi_nccl_pr_ci.yaml
+++ b/.ci/aws/aws_ofi_nccl_pr_ci.yaml
@@ -6,5 +6,6 @@ cluster:
 testing:
   test_target: aws-ofi-nccl
   test_type: pr
+  aws_ofi_nccl_build_type: debug
   test_list:
     - test_nccl_test


### PR DESCRIPTION
Compile aws-ofi-nccl in debug to enable asserts, and make the CI more effective at catching bugs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
