### PR TITLE
(v1.9.x backport) .github/workflows: Remove EPEL from AL2 b/c it doesn't exist anymore

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -56,11 +56,6 @@ jobs:
       - name: Install hwloc, utilities.
         run: |
           sudo yum -y install hwloc-devel yum-utils
-      - name: Add EPEL
-        if: matrix.amazonlinux == 'al2'
-        run: |
-          sudo yum -y install \
-             https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
       - name: Install CUDA
         run: |
           sudo ${{ matrix.configmanager }} --add-repo \


### PR DESCRIPTION
Signed-off-by: Seth Zegelstein <szegel@amazon.com>
(cherry picked from commit 16eece68143c91c85b4cf1d5b34f818ad27a3b75)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
