### PR TITLE
neuron: Disable rdma eager messages by default

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -224,8 +224,19 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
 /*
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
+ *
+ * Neuron perf is better without the eager protocol, so we set the
+ * default to 0 on Neuron platforms.  We really need to have a way to
+ * tweak defaults from the platform file, but this fits our needs for
+ * now.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE",
+#if HAVE_NEURON
+		   0
+#else
+		   8192
+#endif
+);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
For most use cases of interest, the eager protocol hurts performance more than it helps on Neuron platforms.  So we set the default eager size to 0 by default when on Neuron, skipping the eager protocol.

We should make this platform specific rather than the large hammer to set default values from the platform file today, which is something that we should really fix.  But, as always, we're a little short on time, so this will do for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
