### PR TITLE
rdma: ignore cancel events instead of using `fi_cancel`.

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -180,17 +180,13 @@ typedef struct nccl_net_ofi_rdma_req nccl_net_ofi_rdma_req_t;
 typedef struct nccl_net_ofi_rdma_ep nccl_net_ofi_rdma_ep_t;
 typedef struct nccl_net_ofi_ep_rail nccl_net_ofi_ep_rail_t;
 
-typedef struct rdma_req_bounce_data {
+typedef struct {
 	/* Bounce buffer freelist item */
 	nccl_net_ofi_rdma_bounce_fl_item_t *bounce_fl_item;
 	/* Length of bounce buffer */
 	size_t buff_len;
 	/* Length of received data */
 	size_t recv_len;
-
-	/* For storing in posted recv requests list */
-	struct rdma_req_bounce_data *prev;
-	struct rdma_req_bounce_data *next;
 
 	/*
 	 * Keeps tracks of Rail ID which is used to post the bounce buffer.
@@ -664,10 +660,6 @@ struct nccl_net_ofi_rdma_ep {
 	nccl_ofi_freelist_t *bounce_buff_reqs_fl;
 	/* Size of bounce buffers */
 	size_t bounce_buff_size;
-	/* List of posted buffer requests */
-	rdma_req_bounce_data_t *posted_recv_req_list;
-	/* Lock for posted_recv_req_list */
-	pthread_mutex_t posted_recv_req_list_lock;
 
 	/* True if this ep is stored in the thread-local store */
 	bool thread_local_ep;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -26,7 +26,6 @@
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_pthread.h"
 #include "nccl_ofi_platform.h"
-#include "contrib/utlist.h"
 #include "nccl_ofi_mr.h"
 
 /* Template path used to write temporary NCCL topology file */
@@ -1153,16 +1152,10 @@ static inline int handle_bounce_recv(nccl_net_ofi_rdma_device_t *device, int rai
 	}
 
 	bounce_data = get_bounce_data(bounce_req);
-
-	nccl_net_ofi_rdma_ep_t *ep = bounce_data->ep;
-
-	/* Remove from posted buffs deque */
-	nccl_net_ofi_mutex_lock(&ep->posted_recv_req_list_lock);
-	DL_DELETE(ep->posted_recv_req_list, bounce_data);
-	nccl_net_ofi_mutex_unlock(&ep->posted_recv_req_list_lock);
-
 	bounce_data->recv_len = cq_entry->len;
 	bounce_fl_item = bounce_data->bounce_fl_item;
+
+	nccl_net_ofi_rdma_ep_t *ep = bounce_data->ep;
 
 	/* The first 4 bits are the type, but we don't have a base
 	 * header type.  So cast to a control message and lookup the
@@ -1377,16 +1370,12 @@ static const char *req_type_str(nccl_net_ofi_rdma_req_type_t type)
 static const char *nccl_net_ofi_req_str(nccl_net_ofi_rdma_req_t *req)
 {
 	static char buf[256];
-	if (req == NULL) {
-		snprintf(buf, sizeof(buf), "(nil)");
-	} else {
-		snprintf(buf, sizeof(buf), "{ dev: %d, size: %zu, state: %s, type: %s }",
-			 req->dev_id,
-			 req->size,
-			 req_state_str(req->state),
-			 req_type_str(req->type)
-			);
-	}
+	snprintf(buf, sizeof(buf), "{ dev: %d, size: %zu, state: %s, type: %s }",
+		 req->dev_id,
+		 req->size,
+		 req_state_str(req->state),
+		 req_type_str(req->type)
+		);
 	return buf;
 }
 
@@ -1523,26 +1512,13 @@ static inline int process_err_completion(nccl_net_ofi_rdma_device_t *device,
 	}
 
 	if (err_entry.err == FI_ECANCELED) {
-		/* Closing an EP with posted receives will generate cancellation events
-		   for the posted receives */
-		req = (nccl_net_ofi_rdma_req_t *)err_entry.op_context;
-		if (req == NULL || req->type != NCCL_OFI_RDMA_BOUNCE) {
-			NCCL_OFI_WARN("Received canceled event from unexpected request type. Type: %s",
-				nccl_net_ofi_req_str(req));
-			ret = -EIO;
-			goto exit;
-		}
+		/* Closing an EP with posted receives will (erroneously) generate
+		   cancellation events for the posted receives with the EFA provider
+		   in Libfabric versions prior to 1.22. These events are harmless
+		   and can be ignored.
 
-		rdma_req_bounce_data_t *bounce_data = get_bounce_data(req);
-		nccl_net_ofi_rdma_ep_t *ep = bounce_data->ep;
-
-		/* Remove from posted buffs deque */
-		nccl_net_ofi_mutex_lock(&ep->posted_recv_req_list_lock);
-		DL_DELETE(ep->posted_recv_req_list, bounce_data);
-		nccl_net_ofi_mutex_unlock(&ep->posted_recv_req_list_lock);
-
-		NCCL_OFI_TRACE(NCCL_NET, "Processed canceled event for internal receive request %p", req);
-
+		   With Libfabric 1.22 and later, we shouldn't get these cancel
+		   events at all. The plugin does not explicitly call fi_cancel. */
 		ret = -err_entry.err;
 		goto exit;
 	}
@@ -1715,8 +1691,8 @@ static int ofi_process_cq_rail(nccl_net_ofi_rdma_ep_t *ep, nccl_net_ofi_ep_rail_
 				/* Error entry not available yet */
 				break;
 			} else if (ret == -FI_ECANCELED) {
-				/* Non-fatal cancellation event -- continue
-				   processing cq */
+				/* Non-fatal cancellation event -- see comment in
+				   process_err_completion. Ignore. */
 				ret = 0;
 				continue;
 			} else {
@@ -4401,21 +4377,12 @@ static int post_bounce_buffer(nccl_net_ofi_rdma_req_t *req,
 					      bounce_fl_item);
 
 	req->state = NCCL_OFI_RDMA_REQ_CREATED;
-
-	nccl_net_ofi_mutex_lock(&ep->posted_recv_req_list_lock);
-
 	ssize_t rc =
 		fi_recv(ep_rail->ofi_ep, &bounce_fl_item->bounce_msg, bounce_data->buff_len, desc, FI_ADDR_UNSPEC, req);
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Error posting bounce buffer. RC: %zd, Error: %s",
 			      rc, fi_strerror(-rc));
 	}
-
-	if (rc == 0) {
-		DL_APPEND(ep->posted_recv_req_list, bounce_data);
-	}
-
-	nccl_net_ofi_mutex_unlock(&ep->posted_recv_req_list_lock);
 
 	return rc;
 }
@@ -5036,23 +5003,14 @@ static inline int init_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 		return ret;
 	}
 
-	ep->posted_recv_req_list = NULL;
-	ret = nccl_net_ofi_mutex_init(&ep->posted_recv_req_list_lock, NULL);
-	if (ret != 0) {
-		nccl_ofi_freelist_fini(ep->bounce_buff_reqs_fl);
-		return ret;
-	}
-
 	ret = nccl_ofi_freelist_init_mr(sizeof(nccl_net_ofi_rdma_bounce_fl_item_t) + ep->bounce_buff_size,
 					ofi_nccl_rdma_min_posted_bounce_buffers(), 16, 0,
 					freelist_regmr_host_fn, freelist_deregmr_host_fn,
 					ep, 0, BOUNCE_BUFFER_ALIGNMENT, &ep->bounce_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init bounce_buff_fl");
-		if (nccl_ofi_freelist_fini(ep->bounce_buff_reqs_fl)) {
+		if (nccl_ofi_freelist_fini(ep->bounce_buff_reqs_fl))
 			NCCL_OFI_WARN("Also failed to freelist_fini bounce_buff_reqs_fl");
-		}
-		nccl_net_ofi_mutex_destroy(&ep->posted_recv_req_list_lock);
 		return ret;
 	}
 
@@ -5082,18 +5040,6 @@ static inline int init_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 static inline int fini_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 {
 	int ret = 0;
-
-	if (ep->posted_recv_req_list != NULL) {
-		NCCL_OFI_WARN("Cannot finalize bounce buffers: recv buffers still posted");
-		ret = -EBUSY;
-		return ret;
-	}
-
-	ret = nccl_net_ofi_mutex_destroy(&ep->posted_recv_req_list_lock);
-	if (ret != 0) {
-		return ret;
-	}
-
 	ret = nccl_ofi_freelist_fini(ep->bounce_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to fini bounce_buff_fl");
@@ -5654,40 +5600,6 @@ static int init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *device,
 	return ret;
 }
 
-static int cancel_posted_recv_ops(nccl_net_ofi_rdma_ep_t *ep)
-{
-	while (true) {
-		nccl_net_ofi_mutex_lock(&ep->posted_recv_req_list_lock);
-		/* Head element of list */
-		rdma_req_bounce_data_t *bounce_data = ep->posted_recv_req_list;
-
-		if (bounce_data == NULL) {
-			/* List is empty */
-			nccl_net_ofi_mutex_unlock(&ep->posted_recv_req_list_lock);
-			break;
-		}
-
-		struct fid_ep *ofi_ep = bounce_data->rail->ofi_ep;
-		nccl_net_ofi_rdma_req_t *req = container_of(bounce_data,
-			nccl_net_ofi_rdma_req_t, bounce_data);
-		int ret = fi_cancel(&ofi_ep->fid, req);
-
-		nccl_net_ofi_mutex_unlock(&ep->posted_recv_req_list_lock);
-
-		if (ret != 0) {
-			NCCL_OFI_WARN("Call to fi_cancel failed. RC: %d", ret);
-			return ret;
-		}
-
-		ret = ofi_process_cq(ep);
-		if (ret != 0) {
-			return ret;
-		}
-	}
-
-	return 0;
-}
-
 static int release_ep(nccl_net_ofi_ep_t *base_ep)
 {
 	int ret = 0;
@@ -5746,32 +5658,8 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 			}
 		}
 
-		/**
-		 * Before closing the endpoint, cancel currently posted receive
-		 * operations on the endpoint, and wait for the corresponding
-		 * FI_ECANCELED events. We do this for two reasons:
-		 *
-		 * 1. Current Libfabric versions incorrectly generate FI_ECANCELED
-		 *    events for in-progress receive ops when the endpoint is
-		 *    closed. Furthermore, the cancellation events incorrectly
-		 *    have the FI_SEND flag set instead of FI_RECV. Canceling
-		 *    the ops explicitly and waiting for the cancellation events
-		 *    before freeing the requests below ensures the context
-		 *    still points to a valid request when the event is
-		 *    processed, allowing us to verify that these events are
-		 *    from the expected request type before freeing the request
-		 *    below.
-		 *
-		 * 2. In the future (TODO), we should implement some form of
-		 *    accouting to ensure that no recv buffers were leaked from
-		 *    the freelist during the run, which requires explicitly
-		 *    handling the cancellation events.
-		 */
-		ret = cancel_posted_recv_ops(ep);
-		if (ret != 0) {
-			return ret;
-		}
-
+		/* Ideally we would "un-post" the bounce buffers, but this
+		   should be accomplished by closing the endpoint. */
 		release_rdma_ep_resources(ep, device->base.dev_id);
 
 		ret = fini_bounce_buffers(ep);


### PR DESCRIPTION
Previous patches to the plugin called `fi_cancel` to explicitly cancel all posted receive ops. Libfabric in zero-copy mode will not support `fi_cancel`. So, instead, close the endpoint without canceling the outstanding receives.

Versions of Libfabric before 1.22 will erroneously issue cancel events for ops that are posted to the endpoint when it is closed (see https://github.com/ofiwg/libfabric/pull/10139). For backward compatibility, ignore these events if we get them in the CQ.

This reverts commits 0f07c2e2f062e1d2e028b796902d0ce6069dda4d and f7003c42777d68f695e2b1e02b28b90ef866550b.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
