### PR TITLE
[v1.9.x-aws] distcheck: Use efa-installer for dependencies

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -177,22 +177,12 @@ jobs:
           packages: liblttng-ust-dev
           version: lttng
 
-      - name: Install Libfabric
+      - name: Fetch and Install EFA Installer Dependencies
         run: |
-          # We're just doing distchecks, so it is fine if we
-          # just grab the latest master and built a lean build.
-          git clone --depth 1 https://github.com/ofiwg/libfabric.git
-          pushd libfabric
-          ./autogen.sh
-
-          export CC="${{ matrix.realcc || matrix.cc }}"
-          ./configure --prefix="$PWD/install" \
-                      --disable-sockets \
-                      --disable-udp \
-                      --disable-mrail \
-                      --disable-opx
-          make -j "$(nproc)"
-          make install
+          curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
+          tar -xf aws-efa-installer-*.tar.gz
+          pushd aws-efa-installer/
+              sudo ./efa_installer.sh -y --skip-kmod
           popd
 
       - name: Build Plugin
@@ -206,11 +196,13 @@ jobs:
           ./autogen.sh
           if [ "${{ matrix.sdk }}" == "cuda" ]
           then
-            ./configure --with-libfabric="$PWD/libfabric/install" \
+            ./configure --with-mpi=/opt/amazon/openmpi \
+                        --with-libfabric=/opt/amazon/efa \
                         --with-cuda=/usr/local/cuda/ \
+                        --enable-tests \
                         --enable-platform-aws
           else
-            ./configure --with-libfabric="$PWD/libfabric/install" \
+            ./configure --with-libfabric=/opt/amazon/efa \
                         --enable-neuron \
                         --enable-platform-aws
           fi
@@ -279,20 +271,12 @@ jobs:
           packages: cppcheck
           version: codechecker-cppcheck
 
-      - name: Install Libfabric
+      - name: Fetch and Install EFA Installer Dependencies
         run: |
-          # We're just doing distchecks, so it is fine if we
-          # just grab the latest master and built a lean build.
-          git clone --depth 1 https://github.com/ofiwg/libfabric.git
-          pushd libfabric
-          ./autogen.sh
-          ./configure --prefix="$PWD/install" \
-                      --disable-sockets \
-                      --disable-udp \
-                      --disable-mrail \
-                      --disable-opx
-          make -j "$(nproc)"
-          make install
+          curl -O https://efa-installer.amazonaws.com/aws-efa-installer-latest.tar.gz
+          tar -xf aws-efa-installer-*.tar.gz
+          pushd aws-efa-installer/
+              sudo ./efa_installer.sh -y --skip-kmod
           popd
 
       - name: Run Configure
@@ -300,13 +284,15 @@ jobs:
           ./autogen.sh
           if [ "${{ matrix.sdk }}" == "neuron" ]; then
             ./configure \
-              --with-libfabric="$PWD/libfabric/install" \
+              --with-libfabric="/opt/amazon/efa" \
               --enable-neuron \
               --enable-platform-aws
           else
             ./configure \
-              --with-libfabric="$PWD/libfabric/install" \
+              --with-libfabric="/opt/amazon/efa" \
+              --with-mpi="/opt/amazon/openmpi" \
               --with-cuda=/usr/local/cuda/ \
+              --enable-tests \
               --enable-platform-aws
           fi
 


### PR DESCRIPTION
Backport of #419 

Use the EFA installer to get the Libfabric and MPI dependencies. Previously, we thought we only needed Libfabric, but to build the functional tests, we need MPI and it's better to build the functional tests.

Signed-off-by: Raghu Raja <raghunch@amazon.com>
(cherry picked from commit 858f44861ec73bb8d68ea7c91422edc21f4c22da)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
