### PR TITLE
tuner: (fix) setting errno=0 before strtoll

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -43,8 +43,12 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 	long long value = NCCL_OFI_TUNER_NCCL_BUFFSIZE;
 	if ((bs_str = getenv("NCCL_BUFFSIZE")) != NULL && strlen(bs_str) > 0) {
 		char *endptr = NULL;
+		errno = 0;
 		value = strtoll(bs_str, &endptr, 0);
 		if (errno || bs_str == endptr || *endptr != '\0') {
+			NCCL_OFI_WARN(
+				"Tuner: failed to read NCCL_BUFFSIZE, setting it to %d",
+				NCCL_OFI_TUNER_NCCL_BUFFSIZE);
 			value = NCCL_OFI_TUNER_NCCL_BUFFSIZE;
 		}
 	}


### PR DESCRIPTION
The strtoll manual says:

> the calling program should set errno to 0 before the call, and then determine
> if an error occurred by checking whether errno has a nonzero value after the
> call.

When reading the `NCCL_BUFFSIZE` environment variable, the tuner was calling `strtoll` without setting errno first. So, even when `strtoll` was successful, the tuner was most of the time seeing `errno=EAGAIN` set by some previous function, and for this reason was considering buffsize to be the default value of 4MB. This was a problem when, by chance, errno was zero for some rank, so the buffsize was correctly set for some rank and not the others, which caused the tuner to make different algorithm choices for different ranks, causing the test to hang. This commit is setting `errno=0` before the `strtoll` call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
