### PR TITLE
Backport to 1.10.x-awsparam: increase CQ read count to 16 for performance

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -142,7 +142,7 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE", 0);
  * Maximum number of cq entries to read in a single call to
  * fi_cq_read.
  */
-OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
+OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 16);
 
 /*
  * Protocol to use for send/recv operations.  Valid options are


### PR DESCRIPTION
Backport: This patch increases CQ read count to 16.

Experiments turned out that reading up to 16 (instead of 4) CQ entries at once improves performance.

Signed-off-by: Michael Axtmann <axtmannm@amazon.com>
(cherry picked from commit 346be40c777c996932e9474d781dc6fb8dafbc56)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.