### PR TITLE
rdma: (fix) Use ep domain to create fi endpoint resources

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5607,7 +5607,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 	}
 #endif
 
-	ret = nccl_ofi_ofiutils_init_connection(FI_VERSION(1, 18), dev_rail->info, dev_rail->domain, &ep_rail->ofi_ep,
+	ret = nccl_ofi_ofiutils_init_connection(FI_VERSION(1, 18), dev_rail->info, ep_rail->domain, &ep_rail->ofi_ep,
 						&ep_rail->av, &ep_rail->cq);
 	if (ret != 0) {
 		return ret;


### PR DESCRIPTION
When RDMA protocol is used with domain-per-thread feature enabled, protocol initialization segfaults since fid_domain member variable of device is accessed even though fid_domain is only stored in plugin endpoint structure in case domain-per-thread feature is used.

Fix bug by accessing fid_domain member of plugin endpoint structure instead.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
