### PR TITLE
rdma: wait for connect response msg in connect()

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -452,9 +452,6 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	 * connection establishment */
 	nccl_net_ofi_rdma_req_t *conn_resp_req;
 
-	/* Indicates if connection establishment is completed */
-	bool connected;
-
 	/* Message struct send connect message and receive connect
 	 * response message */
 	nccl_ofi_rdma_connection_info_t conn_msg;

--- a/tests/functional/nccl_connection.c
+++ b/tests/functional/nccl_connection.c
@@ -106,17 +106,21 @@ int main(int argc, char* argv[])
 			/* MPI recv */
 			MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
-			/* Connect API */
 			NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", peer_rank);
-			while (sComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm, &s_ignore), res, exit);
+			NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
+
+			while (sComm == NULL || rComm == NULL) {
+				/* Connect API */
+				if (sComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm, &s_ignore), res, exit);
+				}
+
+				/* Accept API */
+				if (rComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore), res, exit);
+				}
 			}
 
-			/* Accept API */
-			NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-			while (rComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore), res, exit);
-			}
 			NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 					peer_rank);
 		}
@@ -129,17 +133,21 @@ int main(int argc, char* argv[])
 			/* MPI send */
 			MPI_Send((void *)handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD);
 
-			/* Connect API */
 			NCCL_OFI_INFO(NCCL_INIT, "Send connection request to rank %d", peer_rank);
-			while (sComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm, &s_ignore), res, exit);
+			NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
+
+			while (sComm == NULL || rComm == NULL) {
+				/* Connect API */
+				if (sComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm, &s_ignore), res, exit);
+				}
+
+				/* Accept API */
+				if (rComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore), res, exit);
+				}
 			}
 
-			/* Accept API */
-			NCCL_OFI_INFO(NCCL_INIT, "Server: Start accepting requests");
-			while (rComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore), res, exit);
-			}
 			NCCL_OFI_INFO(NCCL_INIT, "Successfully accepted connection from rank %d",
 					peer_rank);
 		}

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -175,20 +175,24 @@ int main(int argc, char* argv[])
 			MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR,
 					peer_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
 
-			/* Connect API */
 			NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", peer_rank);
-			while (sComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
-								&s_ignore),
-						res, exit);
+			NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
+
+			while (sComm == NULL || rComm == NULL) {
+				/* Connect API */
+				if (sComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
+									&s_ignore),
+							res, exit);
+				}
+
+				/* Accept API */
+				if (rComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
+							res, exit);
+				}
 			}
 
-			/* Accept API */
-			NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
-			while (rComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
-						res, exit);
-			}
 			NCCL_OFI_INFO(NCCL_NET, "Successfully accepted connection from rank %d",
 					peer_rank);
 		} else if (rank == 1) {
@@ -200,20 +204,26 @@ int main(int argc, char* argv[])
 			/* MPI send */
 			MPI_Send((void *)handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD);
 
-			/* Connect API */
 			NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", peer_rank);
-			while (sComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
-								&s_ignore),
-						res, exit);
+			NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
+
+			while (sComm == NULL || rComm == NULL) {
+
+				/* Connect API */
+				if (sComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
+									&s_ignore),
+							res, exit);
+				}
+
+				/* Accept API */
+				if (rComm == NULL) {
+					OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
+							res, exit);
+				}
+
 			}
 
-			/* Accept API */
-			NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
-			while (rComm == NULL) {
-				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
-						res, exit);
-			}
 			NCCL_OFI_INFO(NCCL_NET, "Successfully accepted connection from rank %d",
 					peer_rank);
 		}


### PR DESCRIPTION
The RDMA protocol connection establishment code currently doesn't wait for the connect response msg (from `accept()` side) before completing.

This can lead to a situation where `connect()` completes, and the corresponding `accept()` hangs because the connect side does not have enough recv buffers available to receive the connect response msg from the accept side.

We particularly see a deadlock in zero-copy mode, where plugin is responsible for posting all receive buffers, likely because plugin posts fewer receive buffers than Libfabric does.

This commit makes `connect` wait to return a valid `s_comm` until the connect response message is received. It also removes code in `send` and `send_close` to handle cases where the `s_comm` connection is not yet complete; these cases aren't necessary if `connect` doesn't return before connection completion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
