### PR TITLE
Class interface cleanups for plugin and device structures

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -453,14 +453,52 @@ struct nccl_net_ofi_recv_comm {
  * on the plugin.
  */
 struct nccl_net_ofi_plugin {
+/* public */
+	int (*assign_device)(nccl_net_ofi_plugin_t *plugin,
+			     size_t device_index, nccl_net_ofi_device_t *device);
+
+	nccl_net_ofi_device_t *(*get_device)(nccl_net_ofi_plugin_t *plugin,
+					     size_t device_index);
+
+	size_t (*get_num_devices)(nccl_net_ofi_plugin_t *plugin);
+
+	int (*release_plugin)(nccl_net_ofi_plugin_t *plugin);
+
+/* private */
 	/* Array of devices */
-	nccl_net_ofi_device_t **devs;
+	nccl_net_ofi_device_t **p_devs;
 
 	/* Number of devices in devs array */
-	int num_devs;
+	size_t p_num_devs;
 };
 
+
+/*
+ * Create a plugin object
+ *
+ * Create a plugin object and initialize all the resources,
+ * including devices, required for operation.  This function will pick
+ * the correct transport and call its create function to actually
+ * create the plugin (which is a little hacky, but it works).
+ */
 int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p);
+
+/*
+ * Constructor for the nccl_net_ofi_plugin class
+ *
+ * Construct a nccl_net_ofi_plugin object.  This is expected to be
+ * called from the transport-specific plugin creation function, which
+ * is called from nccl_net_ofi_create_plugin().
+ */
+int nccl_net_ofi_plugin_init(nccl_net_ofi_plugin_t *plugin, size_t num_devices);
+
+/*
+ * Destructor for the nccl_net_ofi_plugin class
+ *
+ * Destruct a nccl_net_ofi_plugin object.  This is expected to be
+ * called from the transport-specific plugin destructor.
+ */
+int nccl_net_ofi_plugin_fini(nccl_net_ofi_plugin_t *plugin);
 
 /*
  * @brief	Set properties obtained from libfabric NIC Info.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -268,6 +268,11 @@ struct nccl_net_ofi_device {
 	 */
 	int (*get_ep)(nccl_net_ofi_device_t *base_dev,
 			       nccl_net_ofi_ep_t **ep);
+
+	/**
+	 * destructor - releases resources associated with device
+	 */
+	int (*release)(nccl_net_ofi_device_t *device);
 };
 
 /**
@@ -482,6 +487,17 @@ struct nccl_net_ofi_plugin {
  * create the plugin (which is a little hacky, but it works).
  */
 int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p);
+
+/**
+ * Constructor for a device object
+ */
+int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_t *plugin,
+			     int device_index, const char *device_name);
+
+/**
+ * Destructor for a device object
+ */
+int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device);
 
 /*
  * Constructor for the nccl_net_ofi_plugin class

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -678,9 +678,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	/* Array of 'num_rails' device rails */
 	nccl_net_ofi_rdma_device_rail_t *device_rails;
 
-	/* Pointer to provider name of first NIC */
-	char *prov_name;
-
 	/* Maximum number of supported communicator IDs */
 	uint32_t num_comm_ids;
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5835,6 +5835,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 			ret = -EINVAL;
 			goto error;
 		}
+
 		/* Ensure that number of rails are the same across devices */
 		int length = ofi_info_list_length(info_list);
 		if (topo->max_group_size != length) {
@@ -5885,7 +5886,6 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		assert(device->scheduler);
 
 		/* Set NIC information */
-		device->prov_name = info_list->fabric_attr->prov_name;
 		device->num_rails = length;
 		device->device_rails = create_device_rail_array(info_list, length);
 		if (!device->device_rails) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5829,7 +5829,12 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 
 		/* Retrieve NIC info list from topology */
 		info_list = nccl_ofi_topo_next_info_list(&data_iter);
-
+		/* Verify NIC info list from topology */
+		if (!info_list) {
+			NCCL_OFI_WARN("Unable to retrieve next NIC info list from topology");
+			ret = -EINVAL;
+			goto error;
+		}
 		/* Ensure that number of rails are the same across devices */
 		int length = ofi_info_list_length(info_list);
 		if (topo->max_group_size != length) {
@@ -5839,13 +5844,6 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 			goto error;
 		}
 
-		/* Verify NIC info list from topology */
-		if (!info_list) {
-			NCCL_OFI_WARN("Unable to retrieve next NIC info list from topology");
-			ret = -EINVAL;
-			goto error;
-		}
-	
 		/* Allocate device */
 		nccl_net_ofi_rdma_device_t *device = calloc(1, sizeof(nccl_net_ofi_rdma_device_t));
 		if (!device) {


### PR DESCRIPTION
As part of some work to clean up the threading model implementation (in particular, we really need a domain concept as the point of thread ownership, given the desire to move to FI_THREAD_DOMAIN), this patch series fixes a simple bug, removes some dead code, and adds a more well rounded interface for plugin and device classes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
