### PR TITLE
Introduce a memory registration cache for the net plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ tests/unit/idpool
 tests/unit/show_tuner_decisions
 tests/unit/show_tuner_costs
 tests/unit/ep_addr_list
+tests/unit/mr
 
 # http://www.gnu.org/software/automake
 .deps/

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -18,6 +18,7 @@ noinst_HEADERS = \
 	nccl_ofi_memcheck_asan.h \
 	nccl_ofi_memcheck_nop.h \
 	nccl_ofi_memcheck_valgrind.h \
+	nccl_ofi_mr.h \
 	nccl_ofi_msgbuff.h \
 	nccl_ofi_param.h \
 	nccl_ofi_pthread.h \

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -179,12 +179,6 @@ typedef enum nccl_ofi_comm_stage {
 	COMM_CONNECTED,
 } nccl_ofi_comm_stage_t;
 
-/* Determines which object a provider associates MRs with */
-typedef enum nccl_ofi_mr_scope {
-	NCCL_OFI_MR_SCOPE_DOMAIN = 0,
-	NCCL_OFI_MR_SCOPE_ENDPOINT
-} nccl_ofi_mr_scope_t;
-
 typedef struct save_comm_state {
 	nccl_net_ofi_comm_t *comm;
 	nccl_net_ofi_req_t *req;
@@ -231,8 +225,8 @@ typedef struct nccl_ofi_properties {
 	unsigned int max_communicators;
 	/** Maximum number of grouped receives */
 	unsigned int max_group_receives;
-	/** Scope of a memory region registered with a provider **/
-	nccl_ofi_mr_scope_t mr_scope;
+	/** regMr is global if is not tied to a particular comm **/
+	int regIsGlobal;
 } nccl_ofi_properties_t;
 
 /**

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -21,6 +21,7 @@ extern "C" {
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
+#include "nccl_ofi_mr.h"
 
 
 /*
@@ -70,6 +71,9 @@ extern "C" {
 
 /* Flush read size (bytes) */
 #define NCCL_OFI_FLUSH_SIZE	4
+
+/* Initial number of entries in the MR cache of a device */
+#define NCCL_OFI_MR_CACHE_INIT_SIZE     128
 
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t {GDR_UNKNOWN, GDR_SUPPORTED, GDR_UNSUPPORTED};
@@ -247,11 +251,21 @@ struct nccl_net_ofi_device {
 	/* this device's index in the plugin's devices array */
 	int dev_id;
 
-	/* name of the device - should include the provider name, but
-	   may be augmented (in the case of mrail).  Set during the
-	   transport's initialization, and should be read-only from
-	   that point. */
+	/*
+	 * name of the device - should include the provider name, but may be
+	 * augmented (in the case of mrail).  Set during the transport's
+	 * initialization, and should be read-only from that point.
+	 */
 	char *name;
+
+	/*
+	 * Protocol-agnostic MR cache for this device. Note that Registrations
+	 * are tied to domains in libfabric, but we do not have a
+	 * domain-specific object today, so stashing it in the device itself.
+	 * This should change if we were to break up nccl_net_ofi_device into
+	 * separate device and domain objects.
+	 */
+	nccl_ofi_mr_cache_t *mr_cache;
 
 	int (*get_properties)(nccl_net_ofi_device_t *base_dev,
 			      nccl_ofi_properties_t *props);
@@ -261,8 +275,8 @@ struct nccl_net_ofi_device {
 	 * 		nccl_ofi_device.  Create if it does not exist. Store
 	 * 		in pthread key. Increase reference counter. Must be
 	 * 		protected by lock stored in device.
-	 * 
-	 * 		During the plugin initialization, this function will be 
+	 *
+	 * 		During the plugin initialization, this function will be
 	 * 		called once per process using one of the instantiated device structs
 	 * 		to create and configure the endpoint of the initializing thread.
 	 */

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_MR_H_
+#define NCCL_OFI_MR_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <pthread.h>
+
+/**
+ * A memory registration cache entry
+ */
+typedef struct nccl_ofi_reg_entry {
+	uintptr_t addr;
+	size_t pages;
+	int refcnt;
+	void *handle;
+} nccl_ofi_reg_entry_t;
+
+/**
+ * Device-specific memory registration cache.
+ */
+typedef struct nccl_ofi_mr_cache {
+	nccl_ofi_reg_entry_t **slots;
+	size_t system_page_size;
+	size_t size;
+	size_t used;
+	uint32_t hit_count;
+	uint32_t miss_count;
+	pthread_mutex_t lock;
+} nccl_ofi_mr_cache_t;
+
+/**
+ * Create a new mr cache. Both then initial number of entries and the system
+ * page size must be greater than zero.
+ * @return a new mr cache, or NULL if an allocation error occurred
+ */
+nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
+					    size_t system_page_size);
+
+/**
+ * Finalize mr cache
+ */
+void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache);
+
+/**
+ * Lookup a cache entry matching the given address and size
+ * Input addr and size are rounded up to enclosing page boundaries.
+ * If entry is found, refcnt is increased
+ * @return mr handle if found, or NULL if not found
+ */
+void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache,
+				     void *addr,
+				     size_t size);
+
+/**
+ * Insert a new cache entry with the given address and size
+ * Input addr and size are rounded up to enclosing page boundaries.
+ * @return 0, on success
+ *	   -ENOMEM, on allocation failure
+ *	   -EEXIST, if matching entry already exists in cache
+ */
+int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
+				   void *addr,
+				   size_t size,
+				   void *handle);
+
+/**
+ * Decrement refcnt of entry with given handle. If refcnt was reduced to 0,
+ * delete entry from cache. Return value indicates whether entry was deleted
+ * from cache (in which case, caller should deregister the handle).
+ *
+ * @return 0, on success, and reg was not deleted (refcnt not zero)
+ *	   1, on success, and reg was deleted (refcnt was zero)
+ *	   -ENOENT, if no matching entry was found
+ */
+int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle);
+
+#ifdef _cplusplus
+}  // End extern "C"
+#endif
+
+#endif  // End NCCL_OFI_MR_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -127,6 +127,18 @@ OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
 OFI_NCCL_PARAM_INT(mr_key_size, "MR_KEY_SIZE", 2);
 
 /*
+ * Disable the MR cache. The MR cache is used to keep track of registered
+ * memory regions, so that calling regMr() on the same buffer (address and
+ * size), will quickly return a previously globally registered MR on that
+ * buffer, avoiding redundant (and expensive) registrations with the
+ * underlying device.
+ * Disabling the MR cache will make all calls to regMR() result in a
+ * registration with the device, so it may cause a significant performance
+ * degradation.
+ */
+OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE", 0);
+
+/*
  * Maximum number of cq entries to read in a single call to
  * fi_cq_read.
  */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -16,6 +16,7 @@ sources = \
 	nccl_ofi_rdma.c \
 	nccl_ofi_scheduler.c \
 	nccl_ofi_topo.c \
+	nccl_ofi_mr.c \
 	nccl_ofi_msgbuff.c \
 	nccl_ofi_freelist.c \
 	nccl_ofi_deque.c \

--- a/src/nccl_ofi_interface_nvidia.c
+++ b/src/nccl_ofi_interface_nvidia.c
@@ -26,52 +26,26 @@ static ncclResult_t getProperties_v8(int dev_id, ncclNetProperties_v8_t* props)
 		props->ptrSupport |= NCCL_PTR_DMABUF;
 	}
 
-	/*
-	 * NCCL uses regIsGlobal to determine support for User Registrations via
-	 * the NCCL API. If providers tie MRs to endpoints, the plugin can not
-	 * support this model (since NCCL maintains a per-domain registration
-	 * cache which requires (domain-)global registrations.
+	/**
+	 * When net-plugin returns regIsGlobal=1 to NCCL (As part of
+	 * net-plugin getProperties() API), it signals to NCCL that
+	 * registered MRs are global, in the sense that they can be
+	 * used by all communicators. In addition, it also signals to
+	 * NCCL that the net-plugin have a fast MR cache such that
+	 * calling regMr() on same buffer (address and size), will
+	 * quickly return a previously globally registered MR on same
+	 * buffer.
+	 *
+	 * When user registers a buffer with NCCL by using
+	 * ncclCommRegister() API, if net-plugin supports
+	 * regIsGlobal=1, NCCL will register the buffer globally once
+	 * (On each net device) with regMr() API. When the net
+	 * proxy-thread starts to execute a communication task on a
+	 * previously registered user buffer, it will call the
+	 * net-plugin regMr() to quickly fetch the previously globally
+	 * registered MR from the plugin managed MR cache.
 	 */
-	if (ofi_properties.mr_scope == NCCL_OFI_MR_SCOPE_DOMAIN) {
-		/**
-		 * TODO:
-		 * When net-plugin returns regIsGlobal=1 to NCCL (As part of
-		 * net-plugin getProperties() API), it signals to NCCL that
-		 * registered MRs are global, in the sense that they can be
-		 * used by all communicators. In addition, it also signals to
-		 * NCCL that the net-plugin have a fast MR cache such that
-		 * calling regMr() on same buffer (address and size), will
-		 * quickly return a previously globally registered MR on same
-		 * buffer.
-		 *
-		 * When user registers a buffer with NCCL by using
-		 * ncclCommRegister() API, if net-plugin supports
-		 * regIsGlobal=1, NCCL will register the buffer globally once
-		 * (On each net device) with regMr() API. When the net
-		 * proxy-thread starts to execute a communication task on a
-		 * previously registered user buffer, it will call the
-		 * net-plugin regMr() to quickly fetch the previously globally
-		 * registered MR from the plugin managed MR cache.
-		 *
-		 * Even though when ofi_properties.mr_scope == NCCL_OFI_MR_SCOPE_DOMAIN,
-		 * aws-ofi-nccl registers MRs globally (As MRs registered are
-		 * not specific to a communicator), aws-ofi-nccl doesn't have
-		 * such a fast MR cache yet. Therefore, it should return
-		 * regIsGlobal=0 for now. We should re-enable this when we fix
-		 * the perf problem.
-		 */
-
-		/**
-		 * TODO:
-		 * In addtion to the above comment, SENDRECV protocol currently
-		 * does not correctly handle the truncated send case (send size
-		 * > recv size) which NCCL uses when regIsGlobal=1. So, before
-		 * setting this to 1, we need to either fix SENDRECV protocol,
-		 * or refactor this code to set this property in a protocol-
-		 * specific way.
-		 */
-		props->regIsGlobal = 0;
-	}
+	props->regIsGlobal = ofi_properties.regIsGlobal;
 
 	props->speed = ofi_properties.port_speed;
 	props->port = ofi_properties.port_number;

--- a/src/nccl_ofi_mr.c
+++ b/src/nccl_ofi_mr.c
@@ -1,0 +1,273 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <errno.h>
+#include <stdlib.h>
+
+#include "nccl_ofi.h"
+#include "nccl_ofi_mr.h"
+#include "nccl_ofi_pthread.h"
+
+nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
+					    size_t system_page_size)
+{
+	nccl_ofi_mr_cache_t *ret_cache = NULL;
+
+	if (init_num_entries == 0) {
+		NCCL_OFI_WARN("MR cache: initial number of entries must be positive");
+		goto error;
+	}
+
+	if (system_page_size == 0) {
+		NCCL_OFI_WARN("MR cache: system page size must be positive");
+		goto error;
+	}
+
+	ret_cache = (nccl_ofi_mr_cache_t *)calloc(1, sizeof(*ret_cache));
+	if (!ret_cache) {
+		NCCL_OFI_WARN("Could not allocate memory for cache");
+		goto error;
+	}
+
+	ret_cache->slots = (nccl_ofi_reg_entry_t **)calloc(init_num_entries, sizeof(*ret_cache->slots));
+	if (!ret_cache->slots) {
+		NCCL_OFI_WARN("Could not allocate memory for cache slots");
+		goto error;
+	}
+
+	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
+		goto error;
+	}
+
+	ret_cache->system_page_size = system_page_size;
+	ret_cache->size = init_num_entries;
+	ret_cache->used = 0;
+	ret_cache->hit_count = 0;
+	ret_cache->miss_count = 0;
+
+	return ret_cache;
+
+error:
+	if (ret_cache) {
+		if (ret_cache->slots) {
+			free(ret_cache->slots);
+		}
+		free(ret_cache);
+	}
+	return NULL;
+}
+
+void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache)
+{
+	assert(cache);
+
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+		      "MR cache %d hits %d misses",
+		      cache->hit_count,
+		      cache->miss_count);
+
+	nccl_net_ofi_mutex_destroy(&cache->lock);
+
+	free(cache->slots);
+
+	free(cache);
+}
+
+/**
+ * Grow cache to 2x its current size
+ */
+static int nccl_ofi_mr_cache_grow(nccl_ofi_mr_cache_t *cache)
+{
+	void *ptr;
+	int ret = 0;
+	cache->size *= 2;
+	NCCL_OFI_TRACE(NCCL_NET, "Growing cache to size %zu", cache->size);
+	ptr = realloc(cache->slots, cache->size * sizeof(*cache->slots));
+	if (!ptr) {
+		NCCL_OFI_WARN("Unable to grow cache");
+		ret = -ENOMEM;
+		goto out;
+	}
+	cache->slots = (nccl_ofi_reg_entry_t **)ptr;
+
+out:
+	return ret;
+}
+
+static inline void compute_page_address(uintptr_t addr,
+					size_t size,
+					uintptr_t system_page_size,
+					uintptr_t *page_addr,
+					size_t *pages)
+{
+	*page_addr = addr & -system_page_size; /* start of page of data */
+	*pages = (addr + size - (*page_addr) + system_page_size - 1) / system_page_size; /* Number of pages in buffer */
+}
+
+void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache,
+				     void *addr,
+				     size_t size)
+{
+	uintptr_t page_addr;
+	size_t pages;
+
+	compute_page_address((uintptr_t)addr,
+			     size,
+			     (uintptr_t)cache->system_page_size,
+			     &page_addr,
+			     &pages);
+
+	for (size_t slot = 0;; slot++) {
+		assert(slot <= cache->used && slot <= cache->size);
+
+		if (slot == cache->used ||
+		    page_addr < cache->slots[slot]->addr) {
+			/* cache missed */
+			cache->miss_count++;
+			return NULL;
+		} else if ((page_addr >= cache->slots[slot]->addr) &&
+			   ((page_addr - cache->slots[slot]->addr) /
+				    cache->system_page_size +
+			    pages) <= cache->slots[slot]->pages) {
+			/* cache hit */
+			cache->hit_count++;
+			NCCL_OFI_TRACE(
+				NCCL_NET,
+				"Found MR handle %p for %p in cache slot %d",
+				cache->slots[slot]->handle,
+				addr,
+				slot);
+			cache->slots[slot]->refcnt++;
+			return cache->slots[slot]->handle;
+		}
+	}
+}
+
+int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
+				   void *addr,
+				   size_t size,
+				   void *handle)
+{
+	uintptr_t page_addr;
+	size_t pages;
+	int ret = 0;
+
+	compute_page_address((uintptr_t)addr,
+			     size,
+			     (uintptr_t)cache->system_page_size,
+			     &page_addr,
+			     &pages);
+
+	for (size_t slot = 0;; slot++) {
+		assert(slot <= cache->used && slot <= cache->size);
+
+		if (slot == cache->used ||
+		    page_addr < cache->slots[slot]->addr) {
+			/* cache missed */
+
+			/* grow the cache if needed */
+			if (cache->used == cache->size) {
+				ret = nccl_ofi_mr_cache_grow(cache);
+				if (ret != 0) {
+					goto out;
+				}
+			}
+
+			assert(cache->slots);
+			memmove(cache->slots + slot + 1,
+				cache->slots + slot,
+				(cache->used - slot) *
+					sizeof(nccl_ofi_reg_entry_t *));
+			cache->slots[slot] = (nccl_ofi_reg_entry_t *)calloc(
+				1,
+				sizeof(nccl_ofi_reg_entry_t));
+			if (!cache->slots[slot]) {
+				NCCL_OFI_WARN("Failed to allocate new slot");
+				ret = -ENOMEM;
+				goto out;
+			}
+
+			nccl_ofi_reg_entry_t *entry = cache->slots[slot];
+
+			entry->addr = page_addr;
+			entry->pages = pages;
+			entry->refcnt = 1;
+			entry->handle = handle;
+
+			cache->used++;
+			NCCL_OFI_TRACE(
+				NCCL_NET,
+				"Inserted MR handle %p for %p in cache slot %d",
+				handle,
+				addr,
+				slot);
+			goto out;
+		} else if ((page_addr >= cache->slots[slot]->addr) &&
+			   ((page_addr - cache->slots[slot]->addr) /
+				    cache->system_page_size +
+			    pages) <= cache->slots[slot]->pages) {
+			/* cache hit */
+			NCCL_OFI_WARN("Entry already exists for addr %p size %zu", addr, size);
+			ret = -EEXIST;
+			goto out;
+		}
+	}
+
+out:
+	return ret;
+}
+
+static int nccl_ofi_mr_cache_lookup_handle(nccl_ofi_mr_cache_t *cache,
+					   void *handle)
+{
+	for (size_t i = 0; i < cache->used; i++) {
+		if (handle == cache->slots[i]->handle) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
+{
+	int slot = -1;
+	int ret = 0;
+
+	slot = nccl_ofi_mr_cache_lookup_handle(cache, handle);
+	if (slot < 0) {
+		NCCL_OFI_WARN("Did not find entry to delete");
+		ret = -ENOENT;
+		goto out;
+	}
+
+	/* Keep entry alive for other users */
+	if (--cache->slots[slot]->refcnt) {
+		NCCL_OFI_TRACE(
+			NCCL_NET,
+			"Decremented refcnt for MR handle %p in cache slot %d",
+			handle,
+			slot);
+		goto out;
+	}
+
+	/* Free this entry and defrag cache */
+	free(cache->slots[slot]);
+	memmove(cache->slots + slot,
+		cache->slots + slot + 1,
+		(cache->used - slot - 1) * sizeof(nccl_ofi_reg_entry_t *));
+	--cache->used;
+
+	NCCL_OFI_TRACE(NCCL_NET,
+		       "Removed MR handle %p in cache slot %d",
+		       handle,
+		       slot);
+
+	/* Signal to caller to deregister handle */
+	ret = 1;
+
+out:
+	return ret;
+}

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -53,6 +53,14 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 		props->max_communicators = NCCL_OFI_MIN(device->max_tag, INT_MAX);
 	}
 
+	/**
+	 * TODO:
+	 * The SENDRECV protocol currently does not correctly handle the truncated
+	 * send case (send size > recv size) which NCCL may use when regIsGlobal=1.
+	 * Remove this line once that is fixed.
+	 */
+	props->regIsGlobal = 0;
+
 	return ret;
 }
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -17,7 +17,8 @@ noinst_PROGRAMS = \
 	show_tuner_costs \
 	scheduler \
 	idpool \
-	ep_addr_list
+	ep_addr_list \
+	mr
 
 TESTS = $(noinst_PROGRAMS)
 
@@ -32,3 +33,4 @@ freelist_SOURCES = freelist.c
 msgbuff_SOURCES = msgbuff.c
 scheduler_SOURCES = scheduler.c
 ep_addr_list_SOURCES = ep_addr_list.c
+mr_SOURCES = mr.c

--- a/tests/unit/mr.c
+++ b/tests/unit/mr.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2023 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <stdlib.h>
+
+#include "test-common.h"
+#include "nccl_ofi_mr.h"
+
+bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+		 void *expected_val)
+{
+	void *result = nccl_ofi_mr_cache_lookup_entry(cache, addr, size);
+	if (result != expected_val) {
+		NCCL_OFI_WARN("nccl_ofi_mr_cache_lookup_entry returned unexpected result. Expected: %p. Actual: %p",
+			expected_val, result);
+		return false;
+	}
+	return true;
+}
+#define test_lookup(cache, addr, size, expected_val)              \
+	if (!test_lookup_impl(cache, addr, size, expected_val)) { \
+		NCCL_OFI_WARN("test_lookup fail");                \
+		exit(1);                                          \
+	}
+
+bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+		 void *handle, int expected_ret)
+{
+	int ret = nccl_ofi_mr_cache_insert_entry(cache, addr, size, handle);
+	if (ret != expected_ret) {
+		NCCL_OFI_WARN("nccl_ofi_mr_cache_insert_entry returned unexpected result. Expected: %d. Actual: %d",
+			expected_ret, ret);
+		return false;
+	}
+	return true;
+}
+#define test_insert(cache, addr, size, handle, expected_ret)              \
+	if (!test_insert_impl(cache, addr, size, handle, expected_ret)) { \
+		NCCL_OFI_WARN("test_insert fail");                        \
+		exit(1);                                                  \
+	}
+
+bool test_delete_impl(nccl_ofi_mr_cache_t *cache, void *handle, int expected_ret)
+{
+	int ret = nccl_ofi_mr_cache_del_entry(cache, handle);
+	if (ret != expected_ret) {
+		NCCL_OFI_WARN("nccl_ofi_mr_cache_del_entry returned unexpected result. Expected: %d. Actual: %d",
+			expected_ret, ret);
+		return false;
+	}
+	return true;
+}
+#define test_delete(cache, handle, expected_ret)              \
+	if (!test_delete_impl(cache, handle, expected_ret)) { \
+		NCCL_OFI_WARN("test_delete fail");            \
+		exit(1);                                      \
+	}
+
+int main(int argc, char *argv[])
+{
+	ofi_log_function = logger;
+	const size_t cache_init_size = 16;
+
+	/* Doesn't have to be correct -- for functionality test only */
+	const size_t system_page_size = 1024;
+
+	nccl_ofi_mr_cache_t *cache = nccl_ofi_mr_cache_init(cache_init_size,
+		system_page_size);
+	if (!cache) {
+		NCCL_OFI_WARN("nccl_ofi_mr_cache_init failed");
+		exit(1);
+	}
+
+	for (size_t i = 0; i < 4 * cache_init_size; ++i) {
+		if (i != 0) {
+			/* Lookup left hit */
+			test_lookup(cache, (void *)((i - 1) * system_page_size + 2), 2, (void *)(i - 1));
+			/* Lookup left miss overlap right */
+			test_lookup(cache, (void *)(i * system_page_size - 1), 2, NULL);
+			/* Test insert existing */
+			test_insert(cache, (void *)((i - 1) * system_page_size + 1), 1, (void *)i, -EEXIST);
+		}
+		/* Lookup here miss */
+		test_lookup(cache, (void *)(i * system_page_size + 4), 2, NULL);
+		/* Test insert */
+		test_insert(cache, (void *)(i * system_page_size), 1, (void *)i, 0);
+		/* Lookup here hit */
+		test_lookup(cache, (void *)(i * system_page_size), 2, (void *)i);
+		/* Lookup here miss overlap right */
+		test_lookup(cache, (void *)((i + 1) * system_page_size - 1), 2, NULL);
+
+		/* Lookup right miss */
+		test_lookup(cache, (void *)((i + 1) * system_page_size + 2), 2, NULL);
+	}
+
+	/* At this point, every entry should have refcnt==3 (insert, here hit,
+	   and left hit), except the last entry, which only has the insert and
+	   here hit. */
+	/* Test delete middle */
+	test_delete(cache, (void *)(2 * cache_init_size), 0);
+	test_delete(cache, (void *)(2 * cache_init_size), 0);
+	/* Expect refcnt to go to zero here */
+	test_delete(cache, (void *)(2 * cache_init_size), 1);
+	/* Expect the entry to not exist here */
+	test_delete(cache, (void *)(2 * cache_init_size), -ENOENT);
+
+	for (size_t i = 0; i < 4*cache_init_size; ++i) {
+		if (i == 2 * cache_init_size) {
+			/* Was removed above */
+			test_delete(cache, (void *)i, -ENOENT);
+		} else if (i == 4 * cache_init_size - 1) {
+			/* Only expect two entries */
+			test_delete(cache, (void *)i, 0);
+			test_delete(cache, (void *)i, 1);
+			test_delete(cache, (void *)i, -ENOENT);
+		} else {
+			/* Expect three entries */
+			test_delete(cache, (void *)i, 0);
+			test_delete(cache, (void *)i, 0);
+			test_delete(cache, (void *)i, 1);
+			test_delete(cache, (void *)i, -ENOENT);
+		}
+
+		/* Lookup miss after removal */
+		test_lookup(cache, (void *)(i * system_page_size), 1, NULL);
+	}
+
+	nccl_ofi_mr_cache_finalize(cache);
+
+	printf("Test completed successfully!\n");
+}


### PR DESCRIPTION
With user buffer registration capability, when a network plugin reports support for regIsGlobal, NCCL does maintain a cache of registration handles (originally registered with a loopback communicator). At the time of a send, it still calls into the regMr hook of the network plugin for the actual communicator that will be used for the data transfer (in case the net plugin requires communicator-specific state for the registration). With regIsGlobal guarantee, it is possible for NCCL to reuse the handle it has cached, but it does not do that today. This commit introduces a MR cache that is similar in design to NCCL's internal cache (with a linear search in the cache to find a registration that fully covers the list of pages of the buffer in question) to avoid redundant (and expensive) registrations with the underlying device.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
