### PR TITLE
fix -Wc++-compat errors

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 unit test output 
 AC_ARG_ENABLE([picky-compiler],
    [AS_HELP_STRING([--disable-picky-compiler], [Disable adding picky compiler flags.])])
 AS_IF([test "${enable_picky_compiler}" != "no"],
-      [picky_compiler_flags="-Wall"
+      [picky_compiler_flags="-Wall -Wc++-compat -Werror=c++-compat"
        AC_MSG_NOTICE([Adding ${picky_compiler_flags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${picky_compiler_flags}"
        AS_UNSET([picky_compiler_flags])])

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -55,6 +55,7 @@ typedef enum nccl_net_ofi_rdma_req_state {
 	NCCL_OFI_RDMA_REQ_PENDING,
 	NCCL_OFI_RDMA_REQ_COMPLETED,
 	NCCL_OFI_RDMA_REQ_ERROR,
+	NCCL_OFI_RDMA_REQ_INVALID_STATE,
 } nccl_net_ofi_rdma_req_state_t;
 
 typedef enum nccl_net_ofi_rdma_req_type {
@@ -80,14 +81,22 @@ typedef enum nccl_net_ofi_rdma_req_type {
 	NCCL_OFI_RDMA_RECV_CONN_RESP,
 	/* Connect response message send request */
 	NCCL_OFI_RDMA_SEND_CONN_RESP,
+	/* Invalid type */
+	NCCL_OFI_RDMA_INVALID_TYPE,
 } nccl_net_ofi_rdma_req_type_t;
 
 enum nccl_ofi_rdma_msg_type {
-	NCCL_OFI_RDMA_MSG_CONN,
+	NCCL_OFI_RDMA_MSG_CONN = 0,
 	NCCL_OFI_RDMA_MSG_CONN_RESP,
 	NCCL_OFI_RDMA_MSG_CTRL,
-	NCCL_OFI_RDMA_MSG_EAGER
+	NCCL_OFI_RDMA_MSG_EAGER,
+	NCCL_OFI_RDMA_MSG_INVALID = 15,
+	NCCL_OFI_RDMA_MSG_MAX = NCCL_OFI_RDMA_MSG_INVALID,
 };
+
+_Static_assert(NCCL_OFI_RDMA_MSG_MAX <= (0x10),
+	       "Out of space in nccl_ofi_rdma_msg_type; must fit in a nibble");
+
 /* This goes on the wire, so we want the datatype
  * size to be fixed.
  */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -23,6 +23,7 @@ typedef enum nccl_net_ofi_sendrecv_req_state {
 } nccl_net_ofi_sendrecv_req_state_t;
 
 typedef enum nccl_net_ofi_sendrecv_req_direction {
+	NCCL_OFI_SENDRECV_INVALID_DIRECTION = 0,
 	NCCL_OFI_SENDRECV_SEND = 1,
 	NCCL_OFI_SENDRECV_RECV,
 } nccl_net_ofi_sendrecv_req_direction_t;

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -162,7 +162,7 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 		return ncclInternalError;
 	}
 
-	ret = base_ep->listen(base_ep, handle, listen_comm);
+	ret = base_ep->listen(base_ep, (nccl_net_ofi_conn_handle_t *)handle, listen_comm);
 
 	if (ret != ncclSuccess) {
 		base_ep->release_ep(base_ep);
@@ -249,7 +249,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
 	/* Connect */
 	nccl_net_ofi_send_comm_t **send_comm =
 		(nccl_net_ofi_send_comm_t **)sComm;
-	int ret = base_ep->connect(base_ep, handle, send_comm);
+	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm);
 
 	if (ret != 0) {
 		base_ep->release_ep(base_ep);
@@ -345,12 +345,12 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 	case NCCL_NET_OFI_SEND_COMM:;
 		nccl_net_ofi_send_comm_t *send_comm =
 			(nccl_net_ofi_send_comm_t *)base_comm;
-		ret = send_comm->deregMr(send_comm, mhandle);
+		ret = send_comm->deregMr(send_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
 	case NCCL_NET_OFI_RECV_COMM:;
 		nccl_net_ofi_recv_comm_t *recv_comm =
 			(nccl_net_ofi_recv_comm_t *)base_comm;
-		ret = recv_comm->deregMr(recv_comm, mhandle);
+		ret = recv_comm->deregMr(recv_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
 	default:
 		NCCL_OFI_WARN("Unexpected communicator type. Communicator type: %d",

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -173,7 +173,7 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 
 ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm)
 {
-        nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {0};
+        nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
 	ncclResult_t ret;
 
 	ret = nccl_net_ofi_listen(dev, &nccl_net_ofi_handle, listenComm);
@@ -262,7 +262,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
 ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
-        nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {0};
+        nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
 
         memcpy(&nccl_net_ofi_handle, handle, NCCL_NET_HANDLE_MAXSIZE_V4);
 

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -132,7 +132,7 @@ ncclResult_t nccl_net_ofi_get_properties(int dev_id, nccl_ofi_properties_t *ofi_
 
 ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 {
-	ncclResult_t ret = ncclSuccess;
+	int ret = 0;
 	nccl_net_ofi_device_t *device = NULL;
 	nccl_net_ofi_ep_t *base_ep = NULL;
 	nccl_net_ofi_listen_comm_t **listen_comm =
@@ -162,9 +162,11 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 		return ncclInternalError;
 	}
 
-	ret = base_ep->listen(base_ep, (nccl_net_ofi_conn_handle_t *)handle, listen_comm);
+	ret = base_ep->listen(base_ep,
+						  (nccl_net_ofi_conn_handle_t *)handle,
+						  listen_comm);
 
-	if (ret != ncclSuccess) {
+	if (ret != 0) {
 		base_ep->release_ep(base_ep);
 	}
 	return nccl_net_ofi_retval_translate(ret);

--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -25,13 +25,13 @@ void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites = NULL;
 
 #define STRINGIFY(sym) # sym
 
-#define LOAD_SYM(sym)							\
-	nccl_net_ofi_ ## sym = dlsym(cudadriver_lib, STRINGIFY(sym));	\
-	if (nccl_net_ofi_ ## sym == NULL) {				\
-		NCCL_OFI_WARN("Failed to load symbol " STRINGIFY(sym)); \
-		ret = -ENOTSUP;						\
-		goto error;						\
-	}								\
+#define LOAD_SYM(sym)                                                              \
+	nccl_net_ofi_##sym = (typeof(sym) *)dlsym(cudadriver_lib, STRINGIFY(sym)); \
+	if (nccl_net_ofi_##sym == NULL) {                                          \
+		NCCL_OFI_WARN("Failed to load symbol " STRINGIFY(sym));            \
+		ret = -ENOTSUP;                                                    \
+		goto error;                                                        \
+	}
 
 int
 nccl_net_ofi_cuda_init(void)

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -13,7 +13,7 @@
 
 int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 {
-	nccl_ofi_deque_t *deque = malloc(sizeof(nccl_ofi_deque_t));
+	nccl_ofi_deque_t *deque = (nccl_ofi_deque_t *)malloc(sizeof(nccl_ofi_deque_t));
 
 	if (deque == NULL) {
 		NCCL_OFI_WARN("Failed to allocate deque");

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -61,7 +61,7 @@ static int freelist_init_internal(size_t entry_size,
 	int ret;
 	nccl_ofi_freelist_t *freelist = NULL;
 
-	freelist = malloc(sizeof(nccl_ofi_freelist_t));
+	freelist = (nccl_ofi_freelist_t *)malloc(sizeof(nccl_ofi_freelist_t));
 	if (!freelist) {
 		NCCL_OFI_WARN("Allocating freelist failed");
 		return -ENOMEM;

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -41,7 +41,7 @@ int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size)
 	size_t num_long_elements = NCCL_OFI_ROUND_UP(size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
 
 	/* Allocate memory for the pool */
-	idpool->ids = malloc(sizeof(uint64_t) * num_long_elements);
+	idpool->ids = (uint64_t *)malloc(sizeof(uint64_t) * num_long_elements);
 
 	/* Return in case of allocation error */
 	if (NULL == idpool->ids) {

--- a/src/nccl_ofi_msgbuff.c
+++ b/src/nccl_ofi_msgbuff.c
@@ -24,13 +24,14 @@ nccl_ofi_msgbuff_t *nccl_ofi_msgbuff_init(uint16_t max_inprogress, uint16_t bit_
 		goto error;
 	}
 
-	msgbuff = malloc(sizeof(nccl_ofi_msgbuff_t));
+	msgbuff = (nccl_ofi_msgbuff_t *)malloc(sizeof(nccl_ofi_msgbuff_t));
 	if (!msgbuff) {
 		NCCL_OFI_WARN("Memory allocation (msgbuff) failed");
 		goto error;
 	}
 
-	msgbuff->buff = malloc(sizeof(nccl_ofi_msgbuff_elem_t) * max_inprogress);
+	msgbuff->buff =
+		(nccl_ofi_msgbuff_elem_t *)malloc(sizeof(nccl_ofi_msgbuff_elem_t) * max_inprogress);
 	if (!msgbuff->buff) {
 		NCCL_OFI_WARN("Memory allocation (msgbuff->buff) failed");
 		goto error;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -593,7 +593,8 @@ static size_t nccl_net_ofi_plugin_get_num_devices(nccl_net_ofi_plugin_t *plugin)
 int nccl_net_ofi_plugin_init(nccl_net_ofi_plugin_t *plugin,
 			     size_t num_devices)
 {
-	plugin->p_devs = calloc(num_devices, sizeof(nccl_net_ofi_device_t *));
+	plugin->p_devs =
+		(nccl_net_ofi_device_t **)calloc(num_devices, sizeof(nccl_net_ofi_device_t *));
 	if (plugin->p_devs == NULL) {
 		NCCL_OFI_WARN("Unable to allocate "
 			      "nccl_net_ofi_rdma_device_t pointer array");

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -252,7 +252,7 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 				      struct fid_ep **ep, struct fid_av **av, struct fid_cq **cq)
 {
 	int ret = 0;
- 	struct fi_av_attr av_attr = {0};
+	struct fi_av_attr av_attr = {0};
 	struct fi_cq_attr cq_attr = {0};
 
 	/* Create transport level communication endpoint(s) */

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -252,8 +252,8 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 				      struct fid_ep **ep, struct fid_av **av, struct fid_cq **cq)
 {
 	int ret = 0;
-	struct fi_av_attr av_attr = {0};
-	struct fi_cq_attr cq_attr = {0};
+	struct fi_av_attr av_attr = {};
+	struct fi_cq_attr cq_attr = {};
 
 	/* Create transport level communication endpoint(s) */
 	ret = fi_endpoint(domain, info, ep, NULL);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1313,6 +1313,8 @@ static const char *req_state_str(nccl_net_ofi_rdma_req_state_t state)
 		return "COMPLETED";
 	case NCCL_OFI_RDMA_REQ_ERROR:
 		return "ERROR";
+	case NCCL_OFI_RDMA_REQ_INVALID_STATE:
+		return "INVALID";
 	}
 	return "unknown";
 }
@@ -1342,6 +1344,8 @@ static const char *req_type_str(nccl_net_ofi_rdma_req_type_t type)
 		return "FLUSH";
 	case NCCL_OFI_RDMA_EAGER_COPY:
 		return "EAGER_COPY";
+	case NCCL_OFI_RDMA_INVALID_TYPE:
+		return "INVALID";
 	}
 	return "unknown";
 }
@@ -1722,7 +1726,7 @@ static inline void zero_nccl_ofi_req(nccl_net_ofi_rdma_req_t *req)
 	/* Mrail zero-out */
 	req->ncompls = 0;
 
-	req->type = -1;
+	req->type = NCCL_OFI_RDMA_INVALID_TYPE;
 }
 
 /*

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2380,8 +2380,8 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep, void *data,
 			      size_t size, int type, nccl_net_ofi_rdma_mr_handle_t **mhandle)
 {
 	int ret = 0;
-	struct fi_mr_attr mr_attr = {0};
-	struct iovec iov = {0};
+	struct fi_mr_attr mr_attr = {};
+	struct iovec iov = {};
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	struct fid_domain *domain;
 	*mhandle = NULL;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5461,7 +5461,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 
 	/* Obtain thread-local rdma endpoint. Allocate and
 	 * initialize endpoint if necessary. */
-	nccl_net_ofi_rdma_ep_t *ep = pthread_getspecific(device->ep_key);
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)pthread_getspecific(device->ep_key);
 	if (!ep) {
 		int num_rails = device->num_rails;
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5442,8 +5442,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 	return ret;
 }
 
-static int get_ep(nccl_net_ofi_device_t *base_dev,
-				    nccl_net_ofi_ep_t **base_ep)
+static inline int get_ep(nccl_net_ofi_device_t *base_dev, nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
 
@@ -5573,7 +5572,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric and domain to make device rail ready for rail creation.
  */
-static int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_rail_t *rail_dev)
+static inline int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_rail_t *rail_dev)
 {
 	int ret = 0;
 
@@ -5943,7 +5942,7 @@ static void get_hints(struct fi_info *hints)
 }
 
 
-static int nccl_net_ofi_rdma_plugin_fini(nccl_net_ofi_plugin_t *plugin)
+static inline int nccl_net_ofi_rdma_plugin_fini(nccl_net_ofi_plugin_t *plugin)
 {
 	int ret, last_error = 0;
 
@@ -5962,8 +5961,8 @@ static int nccl_net_ofi_rdma_plugin_fini(nccl_net_ofi_plugin_t *plugin)
 }
 
 
-static int nccl_net_ofi_rdma_plugin_create(size_t num_devices,
-					   nccl_net_ofi_plugin_t **plugin_p)
+static inline int nccl_net_ofi_rdma_plugin_create(size_t num_devices,
+						  nccl_net_ofi_plugin_t **plugin_p)
 {
 	int ret;
 	nccl_net_ofi_plugin_t *plugin = NULL;

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -140,7 +140,8 @@ static nccl_net_ofi_schedule_t *get_threshold_schedule(nccl_net_ofi_scheduler_t 
 
 	assert(scheduler != NULL);
 
-	schedule = nccl_ofi_freelist_entry_alloc(scheduler_p->schedule_fl);
+	schedule =
+		(nccl_net_ofi_schedule_t *)nccl_ofi_freelist_entry_alloc(scheduler_p->schedule_fl);
 	if (OFI_UNLIKELY(!schedule)) {
 		NCCL_OFI_WARN("Failed to allocate schedule");
 		return NULL;
@@ -244,7 +245,8 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails,
 	nccl_net_ofi_threshold_scheduler_t *scheduler = NULL;
 	*scheduler_p = NULL;
 
-	scheduler = malloc(sizeof(nccl_net_ofi_threshold_scheduler_t));
+	scheduler = (nccl_net_ofi_threshold_scheduler_t *)malloc(
+		sizeof(nccl_net_ofi_threshold_scheduler_t));
 	if (!scheduler) {
 		NCCL_OFI_WARN("Could not allocate threshold scheduler");
 		return -ENOMEM;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1210,7 +1210,9 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 	}
 
 	/* Build recv_comm */
-	r_comm = calloc(1, sizeof(nccl_net_ofi_sendrecv_recv_comm_t));
+	r_comm = (nccl_net_ofi_sendrecv_recv_comm_t *)calloc(
+		1,
+		sizeof(nccl_net_ofi_sendrecv_recv_comm_t));
 	if (r_comm == NULL) {
 		NCCL_OFI_WARN("Unable to allocate receive Comm object for device %d",
 			      dev_id);
@@ -1339,7 +1341,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		/* Allocate memory for peer address for the first time ONLY */
 		if (conn_info == NULL) {
-			conn_info = calloc(1, sizeof(nccl_ofi_connection_info_t));
+			conn_info = (nccl_ofi_connection_info_t *)calloc(
+				1,
+				sizeof(nccl_ofi_connection_info_t));
 		}
 
 		/* Post a receive message to receive peer connections */
@@ -1525,7 +1529,9 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	}
 
 	/* Build listen_comm */
-	l_comm = calloc(1, sizeof(nccl_net_ofi_sendrecv_listen_comm_t));
+	l_comm = (nccl_net_ofi_sendrecv_listen_comm_t *)calloc(
+		1,
+		sizeof(nccl_net_ofi_sendrecv_listen_comm_t));
 	if (OFI_UNLIKELY(l_comm == NULL)) {
 		NCCL_OFI_WARN("Couldn't allocate listen_comm for dev %d", dev_id);
 		ret = -ENOMEM;
@@ -1797,7 +1803,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->local_ep = ep->ofi_ep;
 	ret_s_comm->remote_ep = remote_addr;
 
-	ret_s_comm->conn_info = calloc(1, sizeof(nccl_ofi_connection_info_t));
+	ret_s_comm->conn_info =
+		(nccl_ofi_connection_info_t *)calloc(1, sizeof(nccl_ofi_connection_info_t));
 	if (!ret_s_comm->conn_info) {
 		ret = -ENOMEM;
 		goto out;
@@ -2108,7 +2115,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 	nccl_net_ofi_sendrecv_ep_t *ep = pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */
-		ep = calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));
+		ep = (nccl_net_ofi_sendrecv_ep_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));
 		if (!ep) {
 			ret = -ENOMEM;
 			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
@@ -2299,7 +2306,8 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 {
 	int ret;
 
-	nccl_net_ofi_sendrecv_device_t *device = calloc(1, sizeof(nccl_net_ofi_sendrecv_device_t));
+	nccl_net_ofi_sendrecv_device_t *device =
+		(nccl_net_ofi_sendrecv_device_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_device_t));
 	if (device == NULL) {
 		NCCL_OFI_WARN("Unable to allocate device %i", dev_id);
 		return NULL;
@@ -2449,7 +2457,7 @@ static int nccl_net_ofi_sendrecv_plugin_create(size_t num_devices,
 	int ret;
 	nccl_net_ofi_plugin_t *plugin = NULL;
 
-	plugin = malloc(sizeof(nccl_net_ofi_plugin_t));
+	plugin = (nccl_net_ofi_plugin_t *)malloc(sizeof(nccl_net_ofi_plugin_t));
 	if (plugin == NULL) {
 		NCCL_OFI_WARN("Unable to allocate nccl_net_ofi_plugin_t");
 		return -ENOMEM;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -502,8 +502,8 @@ static int register_mr_buffers(struct fid_domain *domain, struct fid_ep *ep,
 					int type, struct fid_mr **mr_handle)
 {
 	int ret = 0;
-	struct fi_mr_attr mr_attr = {0};
-	struct iovec iov = {0};
+	struct fi_mr_attr mr_attr = {};
+	struct iovec iov = {};
 
 	/* Check if provider requires registration of local buffers */
 	if ((local_mr != true) && (type == NCCL_PTR_HOST)) {

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2112,7 +2112,8 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 
 	/* Obtain thread-local sendrecv endpoint. Allocate and
 	 * initialize endpoint if necessary. */
-	nccl_net_ofi_sendrecv_ep_t *ep = pthread_getspecific(device->ep_key);
+	nccl_net_ofi_sendrecv_ep_t *ep =
+		(nccl_net_ofi_sendrecv_ep_t *)pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */
 		ep = (nccl_net_ofi_sendrecv_ep_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -247,7 +247,7 @@ static inline void zero_nccl_ofi_req(nccl_net_ofi_sendrecv_req_t *req)
 
 	req->state = NCCL_OFI_SENDRECV_REQ_CREATED;
 
-	req->direction = -1;
+	req->direction = NCCL_OFI_SENDRECV_INVALID_DIRECTION;
 }
 
 /*

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -1042,7 +1042,7 @@ static int get_device_property(unsigned domain, unsigned bus,
 {
 	int ret = 0;
 	FILE *file;
-	char *path_format = "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/%s";
+	const char *path_format = "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/%s";
 	size_t path_len;
 	char *path = NULL;
 
@@ -1116,8 +1116,8 @@ static int get_pci_device_speed(hwloc_obj_t node, bool is_nic,
 {
 	union hwloc_obj_attr_u attr = {};
 	/* Override the following PCI width and speed of libfabric NICs with fallback values */
-	char *override_width = "255";
-	char *override_speed = "Unknown";
+	const char *override_width = "255";
+	const char *override_speed = "Unknown";
 	size_t fallback_width = 8;
 	size_t fallback_speed_idx = 3;
 

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -554,7 +554,7 @@ nccl_ofi_topo_t *nccl_ofi_topo_create(struct fi_info *info_list)
 	int ret = 0;
 
 	/* Allocate NCCL OFI topology */
-	nccl_ofi_topo_t *ofi_topo = calloc(1, sizeof(nccl_ofi_topo_t));
+	nccl_ofi_topo_t *ofi_topo = (nccl_ofi_topo_t *)calloc(1, sizeof(nccl_ofi_topo_t));
 	if (!ofi_topo) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 			       "Unable to allocate nccl_ofi_topo");
@@ -1052,7 +1052,7 @@ static int get_device_property(unsigned domain, unsigned bus,
 		ret = -errno;
 		goto error;
 	}
-	path = malloc(path_len + 1);
+	path = (char *)malloc(path_len + 1);
 	if (!path) {
 		NCCL_OFI_WARN("Device property file path malloc failed: %s", strerror(errno));
 		ret = -ENOMEM;

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -342,6 +342,9 @@ static int configure_ep_max_msg_size(struct fid_ep *ep)
 	return ret;
 }
 
+
+typedef ncclResult_t (*nccl_get_version_fn_t)(int *version);
+
 int configure_nvls_option(void)
 {
 	/* Disable NVLS topology discovery for older NCCL versions. There's a
@@ -349,13 +352,13 @@ int configure_nvls_option(void)
 	 * NVLink Switch support.  We selectively disable NVLS support
 	 * to avoid the bug, which was fixed in 2.18.5.
 	 */
-	ncclResult_t (*nccl_get_version)(int *version);
+	nccl_get_version_fn_t nccl_get_version = NULL;
 	int version = 0;
 	ncclResult_t nccl_ret;
 	int ret;
 
 	if (getenv("NCCL_NVLS_ENABLE") == NULL) {
-		nccl_get_version = dlsym(RTLD_DEFAULT, "ncclGetVersion");
+		nccl_get_version = (nccl_get_version_fn_t)dlsym(RTLD_DEFAULT, "ncclGetVersion");
 		if (nccl_get_version == NULL) {
 			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 			    "Could not find ncclGetVersion symbol; skipping NVLS NCCL version check");

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -146,7 +146,7 @@ static const char* get_platform_type(void)
 	while ((feof(fd) == 0) && (ferror(fd) == 0) && ((ch = fgetc(fd)) != '\n')) {
 		platform_type[len++] = ch;
 		if (len >= platform_type_len) {
-			platform_type = realloc(platform_type, len + platform_type_len);
+			platform_type = (char*)realloc(platform_type, len + platform_type_len);
 		}
 	}
 

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -6,6 +6,7 @@
 #include "config.h"
 
 #define _GNU_SOURCE
+#include <alloca.h>
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -794,7 +795,12 @@ static int get_rail_vf_idx(struct fi_info *info)
 void platform_sort_rails(struct fi_info **info_list, int num_rails)
 {
 	struct fi_info *info_list_in = *info_list;
-	struct fi_info *sorted_info_array[num_rails] = {};
+	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));
+
+	if (num_rails <= 0) {
+		return;
+	}
+
 	for (int i = 0; i < num_rails; ++i) {
 		sorted_info_array[i] = NULL;
 	}

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -791,7 +791,7 @@ static int get_rail_vf_idx(struct fi_info *info)
 void platform_sort_rails(struct fi_info **info_list, int num_rails)
 {
 	struct fi_info *info_list_in = *info_list;
-	struct fi_info *sorted_info_array[num_rails];
+	struct fi_info *sorted_info_array[num_rails] = {};
 	for (int i = 0; i < num_rails; ++i) {
 		sorted_info_array[i] = NULL;
 	}

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -32,7 +32,8 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 	 * initialization. For now, init a plugin-lobal context once.
 	 */
 	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
-	struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx = calloc(1, sizeof(struct nccl_ofi_tuner_context));
+	struct nccl_ofi_tuner_context *nccl_ofi_tuner_ctx =
+		(struct nccl_ofi_tuner_context *)calloc(1, sizeof(struct nccl_ofi_tuner_context));
 	if (nccl_ofi_tuner_ctx == NULL) {
 		NCCL_OFI_WARN("Context allocation failed.");
 		return ncclInternalError;

--- a/tests/functional/nccl_connection.c
+++ b/tests/functional/nccl_connection.c
@@ -22,8 +22,8 @@ int main(int argc, char* argv[])
 	nccl_net_ofi_listen_comm_t *lComm = NULL;
 	nccl_net_ofi_recv_comm_t *rComm = NULL;
 	ncclNetDeviceHandle_v8_t *s_ignore, *r_ignore;
-	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
-	char handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
+	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {};
+	char handle[NCCL_NET_HANDLE_MAXSIZE] = {};
 	test_nccl_net_t *extNet = NULL;
 
 	ofi_log_function = logger;
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
 
 	/* Get Properties for the device */
 	for (int dev = 0; dev < ndev; dev++) {
-		test_nccl_properties_t props = {0};
+		test_nccl_properties_t props = {};
 		OFINCCLCHECKGOTO(extNet->getProperties(dev, &props), res, exit);
 		print_dev_props(dev, &props);
 

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
 	nccl_net_ofi_recv_comm_t *rComm = NULL;
 	test_nccl_net_t *extNet = NULL;
 	ncclNetDeviceHandle_v8_t *s_ignore, *r_ignore;
-	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
+	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {};
 
 	ofi_log_function = logger;
 
@@ -34,7 +34,7 @@ int main(int argc, char* argv[])
 	nccl_net_ofi_req_t *req[NUM_REQUESTS] = {NULL};
 	void *mhandle[NUM_REQUESTS];
 	char handle[NCCL_NET_HANDLE_MAXSIZE];
-	int req_completed[NUM_REQUESTS] = {0};
+	int req_completed[NUM_REQUESTS] = {};
 	int inflight_reqs = NUM_REQUESTS;
 	char *send_buf[NUM_REQUESTS] = {NULL};
 	char *recv_buf[NUM_REQUESTS] = {NULL};
@@ -133,7 +133,7 @@ int main(int argc, char* argv[])
 		goto exit;
 	}
 
-	test_nccl_properties_t props = {0};
+	test_nccl_properties_t props = {};
 
 	/* Get Properties for the device */
 	for (int dev = 0; dev < ndev; dev++) {

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -279,7 +279,7 @@ int main(int argc, char* argv[])
 					NCCL_OFI_TRACE(NCCL_NET, "Successfully registered receive memory for request %d of rank %d", idx, rank);
 					while (req[idx] == NULL) {
 						OFINCCLCHECKGOTO(extNet->irecv((void *)rComm, nrecv,
-										(void *)&recv_buf[idx], sizes, tags,
+										(void **)&recv_buf[idx], sizes, tags,
 										&mhandle[idx], (void **)&req[idx]),
 								res, exit);
 					}

--- a/tests/functional/ring.c
+++ b/tests/functional/ring.c
@@ -20,9 +20,9 @@ int main(int argc, char *argv[])
 	nccl_net_ofi_send_comm_t *sComm_next = NULL;
 	nccl_net_ofi_listen_comm_t *lComm = NULL;
 	nccl_net_ofi_recv_comm_t *rComm = NULL;
-	char handle[NCCL_NET_HANDLE_MAXSIZE] = {0};
-	char src_handle_prev[NCCL_NET_HANDLE_MAXSIZE] = {0};
-	char src_handle_next[NCCL_NET_HANDLE_MAXSIZE] = {0};
+	char handle[NCCL_NET_HANDLE_MAXSIZE] = {};
+	char src_handle_prev[NCCL_NET_HANDLE_MAXSIZE] = {};
+	char src_handle_next[NCCL_NET_HANDLE_MAXSIZE] = {};
 	ncclNetDeviceHandle_v8_t *s_ignore, *r_ignore;
 	test_nccl_net_t *extNet = NULL;
 
@@ -33,8 +33,8 @@ int main(int argc, char *argv[])
 	nccl_net_ofi_req_t *recv_req[NUM_REQUESTS] = {NULL};
 	void *send_mhandle[NUM_REQUESTS];
 	void *recv_mhandle[NUM_REQUESTS];
-	int req_completed_send[NUM_REQUESTS] = {0};
-	int req_completed_recv[NUM_REQUESTS] = {0};
+	int req_completed_send[NUM_REQUESTS] = {};
+	int req_completed_recv[NUM_REQUESTS] = {};
 	int inflight_reqs = NUM_REQUESTS * 2;
 	char *send_buf[NUM_REQUESTS] = {NULL};
 	char *recv_buf[NUM_REQUESTS] = {NULL};
@@ -143,7 +143,7 @@ int main(int argc, char *argv[])
 
 	/* Get Properties for the device */
 	for (int dev = 0; dev < ndev; dev++) {
-		test_nccl_properties_t props = {0};
+		test_nccl_properties_t props = {};
 		OFINCCLCHECKGOTO(extNet->getProperties(dev, &props), res, exit);
 		print_dev_props(dev, &props);
 

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -65,7 +65,7 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	for (i = 0 ; i < 8 ; i++) {
-		entry = nccl_ofi_freelist_entry_alloc(freelist);
+		entry = (struct random_freelisted_item *)nccl_ofi_freelist_entry_alloc(freelist);
 		if (!entry) {
 			NCCL_OFI_WARN("allocation unexpectedly failed");
 			exit(1);
@@ -166,7 +166,7 @@ int main(int argc, char *argv[])
 				exit(1);
 			}
 		}
-		last_buff = entry;
+		last_buff = (char *)entry;
 	}
 	ret = nccl_ofi_freelist_fini(freelist);
 	if (ret != ncclSuccess) {
@@ -195,7 +195,8 @@ int main(int argc, char *argv[])
 		exit(1);
 	}
 	for (i = 0 ; i < 8 ; i++) {
-		struct random_freelisted_item *item = nccl_ofi_freelist_entry_alloc(freelist);
+		struct random_freelisted_item *item =
+			(struct random_freelisted_item *)nccl_ofi_freelist_entry_alloc(freelist);
 		if (!item) {
 			NCCL_OFI_WARN("allocation unexpectedly failed");
 			exit(1);

--- a/tests/unit/idpool.c
+++ b/tests/unit/idpool.c
@@ -23,7 +23,7 @@ int main(int argc, char *argv[]) {
 		/* Scale pool size to number of 64-bit uints (rounded up) */
 		size_t num_long_elements = NCCL_OFI_ROUND_UP(size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
 
-		nccl_ofi_idpool_t *idpool = malloc(sizeof(nccl_ofi_idpool_t));
+		nccl_ofi_idpool_t *idpool = (nccl_ofi_idpool_t *)malloc(sizeof(nccl_ofi_idpool_t));
 		assert(NULL != idpool);
 
 		/* Test nccl_ofi_idpool_init */

--- a/tests/unit/msgbuff.c
+++ b/tests/unit/msgbuff.c
@@ -18,8 +18,7 @@ int main(int argc, char *argv[])
 	const uint16_t field_size = 1 << num_msg_seq_num_bits;
 	uint16_t *result;
 
-	uint16_t *buff_store;
-	buff_store = calloc(max_inprogress, sizeof(uint16_t));
+	uint16_t *buff_store = (uint16_t *)calloc(max_inprogress, sizeof(uint16_t));
 	if (!buff_store) {
 		NCCL_OFI_WARN("Memory allocation failed");
 		return 1;

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -19,7 +19,8 @@ int create_multiplexed(size_t size,
 		       size_t align,
 		       nccl_net_ofi_schedule_t **schedule_p)
 {
-	nccl_net_ofi_schedule_t *schedule = malloc(sizeof(nccl_net_ofi_schedule_t) + num_rails * sizeof(nccl_net_ofi_xfer_info_t));
+	nccl_net_ofi_schedule_t *schedule = (nccl_net_ofi_schedule_t *)malloc(
+		sizeof(nccl_net_ofi_schedule_t) + num_rails * sizeof(nccl_net_ofi_xfer_info_t));
 	if (!schedule) {
 		NCCL_OFI_WARN("Could not allocate schedule");
 		return -ENOMEM;
@@ -74,8 +75,8 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 int test_multiplexing_schedule()
 {
 	nccl_net_ofi_schedule_t *schedule = NULL;
-	nccl_net_ofi_schedule_t *ref_schedule = malloc(sizeof(nccl_net_ofi_schedule_t)
-						       + 3 * sizeof(nccl_net_ofi_xfer_info_t));
+	nccl_net_ofi_schedule_t *ref_schedule = (nccl_net_ofi_schedule_t *)malloc(
+		sizeof(nccl_net_ofi_schedule_t) + 3 * sizeof(nccl_net_ofi_xfer_info_t));
 	if (!ref_schedule) {
 		NCCL_OFI_WARN("Could not allocate schedule");
 		return -ENOMEM;
@@ -304,8 +305,8 @@ int test_threshold_scheduler()
 	int num_rails = 2;
 	int ret = 0;
 	size_t rr_threshold = 8192;
-	nccl_net_ofi_schedule_t *ref_schedule = malloc(sizeof(nccl_net_ofi_schedule_t)
-						      + num_rails * sizeof(nccl_net_ofi_xfer_info_t));
+	nccl_net_ofi_schedule_t *ref_schedule = (nccl_net_ofi_schedule_t *)malloc(
+		sizeof(nccl_net_ofi_schedule_t) + num_rails * sizeof(nccl_net_ofi_xfer_info_t));
 	nccl_net_ofi_scheduler_t *scheduler;
 	if (nccl_net_ofi_threshold_scheduler_init(num_rails, rr_threshold, &scheduler)) {
 		NCCL_OFI_WARN("Failed to initialize threshold scheduler");


### PR DESCRIPTION
*Description of changes:*

```
Unmerged into upstream/master (10)
e516a88 build: enable -W++-compat in "picky compiler"
f270cbf topo: use const char* where possible
92350cb api: listen: use retval_translate
784801d cuda: use typeof() to avoid void* cast error
cee0479 tree: prefer empty brace initializer to {0}
e4b7f49 tree: prefer static inline to static
94f92c0 tree: pthread: cast getspecific calls to types
3e996b2 topo: don't use hwloc inline structs
b43b883 tree: cast void*s from allocators
c0aa2bf transports: create invalid states, types.
```

Series of changes fixing build issues with `-Wc++-compat`, which is an exclusive-to-C option that looks for C-isms that are disallowed under C++. There are other issues that this doesn't fix (mainly, gotos that skip over initializers), but this is a step in the right direction towards being able to use C++ when we need eg: `<unordered_set>`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
