### PR TITLE
Enable autogenerated topology file by default for RDMA protocol

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -156,6 +156,8 @@ AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
 AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
       [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
 
+CHECK_ENABLE_MEMFD_CREATE()
+
 AC_CONFIG_FILES([Makefile
                  include/Makefile
                  src/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -32,6 +32,10 @@ AH_BOTTOM([
 dnl AX_CHECK_ENABLE_DEBUG must be called before AC_PROG_CC or
 dnl AM_PROG_AR
 AX_CHECK_ENABLE_DEBUG([no])
+dnl Enable _GNU_SOURCE and other system extensions. The plugin uses several
+dnl nonstandard system functions, and the plugin only supports Linux OSes, so
+dnl the risk of silently enabling system extensions is minimal.
+AC_USE_SYSTEM_EXTENSIONS
 dnl AM_PROG_AR must be called before LT_INIT
 AM_PROG_AR
 LT_INIT([shared disable-static pic-only])

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -20,4 +20,14 @@
 #define PATH_MAX	4096
 #endif
 
+/* Workaround for platforms without memfd_create */
+#ifndef HAVE_MEMFD_CREATE
+#include <sys/syscall.h>
+#include <unistd.h>
+static inline int memfd_create(const char *name, unsigned int flags)
+{
+    return syscall(SYS_memfd_create, name, flags);
+}
+#endif /* ifndef HAVE_MEMFD_CREATE */
+
 #endif

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -163,13 +163,6 @@ OFI_NCCL_PARAM_STR(protocol, "PROTOCOL", NULL);
 OFI_NCCL_PARAM_INT(domain_per_thread, "DOMAIN_PER_THREAD", -1);
 
 /*
- * When enabled and RDMA communication protocol is used, write NCCL
- * topology file and set environment variable `NCCL_TOPO_FILE`. OFI plugin
- * writes the NCCL topology file to a memfd file.
- */
-OFI_NCCL_PARAM_INT(topo_file_write_enable, "TOPO_FILE_WRITE_ENABLE", 0);
-
-/*
  * Disable the native RDMA write support check when using the "RDMA" protocol
  * for send/recv operations on AWS platforms. When the check is disabled, the
  * "RDMA" protocol can be used even on platforms where native RDMA write is not

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -164,21 +164,10 @@ OFI_NCCL_PARAM_INT(domain_per_thread, "DOMAIN_PER_THREAD", -1);
 
 /*
  * When enabled and RDMA communication protocol is used, write NCCL
- * topology file and set environment variable `NCCL_TOPO_FILE`. By
- * default, OFI plugin writes the NCCL topology file to a unique
- * temporary file using file path template
- * `/tmp/aws-ofi-nccl-topo-XXXXXX` and the file is deleted at normal
- * process termination. See environment variable
- * `OFI_NCCL_TOPO_FILE_TEMPLATE` to control the file destination.
+ * topology file and set environment variable `NCCL_TOPO_FILE`. OFI plugin
+ * writes the NCCL topology file to a memfd file.
  */
 OFI_NCCL_PARAM_INT(topo_file_write_enable, "TOPO_FILE_WRITE_ENABLE", 0);
-
-/*
- * User defined file path template that is used in case NCCL topology
- * file is written. The last six characters of the template must be
- * XXXXXX and will be replaced to make the filename unique.
- */
-OFI_NCCL_PARAM_STR(topo_file_template, "TOPO_FILE_TEMPLATE", NULL);
 
 /*
  * Disable the native RDMA write support check when using the "RDMA" protocol

--- a/m4/check_enable_memfd_create.m4
+++ b/m4/check_enable_memfd_create.m4
@@ -1,0 +1,17 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_ENABLE_MEMFD_CREATE], [
+      AC_CHECK_FUNCS(memfd_create)
+      if test "x$ac_cv_func_memfd_create" != xyes; then
+            # check if we can use workaround syscall
+            AC_CHECK_DECLS(SYS_memfd_create, [], [], [#include <sys/syscall.h>])
+            if test "x$ac_cv_have_decl_SYS_memfd_create" != xyes; then
+                  AC_MSG_ERROR("Could not find memfd_create or SYS_memfd_create")
+            fi
+      fi
+])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#define _GNU_SOURCE
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#define _GNU_SOURCE
 #include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -247,10 +247,8 @@ static inline struct fid_domain *get_domain_from_endpoint(nccl_net_ofi_rdma_ep_t
 /*
  * @brief	Write topology to NCCL topology file
  *
- * If environment variable `OFI_NCCL_TOPO_FILE_WRITE_ENABLE` is set,
- * this function writes a NCCL topology file to a memfd file.
- *
- * It also sets environment variable `NCCL_TOPO_FILE` to the
+ * This function writes a NCCL topology file to a memfd file, and
+ * sets environment variable `NCCL_TOPO_FILE` to the
  * filename path of topology file.
  *
  * @param	topo
@@ -263,13 +261,6 @@ static int write_topo_file(nccl_ofi_topo_t *topo)
 	int ret = 0;
 	int topo_fd = -1;
 	FILE *file = NULL;
-
-	/* This function is a no-op in case writing topology file is not enabled explicitly */
-	if (!ofi_nccl_topo_file_write_enable()) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-			       "Topology write not enabled; skipping");
-		goto exit;
-	}
 
 	/**
 	 * If `NCCL_TOPO_FILE` is already set, don't set it again.

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -67,7 +67,7 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "p5.48xlarge",
-		.topology = "p5.48xl-topo.xml",
+		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 75.0,
 		.gdr_required = true,

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -5,7 +5,6 @@
 
 #include "config.h"
 
-#define _GNU_SOURCE
 #include <alloca.h>
 #include <limits.h>
 #include <stdio.h>


### PR DESCRIPTION
Autogenerated topology files will be the default on the AWS P5 platform that uses RDMA protocol. Also uses anonymous mem-backed file for autogenerated topology file.

~~Needs testing to ensure behavior is correct in ML apps with `fork()` behavior.~~ done

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
