### PR TITLE
Cleanup nccl_ofi.h / utility macros.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@ src/*.lo
 src/*.la
 libnccl-net.so
 tags
-config.h
 
 src/tuner/.dirstamp
 src/tuner/*.lo
@@ -45,7 +44,6 @@ autom4te.cache
 /aclocal.m4
 /compile
 /config.guess
-/config.h.in
 /config.log
 /config.status
 /config.sub
@@ -56,6 +54,9 @@ autom4te.cache
 /install-sh
 /missing
 /stamp-h1
+/include/stamp-h1
+/include/config.h
+/include/config.h.in
 
 # https://www.gnu.org/software/libtool/
 /ltmain.sh

--- a/configure.ac
+++ b/configure.ac
@@ -10,11 +10,24 @@ AC_INIT([aws-ofi-nccl], [GitHub-dev], [al-ofi-nccl-team@amazon.com], , [http://g
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])
-AC_CONFIG_HEADERS([config.h])
+AC_CONFIG_HEADERS([include/config.h])
 AC_CONFIG_MACRO_DIRS([m4])
 
 AM_INIT_AUTOMAKE([-Wall -Werror foreign subdir-objects tar-pax])
 AM_SILENT_RULES([yes])
+
+AH_TOP([/*
+ * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_CONFIG_H
+#define NCCL_OFI_CONFIG_H
+
+])
+AH_BOTTOM([
+#include "nccl_ofi_config_bottom.h"
+#endif /* NCCL_OFI_CONFIG_H */
+])
 
 dnl AX_CHECK_ENABLE_DEBUG must be called before AC_PROG_CC or
 dnl AM_PROG_AR
@@ -49,6 +62,7 @@ AC_CHECK_HEADER([stdlib.h], [], [AC_MSG_ERROR([NCCL OFI Plugin rquires stdlib.h]
 AC_CHECK_HEADER([string.h], [], [AC_MSG_ERROR([NCCL OFI Plugin rquires string.h])])
 AC_CHECK_HEADER([unistd.h], [], [AC_MSG_ERROR([NCCL OFI Plugin rquires unistd.h])])
 
+AC_CHECK_HEADERS([linux/limits.h])
 
 # Checks for types
 AC_TYPE_SIZE_T

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -7,6 +7,7 @@
 noinst_HEADERS = \
 	nccl_ofi.h \
 	nccl_ofi_api.h \
+	nccl_ofi_config_bottom.h \
 	nccl_ofi_cuda.h \
 	nccl_ofi_deque.h \
 	nccl_ofi_freelist.h \

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -30,9 +30,6 @@ extern "C" {
 #define OFI_UNLIKELY(x)	(x)
 #endif
 
-#define MAX_PROV_INFO		(15)
-#define MAX_BDF_LEN		(25)
-
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
  * An endpoint address buffer of 56 bytes *should* be large enough to hold

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -22,13 +22,6 @@ extern "C" {
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
 
-#ifdef __GNUC__
-#define OFI_LIKELY(x)	__builtin_expect((x), 1)
-#define OFI_UNLIKELY(x)	__builtin_expect((x), 0)
-#else
-#define OFI_LIKELY(x)	(x)
-#define OFI_UNLIKELY(x)	(x)
-#endif
 
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
@@ -74,9 +67,6 @@ extern "C" {
  * requests.
  */
 #define NCCL_OFI_MAX_SEND_REQUESTS (NCCL_OFI_MAX_REQUESTS * NCCL_OFI_MAX_RECVS)
-
-/* Maximum length of directory path */
-#define PATH_MAX	4096
 
 /* Flush read size (bytes) */
 #define NCCL_OFI_FLUSH_SIZE	4

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_CONFIG_BOTTOM_H
+#define NCCL_OFI_CONFIG_BOTTOM_H
+
+/* configure aborts if __buildin_expect() isn't available */
+#define OFI_LIKELY(x)   __builtin_expect((x), 1)
+#define OFI_UNLIKELY(x) __builtin_expect((x), 0)
+
+/* Maximum length of directory path */
+#ifdef HAVE_LINUX_LIMITS_H
+#include <linux/limits.h>
+#endif
+
+#ifndef PATH_MAX
+#define PATH_MAX	4096
+#endif
+
+#endif

--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 #include <assert.h>
-#include <stdlib.h>
 #include <pthread.h>
+#include <stdbool.h>
 
 #include "nccl_ofi_pthread.h"
 

--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -10,8 +10,8 @@ extern "C" {
 #endif
 
 #include <pthread.h>
+#include <string.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 
 

--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -6,9 +6,11 @@
 #include "config.h"
 
 #include <dlfcn.h>
+#include <errno.h>
+#include <stdio.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_cuda.h"
+#include "nccl_ofi_log.h"
 
 CUresult (*nccl_net_ofi_cuDriverGetVersion)(int *driverVersion) = NULL;
 CUresult (*nccl_net_ofi_cuPointerGetAttribute)(void *data, CUpointer_attribute attribute, CUdeviceptr ptr) = NULL;

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -5,9 +5,11 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
+#include <pthread.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_deque.h"
+#include "nccl_ofi_log.h"
 
 int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 {

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -5,9 +5,13 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
+#include <pthread.h>
+#include <stdlib.h>
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"
+#include "nccl_ofi_log.h"
 #include "nccl_ofi_math.h"
 
 /*

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -4,7 +4,9 @@
 
 #include "config.h"
 
-#include "nccl_ofi.h"
+#include <errno.h>
+#include <stdlib.h>
+
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_pthread.h"

--- a/src/nccl_ofi_msgbuff.c
+++ b/src/nccl_ofi_msgbuff.c
@@ -4,11 +4,12 @@
 
 #include "config.h"
 
+#include <assert.h>
+#include <errno.h>
 #include <stdlib.h>
 #include <inttypes.h>
 
 #include "nccl_ofi_msgbuff.h"
-#include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_pthread.h"
 

--- a/src/nccl_ofi_pthread.c
+++ b/src/nccl_ofi_pthread.c
@@ -8,7 +8,6 @@
 #include <pthread.h>
 #include <stdlib.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_pthread.h"
 

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -5,9 +5,10 @@
 #include "config.h"
 
 #include <assert.h>
+#include <errno.h>
 #include <pthread.h>
+#include <stdbool.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_scheduler.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_pthread.h"

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -13,7 +13,6 @@
 #include <assert.h>
 
 #include "nccl_ofi_log.h"
-#include "nccl_ofi.h"
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_ofiutils.h"


### PR DESCRIPTION
While working on the pthread wrapper patch (https://github.com/aws/aws-ofi-nccl/pull/431), I got caught up in having to include nccl_ofi.h (and then breaking some bits) for OFI_LIKELY, which lead me down a rabbit hole.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
