### PR TITLE
.ci/aws: Bump NCCL Version to v2.22.3-1

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                 script {
                     def stages = [:]
 
-                    def nccl_version = "--test-nccl-version v2.20.5-1"
+                    def nccl_version = "--test-nccl-version v2.22.3-1"
                     def timeout = "--timeout 120"
                     def cluster_type = "--cluster-type manual_cluster"
                     def test_target = "--test-target aws-ofi-nccl"


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
