### PR TITLE
.ci/aws: Add aws-ofi-nccl functional tests to ci

### DIFF
--- a/.ci/aws/aws_ofi_nccl_pr_ci.yaml
+++ b/.ci/aws/aws_ofi_nccl_pr_ci.yaml
@@ -9,3 +9,4 @@ testing:
   aws_ofi_nccl_build_type: debug
   test_list:
     - test_nccl_test
+    - test_ofi_nccl_functional


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
