### PR TITLE
[v1.10.x-aws] Revert "param: increase CQ read count to 16 for performance"

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -142,7 +142,7 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE", 0);
  * Maximum number of cq entries to read in a single call to
  * fi_cq_read.
  */
-OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 16);
+OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
 
 /*
  * Protocol to use for send/recv operations.  Valid options are


### PR DESCRIPTION
We decided not to include this patch in the 1.10 release. It did not have a significant perf impact on P5 platform.

This reverts commit 3cc3af2260f18bf9291fbb4f940a7b62ac905d7c.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
