### PR TITLE
revert, unit fix

### DIFF
--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -6,7 +6,7 @@
 #define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
-#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracing_impl/lttng.h"
+#define LTTNG_UST_TRACEPOINT_INCLUDE "tracing_impl/lttng.h"
 
 /*
  * To add a tracepoint at the nccl_ofi_plugin layer:

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -73,7 +73,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 
 int test_multiplexing_schedule()
 {
-	nccl_net_ofi_schedule_t *schedule;
+	nccl_net_ofi_schedule_t *schedule = NULL;
 	nccl_net_ofi_schedule_t *ref_schedule = malloc(sizeof(nccl_net_ofi_schedule_t)
 						       + 3 * sizeof(nccl_net_ofi_xfer_info_t));
 	if (!ref_schedule) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Reverts recent lttng fix due to breaking builds where lttng is available via /usr/include, but not requested at configure time.

Fixes a warning on a unit test with some compilers by initializing a null pointer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
