### PR TITLE
api: fail when using connect/accept_v4 with RDMA protocol

### DIFF
--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -176,6 +176,11 @@ ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm)
         nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
 	ncclResult_t ret;
 
+	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
+		NCCL_OFI_WARN("RDMA protocol does not support listen_v4 interface");
+		return ncclInternalError;
+	}
+
 	ret = nccl_net_ofi_listen(dev, &nccl_net_ofi_handle, listenComm);
 	if (ret == ncclSuccess) {
 		memcpy(handle, &nccl_net_ofi_handle, NCCL_NET_HANDLE_MAXSIZE_V4);
@@ -263,6 +268,11 @@ ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
         nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
+
+	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
+		NCCL_OFI_WARN("RDMA protocol does not support blocking connect_v4 interface");
+		return ncclInternalError;
+	}
 
         memcpy(&nccl_net_ofi_handle, handle, NCCL_NET_HANDLE_MAXSIZE_V4);
 
@@ -451,6 +461,11 @@ error:
 ncclResult_t nccl_net_ofi_accept_v4(void* listenComm, void** recvComm)
 {
 	ncclResult_t ret = ncclInvalidArgument;
+
+	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
+		NCCL_OFI_WARN("RDMA protocol does not support blocking accept_v4 interface.");
+		return ncclInternalError;
+	}
 
 	while (*recvComm == NULL) {
 		ret = nccl_net_ofi_accept(listenComm, recvComm);


### PR DESCRIPTION
Since 4763d60, RDMA protocol does not support the old blocking connection establishment API. Issue an error message and fail, rather than hanging.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
