### PR TITLE
.ci/aws: Add stable p3dn testing into CI

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -58,12 +58,22 @@ pipeline {
                     def addl_args_pr = "--test-aws-ofi-nccl-pr $env.CHANGE_ID --test-nccl-version ${nccl_version}"
                     def config = ".ci/aws/aws_ofi_nccl_pr_ci.yaml"
                     def num_instances = 4
+                    def p3dn_lock_label = "p3dn-1-4node"
+                    def p3dn_region = "us-east-1"
+                    def p3dn_odcr = "cr-0ca89ca67f047efa8"
+                    def p3dn_addl_args = "${addl_args_pr} --odcr-placement-group-name efa-placement-group2"
+                    def p3dn_al2_addl_args = "${p3dn_addl_args} --ami-id ami-0204943b2053d4808"
                     def p4d_lock_label = "p4d-1-4node"
                     def p4d_region = "us-east-2"
                     def p4d_odcr = "cr-0e5eebb3c896f6af0"
                     def p5_lock_label = "p5-1-4node"
                     def p5_region = "af-south-1"
                     def p5_odcr = "cr-02eb632dcd8175139"
+
+                    // p3dn tests
+                    stages["4_p3dn_al2"] = common.get_test_stage_with_lock("4_p3dn_al2", env.BUILD_TAG, "alinux2", "p3dn.24xlarge", p3dn_region, p3dn_lock_label, num_instances, config, p3dn_odcr, p3dn_al2_addl_args)
+                    stages["4_p3dn_ubuntu2004"] = common.get_test_stage_with_lock("4_p3dn_ubuntu2004", env.BUILD_TAG, "ubuntu2004", "p3dn.24xlarge", p3dn_region, p3dn_lock_label, num_instances, config, p3dn_odcr, p3dn_addl_args)
+                    stages["4_p3dn_ubuntu2204"] = common.get_test_stage_with_lock("4_p3dn_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "p3dn.24xlarge", p3dn_region, p3dn_lock_label, num_instances, config, p3dn_odcr, p3dn_addl_args)
 
                     // p4d tests
                     stages["4_p4d_alinux2"] = common.get_test_stage_with_lock("4_p4d_alinux2", env.BUILD_TAG, "alinux2", "p4d.24xlarge", p4d_region, p4d_lock_label, num_instances, config, p4d_odcr, addl_args_pr)

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -18,3 +18,6 @@ configure.ac	@bwbarrett
 
 # Github Workflows
 /.github/	@rajachan
+
+# AWS CI
+/.ci/aws	@a-szegel


### PR DESCRIPTION
* This changes pins our alinux2 ami to a fixed manually prebuilt AMI.  This is a work around for our image builder problems where we can only build a p3dn ami on a p3dn.
* Adds a 5 minute sleep before launching p3dn's as an attempt to fix the p3dn ICE'ing issues

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
