### PR TITLE
Remove unused reference to OFI_NCCL_ARCHIVE in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,10 +92,8 @@ have_device_interface=no
 CHECK_PKG_NEURON([AS_IF([test -n "${want_cuda}"],
                         [AC_MSG_ERROR([Cannot enable both CUDA and neuron.])],
                         [want_cuda=no])
-                  have_device_interface=neuron]
-                  AC_SUBST([OFI_NCCL_ARCHIVE], [nccom-net]))
-CHECK_PKG_CUDA([have_device_interface=cuda]
-               AC_SUBST([OFI_NCCL_ARCHIVE], [nccl-net]))
+                  have_device_interface=neuron])
+CHECK_PKG_CUDA([have_device_interface=cuda])
 
 AS_IF([test "${have_device_interface}" = "no"],
       [AC_MSG_ERROR([NCCL OFI Plugin requires either CUDA or Neuron runtime.])])

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -46,8 +46,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [check_pkg_define=1
          $1],
         [check_pkg_define=0
-         CPPFLAGS="${check_pkg_CPPFLAGS_save}"
-         $2])
+         CPPFLAGS="${check_pkg_CPPFLAGS_save}"])
 
   AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
   AM_CONDITIONAL([HAVE_CUDA], [test "${check_pkg_found}" = "yes"])


### PR DESCRIPTION
The use of OFI_NCCL_ARCHIVE was removed in commit: f1a015c916060efc3849331e93a33f6bce80d1cb
(Build plugins as DSOs instead of shared libraries)

Remove the reference to it from configure.ac.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
