### PR TITLE
tree: set export symbol visibility

### DIFF
--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -9,6 +9,8 @@
 #define OFI_LIKELY(x)   __builtin_expect((x), 1)
 #define OFI_UNLIKELY(x) __builtin_expect((x), 0)
 
+#define NCCL_OFI_EXPORT_SYMBOL __attribute__((visibility("default")))
+
 /* Maximum length of directory path */
 #ifdef HAVE_LINUX_LIMITS_H
 #include <linux/limits.h>

--- a/include/nccl_ofi_tuner.h
+++ b/include/nccl_ofi_tuner.h
@@ -5,6 +5,7 @@
 #ifndef NCCL_OFI_TUNER_H_
 #define NCCL_OFI_TUNER_H_
 
+#include "config.h"
 #include "nccl_ofi_param.h"
 
 #include "nccl-headers/nvidia/tuner.h"
@@ -44,9 +45,9 @@ double nccl_ofi_tuner_compute_cost(struct nccl_ofi_tuner_model_dims const* dims,
  * in our configure script, but by definining this manually in cflags, you can
  * choose at plugin build-time which interface to implement. */
 #if defined(AWS_OFI_NCCL_MIN_TUNER_COMPAT) || (AWS_OFI_NCCL_MIN_TUNER_COMPAT <= 1)
-extern const ncclTuner_v2_t ncclTunerPlugin_v2;
+NCCL_OFI_EXPORT_SYMBOL extern const ncclTuner_v2_t ncclTunerPlugin_v2;
 #else
-extern const ncclTuner_v1_t ncclTunerPlugin_v1;
+NCCL_OFI_EXPORT_SYMBOL extern const ncclTuner_v1_t ncclTunerPlugin_v1;
 #endif /* !defined(AWS_OFI_NCCL_MIN_TUNER_COMPAT) || (AWS_OFI_NCCL_MIN_TUNER_COMPAT <= 1) */
 
 #endif /* NCCL_OFI_TUNER_H_ */

--- a/src/nccl_ofi_interface_neuron.c
+++ b/src/nccl_ofi_interface_neuron.c
@@ -30,7 +30,7 @@ static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
 }
 
 
-const ncclNet_v4_t ncclNetPlugin_v4 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "AWS Libfabric",
 	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,

--- a/src/nccl_ofi_interface_nvidia.c
+++ b/src/nccl_ofi_interface_nvidia.c
@@ -204,7 +204,7 @@ static ncclResult_t accept_v7(void* listenComm, void** recvComm,
 }
 
 
-const ncclNet_v2_t ncclNetPlugin_v2 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v2_t ncclNetPlugin_v2 = {
 	.name = "AWS Libfabric",
 	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
@@ -224,7 +224,7 @@ const ncclNet_v2_t ncclNetPlugin_v2 = {
 	.closeListen = nccl_net_ofi_closeListen,
 };
 
-const ncclNet_v3_t ncclNetPlugin_v3 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v3_t ncclNetPlugin_v3 = {
 	.name = "AWS Libfabric",
 	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
@@ -243,7 +243,7 @@ const ncclNet_v3_t ncclNetPlugin_v3 = {
 	.closeListen = nccl_net_ofi_closeListen,
 };
 
-const ncclNet_v4_t ncclNetPlugin_v4 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "AWS Libfabric",
 	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
@@ -262,7 +262,7 @@ const ncclNet_v4_t ncclNetPlugin_v4 = {
 	.closeListen = nccl_net_ofi_closeListen,
 };
 
-const ncclNet_v5_t ncclNetPlugin_v5 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v5_t ncclNetPlugin_v5 = {
 	.name = "AWS Libfabric",
 	.init = nccl_net_ofi_init,
 	.devices = nccl_net_ofi_devices,
@@ -281,7 +281,7 @@ const ncclNet_v5_t ncclNetPlugin_v5 = {
 	.closeListen = nccl_net_ofi_closeListen,
 };
 
-const ncclNet_v6_t ncclNetPlugin_v6 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v6_t ncclNetPlugin_v6 = {
         .name = "AWS Libfabric",
         .init = nccl_net_ofi_init,
         .devices = nccl_net_ofi_devices,
@@ -301,7 +301,7 @@ const ncclNet_v6_t ncclNetPlugin_v6 = {
         .closeListen = nccl_net_ofi_closeListen,
 };
 
-const ncclNet_v7_t ncclNetPlugin_v7 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v7_t ncclNetPlugin_v7 = {
         .name = "AWS Libfabric",
         .init = nccl_net_ofi_init,
         .devices = nccl_net_ofi_devices,
@@ -323,7 +323,7 @@ const ncclNet_v7_t ncclNetPlugin_v7 = {
 	.irecvConsumed = NULL,
 };
 
-const ncclNet_v8_t ncclNetPlugin_v8 = {
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v8_t ncclNetPlugin_v8 = {
         .name = "AWS Libfabric",
         .init = nccl_net_ofi_init,
         .devices = nccl_net_ofi_devices,


### PR DESCRIPTION
enables builds with `-fvisibility=hidden` to work correctly, at least
under some compilers.

The end-goal is to get cross translation unit optimization and LTO working well,
to negate some of the negative impacts of our usage of globals