### PR TITLE
Fix naming of array in nccl_net_ofi_plugin_init

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -602,7 +602,7 @@ int nccl_net_ofi_plugin_init(nccl_net_ofi_plugin_t *plugin,
 		(nccl_net_ofi_device_t **)calloc(num_devices, sizeof(nccl_net_ofi_device_t *));
 	if (plugin->p_devs == NULL) {
 		NCCL_OFI_WARN("Unable to allocate "
-			      "nccl_net_ofi_rdma_device_t pointer array");
+			      "nccl_net_ofi_device_t pointer array");
 		return -ENOMEM;
 	}
 


### PR DESCRIPTION
nccl_net_ofi_plugin_init refers to the rdma pointer array, but this code is shared between rdma and sendrecv, so the error message should be generic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
