### PR TITLE
Add platform hook to sort rails and EFA implementation

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -47,4 +47,5 @@ noinst_HEADERS = \
 	nccl-headers/nvidia/tuner_v1.h \
 	nccl-headers/nvidia/tuner_v2.h \
 	nccl-headers/neuron/net.h \
-	nccl-headers/neuron/error.h
+	nccl-headers/neuron/error.h \
+	nccl_ofi_platform.h

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -582,22 +582,6 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);
 
-/* Declare a platform-specific initialization hook that can be
- * provided by platform-specific source files (such as the optionally
- * compiled platform_aws.c).  The function is declared as a weak
- * symbol so that linkage will not break if no platform specific hook
- * is provided; in that case platform_init will be NULL at runtime.
- */
-int platform_init(const char **provider_filter) __attribute__((weak));
-
-/* Declare a platform-specific endpoint configuration hook that can be
- * provided by platform-specific source files (such as the optionally
- * compiled platform_aws.c).  The function is declared as a weak
- * symbol so that linkage will not break if no platform specific hook
- * is provided; in that case platform_config_endpoint will be NULL at runtime.
- */
-int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribute__((weak));
-
 #ifdef _cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_PLATFORM_H_
+#define NCCL_OFI_PLATFORM_H_
+
+#ifdef _cplusplus
+extern "C" {
+#endif
+
+#include <rdma/fabric.h>
+#include <rdma/fi_endpoint.h>
+
+/* Declare platform-specific hooks that can be provided by platform-specific
+ * source files (such as the optionally compiled platform_aws.c).  The functions
+ * here are declared as weak symbols so that linkage will not break if no
+ * platform specific hook is provided; in that case the hook will be NULL at
+ * runtime.
+ */
+
+/* Platform-specific initialization hook.
+ */
+int platform_init(const char **provider_filter) __attribute__((weak));
+
+/* Platform-specific endpoint configuration hook
+ */
+int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribute__((weak));
+
+#endif // End NCCL_OFI_PLATFORM_H_

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -27,4 +27,12 @@ int platform_init(const char **provider_filter) __attribute__((weak));
  */
 int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribute__((weak));
 
+/* Platform-specific hook to sort in the multi-rail protocol of the plugin. Some
+ * providers rely on having a consistent ordering of rail indices for best
+ * performance.
+ * @param info_list: pointer to list of `num_rails` info objects
+ * @param num_rails: number of rails
+ */
+void platform_sort_rails(struct fi_info **info_list, int num_rails) __attribute__((weak));
+
 #endif // End NCCL_OFI_PLATFORM_H_

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -26,6 +26,7 @@
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_idpool.h"
+#include "nccl_ofi_platform.h"
 
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t support_gdr = GDR_UNKNOWN;

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -23,6 +23,7 @@
 #endif
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_ofiutils.h"
+#include "nccl_ofi_platform.h"
 
 #define EFA_PROVIDER_NAME "efa"
 #define IS_EFA_PROVIDER(NAME) (strcmp((NAME), EFA_PROVIDER_NAME)==0)

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -24,6 +24,7 @@
 #include "nccl_ofi_memcheck.h"
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_pthread.h"
+#include "nccl_ofi_platform.h"
 
 /* Template path used to write temporary NCCL topology file */
 static const char *topo_file_template = "/tmp/aws-ofi-nccl-topo-XXXXXX";
@@ -5681,6 +5682,10 @@ static nccl_net_ofi_rdma_device_rail_t *create_device_rail_array(struct fi_info 
 		calloc(num_infos, sizeof(nccl_net_ofi_rdma_device_rail_t));
 	if (device_rails == NULL) {
 		return NULL;
+	}
+
+	if (platform_sort_rails != NULL) {
+		platform_sort_rails(&info_list, num_infos);
 	}
 
 	for (int i = 0 ; i < num_infos ; i++) {

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -18,6 +18,7 @@
 #include <dlfcn.h>
 
 #include "nccl_ofi.h"
+#include "nccl_ofi_platform.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_rdma.h"


### PR DESCRIPTION
Some providers (including EFA) rely on having a consistent ordering of
rail indices for best performance.

On EFA, ensure plugin's multi-rail protocol consistently sorts rails in order of
VF index for best performance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
