### PR TITLE
platform: Set RDMA protocol as default for trn1/trn1n platforms

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -95,14 +95,14 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
-		.default_protocol = "SENDRECV",
+		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
 		.domain_per_thread = 1,
 	},
 	{
 		.name = "trn1n.32xlarge",
-		.default_protocol = "SENDRECV",
+		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
 		.domain_per_thread = 1,


### PR DESCRIPTION
With switching to this plugin implementation, we want to take advantage of the RDMA protocol on trn1/trn1n platforms without setting environment variables.

This commit sets RDMA protocol as default for trn1/trn1n platforms.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
