### PR TITLE
fix: check if DevComm is valid before setting it

### DIFF
--- a/src/nccl_ofi_interface_nvidia.c
+++ b/src/nccl_ofi_interface_nvidia.c
@@ -155,7 +155,6 @@ static ncclResult_t ptrSupport_v2(int dev_id, int *supportedTypes)
 static ncclResult_t connect_v7(int dev, void* handle, void** sendComm,
 			       ncclNetDeviceHandle_v7_t** sendDevComm)
 {
-	*sendDevComm = NULL;
 	return nccl_net_ofi_connect(dev, handle, sendComm);
 }
 
@@ -163,7 +162,6 @@ static ncclResult_t connect_v7(int dev, void* handle, void** sendComm,
 static ncclResult_t accept_v7(void* listenComm, void** recvComm,
 			      ncclNetDeviceHandle_v7_t** recvDevComm)
 {
-	*recvDevComm = NULL;
 	return nccl_net_ofi_accept(listenComm, recvComm);
 }
 


### PR DESCRIPTION
NCCL's v7 plugin APIs added the sendDevComm/recvSendComm parameter to
connect/accept. We are not using it, but it can happen that NCCL calls
connect/accept with this parameter equal to NULL, so we need to be careful
before dereferencing the double pointer. Since IB and other plugins are
just ignoring this parameter, we will do the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
