### PR TITLE
Cherry-picks for 1.9.2-aws

### DIFF
--- a/.github/codechecker.yaml
+++ b/.github/codechecker.yaml
@@ -1,0 +1,6 @@
+---
+analyzer:
+  - --disable=clang-diagnostic-unused-parameter
+  - --ignore=.github/codechecker_skips.txt
+  - --analyzer-config=clangsa:unroll-loops=true
+  - --report-hash=context-free-v2

--- a/.github/codechecker_skips.txt
+++ b/.github/codechecker_skips.txt
@@ -1,0 +1,3 @@
+-/tests/functional/*
+-/tests/unit/*
+-/include/nccl-headers/*/*

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -76,14 +76,19 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install Dependencies
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install -y ${{ env.APT_PACKAGES }}
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ${{ env.APT_PACKAGES }}
+          version: base-packages
+
       - name: Install CUDA SDK
         if: matrix.sdk == 'cuda'
-        run: |
-          sudo apt-get install -y nvidia-cuda-toolkit
-      - name: Install Neuron SDK
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: nvidia-cuda-toolkit
+          version: cuda-packages
+
+      - name: Configure Neuron SDK Repository
         if: matrix.sdk == 'neuron'
         run: |
           # Configure Linux for Neuron repository updates
@@ -93,8 +98,12 @@ jobs:
           wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
           sudo apt update -y
 
-          # Install Neuron Runtime
-          sudo apt-get install aws-neuronx-runtime-lib -y
+      - name: Install Neuron SDK
+        if: matrix.sdk == 'neuron'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: aws-neuronx-runtime-lib
+          version: neuron-packages
 
       - name: Install Libfabric
         run: |

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -9,6 +9,58 @@ env:
     libhwloc-dev
     make
 jobs:
+  al2build:
+    runs-on: codebuild-ghactions-al2-${{ github.run_id }}-${{ github.run_attempt }}
+    strategy:
+      matrix:
+        sdk:
+          - cuda
+        efainstaller:
+          - latest
+          - 1.32.0
+          - 1.31.0
+          - 1.30.0
+    name: al2/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/distcheck
+    steps:
+      # note, do not bump to v4: https://github.com/actions/checkout/issues/1590
+      - uses: actions/checkout@v3
+      - name: Fetch and Install EFA Installer Dependencies
+        run: |
+          curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${{ matrix.efainstaller }}.tar.gz
+          tar -xvf aws-efa-installer-*.tar.gz
+          cd aws-efa-installer/RPMS/ALINUX2/x86_64
+          find . | grep rpm$ | xargs sudo yum -y localinstall
+
+      - name: Install hwloc, utilities.
+        run: |
+          sudo yum -y install hwloc-devel yum-utils
+
+      - name: Configure EPEL and Install CUDA
+        run: |
+          sudo yum -y install \
+             https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
+          sudo yum-config-manager --add-repo \
+             http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo \
+             --save
+          sudo yum -y clean expire-cache
+          sudo yum -y install cuda libcudnn8-devel
+
+      - name: Call `autoreconf -ivf`
+        run: ./autogen.sh
+
+      - name: Call `./configure`
+        run: |
+          ./configure --prefix=/opt/aws-ofi-nccl --with-mpi=/opt/amazon/openmpi \
+             --with-libfabric=/opt/amazon/efa \
+             --with-cuda=/usr/local/cuda \
+             --enable-platform-aws
+
+      - name: Call `make distcheck`
+        run: make distcheck -j
+
+      - name: Call `make install`
+        run: sudo make install
+
   distcheck:
     runs-on: ubuntu-22.04
     strategy:

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -6,6 +6,11 @@ env:
     git
     libhwloc-dev
     make
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   al2build:
     runs-on: codebuild-ghactions-al2-${{ github.run_id }}-${{ github.run_attempt }}

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -3,8 +3,6 @@ on: [push, pull_request]
 env:
   APT_PACKAGES: >-
     build-essential
-    clang
-    gcc
     git
     libhwloc-dev
     make
@@ -65,17 +63,70 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
+        cc-variant:
+          - latest
+          - legacy
         cc:
           - gcc
           - clang
         sdk:
           - cuda
           - neuron
+
+        include:
+          - cc-variant: latest
+            cc: clang
+            cc-version: 19
+          - cc-variant: latest
+            cc: gcc
+            cc-version: 13
+
+        exclude:
+          # fails with
+          # > checking if __builtin_expect is available... no
+          # > configure: error: __builtin_expect not available
+          # clang-19 definitely supports this, so it's something in our m4.
+          - cc: clang
+            cc-variant: latest
       fail-fast: false
+    name: u2204/${{ matrix.sdk }}/libfabric@git/${{matrix.cc}}(${{matrix.cc-variant}})/distcheck/
     steps:
       - uses: actions/checkout@v4
+      - name: Configure Neuron SDK Repository
+        if: matrix.sdk == 'neuron'
+        run: |
+          # Configure Linux for Neuron repository updates
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null << EOF
+          deb https://apt.repos.neuron.amazonaws.com jammy main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt update -y
 
-      - name: Install Dependencies
+      - name: Add compiler repositories
+        if: matrix.cc-variant == 'latest'
+        run: |
+          if [ "${{ matrix.cc }}" == "clang" ]; then
+            wget https://apt.llvm.org/llvm.sh
+            chmod +x llvm.sh
+            # Delete the last line, allowing us to use the cache below for
+            # actually installing the package; this just adds the
+            # repository.
+            sed -i '$ d' llvm.sh
+            sudo ./llvm.sh ${{ matrix.cc-version }}
+          fi
+
+          if [ "${{ matrix.cc }}" == "gcc" ]; then
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          fi
+
+      - name: Install Latest Compiler
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        if: matrix.cc-variant == 'latest'
+        with:
+          packages: ${{ matrix.cc }}-${{matrix.cc-version}}
+          version: compiler-${{ matrix.cc }}-${{matrix.cc-version}}
+
+      - name: Install Base Dependencies
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: ${{ env.APT_PACKAGES }}
@@ -87,16 +138,6 @@ jobs:
         with:
           packages: nvidia-cuda-toolkit
           version: cuda-packages
-
-      - name: Configure Neuron SDK Repository
-        if: matrix.sdk == 'neuron'
-        run: |
-          # Configure Linux for Neuron repository updates
-          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null << EOF
-          deb https://apt.repos.neuron.amazonaws.com jammy main
-          EOF
-          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
-          sudo apt update -y
 
       - name: Install Neuron SDK
         if: matrix.sdk == 'neuron'
@@ -112,12 +153,13 @@ jobs:
           git clone --depth 1 https://github.com/ofiwg/libfabric.git
           pushd libfabric
           ./autogen.sh
+
+          export CC="${{ matrix.realcc || matrix.cc }}"
           ./configure --prefix="$PWD/install" \
                       --disable-sockets \
                       --disable-udp \
                       --disable-mrail \
-                      --disable-opx \
-                      CC="${{ matrix.cc }}"
+                      --disable-opx
           make -j "$(nproc)"
           make install
           popd
@@ -126,6 +168,8 @@ jobs:
         run: |
           set -x
 
+          export CC="${{ matrix.realcc || matrix.cc }}"
+
           # actions/checkout@v4 would drop the plugin source in $PWD,
           # so go ahead and build it.
           ./autogen.sh
@@ -133,13 +177,11 @@ jobs:
           then
             ./configure --with-libfabric="$PWD/libfabric/install" \
                         --with-cuda=/usr/local/cuda/ \
-                        --enable-platform-aws \
-                        CC="${{ matrix.cc }}"
+                        --enable-platform-aws
           else
             ./configure --with-libfabric="$PWD/libfabric/install" \
                         --enable-neuron \
-                        --enable-platform-aws \
-                        CC="${{ matrix.cc }}"
+                        --enable-platform-aws
           fi
           make -j "$(nproc)"
 
@@ -150,7 +192,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.cc }}-${{ matrix.sdk }}-config.log
+          name: ${{ matrix.cc }}-${{ matrix.cc-variant }}-${{ matrix.sdk }}-config.log
           path: config.log
           if-no-files-found: ignore
 
@@ -173,7 +215,7 @@ jobs:
         if: matrix.cc == 'clang'
         uses: actions/upload-artifact@v4
         with:
-          name: "CodeChecker Bug Reports for ${{ matrix.sdk }}"
+          name: CodeChecker Bug Reports for ${{ matrix.sdk }}-${{ matrix.cc-version }}
           path: ${{ steps.codechecker.outputs.result-html-dir }}/*.html
 
       - name: CodeChecker Pass Or Fail?

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -12,41 +12,58 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  al2build:
-    runs-on: codebuild-ghactions-al2-${{ github.run_id }}-${{ github.run_attempt }}
+  amazonlinux:
     strategy:
       matrix:
         sdk:
           - cuda
+        amazonlinux:
+          - al2023
+          - al2
         efainstaller:
           - latest
           - 1.32.0
           - 1.31.0
           - 1.30.0
-    name: al2/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/distcheck
+        include:
+          - amazonlinux: al2023
+            efainstallerdir: ALINUX2023
+            nvidiadistro: fedora37
+            configmanager: dnf config-manager
+            cudapackages: cuda-cudart-devel-12-3 cuda-driver-devel-12-3
+
+          - amazonlinux: al2
+            efainstallerdir: ALINUX2
+            nvidiadistro: rhel7
+            configmanager: yum-config-manager
+            cudapackages: cuda-cudart-devel-12-3 cuda-driver-devel-12-3
+
+    runs-on: codebuild-ghactions-${{ matrix.amazonlinux }}-${{ github.run_id }}-${{ github.run_attempt }}
+    name: ${{matrix.amazonlinux}}/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/makeinstall
     steps:
       # note, do not bump to v4: https://github.com/actions/checkout/issues/1590
       - uses: actions/checkout@v3
       - name: Fetch and Install EFA Installer Dependencies
         run: |
           curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${{ matrix.efainstaller }}.tar.gz
-          tar -xvf aws-efa-installer-*.tar.gz
-          cd aws-efa-installer/RPMS/ALINUX2/x86_64
+          tar -xf aws-efa-installer-*.tar.gz
+          cd aws-efa-installer/RPMS/${{ matrix.efainstallerdir }}/x86_64
           find . | grep rpm$ | xargs sudo yum -y localinstall
-
       - name: Install hwloc, utilities.
         run: |
           sudo yum -y install hwloc-devel yum-utils
-
-      - name: Configure EPEL and Install CUDA
+      - name: Add EPEL
+        if: matrix.amazonlinux == 'al2'
         run: |
           sudo yum -y install \
              https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-          sudo yum-config-manager --add-repo \
-             http://developer.download.nvidia.com/compute/cuda/repos/rhel7/x86_64/cuda-rhel7.repo \
+      - name: Install CUDA
+        run: |
+          sudo ${{ matrix.configmanager }} --add-repo \
+             http://developer.download.nvidia.com/compute/cuda/repos/${{ matrix.nvidiadistro }}/x86_64/cuda-${{ matrix.nvidiadistro }}.repo \
              --save
           sudo yum -y clean expire-cache
-          sudo yum -y install cuda libcudnn8-devel
+          sudo yum -y install ${{ matrix.cudapackages }}
 
       - name: Call `autoreconf -ivf`
         run: ./autogen.sh
@@ -54,12 +71,13 @@ jobs:
       - name: Call `./configure`
         run: |
           ./configure --prefix=/opt/aws-ofi-nccl --with-mpi=/opt/amazon/openmpi \
-             --with-libfabric=/opt/amazon/efa \
-             --with-cuda=/usr/local/cuda \
-             --enable-platform-aws
+               --with-libfabric=/opt/amazon/efa \
+               --with-cuda=/usr/local/cuda \
+               --enable-tests=no \
+               --enable-platform-aws
 
-      - name: Call `make distcheck`
-        run: make distcheck -j
+      - name: Call `make`
+        run: make -j
 
       - name: Call `make install`
         run: sudo make install

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -150,8 +150,10 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.cc }}-config.log
+          name: ${{ matrix.cc }}-${{ matrix.sdk }}-config.log
           path: config.log
+          if-no-files-found: ignore
+
 
       - uses: actions/setup-python@v5
         if: matrix.cc == 'clang'

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -88,7 +88,6 @@ jobs:
           # clang-19 definitely supports this, so it's something in our m4.
           - cc: clang
             cc-variant: latest
-      fail-fast: false
     name: u2204/${{ matrix.sdk }}/libfabric@git/${{matrix.cc}}(${{matrix.cc-variant}})/distcheck/
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -103,13 +103,13 @@ jobs:
           git clone --depth 1 https://github.com/ofiwg/libfabric.git
           pushd libfabric
           ./autogen.sh
-          ./configure --prefix=$PWD/install \
+          ./configure --prefix="$PWD/install" \
                       --disable-sockets \
                       --disable-udp \
                       --disable-mrail \
                       --disable-opx \
-                      CC=${{ matrix.cc }}
-          make -j $(nproc)
+                      CC="${{ matrix.cc }}"
+          make -j "$(nproc)"
           make install
           popd
 
@@ -120,19 +120,19 @@ jobs:
           # actions/checkout@v4 would drop the plugin source in $PWD,
           # so go ahead and build it.
           ./autogen.sh
-          if [ ${{ matrix.sdk }} == "cuda" ]
+          if [ "${{ matrix.sdk }}" == "cuda" ]
           then
-            ./configure --with-libfabric=$PWD/libfabric/install \
+            ./configure --with-libfabric="$PWD/libfabric/install" \
                         --with-cuda=/usr/local/cuda/ \
                         --enable-platform-aws \
-                        CC=${{ matrix.cc }}
+                        CC="${{ matrix.cc }}"
           else
-            ./configure --with-libfabric=$PWD/libfabric/install \
+            ./configure --with-libfabric="$PWD/libfabric/install" \
                         --enable-neuron \
                         --enable-platform-aws \
-                        CC=${{ matrix.cc }}
+                        CC="${{ matrix.cc }}"
           fi
-          make -j $(nproc)
+          make -j "$(nproc)"
 
       - name: Run Dist Check
         run: make distcheck
@@ -166,7 +166,7 @@ jobs:
           path: ${{ steps.codechecker.outputs.result-html-dir }}/*.html
 
       - name: CodeChecker Pass Or Fail?
-        if: matrix.cc == 'clang' && ${{ steps.codechecker.outputs.warnings-in-diff == 'true' }}
+        if: matrix.cc == 'clang' && steps.codechecker.outputs.warnings-in-diff == 'true'
         shell: bash
         run: |
           echo "::error title=Static Analyzers Failed::Analysed commit(s) caused static analysis warnings"

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -74,6 +74,9 @@ jobs:
         cc:
           - gcc
           - clang
+        tracing:
+          - lttng
+          - none
         sdk:
           - cuda
           - neuron
@@ -149,6 +152,13 @@ jobs:
         with:
           packages: aws-neuronx-runtime-lib
           version: neuron-packages
+
+      - name: Install lttng
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        if: matrix.tracing == 'lttng'
+        with:
+          packages: liblttng-ust-dev
+          version: lttng
 
       - name: Install Libfabric
         run: |

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -201,30 +201,104 @@ jobs:
           if-no-files-found: ignore
 
 
+  codechecker:
+    runs-on: ubuntu-22.04
+    needs: [distcheck]
+    strategy:
+      matrix:
+        sdk:
+          - cuda
+          - neuron
+    name: CodeChecker - ${{ matrix.sdk }}
+    steps:
+      - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
-        if: matrix.cc == 'clang'
         with:
           python-version: '3.9'
 
+      - name: Configure Neuron SDK Repository
+        if: matrix.sdk == 'neuron'
+        run: |
+          # Configure Linux for Neuron repository updates
+          sudo tee /etc/apt/sources.list.d/neuron.list > /dev/null << EOF
+          deb https://apt.repos.neuron.amazonaws.com jammy main
+          EOF
+          wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NEURON.PUB | sudo apt-key add -
+          sudo apt update -y
+
+      - name: Install Base Dependencies
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: ${{ env.APT_PACKAGES }}
+          version: base-packages
+
+      - name: Install CUDA SDK
+        if: matrix.sdk == 'cuda'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: nvidia-cuda-toolkit
+          version: cuda-packages
+
+      - name: Install Neuron SDK
+        if: matrix.sdk == 'neuron'
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: aws-neuronx-runtime-lib
+          version: neuron-packages
+
+      - name: Install cppcheck
+        uses: awalsh128/cache-apt-pkgs-action@latest
+        with:
+          packages: cppcheck
+          version: codechecker-cppcheck
+
+      - name: Install Libfabric
+        run: |
+          # We're just doing distchecks, so it is fine if we
+          # just grab the latest master and built a lean build.
+          git clone --depth 1 https://github.com/ofiwg/libfabric.git
+          pushd libfabric
+          ./autogen.sh
+          ./configure --prefix="$PWD/install" \
+                      --disable-sockets \
+                      --disable-udp \
+                      --disable-mrail \
+                      --disable-opx
+          make -j "$(nproc)"
+          make install
+          popd
+
+      - name: Run Configure
+        run: |
+          ./autogen.sh
+          if [ "${{ matrix.sdk }}" == "neuron" ]; then
+            ./configure \
+              --with-libfabric="$PWD/libfabric/install" \
+              --enable-neuron \
+              --enable-platform-aws
+          else
+            ./configure \
+              --with-libfabric="$PWD/libfabric/install" \
+              --with-cuda=/usr/local/cuda/ \
+              --enable-platform-aws
+          fi
+
       - name: Run CodeChecker
-        if: matrix.cc == 'clang'
         uses: whisperity/codechecker-analysis-action@v1
         id: codechecker
         with:
-          # clean and rebuild so that compile_commands.json can be detected
-          build-command: "make clean && make"
+          build-command: make
           ctu: true
           config: .github/codechecker.yaml
 
       - name: Save CodeChecker HTML output.
-        if: matrix.cc == 'clang'
         uses: actions/upload-artifact@v4
         with:
-          name: CodeChecker Bug Reports for ${{ matrix.sdk }}-${{ matrix.cc-version }}
+          name: CodeChecker Bug Reports for ${{ matrix.sdk }}
           path: ${{ steps.codechecker.outputs.result-html-dir }}/*.html
 
       - name: CodeChecker Pass Or Fail?
-        if: matrix.cc == 'clang' && steps.codechecker.outputs.warnings-in-diff == 'true'
+        if: steps.codechecker.outputs.warnings-in-diff == 'true'
         shell: bash
         run: |
           echo "::error title=Static Analyzers Failed::Analysed commit(s) caused static analysis warnings"

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -214,6 +214,7 @@ jobs:
           # clean and rebuild so that compile_commands.json can be detected
           build-command: "make clean && make"
           ctu: true
+          config: .github/codechecker.yaml
 
       - name: Save CodeChecker HTML output.
         if: matrix.cc == 'clang'

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -25,7 +25,8 @@ noinst_HEADERS = \
 	nccl_ofi_topo.h \
 	nccl_ofi_tuner.h \
 	nccl_ofi_ofiutils.h \
-	tracepoint.h \
+	nccl_ofi_tracepoint.h \
+	tracing_impl/lttng.h \
 	nccl-headers/net.h \
 	nccl-headers/error.h \
 	nccl-headers/nvidia/err.h \

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -58,12 +58,16 @@ typedef enum nccl_net_ofi_rdma_req_type {
 	NCCL_OFI_RDMA_SEND_CONN_RESP,
 } nccl_net_ofi_rdma_req_type_t;
 
-typedef enum nccl_ofi_rdma_msg_type {
+enum nccl_ofi_rdma_msg_type {
 	NCCL_OFI_RDMA_MSG_CONN,
 	NCCL_OFI_RDMA_MSG_CONN_RESP,
 	NCCL_OFI_RDMA_MSG_CTRL,
 	NCCL_OFI_RDMA_MSG_EAGER
-} nccl_ofi_rdma_msg_type_t;
+};
+/* This goes on the wire, so we want the datatype
+ * size to be fixed.
+ */
+typedef uint16_t nccl_ofi_rdma_msg_type_t;
 
 /*
  * @brief	Rdma memory registration handle
@@ -83,7 +87,7 @@ typedef struct nccl_net_ofi_rdma_mr_handle {
    destination buffer */
 typedef struct nccl_net_ofi_rdma_ctrl_msg {
 	/* Message type, must be NCCL_OFI_RDMA_MSG_CTRL */
-	uint16_t type;
+	nccl_ofi_rdma_msg_type_t type;
 
 	/* Message sequence number */
 	uint16_t msg_seq_num;
@@ -317,7 +321,7 @@ typedef struct nccl_ofi_rdma_connection_info {
 	/* Message type
 	 * either NCCL_OFI_RDMA_MSG_CONN or NCCL_OFI_RDMA_MSG_CONN_RESP
 	 */
-	uint16_t type;
+	nccl_ofi_rdma_msg_type_t type;
 
 	/* Number of rails */
 	uint16_t num_rails;

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+
+#ifndef NCCL_OFI_TRACEPOINT_H_
+#define NCCL_OFI_TRACEPOINT_H_
+
+#include "config.h"
+#include "tracing_impl/lttng.h"
+
+#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_SEND_CTRL_RECV(dev, rail_id, comm, msg_seq_num) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num); \
+	} while (0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(dev, rail_id, size, comm, msg_seq_num, request) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(dev, rail_id, comm, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_complete, dev, rail_id, comm, msg_seq_num, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) do { \
+		lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_FLUSH(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_INSERT(request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request); \
+	} while(0)
+
+#define NCCL_OFI_TRACE_PENDING_REMOVE(request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_remove, request); \
+	} while(0)
+
+#endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -9,6 +9,24 @@
 #include "config.h"
 #include "tracing_impl/lttng.h"
 
+/***** SENDRECV PROTOCOL *****/
+#define NCCL_OFI_TRACE_SEND_SENDRECV(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
+} while (0)
+
+#define NCCL_OFI_TRACE_RECV_SENDRECV(dev, tag, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_FLUSH_SENDRECV(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+} while(0)
+
+/***** RDMA PROTOCL *****/
 #define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
 	} while(0)

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -1,12 +1,17 @@
 /*
- * Copyright (c) 2022 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
+
+#ifndef LTTNG_H_
+#define LTTNG_H_
+
+#if HAVE_LTTNG_UST
 
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
 #define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
-#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracepoint.h"
+#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracing_impl/lttng.h"
 
 /*
  * To add a tracepoint at the nccl_ofi_plugin layer:
@@ -28,9 +33,9 @@
  * tracing output, and arguments <arg1> and <arg2> with <name1> and
  * <name2> will appear in that trace as data.
  *
+ * Add a macro to the top level nccl_ofi_tracepoint.h
+ *
  */
-
-#if HAVE_LIBLTTNG_UST == 1
 
 /*
  * LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ must be included so that the tracepoints
@@ -64,8 +69,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -83,8 +88,9 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
     )
 )
-#define NCCL_OFI_TRACE_SEND_CTRL_RECV(dev, rail_id, comm, msg_seq_num) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_recv, dev, rail_id, comm, msg_seq_num)
+
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -106,8 +112,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(dev, rail_id, size, comm, msg_seq_num, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -127,8 +133,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(dev, rail_id, comm, msg_seq_num, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_complete, dev, rail_id, comm, msg_seq_num, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -148,8 +154,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_RECV(dev, comm_id, size, request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm_id, size, request, nccl_req)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -161,8 +167,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -180,8 +186,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -199,8 +204,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
     )
 )
-#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -214,8 +218,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
     )
 )
-#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -229,8 +233,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )
 )
-#define NCCL_OFI_TRACE_FLUSH(request, nccl_req) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -242,8 +245,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_PENDING_INSERT(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -255,26 +257,13 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
-#define NCCL_OFI_TRACE_PENDING_REMOVE(request) \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_remove, request)
 
 #endif /* NCCL_OFI_TRACEPOINT_H */
 
 #include <lttng/tracepoint-event.h>
 
 #else
+#define lttng_ust_tracepoint(...)
+#endif
 
-#define NCCL_OFI_TRACE_SEND(...)
-#define NCCL_OFI_TRACE_SEND_CTRL_RECV(...)
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_START(...)
-#define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE(...)
-#define NCCL_OFI_TRACE_RECV(...)
-#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(...)
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(...)
-#define NCCL_OFI_TRACE_EAGER_RECV(...)
-#define NCCL_OFI_TRACE_FLUSH(...)
-#define NCCL_OFI_TRACE_PENDING_INSERT(...)
-#define NCCL_OFI_TRACE_PENDING_REMOVE(...)
-#define NCCL_OFI_TRACE_COMPLETIONS(...)
-
-#endif // HAVE_LIBLTTNG_UST
+#endif /* LTTNG_H_ */

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -2,11 +2,6 @@
  * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef LTTNG_H_
-#define LTTNG_H_
-
-#if HAVE_LTTNG_UST
-
 #undef LTTNG_UST_TRACEPOINT_PROVIDER
 #define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
 
@@ -37,15 +32,18 @@
  *
  */
 
+#if HAVE_LIBLTTNG_UST == 1
+
 /*
  * LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ must be included so that the tracepoints
  * can be defined and compiled from tracepoint.c, and so they can be referenced
  * from any other files.
  *
+ * Sample header syntax: https://lttng.org/man/3/lttng-ust/v2.13/#doc-creating-tp
  */
 
-#if !defined(NCCL_OFI_TRACEPOINT_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
-#define NCCL_OFI_TRACEPOINT_H
+#if !defined(LTTNG_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ)
+#define LTTNG_H
 
 #include <lttng/tracepoint.h>
 
@@ -258,12 +256,12 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-#endif /* NCCL_OFI_TRACEPOINT_H */
+#endif /* !defined(LTTNG_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ) */
 
 #include <lttng/tracepoint-event.h>
 
 #else
-#define lttng_ust_tracepoint(...)
-#endif
 
-#endif /* LTTNG_H_ */
+#define lttng_ust_tracepoint(...)
+
+#endif /* HAVE_LIBLTTNG_UST == 1 */

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -6,7 +6,7 @@
 #define LTTNG_UST_TRACEPOINT_PROVIDER nccl_ofi_plugin
 
 #undef LTTNG_UST_TRACEPOINT_INCLUDE
-#define LTTNG_UST_TRACEPOINT_INCLUDE "include/tracing_impl/lttng.h"
+#define LTTNG_UST_TRACEPOINT_INCLUDE "tracing_impl/lttng.h"
 
 /*
  * To add a tracepoint at the nccl_ofi_plugin layer:

--- a/m4/check_pkg_lttng.m4
+++ b/m4/check_pkg_lttng.m4
@@ -35,7 +35,7 @@ AC_DEFUN([CHECK_PKG_LTTNG], [
          LIBS="${check_pkg_LIBS_save}"
          $2])
 
-  AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
+  AC_DEFINE_UNQUOTED([HAVE_LIBLTTNG_UST], [${check_pkg_found}], [Defined to 1 if lttng-ust is requested and available])
 
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])

--- a/m4/check_pkg_lttng.m4
+++ b/m4/check_pkg_lttng.m4
@@ -35,7 +35,7 @@ AC_DEFUN([CHECK_PKG_LTTNG], [
          LIBS="${check_pkg_LIBS_save}"
          $2])
 
-  AC_DEFINE_UNQUOTED([HAVE_LIBLTTNG_UST], [${check_pkg_found}], [Defined to 1 if lttng-ust is requested and available])
+  AC_DEFINE_UNQUOTED([HAVE_LIBLTTNG_UST], [${check_pkg_define}], [Defined to 1 if lttng-ust is requested and available])
 
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -17,7 +17,7 @@
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -17,7 +17,7 @@
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -18,7 +18,7 @@
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_math.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #include "nccl_ofi_scheduler.h"
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_memcheck.h"

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1171,7 +1171,8 @@ static inline int handle_bounce_recv(nccl_net_ofi_rdma_ep_t *ep, int rail_id, st
 	bounce_data->recv_len = cq_entry->len;
 	bounce_fl_item = bounce_data->bounce_fl_item;
 
-	nccl_ofi_rdma_msg_type_t msg_type = eager ? NCCL_OFI_RDMA_MSG_EAGER : *(uint16_t *)&bounce_fl_item->bounce_msg;
+	nccl_ofi_rdma_msg_type_t msg_type =
+		eager ? NCCL_OFI_RDMA_MSG_EAGER : *(nccl_ofi_rdma_msg_type_t *)&bounce_fl_item->bounce_msg;
 
 	switch (msg_type) {
 	case NCCL_OFI_RDMA_MSG_CONN:

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1424,7 +1424,7 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 
 			if (req->type == NCCL_OFI_RDMA_SEND_CONN || req->type == NCCL_OFI_RDMA_SEND_CONN_RESP) {
 				/* CONN or CONN_RESP send completion */
-				ret = inc_req_completion(req, cq_entry[comp_idx].len, 1);
+				ret = inc_req_completion(req, sizeof(nccl_ofi_rdma_connection_info_t), 1);
 
 			} else if (req->type == NCCL_OFI_RDMA_SEND_CTRL) {
 				/* CTRL message send completion */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4933,7 +4933,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
 			      dev_id, ret);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto error;
 	}
 
 	/* Store remote address of first rail in communicator */
@@ -4949,7 +4950,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not allocate NCCL OFI request free list for dev %d rail %d",
 			      dev_id, rail_id);
-		return ret;
+		goto error;
 	}
 
 	/* Allocate and initialize connect message */

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -18,7 +18,7 @@
 #include "nccl_ofi_sendrecv.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_ofiutils.h"
-#include "tracepoint.h"
+#include "nccl_ofi_tracepoint.h"
 #include "nccl_ofi_math.h"
 
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -92,7 +92,7 @@ static inline int process_completions(struct fi_cq_tagged_entry *cq_entry,
 		comp_flags = cq_entry[comp_idx].flags;
 		req = container_of(op_ctx, nccl_net_ofi_sendrecv_req_t, ctx);
 
-		NCCL_OFI_TRACE_COMPLETIONS(req, &req->ctx);
+		NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req, &req->ctx);
 
 		/* Determine if this is control message */
 		if (OFI_UNLIKELY(cq_entry[comp_idx].tag & control_bit_mask)) {
@@ -854,7 +854,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 			desc = fi_mr_desc(mr_handles[recv_n]);
 		}
 
-		NCCL_OFI_TRACE_RECV(dev_id, r_comm->tag, sizes[recv_n], req, base_req);
+		NCCL_OFI_TRACE_RECV_SENDRECV(dev_id, r_comm->tag, sizes[recv_n], req, base_req);
 
 		/*
 		 * TODO: Use NCCL provided tags when plugin supports grouped
@@ -1035,7 +1035,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		}
 	}
 
-	NCCL_OFI_TRACE_FLUSH(req, base_req);
+	NCCL_OFI_TRACE_FLUSH_SENDRECV(req, base_req);
 
 	/* Issue RDMA read */
 	do {
@@ -1634,7 +1634,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	if (mr_handle != NULL)
 		desc = fi_mr_desc(mr_handle);
 
-	NCCL_OFI_TRACE_SEND(req->dev_id, size, s_comm, 0, req, base_req);
+	NCCL_OFI_TRACE_SEND_SENDRECV(req->dev_id, size, s_comm, 0, req, base_req);
 
 	/*
 	 * Try sending data to remote EP; Return NULL request

--- a/src/tracepoint.c
+++ b/src/tracepoint.c
@@ -15,6 +15,6 @@
  *
  */
 
-#include <tracepoint.h>
+#include <tracing_impl/lttng.h>
 
 #endif // HAVE_LIBLTTNG_UST == 1

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -61,6 +61,15 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context, ncclFunc_t collType, si
 	if (nccl_ofi_tuner_ctx->dims.num_nodes <= 2)
 		return ncclSuccess;
 
+	if (collType == ncclFuncAllReduce && nccl_ofi_tuner_ctx->dims.num_nodes == 16 &&
+	    nccl_ofi_tuner_ctx->dims.num_ranks == 128 && nvlsSupport && nBytes > 3ULL * 1024ULL * 1024ULL * 1024ULL &&
+	    nBytes <= 5ULL * 1024ULL * 1024ULL * 1024ULL) {
+		lowest = 0;
+		*algorithm = NCCL_ALGO_NVLS_TREE;
+		*protocol = NCCL_PROTO_SIMPLE;
+		goto exit;
+	}
+
 	/*
 	 * Ideally, this should just be a lookup and not be in-flight math
 	 * We do not want divs in the hot path, but working with the API we've
@@ -97,6 +106,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context, ncclFunc_t collType, si
 		}
 	}
 
+exit:
 	NCCL_OFI_INFO(NCCL_TUNING, "Choosing algo %d proto %d with cost %.8f µsecs for coll %d size %ld.",
 				    *algorithm, *protocol, lowest, collType, nBytes);
 	return ncclSuccess;

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -73,7 +73,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 
 int test_multiplexing_schedule()
 {
-	nccl_net_ofi_schedule_t *schedule;
+	nccl_net_ofi_schedule_t *schedule = NULL;
 	nccl_net_ofi_schedule_t *ref_schedule = malloc(sizeof(nccl_net_ofi_schedule_t)
 						       + 3 * sizeof(nccl_net_ofi_xfer_info_t));
 	if (!ref_schedule) {


### PR DESCRIPTION
Cherry-picked commits (newest on top):

- [tuner: prefer NVLSTREE on 16 nodes at (3GB, 5GB\]](https://github.com/aws/aws-ofi-nccl/commit/83f8fa96c93375b8aede8f74b20a484dc5762060)
- [ci(github): add an al2023 build](https://github.com/aws/aws-ofi-nccl/commit/309d83495910db22a118d14f06f053d98bfc468c)
- [ci(github): add an lttng build](https://github.com/aws/aws-ofi-nccl/commit/a653337ec332d8b8c01b3f59210b1935d3e7afe4)
- [ci(github): split codechecker to separate job](https://github.com/aws/aws-ofi-nccl/commit/dc79f83d6c728bc9461ee5ef256f8ece74ab843d)
- [ci(github): add a configuration file for codechecker](https://github.com/aws/aws-ofi-nccl/commit/3bd89acfa8461d9157b72e6cf46e446f5e7eef95)
- [ci(github): add concurrency block](https://github.com/aws/aws-ofi-nccl/commit/6bf425eab77833215d879009427278fbfd8339cf)
- [ci(github): ubuntu: re-enable fail-fast](https://github.com/aws/aws-ofi-nccl/commit/b845c37bd0c2e1d2dc98390be4db4dd7a5c2999f)
- [ci(github): expand matrix for latest cc](https://github.com/aws/aws-ofi-nccl/commit/94041bd9b221f882d1eac28f45ebdd61838ae6ef)
- [ci(github): rename config.log artifacts](https://github.com/aws/aws-ofi-nccl/commit/453c11ad92e47469a9e379e7846ed811a7eb19b3)
- [ci(github): distcheck: use github cache](https://github.com/aws/aws-ofi-nccl/commit/74cd3e1b86efc594bd855993b75cb5394cf6fd57)
- [ci(github): fix: take actionlint fixes](https://github.com/aws/aws-ofi-nccl/commit/e2057b83dd9031086af9526d0d59d70eb9c85f84)
- [ci(github): add al2 build](https://github.com/aws/aws-ofi-nccl/commit/4c296bf474494205db3af490b40adc68fe0186d1)
- [fix: lttng: fix include define](https://github.com/aws/aws-ofi-nccl/commit/8158c2b242460a89dd83cbf378aaf0e0a828e810)
- [test: nit: null-initialize test member](https://github.com/aws/aws-ofi-nccl/commit/b11f40fcff177cf4f6104619c0c3eed23b8beb95)
- [fix(lttng): fix LTTNG support in master branch](https://github.com/aws/aws-ofi-nccl/commit/69e53b025ea3d75231d210c7360934248bd14476)
- [rdma: typedef msg_type to uint16](https://github.com/aws/aws-ofi-nccl/commit/397d42a2d453e8b489438fa637d1dd39ddf3689c)
- [rdma: (fix) free resources if scomm creation fails](https://github.com/aws/aws-ofi-nccl/commit/5cb9abe959c065e938883a330013aa133804230b)
- [rdma: (fix) do not use cq_entry.buf in recv completions](https://github.com/aws/aws-ofi-nccl/commit/c3baab9de39fc85ffbad79c4a37dd5dea29dd013)
- [rdma: (fix) do not use cq_entry.len in send completions](https://github.com/aws/aws-ofi-nccl/commit/2c191c970ea518d7d95b95cc6bff7662211b52d8)
- ~~[feat(tracing): add nvtx provider](https://github.com/aws/aws-ofi-nccl/commit/a3aea9ee5af6da9d382c292a51228a3abc1892ec)~~
- [tracing: Add separate SENDRECV trace functions](https://github.com/aws/aws-ofi-nccl/commit/6a41fbb78c9a7216711f61f364aabb734660b23e)
- [refactor(trace/lttng): move into tracing_impl](https://github.com/aws/aws-ofi-nccl/commit/d1bc2dbaeaed4f1ba3565be5b289dbda141f9625)
- ~~[build(tracing/nvtx): m4: add CHECK_PKG_NVTX](https://github.com/aws/aws-ofi-nccl/commit/5b0c54bf17310750782207f5cedcbe5f486bd48a)~~
- [build(lttng): m4: stop setting HAVE_CUDA](https://github.com/aws/aws-ofi-nccl/commit/d5629f5d88dfb1875953135fe5dbc48df38c94ba)
- ~~[Fix log message for OFI_NCCL_DOMAIN_PER_THREAD setting](https://github.com/aws/aws-ofi-nccl/commit/1006b3f0ec771781fd58790d6e200c86edf11f85)~~
- ~~[Separate the domain, and abstract access to the domain.](https://github.com/aws/aws-ofi-nccl/commit/b62f8997dc8571dc286ae45b076f470b6fedc964)~~
- ~~[Add environment and domain variables to create domain per device or endpoint](https://github.com/aws/aws-ofi-nccl/commit/8f0a4b0d578da14456608d62e8ebdc70454a5d28)~~

This commit is also included in the release, but was already cherry-picked:

- [fix(tuner): remove spurious deref from context arg](https://github.com/aws/aws-ofi-nccl/commit/2fe67477eac261a37dc2bf8e1e7b404b39137181)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
