### PR TITLE
ci: add another workaround for ancient al2 glibc

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -7,10 +7,14 @@ env:
     libhwloc-dev
     make
 
+  # note, related to issue around actions/checkout@v4, linked below. This
+  # environment variable is also now needed, as of july 2024.
+  # ref: https://github.com/actions/runner/issues/2906#issuecomment-2208546951
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 jobs:
   amazonlinux:
     strategy:


### PR DESCRIPTION
*Description of changes:*

CI started failing in the past few days unexpectedly. We need to work around AL2 glibc being older than expected for the node binary that the github clone action needs. Originally, pinning to an older version (v3 instead of v4) was sufficient. Now, we need to add an environment variable that allows it to continue to use node16 (which works fine against al2 glibc) instead of upgrading to node20 (where al2 glibc is too old). 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
