### PR TITLE
net.h: add FATAL debug log level to neuron

### DIFF
--- a/include/nccl-headers/neuron/net.h
+++ b/include/nccl-headers/neuron/net.h
@@ -28,10 +28,11 @@ extern "C" {
 typedef enum {
         NCCL_LOG_NONE=0,
         NCCL_LOG_VERSION=1,
-        NCCL_LOG_WARN=2,
-        NCCL_LOG_INFO=3,
-        NCCL_LOG_ABORT=4,
-        NCCL_LOG_TRACE=5
+        NCCL_LOG_FATAL=2,
+        NCCL_LOG_WARN=3,
+        NCCL_LOG_INFO=4,
+        NCCL_LOG_ABORT=5,
+        NCCL_LOG_TRACE=6
 } ncclDebugLogLevel;
 
 typedef enum {


### PR DESCRIPTION
For neuron, a fatal log level has been introduced. Reflect this change in aws-ofi-nccl by adding fatal log level in neuron's net.h. This is required since user of the aws-ofi-nccl interface passes debug logger to aws-ofi-nccl.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
