### PR TITLE
v1.10.x-aws cherry-pick: Disable Libfabric shared memory when possible

### DIFF
--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -55,7 +55,8 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
                   FI_OPT_EFA_EMULATED_WRITE,
                   FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
                   FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES,
-                  FI_OPT_MAX_MSG_SIZE],
+                  FI_OPT_MAX_MSG_SIZE,
+                  FI_OPT_SHARED_MEMORY_PERMITTED],
                   [], [], [AC_INCLUDES_DEFAULT
 [#include <rdma/fi_endpoint.h>
 #ifdef HAVE_RDMA_FI_EXT_H


### PR DESCRIPTION
For a bunch of reasons (detailed in the code), there's no upside to leaving shared memory enabled, and we really need it disabled for correctness when flush() is needed, so that the flush operation flows through the NIC.  Therefore try to disable shared memory whenever possible.

Signed-off-by: Brian Barrett <bbarrett@amazon.com>
(cherry picked from commit 234d1a055d21a28ec14608d3accb18b963f1953c)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
