### PR TITLE
Remove unused reference to OFI_NCCL_ARCHIVE in configure.ac

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -92,10 +92,8 @@ have_device_interface=no
 CHECK_PKG_NEURON([AS_IF([test -n "${want_cuda}"],
                         [AC_MSG_ERROR([Cannot enable both CUDA and neuron.])],
                         [want_cuda=no])
-                  have_device_interface=neuron]
-                  AC_SUBST([OFI_NCCL_ARCHIVE], [nccom-net]))
-CHECK_PKG_CUDA([have_device_interface=cuda]
-               AC_SUBST([OFI_NCCL_ARCHIVE], [nccl-net]))
+                  have_device_interface=neuron])
+CHECK_PKG_CUDA([have_device_interface=cuda])
 
 AS_IF([test "${have_device_interface}" = "no"],
       [AC_MSG_ERROR([NCCL OFI Plugin requires either CUDA or Neuron runtime.])])


### PR DESCRIPTION
The use of OFI_NCCL_ARCHIVE was removed in commit: f1a015c916060efc3849331e93a33f6bce80d1cb
(Build plugins as DSOs instead of shared libraries)

Remove the reference to it from configure.ac.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
