### PR TITLE
pthread: add missing errno include

### DIFF
--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -9,6 +9,7 @@
 extern "C" {
 #endif
 
+#include <errno.h>
 #include <pthread.h>
 #include <string.h>
 


### PR DESCRIPTION
> ../include/nccl_ofi_pthread.h: In function 'nccl_net_ofi_mutex_trylock_impl':
> ../include/nccl_ofi_pthread.h:75:45: error: 'EBUSY' undeclared (first use in this function)
>    75 |         if (OFI_UNLIKELY(ret != 0 && ret != EBUSY)) {

-------

*Issue #, if available:* n/a

*Description of changes:* add a missing include


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.