### PR TITLE
.ci/aws: Disable verbose printing in order to easily see error

### DIFF
--- a/.ci/aws/aws_ofi_nccl_pr_ci.yaml
+++ b/.ci/aws/aws_ofi_nccl_pr_ci.yaml
@@ -1,6 +1,5 @@
 general:
   timeout: 180
-  enable_live_log: true
 cluster:
   cluster_type: manual_cluster
 testing:


### PR DESCRIPTION
Since I have write access to aws-ofi-nccl, the Jenkins changes that I make will be executed for this PR.  You can see the logs on this PR to determine if they are better or worse.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
