### PR TITLE
platform-aws: handle NULL platform_data for domain_per_thread

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -580,7 +580,11 @@ int platform_init(const char **provider_filter)
 
 	domain_per_thread = ofi_nccl_domain_per_thread();
 	if (domain_per_thread == -1) {
-		domain_per_thread = platform_data->domain_per_thread;
+		if (platform_data != NULL) {
+			domain_per_thread = platform_data->domain_per_thread;
+		} else {
+			domain_per_thread = 0;
+		}
 	}
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Creating one domain per %s", domain_per_thread ? "thread" : "process");
 


### PR DESCRIPTION
Check if `platform_data` is NULL before using
`platform_data->domain_per_thread`. This avoids a segfault when `platform_data` is NULL (on platforms without a `platform_data` entry)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
