### PR TITLE
Enable platform specific "cq read count" and "eager max size" and adjust values for TRN1(n)

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -140,9 +140,10 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE", 0);
 
 /*
  * Maximum number of cq entries to read in a single call to
- * fi_cq_read.
+ * fi_cq_read. Defaults to 4, unless the configured platform sets a
+ * specific value.
  */
-OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
+OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", -1);
 
 /*
  * Protocol to use for send/recv operations.  Valid options are

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -225,8 +225,9 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
 /*
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
+ * Defaults to 8192, unless the configured platform sets a specific value.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", -1);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -51,6 +51,9 @@ extern "C" {
  */
 #define NCCL_OFI_RDMA_SEQ_BITS     (10)
 
+/* Maximum size of eager message */
+extern size_t eager_max_size;
+
 typedef enum nccl_net_ofi_rdma_req_state {
 	NCCL_OFI_RDMA_REQ_CREATED = 0,
 	NCCL_OFI_RDMA_REQ_PENDING,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -192,6 +192,9 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		cq_read_count = ofi_nccl_cq_read_count();
 	}
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "CQ read count %ds", cq_read_count);
+	if (ofi_nccl_eager_max_size() != -1) {
+		eager_max_size = ofi_nccl_eager_max_size();
+	}
 
 	/* Select and initialize protocol data structure.
 	 * platform_init() may change the default, so this must occur

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -46,7 +46,7 @@ int nic_dup_conns = 0;
    This variable will be updated during init (hence, can not be
    const), but will not change during execution.  Therefore, it may be
    read in the polling loop without protection of a lock. */
-size_t cq_read_count = 1;
+size_t cq_read_count = 4;
 
 const char *provider_filter = NULL;
 
@@ -181,13 +181,17 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	/* configuration parameters */
 	nic_dup_conns = ofi_nccl_nic_dup_conns();
 	net_latency = (float)ofi_nccl_net_latency();
-	cq_read_count = ofi_nccl_cq_read_count();
 
 	if (platform_init) {
 		ret = platform_init(&provider_filter);
 		if (ret != 0)
 			goto exit;
 	}
+
+	if (ofi_nccl_cq_read_count() != -1) {
+		cq_read_count = ofi_nccl_cq_read_count();
+	}
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "CQ read count %ds", cq_read_count);
 
 	/* Select and initialize protocol data structure.
 	 * platform_init() may change the default, so this must occur

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -96,7 +96,7 @@ static pthread_mutex_t topo_file_lock = PTHREAD_MUTEX_INITIALIZER;
 /** Global variables **/
 
 /* Maximum size of an eager message (see OFI_NCCL_EAGER_MAX_SIZE) */
-static size_t eager_max_size = 0;
+size_t eager_max_size = 8192;
 
 /* Function prototypes */
 static int send_progress(nccl_net_ofi_rdma_req_t *req);
@@ -6473,13 +6473,12 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	if (ofi_nccl_eager_max_size() < 0 ||
-	    ofi_nccl_eager_max_size() > rr_threshold) {
+	if (eager_max_size < 0 ||
+	    eager_max_size > rr_threshold) {
 		NCCL_OFI_WARN("Invalid value for EAGER_MAX_SIZE");
 		ret = ncclInvalidArgument;
 		goto error;
 	}
-	eager_max_size = (size_t) ofi_nccl_eager_max_size();
 
 	if (domain_per_thread == 1 && ofi_nccl_endpoint_per_communicator() != 0) {
 		/* TODO support this configuration */

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -36,6 +36,7 @@ struct ec2_platform_data {
 	const char *default_protocol;
 	int domain_per_thread;
 	size_t cq_read_count;
+	size_t eager_max_size;
 } platform_data_map[] = {
 	{
 		.name = "p4d.24xlarge",
@@ -47,6 +48,7 @@ struct ec2_platform_data {
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
 		.cq_read_count = 4,
+		.eager_max_size = 8192,
 	},
 	{
 		.name = "p4de.24xlarge",
@@ -58,6 +60,7 @@ struct ec2_platform_data {
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
 		.cq_read_count = 4,
+		.eager_max_size = 8192,
 	},
 	{
 		.name = "p3dn.24xlarge",
@@ -69,6 +72,7 @@ struct ec2_platform_data {
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
 		.cq_read_count = 4,
+		.eager_max_size = 8192,
 	},
 	{
 		.name = "p5.48xlarge",
@@ -80,6 +84,7 @@ struct ec2_platform_data {
 		.default_protocol = "RDMA",
 		.domain_per_thread = 0,
 		.cq_read_count = 4,
+		.eager_max_size = 8192,
 	},
 	{
 		.name = "g5.48xlarge",
@@ -89,6 +94,7 @@ struct ec2_platform_data {
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
 		.cq_read_count = 4,
+		.eager_max_size = 8192,
 	},
 	{
 		.name = "trn1.32xlarge",
@@ -97,6 +103,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.domain_per_thread = 1,
 		.cq_read_count = 16,
+		.eager_max_size = 0,
 	},
 	{
 		.name = "trn1n.32xlarge",
@@ -105,6 +112,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.domain_per_thread = 1,
 		.cq_read_count = 16,
+		.eager_max_size = 0,
 	}
 };
 
@@ -332,7 +340,6 @@ static int configure_ep_max_msg_size(struct fid_ep *ep)
 	int ret = 0;
 
 #if HAVE_DECL_FI_OPT_MAX_MSG_SIZE
-	size_t eager_max_size = (size_t)ofi_nccl_eager_max_size();
 	size_t optval = NCCL_OFI_MAX(NCCL_OFI_MAX(sizeof(nccl_net_ofi_rdma_ctrl_msg_t), eager_max_size),
 				     sizeof(nccl_ofi_rdma_connection_info_t));
 
@@ -587,6 +594,7 @@ int platform_init(const char **provider_filter)
 			nccl_ofi_selected_protocol = platform_data->default_protocol;
 		}
 		cq_read_count = platform_data->cq_read_count;
+		eager_max_size = platform_data->eager_max_size;
 	}
 
 	domain_per_thread = ofi_nccl_domain_per_thread();

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -35,6 +35,7 @@ struct ec2_platform_data {
 	bool net_flush_required;
 	const char *default_protocol;
 	int domain_per_thread;
+	size_t cq_read_count;
 } platform_data_map[] = {
 	{
 		.name = "p4d.24xlarge",
@@ -45,6 +46,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
+		.cq_read_count = 4,
 	},
 	{
 		.name = "p4de.24xlarge",
@@ -55,6 +57,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
+		.cq_read_count = 4,
 	},
 	{
 		.name = "p3dn.24xlarge",
@@ -65,6 +68,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
+		.cq_read_count = 4,
 	},
 	{
 		.name = "p5.48xlarge",
@@ -75,6 +79,7 @@ struct ec2_platform_data {
 		.net_flush_required = false,
 		.default_protocol = "RDMA",
 		.domain_per_thread = 0,
+		.cq_read_count = 4,
 	},
 	{
 		.name = "g5.48xlarge",
@@ -83,6 +88,7 @@ struct ec2_platform_data {
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 0,
+		.cq_read_count = 4,
 	},
 	{
 		.name = "trn1.32xlarge",
@@ -90,6 +96,7 @@ struct ec2_platform_data {
 		.gdr_required = true,
 		.net_flush_required = true,
 		.domain_per_thread = 1,
+		.cq_read_count = 16,
 	},
 	{
 		.name = "trn1n.32xlarge",
@@ -97,6 +104,7 @@ struct ec2_platform_data {
 		.gdr_required = true,
 		.net_flush_required = true,
 		.domain_per_thread = 1,
+		.cq_read_count = 16,
 	}
 };
 
@@ -574,8 +582,11 @@ int platform_init(const char **provider_filter)
 				net_latency);
 	}
 
-	if (select_efa && ofi_nccl_protocol() == NULL && platform_data) {
-		nccl_ofi_selected_protocol = platform_data->default_protocol;
+	if (platform_data) {
+		if (select_efa && ofi_nccl_protocol() == NULL)  {
+			nccl_ofi_selected_protocol = platform_data->default_protocol;
+		}
+		cq_read_count = platform_data->cq_read_count;
 	}
 
 	domain_per_thread = ofi_nccl_domain_per_thread();


### PR DESCRIPTION
This CR enable platform specific "cq read count" and "eager max size" and adjust values for TRN1(n). Default value and value for all platforms except for TRN1(n) remain the same.

Values for TRN1(n) have been adjusted to `cq_read_count = 16` and `eager_max_size = 0`.