### PR TITLE
log: removed double "Initializing aws-ofi-nccl" log

### DIFF
--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -83,8 +83,6 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 
 	ofi_log_function = logFunction;
 
-	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
-
 	ret = nccl_net_ofi_create_plugin(&plugin);
 
 	return nccl_net_ofi_retval_translate(ret);


### PR DESCRIPTION
The plugin was printing the "Initializing aws-ofi-nccl" log statement twice per rank, once in `nccl_net_ofi_init()` and again, immediately after, in `nccl_net_ofi_create_plugin()`.
This PR is removing the first one.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
