### PR TITLE
[v1.9.x-aws].ci/aws: Move p5 ODCR to af-south-1

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -67,8 +67,8 @@ pipeline {
                     def p4d_odcr = "cr-0e5eebb3c896f6af0"
                     def p4d_addl_args = "${addl_args_pr} --odcr ${p4d_odcr}"
                     def p5_lock_label = "p5-1-4node"
-                    def p5_region = "us-east-2"
-                    def p5_odcr = "cr-0b5693c31bc89b82d"
+                    def p5_region = "af-south-1"
+                    def p5_odcr = "cr-02eb632dcd8175139"
                     def p5_addl_args = "${addl_args_pr} --odcr ${p5_odcr}"
 
                     // p3dn tests


### PR DESCRIPTION
Signed-off-by: Seth Zegelstein <szegel@amazon.com>
(cherry picked from commit 31d2c083f8009a836bda95ff712fc1819e238a77)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
