### PR TITLE
[v1.9.x-aws] ci: add another workaround for ancient al2 glibc

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -7,10 +7,14 @@ env:
     libhwloc-dev
     make
 
+  # note, related to issue around actions/checkout@v4, linked below. This
+  # environment variable is also now needed, as of july 2024.
+  # ref: https://github.com/actions/runner/issues/2906#issuecomment-2208546951
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
+
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-
 jobs:
   amazonlinux:
     strategy:


### PR DESCRIPTION
(cherry picked from commit acceaa31b30e13089d2b742eff80b3964b4d75fc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
