### PR TITLE
platform-aws: configuration for P5e instances

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -77,6 +77,16 @@ struct ec2_platform_data {
 		.domain_per_thread = 0,
 	},
 	{
+		.name = "p5e.48xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
+		.gdr_required = true,
+		.net_flush_required = false,
+		.default_protocol = "RDMA",
+		.domain_per_thread = 0,
+	},
+	{
 		.name = "g5.48xlarge",
 		.topology = "g5.48xl-topo.xml",
 		.gdr_required = false,


### PR DESCRIPTION
P5e will use the same autogenerated topology file approach as P5.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
