### PR TITLE
Log prov_errno number in case of completion errors

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1510,8 +1510,9 @@ static inline int process_err_completion(nccl_net_ofi_rdma_ep_t *ep,
 		req = err_entry.op_context;
 	}
 
-	NCCL_OFI_WARN("Request %p completed with error. RC: %d. Error: %s. Completed length: %ld, Request: %s",
+	NCCL_OFI_WARN("Request %p completed with error. RC: %d. Error: %d (%s). Completed length: %ld, Request: %s",
 		      req, err_entry.err,
+		      err_entry.prov_errno,
 		      fi_cq_strerror(rail->cq, err_entry.prov_errno, err_entry.err_data, NULL, 0),
 		      (long)err_entry.len, nccl_net_ofi_req_str(req));
 	if (req->type == NCCL_OFI_RDMA_BOUNCE) {

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -206,9 +206,10 @@ static int ofi_process_cq(struct fid_cq *cq, uint64_t max_tag)
 
 			req = container_of(err_buffer.op_context,
 					   nccl_net_ofi_sendrecv_req_t, ctx);
-			NCCL_OFI_WARN("Request %p completed with error. RC: %d. Error: %s. Completed length: %ld, Request: %s",
+			NCCL_OFI_WARN("Request %p completed with error. RC: %d. Error: %d (%s). Completed length: %ld, Request: %s",
 				      req,
 				      err_buffer.err,
+				      err_buffer.prov_errno,
 				      fi_cq_strerror(cq,
 						     err_buffer.prov_errno,
 						     err_buffer.err_data, NULL, 0),


### PR DESCRIPTION
When there is a completion error, the plugin is calling fi_cq_strerror() to get a string message corresponding to the specific error. However, there are errors that are not recognized by libfabric, and that function will just return "Unknown error". This PR is adding the prov_errno value, together with the string representation, to the error log statement, to make it easier to debug such cases.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
