### PR TITLE
Mutex behavior cleanup / improvements

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -19,6 +19,7 @@ noinst_HEADERS = \
 	nccl_ofi_memcheck_valgrind.h \
 	nccl_ofi_msgbuff.h \
 	nccl_ofi_param.h \
+	nccl_ofi_pthread.h \
 	nccl_ofi_rdma.h \
 	nccl_ofi_sendrecv.h \
 	nccl_ofi_scheduler.h \

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -214,6 +214,19 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  */
 OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
 
+/*
+ * Decide whether or not mutexes should default to errorcheck mode.
+ * Defaults to no, unless debugging is enabled, in which case it
+ * defaults to 1.
+ */
+#if defined(NDEBUG) && NDEBUG != 0
+#define OFI_NCCL_PARAM_ERRORCHECK_MUTEX_DEFAULT 0
+#else
+#define OFI_NCCL_PARAM_ERRORCHECK_MUTEX_DEFAULT 1
+#endif
+OFI_NCCL_PARAM_INT(errorcheck_mutex, "ERRORCHECK_MUTEX",
+		   OFI_NCCL_PARAM_ERRORCHECK_MUTEX_DEFAULT)
+
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -16,6 +16,7 @@ extern "C" {
 #include <stdbool.h>
 
 #include "nccl_ofi_log.h"
+#include "nccl_ofi_pthread.h"
 
 #define OFI_NCCL_PARAM_INT(name, env, default_value) \
 static pthread_mutex_t ofi_nccl_param_lock_##name = PTHREAD_MUTEX_INITIALIZER; \
@@ -25,7 +26,7 @@ static inline int64_t ofi_nccl_##name() { \
     if (initialized) { \
 	return value; \
     } \
-    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_mutex_lock(&ofi_nccl_param_lock_##name); \
     int64_t v; \
     char *str, *endptr; \
     if (!initialized) { \
@@ -45,7 +46,7 @@ static inline int64_t ofi_nccl_##name() { \
         } \
 	initialized = true; \
     } \
-    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_mutex_unlock(&ofi_nccl_param_lock_##name); \
     return value; \
 }
 
@@ -57,7 +58,7 @@ static inline const char *ofi_nccl_##name() { \
     if (initialized) { \
 	return value; \
     } \
-    pthread_mutex_lock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_mutex_lock(&ofi_nccl_param_lock_##name); \
     char *str; \
     if (!initialized) { \
         str = getenv("OFI_NCCL_" env); \
@@ -75,7 +76,7 @@ static inline const char *ofi_nccl_##name() { \
         } \
 	initialized = true; \
     } \
-    pthread_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_mutex_unlock(&ofi_nccl_param_lock_##name); \
     return value; \
 }
 

--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_PTHREAD_H
+#define NCCL_OFI_PTHREAD_H
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+
+#include "nccl_ofi.h"
+#include "nccl_ofi_log.h"
+
+
+/**
+ * Create a mutex
+ *
+ * Takes the same arguments and has the same behaviors as
+ * pthread_mutex_init() (and is, in fact, a wrapper around
+ * pthread_mutex_init()), with one important difference.  If debugging
+ * is enabled, the type of the mutex will be set to
+ * PTHREAD_MUTEX_ERRORCHECK if the attr argument is NULL.
+ *
+ * See pthread_mutex_init() for possible return codes
+ */
+int nccl_net_ofi_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+
+
+/**
+ * Free resources allocated for a mutex
+ *
+ * Wrapper around pthread_mutex_destroy() to handle any cleanup
+ * required due to differences in nccl_net_ofi_mutex_init() behavior.
+ *
+ * See pthread_mutex_destroy() for possible return codes
+ */
+int nccl_net_ofi_mutex_destroy(pthread_mutex_t *mutex);
+
+
+/**
+ * Lock a mutex
+ *
+ * Wrapper around pthread_mutex_lock() which will abort the current
+ * process if an error occurs.
+ */
+static inline void
+nccl_net_ofi_mutex_lock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+{
+	int ret = pthread_mutex_lock(mutex);
+	if (OFI_UNLIKELY(ret != 0)) {
+		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+				    "NET/OFI pthread_mutex_lock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+}
+#define nccl_net_ofi_mutex_lock(mutex) nccl_net_ofi_mutex_lock_impl(mutex, __FILE__, __LINE__);
+
+/**
+ * Attempt to lock a mutex without blocking
+ *
+ * Wrapper around pthread_mutex_trylock() which will abort the current
+ * process if any error other than EBUSY occurs.
+ *
+ * Returns 0 if the lock is acquired, EBUSY if the lock is already
+ * locked, and aborts the process otherwise.
+ */
+static inline int
+nccl_net_ofi_mutex_trylock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+{
+	int ret = pthread_mutex_trylock(mutex);
+	if (OFI_UNLIKELY(ret != 0 && ret != EBUSY)) {
+		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+				    "NET/OFI pthread_mutex_trylock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+     return ret;
+}
+#define nccl_net_ofi_mutex_trylock(mutex) nccl_net_ofi_mutex_trylock_impl(mutex, __FILE__, __LINE__);
+
+
+/**
+ * Unlock a mutex
+ *
+ * Wrapper around pthread_mutex_unlock() which will abort the current
+ * process if an error occurs.
+ */
+static inline void
+nccl_net_ofi_mutex_unlock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+{
+	int ret = pthread_mutex_unlock(mutex);
+	if (OFI_UNLIKELY(ret != 0)) {
+		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+				    "NET/OFI pthread_mutex_unlock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+}
+#define nccl_net_ofi_mutex_unlock(mutex) nccl_net_ofi_mutex_unlock_impl(mutex, __FILE__, __LINE__);
+
+
+#ifdef _cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_PTHREAD_H

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -21,6 +21,7 @@ sources = \
 	nccl_ofi_deque.c \
 	nccl_ofi_idpool.c \
 	nccl_ofi_ofiutils.c \
+	nccl_ofi_pthread.c \
 	tracepoint.c
 
 if WANT_PLATFORM_AWS

--- a/src/nccl_ofi_pthread.c
+++ b/src/nccl_ofi_pthread.c
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <pthread.h>
+#include <stdlib.h>
+
+#include "nccl_ofi.h"
+#include "nccl_ofi_param.h"
+#include "nccl_ofi_pthread.h"
+
+static pthread_once_t errorcheck_once = PTHREAD_ONCE_INIT;
+static pthread_mutexattr_t errorcheck_attr;
+
+
+void errorcheck_init(void)
+{
+	int ret;
+
+	ret = pthread_mutexattr_init(&errorcheck_attr);
+	if (ret != 0) {
+		NCCL_OFI_WARN("pthread_once failed: %s", strerror(ret));
+		abort();
+	}
+
+	ret = pthread_mutexattr_settype(&errorcheck_attr, PTHREAD_MUTEX_ERRORCHECK);
+	if (ret != 0) {
+		NCCL_OFI_WARN("pthread_once failed: %s", strerror(ret));
+		abort();
+	}
+}
+
+
+int
+nccl_net_ofi_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr)
+{
+	int ret;
+	const pthread_mutexattr_t *passed_attr;
+
+	int want_errorcheck = ofi_nccl_errorcheck_mutex();
+
+	ret = pthread_once(&errorcheck_once, errorcheck_init);
+	if (ret != 0) {
+		NCCL_OFI_WARN("pthread_once failed: %s", strerror(ret));
+		return ret;
+	}
+
+	if (attr != NULL || want_errorcheck == 0) {
+		passed_attr = attr;
+	} else {
+		NCCL_OFI_TRACE(NCCL_NET, "Enabling error checking on mutex");
+		passed_attr = &errorcheck_attr;
+	}
+
+	ret = pthread_mutex_init(mutex, passed_attr);
+	if (ret != 0) {
+		NCCL_OFI_WARN("pthread_mutex_init failed: %s", strerror(ret));
+		return ret;
+	}
+
+	return ret;
+}
+
+
+int
+nccl_net_ofi_mutex_destroy(pthread_mutex_t *mutex)
+{
+	int ret;
+
+	ret = pthread_mutex_destroy(mutex);
+	if (ret != 0) {
+		NCCL_OFI_WARN("pthread_mutex_destroy failed: %s", strerror(ret));
+	}
+
+	return ret;
+}


### PR DESCRIPTION
This patch series fixes two issues with locking in the code base.  First, we were inconsistent about whether or not we checked error codes from pthread_mutex_{lock,unlock} and whether or not the error checking was in an OFI_UNLIKELY check.  With this patch, there's no checking return codes from the newly added wrappers, and we will abort() if any lock/unlock fails (since there's really no recovery from that).

Second, while it's really nice to be able to enable error checking locks when debugging changes to locking, so add an environment variable (that effectively defaults to "not enabled") to allow error checking mutexes, which (with the first change) will abort() as soon as we goof up locking.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
