### PR TITLE
[v1.9.x-aws] regIsGlobal=0 and related fixes

### DIFF
--- a/.ci/aws/aws_ofi_nccl_pr_ci.yaml
+++ b/.ci/aws/aws_ofi_nccl_pr_ci.yaml
@@ -9,3 +9,4 @@ testing:
   aws_ofi_nccl_build_type: debug
   test_list:
     - test_nccl_test
+    - test_ofi_nccl_functional

--- a/src/nccl_ofi_interface_nvidia.c
+++ b/src/nccl_ofi_interface_nvidia.c
@@ -32,8 +32,46 @@ static ncclResult_t getProperties_v8(int dev_id, ncclNetProperties_v8_t* props)
 	 * support this model (since NCCL maintains a per-domain registration
 	 * cache which requires (domain-)global registrations.
 	 */
-	if (ofi_properties.mr_scope == NCCL_OFI_MR_SCOPE_DOMAIN)
-		props->regIsGlobal = 1;
+	if (ofi_properties.mr_scope == NCCL_OFI_MR_SCOPE_DOMAIN) {
+		/**
+		 * TODO:
+		 * When net-plugin returns regIsGlobal=1 to NCCL (As part of
+		 * net-plugin getProperties() API), it signals to NCCL that
+		 * registered MRs are global, in the sense that they can be
+		 * used by all communicators. In addition, it also signals to
+		 * NCCL that the net-plugin have a fast MR cache such that
+		 * calling regMr() on same buffer (address and size), will
+		 * quickly return a previously globally registered MR on same
+		 * buffer.
+		 *
+		 * When user registers a buffer with NCCL by using
+		 * ncclCommRegister() API, if net-plugin supports
+		 * regIsGlobal=1, NCCL will register the buffer globally once
+		 * (On each net device) with regMr() API. When the net
+		 * proxy-thread starts to execute a communication task on a
+		 * previously registered user buffer, it will call the
+		 * net-plugin regMr() to quickly fetch the previously globally
+		 * registered MR from the plugin managed MR cache.
+		 *
+		 * Even though when ofi_properties.mr_scope == NCCL_OFI_MR_SCOPE_DOMAIN,
+		 * aws-ofi-nccl registers MRs globally (As MRs registered are
+		 * not specific to a communicator), aws-ofi-nccl doesn't have
+		 * such a fast MR cache yet. Therefore, it should return
+		 * regIsGlobal=0 for now. We should re-enable this when we fix
+		 * the perf problem.
+		 */
+
+		/**
+		 * TODO:
+		 * In addtion to the above comment, SENDRECV protocol currently
+		 * does not correctly handle the truncated send case (send size
+		 * > recv size) which NCCL uses when regIsGlobal=1. So, before
+		 * setting this to 1, we need to either fix SENDRECV protocol,
+		 * or refactor this code to set this property in a protocol-
+		 * specific way.
+		 */
+		props->regIsGlobal = 0;
+	}
 
 	props->speed = ofi_properties.port_speed;
 	props->port = ofi_properties.port_number;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -105,7 +105,11 @@ static inline int process_completions(struct fi_cq_tagged_entry *cq_entry,
 			}
 		}
 
-		update_nccl_ofi_req(req, NCCL_OFI_SENDRECV_REQ_COMPLETED, cq_entry[comp_idx].len);
+		if (comp_flags & FI_RECV) {
+			update_nccl_ofi_req(req, NCCL_OFI_SENDRECV_REQ_COMPLETED, cq_entry[comp_idx].len);
+		} else {
+			update_nccl_ofi_req(req, NCCL_OFI_SENDRECV_REQ_COMPLETED, req->size);
+		}
 	}
 
  exit:
@@ -1083,6 +1087,9 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 
 	(r_comm->num_inflight_reqs)++;
 
+	/* Set request size */
+	req->size = r_comm->flush_buff.size;
+
 	*base_req = &req->base;
 
 	return ret;
@@ -1657,6 +1664,9 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	}
 
 	(s_comm->num_inflight_reqs)++;
+
+	/* Set request size */
+	req->size = size;
 
 	/* Return request to NCCL */
 	*base_req = &req->base;

--- a/tests/functional/test-common.h
+++ b/tests/functional/test-common.h
@@ -98,6 +98,7 @@ void print_dev_props(int dev, test_nccl_properties_t *props)
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Grouped Receives: %d", props->name, props->maxRecvs);
+	NCCL_OFI_TRACE(NCCL_NET, "%s: Global registration: %d", props->name, props->regIsGlobal);
 }
 
 int is_gdr_supported_nic(uint64_t ptr_support)


### PR DESCRIPTION
* Set regIsGlobal=0
* Remove send truncation from functional test for `regIsGlobal=0`
* Fix SENDRECV protocol size result (cq_entry.len not valid in send completions)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
