### PR TITLE
dist: set `TAR_OPTIONS` to remove ownership info

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,3 +17,8 @@ EXTRA_DIST = \
 	RELEASENOTES.md
 
 AM_DISTCHECK_CONFIGURE_FLAGS=$(NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS)
+
+# Reset ownership to 0 (root) in distribution tarball
+# Ref: https://www.gnu.org/software/automake/manual/html_node/Basics-of-Distribution.html
+TAR_OPTIONS = --owner=0 --group=0
+export TAR_OPTIONS


### PR DESCRIPTION
This resets the file ownership to root in the dist tarballs

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
