### PR TITLE
rdma: add dev_id to req completion LTTNG trace point

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -23,8 +23,8 @@
 	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
 } while(0)
 
-#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(request,ctx) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(dev,request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, dev,request,ctx); \
 } while(0)
 
 /***** RDMA PROTOCL *****/
@@ -94,8 +94,8 @@
 	NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num); \
 } while(0)
 
-#define NCCL_OFI_TRACE_COMPLETIONS(request,ctx) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, request,ctx); \
+#define NCCL_OFI_TRACE_COMPLETIONS(dev,request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, dev,request,ctx); \
 } while(0)
 
 #define NCCL_OFI_TRACE_FLUSH(request, nccl_req) do { \

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -208,10 +208,12 @@ LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
     ProcessCompletions,
     LTTNG_UST_TP_ARGS(
+	    int, dev,
             void *, request,
             void *, ctx
     ),
     LTTNG_UST_TP_FIELDS(
+	    lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
     )

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -659,7 +659,7 @@ static inline int inc_req_completion(nccl_net_ofi_rdma_req_t *req,
 		req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
 
 		/* Trace this completion */
-		NCCL_OFI_TRACE_COMPLETIONS(req, req);
+		NCCL_OFI_TRACE_COMPLETIONS(req->dev_id, req, req);
 	}
 
 	nccl_net_ofi_mutex_unlock(&req->req_lock);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -96,7 +96,7 @@ static inline int process_completions(struct fi_cq_tagged_entry *cq_entry,
 		comp_flags = cq_entry[comp_idx].flags;
 		req = container_of(op_ctx, nccl_net_ofi_sendrecv_req_t, ctx);
 
-		NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req, &req->ctx);
+		NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req->dev_id, req, &req->ctx);
 
 		/* Determine if this is control message */
 		if (OFI_UNLIKELY(cq_entry[comp_idx].tag & control_bit_mask)) {


### PR DESCRIPTION
This adds dev_id to NCCL_OFI_TRACE_COMPLETIONS trace point, which enables collecting SEND/RECV completions per dev_id. Adding dev_id is also aligned with existing NCCL_OFI_TRACE_SEND/NCCL_OFI_TRACE_RECV trace points that already have dev_id to the trace.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
