### PR TITLE
Use the zero-copy path in the EFA provider for the RDMA protocol

### DIFF
--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -54,7 +54,8 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
                   FI_OPT_EFA_USE_DEVICE_RDMA,
                   FI_OPT_EFA_EMULATED_WRITE,
                   FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
-                  FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES],
+                  FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES,
+                  FI_OPT_MAX_MSG_SIZE],
                   [], [], [AC_INCLUDES_DEFAULT
 [#include <rdma/fi_endpoint.h>
 #ifdef HAVE_RDMA_FI_EXT_H

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1959,7 +1959,7 @@ static inline nccl_net_ofi_rdma_req_t *alloc_bounce_req(nccl_net_ofi_rdma_ep_t *
 	nccl_net_ofi_rdma_bounce_fl_item_t *bounce_fl_item =
 		nccl_ofi_freelist_entry_alloc(ep->bounce_buff_fl);
 	if (!bounce_fl_item) {
-		NCCL_OFI_WARN("Failed to allocate ctrl_fl_item");
+		NCCL_OFI_WARN("Failed to allocate bounce_fl_item");
 		req->free(req, false);
 		return NULL;
 	}


### PR DESCRIPTION
To use the zero-copy path in the EFA provider, for fi_send/fi_recv operations, we need:

1. to have no ordering requirements (already satisfied)
2. to not use tagged operations (already satisfied)
3. to set the FI_OPT_MAX_MSG_SIZE endpoint option to a value less than mtu. Since the larger messages we exchange with fi_send/fi_recv are eager messages, we need them to be less than the mtu, which is satisfied with the current default eager threshold size of 8KB.

This commit is setting the FI_OPT_MAX_MSG_SIZE option to the max size we use for fi_send/fi_recv operations, only for AWS platforms, since this is not needed for other providers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
