### PR TITLE
tuner: prefer NVLSTREE on 16 nodes at 4GB

### DIFF
--- a/tests/unit/static/current_tuner_decisions.csv
+++ b/tests/unit/static/current_tuner_decisions.csv
@@ -315,7 +315,7 @@ nodes,ranks,size,algorithm,protocol
 16,128,512MiB,nvlstree,simple
 16,128,1024MiB,ring,simple
 16,128,2048MiB,ring,simple
-16,128,4096MiB,ring,simple
+16,128,4096MiB,nvlstree,simple
 16,128,8192MiB,ring,simple
 16,128,16384MiB,ring,simple
 16,128,32768MiB,ring,simple


### PR DESCRIPTION
Our tests showed that the tuner is currently making the wrong decision at 4GB on 16 P5s, which caused a regression. This is a temporary workaround to force NVLSTREE while we work to make the model more accurate.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
