### PR TITLE
prefer spinlocks where possible

### DIFF
--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -78,7 +78,7 @@ static inline int nccl_ofi_deque_insert_back(nccl_ofi_deque_t *deque, nccl_ofi_d
 	assert(deque);
 	assert(deque_elem);
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
+	nccl_net_ofi_lock(&deque->lock);
 
 	deque_elem->next = &deque->head;
 	deque_elem->prev = deque->head.prev;
@@ -87,7 +87,7 @@ static inline int nccl_ofi_deque_insert_back(nccl_ofi_deque_t *deque, nccl_ofi_d
 	deque->head.prev->next = deque_elem;
 	deque->head.prev = deque_elem;
 
-	nccl_net_ofi_mutex_unlock(&deque->lock);
+	nccl_net_ofi_unlock(&deque->lock);
 
 	return 0;
 }
@@ -103,7 +103,7 @@ static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	assert(deque);
 	assert(deque_elem);
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
+	nccl_net_ofi_lock(&deque->lock);
 
 	deque_elem->next = deque->head.next;
 	deque_elem->prev = &deque->head;
@@ -112,7 +112,7 @@ static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	deque->head.next->prev = deque_elem;
 	deque->head.next = deque_elem;
 
-	nccl_net_ofi_mutex_unlock(&deque->lock);
+	nccl_net_ofi_unlock(&deque->lock);
 
 	return 0;
 }
@@ -143,7 +143,7 @@ static inline int nccl_ofi_deque_remove_front(nccl_ofi_deque_t *deque, nccl_ofi_
 		return 0;
 	}
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
+	nccl_net_ofi_lock(&deque->lock);
 
 	/* Check for empty deque. We need to do this again because the check above
 	   was before we acquired the lock. */
@@ -157,7 +157,7 @@ static inline int nccl_ofi_deque_remove_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	(*deque_elem)->next->prev = &deque->head;
 
 unlock:
-	nccl_net_ofi_mutex_unlock(&deque->lock);
+	nccl_net_ofi_unlock(&deque->lock);
 
 	return 0;
 }

--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -47,7 +47,7 @@ struct nccl_ofi_deque_t {
 	 */
 	nccl_ofi_deque_elem_t head;
 	/* Lock for deque operations */
-	pthread_mutex_t lock;
+	pthread_spinlock_t lock;
 };
 typedef struct nccl_ofi_deque_t nccl_ofi_deque_t;
 

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -123,7 +123,7 @@ struct nccl_ofi_freelist_t {
 
 	size_t memcheck_redzone_size;
 
-	pthread_mutex_t lock;
+	pthread_spinlock_t lock;
 };
 typedef struct nccl_ofi_freelist_t nccl_ofi_freelist_t;
 

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -257,7 +257,7 @@ static inline void *nccl_ofi_freelist_entry_alloc(nccl_ofi_freelist_t *freelist)
 
 	assert(freelist);
 
-	nccl_net_ofi_mutex_lock(&freelist->lock);
+	nccl_net_ofi_lock(&freelist->lock);
 
 	if (!freelist->entries) {
 		ret = nccl_ofi_freelist_add(freelist, freelist->increase_entry_count);
@@ -275,7 +275,7 @@ static inline void *nccl_ofi_freelist_entry_alloc(nccl_ofi_freelist_t *freelist)
 	nccl_ofi_freelist_entry_set_undefined(freelist, buf);
 
 cleanup:
-	nccl_net_ofi_mutex_unlock(&freelist->lock);
+	nccl_net_ofi_unlock(&freelist->lock);
 
 	return buf;
 }
@@ -295,7 +295,7 @@ static inline void nccl_ofi_freelist_entry_free(nccl_ofi_freelist_t *freelist, v
 	assert(freelist);
 	assert(entry_p);
 
-	nccl_net_ofi_mutex_lock(&freelist->lock);
+	nccl_net_ofi_lock(&freelist->lock);
 
 	if (freelist->have_reginfo) {
 		entry = (struct nccl_ofi_freelist_elem_t *)((char*)entry_p + freelist->reginfo_offset);
@@ -310,7 +310,7 @@ static inline void nccl_ofi_freelist_entry_free(nccl_ofi_freelist_t *freelist, v
 
 	nccl_net_ofi_mem_noaccess(entry_p, user_entry_size);
 
-	nccl_net_ofi_mutex_unlock(&freelist->lock);
+	nccl_net_ofi_unlock(&freelist->lock);
 }
 
 #ifdef _cplusplus

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -25,7 +25,7 @@ typedef struct nccl_ofi_idpool {
 	uint64_t *ids;
 
 	/* Lock for concurrency */
-	pthread_mutex_t lock;
+	pthread_spinlock_t lock;
 } nccl_ofi_idpool_t;
 
 /*

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -101,7 +101,7 @@ typedef struct {
 	// Points to the message after the inserted message with highest sequence number.
 	uint16_t msg_next;
 	// Mutex for this msg buffer -- locks all non-init operations
-	pthread_mutex_t lock;
+	pthread_spinlock_t lock;
 } nccl_ofi_msgbuff_t;
 
 /**

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -26,7 +26,7 @@ static inline int64_t ofi_nccl_##name() { \
     if (initialized) { \
 	return value; \
     } \
-    nccl_net_ofi_mutex_lock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_lock(&ofi_nccl_param_lock_##name); \
     int64_t v; \
     char *str, *endptr; \
     if (!initialized) { \
@@ -46,7 +46,7 @@ static inline int64_t ofi_nccl_##name() { \
         } \
 	initialized = true; \
     } \
-    nccl_net_ofi_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_unlock(&ofi_nccl_param_lock_##name); \
     return value; \
 }
 
@@ -58,7 +58,7 @@ static inline const char *ofi_nccl_##name() { \
     if (initialized) { \
 	return value; \
     } \
-    nccl_net_ofi_mutex_lock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_lock(&ofi_nccl_param_lock_##name); \
     char *str; \
     if (!initialized) { \
         str = getenv("OFI_NCCL_" env); \
@@ -76,7 +76,7 @@ static inline const char *ofi_nccl_##name() { \
         } \
 	initialized = true; \
     } \
-    nccl_net_ofi_mutex_unlock(&ofi_nccl_param_lock_##name); \
+    nccl_net_ofi_unlock(&ofi_nccl_param_lock_##name); \
     return value; \
 }
 

--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -9,11 +9,54 @@
 extern "C" {
 #endif
 
+#include <assert.h>
 #include <pthread.h>
 #include <string.h>
 
 #include "nccl_ofi_log.h"
 
+#define _GOOD_NCCL_OFI_LOCK(lock)                                                                \
+	_Static_assert(__builtin_types_compatible_p(__typeof__(*lock), pthread_spinlock_t) ||    \
+			       __builtin_types_compatible_p(__typeof__(*lock), pthread_mutex_t), \
+		       "Expected pointer to pthread_spinlock_t or pthread_mutex_t")
+
+#define _USE_IMPL_1(lock, f, l, spinimpl, muteximpl)                                              \
+	({                                                                                        \
+		_GOOD_NCCL_OFI_LOCK(lock);                                                        \
+		__builtin_choose_expr(                                                            \
+			__builtin_types_compatible_p(__typeof__(*lock), pthread_spinlock_t),      \
+			spinimpl((pthread_spinlock_t *)lock, f, l),                               \
+			__builtin_choose_expr(                                                    \
+				__builtin_types_compatible_p(__typeof__(*lock), pthread_mutex_t), \
+				muteximpl((pthread_mutex_t *)lock, f, l),                         \
+				1));                                                              \
+	})
+
+
+#define _USE_IMPL_2(lock, a, spinimpl, muteximpl)                                                 \
+	({                                                                                        \
+		_GOOD_NCCL_OFI_LOCK(lock);                                                        \
+		__builtin_choose_expr(                                                            \
+			__builtin_types_compatible_p(__typeof__(*lock), pthread_spinlock_t),      \
+			spinimpl((pthread_spinlock_t *)lock, a),                                  \
+			__builtin_choose_expr(                                                    \
+				__builtin_types_compatible_p(__typeof__(*lock), pthread_mutex_t), \
+				muteximpl((pthread_mutex_t *)lock, a),                            \
+				1));                                                              \
+	})
+
+
+#define _USE_IMPL_3(lock, spinimpl, muteximpl)                                                    \
+	({                                                                                        \
+		_GOOD_NCCL_OFI_LOCK(lock);                                                        \
+		__builtin_choose_expr(                                                            \
+			__builtin_types_compatible_p(__typeof__(*lock), pthread_spinlock_t),      \
+			spinimpl((pthread_spinlock_t *)lock),                                     \
+			__builtin_choose_expr(                                                    \
+				__builtin_types_compatible_p(__typeof__(*lock), pthread_mutex_t), \
+				muteximpl((pthread_mutex_t *)lock),                               \
+				1));                                                              \
+	})
 
 /**
  * Create a mutex
@@ -26,7 +69,10 @@ extern "C" {
  *
  * See pthread_mutex_init() for possible return codes
  */
-int nccl_net_ofi_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *attr);
+int nccl_net_ofi_mutex_init(pthread_mutex_t *lock, const pthread_mutexattr_t *attr);
+int nccl_net_ofi_spin_init(pthread_spinlock_t *lock, int shared);
+#define nccl_net_ofi_lock_init(lock, attr) \
+	_USE_IMPL_2(lock, attr, nccl_net_ofi_spin_init, nccl_net_ofi_mutex_init)
 
 
 /**
@@ -37,8 +83,10 @@ int nccl_net_ofi_mutex_init(pthread_mutex_t *mutex, const pthread_mutexattr_t *a
  *
  * See pthread_mutex_destroy() for possible return codes
  */
-int nccl_net_ofi_mutex_destroy(pthread_mutex_t *mutex);
-
+int nccl_net_ofi_mutex_destroy(pthread_mutex_t *lock);
+int nccl_net_ofi_spin_destroy(pthread_spinlock_t *lock);
+#define nccl_net_ofi_lock_destroy(lock) \
+	_USE_IMPL_3(lock, nccl_net_ofi_spin_destroy, nccl_net_ofi_mutex_destroy)
 
 /**
  * Lock a mutex
@@ -46,41 +94,106 @@ int nccl_net_ofi_mutex_destroy(pthread_mutex_t *mutex);
  * Wrapper around pthread_mutex_lock() which will abort the current
  * process if an error occurs.
  */
-static inline void
-nccl_net_ofi_mutex_lock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+static inline void nccl_net_ofi_mutex_lock_impl(pthread_mutex_t *lock,
+						const char *file,
+						size_t line)
 {
-	int ret = pthread_mutex_lock(mutex);
+	int ret = pthread_mutex_lock(lock);
 	if (OFI_UNLIKELY(ret != 0)) {
-		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
 				    "NET/OFI pthread_mutex_lock failed: %s",
 				    strerror(ret));
 		abort();
 	}
 }
-#define nccl_net_ofi_mutex_lock(mutex) nccl_net_ofi_mutex_lock_impl(mutex, __FILE__, __LINE__);
+
+/**
+ * Lock a spinlock
+ *
+ * Wrapper around pthread_spin_lock() which will abort the current
+ * process if an error occurs.
+ */
+static inline void nccl_net_ofi_spin_lock_impl(pthread_spinlock_t *lock,
+					       const char *file,
+					       size_t line)
+{
+	int ret = pthread_spin_lock(lock);
+	if (OFI_UNLIKELY(ret != 0)) {
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
+				    "NET/OFI pthread_mutex_lock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+}
+#define nccl_net_ofi_lock(lock)                  \
+	_USE_IMPL_1(lock,                        \
+		    __FILE__,                    \
+		    __LINE__,                    \
+		    nccl_net_ofi_spin_lock_impl, \
+		    nccl_net_ofi_mutex_lock_impl)
 
 /**
  * Attempt to lock a mutex without blocking
  *
- * Wrapper around pthread_mutex_trylock() which will abort the current
+ * Wrapper around pthread_spinlock_trylock() which will abort the current
  * process if any error other than EBUSY occurs.
  *
  * Returns 0 if the lock is acquired, EBUSY if the lock is already
  * locked, and aborts the process otherwise.
  */
-static inline int
-nccl_net_ofi_mutex_trylock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+static inline int nccl_net_ofi_mutex_trylock_impl(pthread_mutex_t *mutex,
+						  const char *file,
+						  size_t line)
 {
 	int ret = pthread_mutex_trylock(mutex);
 	if (OFI_UNLIKELY(ret != 0 && ret != EBUSY)) {
-		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
 				    "NET/OFI pthread_mutex_trylock failed: %s",
 				    strerror(ret));
 		abort();
 	}
-     return ret;
+	return ret;
 }
-#define nccl_net_ofi_mutex_trylock(mutex) nccl_net_ofi_mutex_trylock_impl(mutex, __FILE__, __LINE__);
+/**
+ * Attempt to lock a mutex without blocking
+ *
+ * Wrapper around pthread_spinlock_trylock() which will abort the current
+ * process if any error other than EBUSY occurs.
+ *
+ * Returns 0 if the lock is acquired, EBUSY if the lock is already
+ * locked, and aborts the process otherwise.
+ */
+static inline int nccl_net_ofi_spin_trylock_impl(pthread_spinlock_t *lock,
+						 const char *file,
+						 size_t line)
+{
+	int ret = pthread_spin_trylock(lock);
+	if (OFI_UNLIKELY(ret != 0 && ret != EBUSY)) {
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
+				    "NET/OFI pthread_mutex_trylock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+	return ret;
+}
+#define nccl_net_ofi_trylock(lock)                  \
+	_USE_IMPL_1(lock,                           \
+		    __FILE__,                       \
+		    __LINE__,                       \
+		    nccl_net_ofi_spin_trylock_impl, \
+		    nccl_net_ofi_mutex_trylock_impl)
 
 
 /**
@@ -89,22 +202,52 @@ nccl_net_ofi_mutex_trylock_impl(pthread_mutex_t *mutex, const char *file, size_t
  * Wrapper around pthread_mutex_unlock() which will abort the current
  * process if an error occurs.
  */
-static inline void
-nccl_net_ofi_mutex_unlock_impl(pthread_mutex_t *mutex, const char *file, size_t line)
+static inline void nccl_net_ofi_mutex_unlock_impl(pthread_mutex_t *lock,
+						  const char *file,
+						  size_t line)
 {
-	int ret = pthread_mutex_unlock(mutex);
+	int ret = pthread_mutex_unlock(lock);
 	if (OFI_UNLIKELY(ret != 0)) {
-		(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, file, line,
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
 				    "NET/OFI pthread_mutex_unlock failed: %s",
 				    strerror(ret));
 		abort();
 	}
 }
-#define nccl_net_ofi_mutex_unlock(mutex) nccl_net_ofi_mutex_unlock_impl(mutex, __FILE__, __LINE__);
 
+/**
+ * Unlock a spinlock
+ *
+ * Wrapper around pthread_spin_unlock() which will abort the current
+ * process if an error occurs.
+ */
+static inline void nccl_net_ofi_spin_unlock_impl(pthread_spinlock_t *lock,
+						 const char *file,
+						 size_t line)
+{
+	int ret = pthread_spin_unlock(lock);
+	if (OFI_UNLIKELY(ret != 0)) {
+		(*ofi_log_function)(NCCL_LOG_WARN,
+				    NCCL_ALL,
+				    file,
+				    line,
+				    "NET/OFI pthread_mutex_unlock failed: %s",
+				    strerror(ret));
+		abort();
+	}
+}
+#define nccl_net_ofi_unlock(lock)                  \
+	_USE_IMPL_1(lock,                          \
+		    __FILE__,                      \
+		    __LINE__,                      \
+		    nccl_net_ofi_spin_unlock_impl, \
+		    nccl_net_ofi_mutex_unlock_impl)
 
 #ifdef _cplusplus
-} // End extern "C"
+}  // End extern "C"
 #endif
 
-#endif // End NCCL_OFI_PTHREAD_H
+#endif  // End NCCL_OFI_PTHREAD_H

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -296,7 +296,7 @@ typedef struct nccl_net_ofi_rdma_req {
 	 * Protect updating critical fields such as size and ncompls when
 	 * network xfer happened over multiple rails
 	 */
-	pthread_mutex_t req_lock;
+	pthread_spinlock_t req_lock;
 
 	/* State of request */
 	nccl_net_ofi_rdma_req_state_t state;
@@ -555,7 +555,7 @@ struct nccl_net_ofi_ep_rail {
 	/* Maximum posted bounce buffers (see RDMA_MAX_POSTED_BOUNCE_BUFFERS) */
 	size_t max_bounce_posted;
 	/* Mutex for bounce buffer operations */
-	pthread_mutex_t bounce_mutex;
+	pthread_spinlock_t bounce_mutex;
 };
 
 /*
@@ -670,7 +670,7 @@ typedef struct nccl_net_ofi_rdma_device {
 
 	/* Lock for concurrency since endpoints can be shared by
 	 * multiple entities. */
-	pthread_mutex_t ep_lock;
+	pthread_spinlock_t ep_lock;
 
 	/* Number of rails */
 	int num_rails;

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -92,7 +92,7 @@ typedef struct nccl_net_ofi_threshold_scheduler {
 	/* Round robin counter */
 	unsigned int rr_counter;
 	/* Lock for round robin counter */
-	pthread_mutex_t rr_lock;
+	pthread_spinlock_t rr_lock;
 	/* Maximum size of a message in bytes before message is
 	 * multiplexed */
 	size_t rr_threshold;

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -169,7 +169,7 @@ typedef struct nccl_net_ofi_sendrecv_device {
 
 	/* Lock for concurrency since endpoints can be shared by
 	 * multiple entities. */
-	pthread_mutex_t ep_lock;
+	pthread_spinlock_t ep_lock;
 
 	/* Device provider */
 	struct fi_info *info;

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -24,7 +24,7 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 	deque->head.prev = &deque->head;
 	deque->head.next = &deque->head;
 
-	ret = nccl_net_ofi_lock_init(&deque->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&deque->lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to initialize deque mutex.");
 		free(deque);

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -96,17 +96,16 @@ static int freelist_init_internal(size_t entry_size,
 	freelist->regmr_opaque = regmr_opaque;
 	freelist->reginfo_offset = reginfo_offset;
 
-	ret = pthread_mutex_init(&freelist->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&freelist->lock, NULL);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
 		free(freelist);
 		return -ret;
 	}
-
 	ret = nccl_ofi_freelist_add(freelist, initial_entry_count);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Allocating initial freelist entries failed: %d", ret);
-		pthread_mutex_destroy(&freelist->lock);
+		nccl_net_ofi_lock_destroy(&freelist->lock);
 		free(freelist);
 		return ret;
 
@@ -198,7 +197,7 @@ int nccl_ofi_freelist_fini(nccl_ofi_freelist_t *freelist)
 	freelist->entry_size = 0;
 	freelist->entries = NULL;
 
-	pthread_mutex_destroy(&freelist->lock);
+	nccl_net_ofi_lock_destroy(&freelist->lock);
 
 	free(freelist);
 

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -96,7 +96,7 @@ static int freelist_init_internal(size_t entry_size,
 	freelist->regmr_opaque = regmr_opaque;
 	freelist->reginfo_offset = reginfo_offset;
 
-	ret = nccl_net_ofi_lock_init(&freelist->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&freelist->lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
 		free(freelist);

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -56,7 +56,7 @@ int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size)
 	}
 
 	/* Initialize mutex */
-	ret = nccl_net_ofi_mutex_init(&idpool->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&idpool->lock, NULL);
 	if (OFI_UNLIKELY(ret)) {
 		NCCL_OFI_WARN("Unable to initialize mutex");
 		free(idpool->ids);
@@ -100,7 +100,7 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
 	/* Scale pool size to number of 64-bit uints (rounded up) */
 	size_t num_long_elements = NCCL_OFI_ROUND_UP(idpool->size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
 
-	nccl_net_ofi_mutex_lock(&idpool->lock);
+	nccl_net_ofi_lock(&idpool->lock);
 
 	int entry_index = 0;
 	int id = -1;
@@ -118,7 +118,7 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
 		}
 	}
 
-	nccl_net_ofi_mutex_unlock(&idpool->lock);
+	nccl_net_ofi_unlock(&idpool->lock);
 
 	if (-1 == id || id >= idpool->size) {
 		NCCL_OFI_WARN("No IDs available (max: %lu)", idpool->size);
@@ -162,7 +162,7 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
 		return -EINVAL;
 	}
 
-	nccl_net_ofi_mutex_lock(&idpool->lock);
+	nccl_net_ofi_lock(&idpool->lock);
 
 	size_t i = id / (sizeof(uint64_t) * 8);
 	size_t entry_index = id % (sizeof(uint64_t) * 8);
@@ -171,14 +171,14 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
 	if (idpool->ids[i] & (1ULL << entry_index)) {
 		NCCL_OFI_WARN("Attempted to free an ID that's not in use (%lu)", id);
 
-		nccl_net_ofi_mutex_unlock(&idpool->lock);
+		nccl_net_ofi_unlock(&idpool->lock);
 		return -ENOTSUP;
 	}
 
 	/* Set bit to 1, making the ID available */
 	idpool->ids[i] |= 1ULL << (entry_index);
 
-	nccl_net_ofi_mutex_unlock(&idpool->lock);
+	nccl_net_ofi_unlock(&idpool->lock);
 
 	return 0;
 }
@@ -205,7 +205,7 @@ int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool)
 	}
 
 	/* Destroy mutex */
-	ret = nccl_net_ofi_mutex_destroy(&idpool->lock);
+	ret = nccl_net_ofi_lock_destroy(&idpool->lock);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Unable to destroy mutex");
 	}

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -56,7 +56,7 @@ int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size)
 	}
 
 	/* Initialize mutex */
-	ret = nccl_net_ofi_lock_init(&idpool->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&idpool->lock, PTHREAD_PROCESS_PRIVATE);
 	if (OFI_UNLIKELY(ret)) {
 		NCCL_OFI_WARN("Unable to initialize mutex");
 		free(idpool->ids);

--- a/src/nccl_ofi_msgbuff.c
+++ b/src/nccl_ofi_msgbuff.c
@@ -42,7 +42,7 @@ nccl_ofi_msgbuff_t *nccl_ofi_msgbuff_init(uint16_t max_inprogress, uint16_t bit_
 	msgbuff->field_mask = (uint16_t)(1 << bit_width) - 1;
 	msgbuff->max_inprogress = max_inprogress;
 
-	ret = nccl_net_ofi_mutex_init(&msgbuff->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&msgbuff->lock, NULL);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
 		goto error;
@@ -76,7 +76,7 @@ bool nccl_ofi_msgbuff_destroy(nccl_ofi_msgbuff_t *msgbuff)
 		return false;
 	}
 	free(msgbuff->buff);
-	nccl_net_ofi_mutex_destroy(&msgbuff->lock);
+	nccl_net_ofi_lock_destroy(&msgbuff->lock);
 	free(msgbuff);
 	return true;
 }
@@ -136,7 +136,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
 {
 	assert(msgbuff);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
+	nccl_net_ofi_lock(&msgbuff->lock);
 
 	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
 	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
@@ -158,7 +158,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
 		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
+	nccl_net_ofi_unlock(&msgbuff->lock);
 	return ret;
 }
 
@@ -168,7 +168,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
 {
 	assert(msgbuff);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
+	nccl_net_ofi_lock(&msgbuff->lock);
 
 	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
 	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
@@ -181,7 +181,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
 		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
+	nccl_net_ofi_unlock(&msgbuff->lock);
 	return ret;
 }
 
@@ -195,7 +195,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
 		NCCL_OFI_WARN("elem is NULL");
 		return NCCL_OFI_MSGBUFF_ERROR;
 	}
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
+	nccl_net_ofi_lock(&msgbuff->lock);
 
 	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
 	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
@@ -212,7 +212,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
 		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
+	nccl_net_ofi_unlock(&msgbuff->lock);
 	return ret;
 }
 
@@ -221,7 +221,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
 {
 	assert(msgbuff);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
+	nccl_net_ofi_lock(&msgbuff->lock);
 
 	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
 	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
@@ -243,6 +243,6 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
 		}
 		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
 	}
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
+	nccl_net_ofi_unlock(&msgbuff->lock);
 	return ret;
 }

--- a/src/nccl_ofi_msgbuff.c
+++ b/src/nccl_ofi_msgbuff.c
@@ -42,7 +42,7 @@ nccl_ofi_msgbuff_t *nccl_ofi_msgbuff_init(uint16_t max_inprogress, uint16_t bit_
 	msgbuff->field_mask = (uint16_t)(1 << bit_width) - 1;
 	msgbuff->max_inprogress = max_inprogress;
 
-	ret = nccl_net_ofi_lock_init(&msgbuff->lock, NULL);
+	ret = nccl_net_ofi_lock_init(&msgbuff->lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
 		goto error;

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -261,7 +261,7 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails,
 	scheduler->rr_counter = 0;
 	scheduler->rr_threshold = rr_threshold;
 
-	ret = nccl_net_ofi_lock_init(&scheduler->rr_lock, NULL);
+	ret = nccl_net_ofi_lock_init(&scheduler->rr_lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret) {
 		NCCL_OFI_WARN("Could not initialize mutex for round robin counter");
 		scheduler_fini(&scheduler->base);

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -63,13 +63,13 @@ static inline int set_round_robin_schedule(nccl_net_ofi_threshold_scheduler_t *s
 {
 	int rail_id;
 
-	nccl_net_ofi_mutex_lock(&scheduler->rr_lock);
+	nccl_net_ofi_lock(&scheduler->rr_lock);
 
 	/* Retieve and increment round-robin counter; wrap around if required */
 	rail_id = (scheduler->rr_counter)++;
 	scheduler->rr_counter = scheduler->rr_counter == num_rails ? 0 : scheduler->rr_counter;
 
-	nccl_net_ofi_mutex_unlock(&scheduler->rr_lock);
+	nccl_net_ofi_unlock(&scheduler->rr_lock);
 
 	schedule->num_xfer_infos = 1;
 	schedule->rail_xfer_infos[0].rail_id = rail_id;
@@ -194,7 +194,7 @@ static int threshold_scheduler_fini(nccl_net_ofi_scheduler_t *scheduler_p)
 	assert(scheduler_p);
 	assert(scheduler_p->schedule_fl);
 
-	ret = nccl_net_ofi_mutex_destroy(&scheduler->rr_lock);
+	ret = nccl_net_ofi_lock_destroy(&scheduler->rr_lock);
 	if (ret) {
 		NCCL_OFI_WARN("Could not destroy threshold scheduler pthread mutex");
 		return -ret;
@@ -261,7 +261,7 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails,
 	scheduler->rr_counter = 0;
 	scheduler->rr_threshold = rr_threshold;
 
-	ret = nccl_net_ofi_mutex_init(&scheduler->rr_lock, NULL);
+	ret = nccl_net_ofi_lock_init(&scheduler->rr_lock, NULL);
 	if (ret) {
 		NCCL_OFI_WARN("Could not initialize mutex for round robin counter");
 		scheduler_fini(&scheduler->base);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1322,9 +1322,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(device->ep_lock));
+		nccl_net_ofi_lock(&(device->ep_lock));
 		ep->ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(device->ep_lock));
+		nccl_net_ofi_unlock(&(device->ep_lock));
 
 		/* Prepare receive request to accept connections */
 		req = prepare_recv_req(l_comm);
@@ -2049,7 +2049,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 		goto exit;
 	}
 
-	nccl_net_ofi_mutex_lock(&device->ep_lock);
+	nccl_net_ofi_lock(&device->ep_lock);
 
 	/* Decrease reference counter of endpoint. */
 	ep->ref_cnt--;
@@ -2079,7 +2079,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 		ep->cq = NULL;
 	}
 
-	nccl_net_ofi_mutex_unlock(&device->ep_lock);
+	nccl_net_ofi_unlock(&device->ep_lock);
 
  exit:
 	return ret;
@@ -2100,7 +2100,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 	}
 
 	/* Obtain lock */
-	nccl_net_ofi_mutex_lock(&device->ep_lock);
+	nccl_net_ofi_lock(&device->ep_lock);
 
 	/* Obtain thread-local sendrecv endpoint. Allocate and
 	 * initialize endpoint if necessary. */
@@ -2162,7 +2162,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 	*base_ep = &ep->base;
 
  unlock:
-	nccl_net_ofi_mutex_unlock(&device->ep_lock);
+	nccl_net_ofi_unlock(&device->ep_lock);
 
  exit:
 	return ret;
@@ -2247,7 +2247,7 @@ static int device_init_thread_local(nccl_net_ofi_sendrecv_device_t *devices)
 	}
 
 	/* Intiaialize mutex for endpoint access */
-	ret = nccl_net_ofi_mutex_init(&devices->ep_lock, NULL);
+	ret = nccl_net_ofi_lock_init(&devices->ep_lock, NULL);
 	if (ret != 0) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 			       "Unable to initialize mutex");

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2247,7 +2247,7 @@ static int device_init_thread_local(nccl_net_ofi_sendrecv_device_t *devices)
 	}
 
 	/* Intiaialize mutex for endpoint access */
-	ret = nccl_net_ofi_lock_init(&devices->ep_lock, NULL);
+	ret = nccl_net_ofi_lock_init(&devices->ep_lock, PTHREAD_PROCESS_PRIVATE);
 	if (ret != 0) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 			       "Unable to initialize mutex");

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -117,10 +117,10 @@ static const char* get_platform_type(void)
 	static char *platform_type = NULL;
 	static pthread_mutex_t platform_mutex = PTHREAD_MUTEX_INITIALIZER;
 
-	nccl_net_ofi_mutex_lock(&platform_mutex);
+	nccl_net_ofi_lock(&platform_mutex);
 
 	if (init) {
-		nccl_net_ofi_mutex_unlock(&platform_mutex);
+		nccl_net_ofi_unlock(&platform_mutex);
 		return platform_type;
 	}
 
@@ -167,7 +167,7 @@ exit:
 	if (fd)
 		fclose(fd);
 
-	nccl_net_ofi_mutex_unlock(&platform_mutex);
+	nccl_net_ofi_unlock(&platform_mutex);
 
 	return platform_type;
 }
@@ -188,17 +188,17 @@ struct ec2_platform_data *get_platform_data()
 	const size_t platform_n = sizeof(platform_data_map)/sizeof(platform_data_map[0]);
 	const char* platform_type = NULL;
 
-	nccl_net_ofi_mutex_lock(&mutex);
+	nccl_net_ofi_lock(&mutex);
 
 	if (init) {
-		nccl_net_ofi_mutex_unlock(&mutex);
+		nccl_net_ofi_unlock(&mutex);
 		return platform_data;
 	}
 	init = true;
 
 	platform_type = get_platform_type();
 	if (platform_type == NULL) {
-		nccl_net_ofi_mutex_unlock(&mutex);
+		nccl_net_ofi_unlock(&mutex);
 		return NULL;
 	}
 
@@ -207,7 +207,7 @@ struct ec2_platform_data *get_platform_data()
 			platform_data = &platform_data_map[idx];
 	}
 
-	nccl_net_ofi_mutex_unlock(&mutex);
+	nccl_net_ofi_unlock(&mutex);
 
 	return platform_data;
 }
@@ -619,7 +619,7 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 		goto exit;
 	}
 
-	nccl_net_ofi_mutex_lock(&mutex);
+	nccl_net_ofi_lock(&mutex);
 	/* If we know we need byte delivery ordering (need_ordering ==
 	 * true) or this is the first time that we're configuring an
 	 * endpoint (nccl_proto_configured == false), then try to
@@ -688,7 +688,7 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 		}
 	}
 unlock:
-	nccl_net_ofi_mutex_unlock(&mutex);
+	nccl_net_ofi_unlock(&mutex);
 #endif // HAVE_CUDA
 
 exit:

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -25,8 +25,8 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 	/*
 	 * The tuner API is missing a mechanism to pass around context after
 	 * initialization. For now, init a plugin-lobal context once.
-	 */ 
-	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
+	 */
+	nccl_net_ofi_lock(&nccl_ofi_tuner_ctx_lock);
 	struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx =
 		calloc(1, sizeof(struct nccl_ofi_tuner_context));
 	if (nccl_ofi_tuner_ctx == NULL) {
@@ -37,7 +37,7 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 	nccl_ofi_tuner_ctx->dims.num_ranks = nRanks;
 	nccl_ofi_tuner_ctx->dims.num_nodes = nNodes;
 	*context = (void*)nccl_ofi_tuner_ctx;
-	nccl_net_ofi_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
+	nccl_net_ofi_unlock(&nccl_ofi_tuner_ctx_lock);
 
 	NCCL_OFI_TRACE(NCCL_TUNING, "Tuner init: comm with %ld ranks and %ld nodes.", nRanks, nNodes);
 	return ncclSuccess;
@@ -109,11 +109,11 @@ exit:
 
 ncclResult_t nccl_ofi_tuner_destroy(void *context)
 {
-	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
+	nccl_net_ofi_lock(&nccl_ofi_tuner_ctx_lock);
 	if (context != NULL) {
 		free(context);
 	}
-	nccl_net_ofi_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
+	nccl_net_ofi_unlock(&nccl_ofi_tuner_ctx_lock);
 
 	return ncclSuccess;
 }
@@ -132,13 +132,13 @@ static ncclResult_t nccl_ofi_tuner_destroy_v1(void)
 {
 	void *context = NULL;
 
-	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
+	nccl_net_ofi_lock(&nccl_ofi_tuner_ctx_lock);
 	if (nccl_ofi_tuner_ctx_internal != NULL) {
 		/* Prevent other threads from freeing a dangling global ctx */
 		context = (void*)nccl_ofi_tuner_ctx_internal;
 		nccl_ofi_tuner_ctx_internal = NULL;
 	}
-	nccl_net_ofi_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
+	nccl_net_ofi_unlock(&nccl_ofi_tuner_ctx_lock);
 
 	return nccl_ofi_tuner_destroy(context);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

pthread_mutex_t is 10x larger than pthread_spinlock_t and blows several of our
structs above the threshold for an additional a cache line. We don't expect
these locks to be contended under normal usage and the cache impacts are
definitely not worth the extra features of a full mutex. In the rare case that
any of these locks are contended, spinning is probably the right thing to do
in the first place.

First commit reworks the lock macros such that they can accept either a
pthread_mutex_t or a pthread_spinlock_t and converts all datapath usages. Follow
up commit actually makes the changes in the structs, but because the first
commit makes the callsites generic, very few code changes are needed (the
exception is to change initialization parameters).

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.