### PR TITLE
ci: build oldest working EFA installer and latest 

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -26,9 +26,7 @@ jobs:
           - al2
         efainstaller:
           - latest
-          - 1.32.0
-          - 1.31.0
-          - 1.30.0
+          - 1.25.0
         include:
           - amazonlinux: al2023
             efainstallerdir: ALINUX2023


### PR DESCRIPTION
Build only the oldest and newest efa installer versions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
