### PR TITLE
.ci/aws: Kill all clusters of same instance type/region on lock acquisition

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -105,9 +105,8 @@ pipeline {
             sh 'echo "Jenkins pipeline has failed."'
         }
         aborted {
-            sh '. venv/bin/activate; ./PortaFiducia/scripts/delete_manual_cluster.py --cluster-name "$BUILD_TAG"\'*\' --region $REGION'
+            sh 'echo "Jenkins pipeline aborted."'
         }
-        // Cleanup workspace after job completes.
         cleanup {
             deleteDir()
         }


### PR DESCRIPTION
- Include full instance type name in job name (size limit was for pcluster, not being used)
- Milestones force kill after 20s, so move cleanup to before we start a new job
   - This is a temporary solution b/c it causes us to not be able to add more resources to the server, will figure out a better solution 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
