### PR TITLE
Feature/v6 rma ops

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -50,6 +50,7 @@ noinst_HEADERS = \
 	nccl-headers/nvidia/tuner_v2.h \
 	nccl-headers/neuron/net.h \
 	nccl-headers/neuron/net_v4.h \
+	nccl-headers/neuron/net_v5.h \
 	nccl-headers/neuron/error.h \
 	nccl_ofi_platform.h \
 	contrib/uthash.h \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -49,6 +49,7 @@ noinst_HEADERS = \
 	nccl-headers/nvidia/tuner_v1.h \
 	nccl-headers/nvidia/tuner_v2.h \
 	nccl-headers/neuron/net.h \
+	nccl-headers/neuron/net_v4.h \
 	nccl-headers/neuron/error.h \
 	nccl_ofi_platform.h \
 	contrib/uthash.h \

--- a/include/nccl-headers/neuron/net.h
+++ b/include/nccl-headers/neuron/net.h
@@ -20,7 +20,6 @@ extern "C" {
 #define NCCL_PTR_NEURON 0x4
 
 #define NCCL_NET_HANDLE_MAXSIZE 128
-#define NCCL_NET_HANDLE_MAXSIZE_V4 64
 
 // Maximum number of requests per comm object
 #define NCCL_NET_MAX_REQUESTS 128
@@ -50,58 +49,10 @@ typedef enum {
 
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 
-typedef struct {
-	char* name;     // Used mostly for logging.
-	char* pciPath;  // Path to the PCI device in /sys.
-	uint64_t guid;  // Unique identifier for the NIC chip. Important for
-			// cards with multiple PCI functions (Physical or virtual).
-	int ptrSupport; // NCCL_PTR_HOST or NCCL_PTR_HOST|NCCL_PTR_CUDA
-	int speed;      // Port speed in Mbps.
-	int port;       // Port number.
-	int maxComms;   // Maximum number of comms we can create
-} ncclNetProperties_v4_t;
-
-typedef struct {
-	// Name of the network (mainly for logs)
-	const char* name;
-	// Initialize the network.
-	ncclResult_t (*init)(ncclDebugLogger_t logFunction);
-	// Return the number of adapters.
-	ncclResult_t (*devices)(int* ndev);
-	// Get various device properties.
-	ncclResult_t (*getProperties)(int dev, ncclNetProperties_v4_t* props);
-	// Create a receiving object and provide a handle to connect to it. The
-	// handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
-	// between ranks to create a connection.
-	ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
-	// Connect to a handle and return a sending comm object for that peer.
-	ncclResult_t (*connect)(int dev, void* handle, void** sendComm);
-	// Finalize connection establishment after remote peer has called connectHandle
-	ncclResult_t (*accept)(void* listenComm, void** recvComm);
-	// Register/Deregister memory. Comm can be either a sendComm or a recvComm.
-	// Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
-	ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
-	ncclResult_t (*deregMr)(void* comm, void* mhandle);
-	// Asynchronous send to a peer.
-	// May return request == NULL if the call cannot be performed (or would block)
-	ncclResult_t (*isend)(void* sendComm, void* data, int size, void* mhandle, void** request);
-	// Asynchronous recv from a peer.
-	// May return request == NULL if the call cannot be performed (or would block)
-	ncclResult_t (*irecv)(void* recvComm, void* data, int size, void* mhandle, void** request);
-	// Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
-	// visible to the GPU
-	ncclResult_t (*iflush)(void* recvComm, void* data, int size, void* mhandle, void** request);
-	// Test whether a request is complete. If size is not NULL, it returns the
-	// number of bytes sent/received.
-	ncclResult_t (*test)(void* request, int* done, int* size);
-	// Close and free send/recv comm objects
-	ncclResult_t (*closeSend)(void* sendComm);
-	ncclResult_t (*closeRecv)(void* recvComm);
-	ncclResult_t (*closeListen)(void* listenComm);
-} ncclNet_v4_t;
-
 #ifdef __cplusplus
 } // End extern "C"
 #endif
+
+#include "net_v4.h"
 
 #endif // End NCCL_HEADERS_NEURON_NET_H

--- a/include/nccl-headers/neuron/net.h
+++ b/include/nccl-headers/neuron/net.h
@@ -54,5 +54,6 @@ typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, 
 #endif
 
 #include "net_v4.h"
+#include "net_v5.h"
 
 #endif // End NCCL_HEADERS_NEURON_NET_H

--- a/include/nccl-headers/neuron/net_v4.h
+++ b/include/nccl-headers/neuron/net_v4.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2023-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_HEADERS_NEURON_NET_V4_H_
+#define NCCL_HEADERS_NEURON_NET_V4_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "error.h"
+
+#define NCCL_NET_HANDLE_MAXSIZE_V4 64
+
+typedef struct {
+	char* name;     // Used mostly for logging.
+	char* pciPath;  // Path to the PCI device in /sys.
+	uint64_t guid;  // Unique identifier for the NIC chip. Important for
+			// cards with multiple PCI functions (Physical or virtual).
+	int ptrSupport; // NCCL_PTR_HOST or NCCL_PTR_HOST|NCCL_PTR_CUDA
+	int speed;      // Port speed in Mbps.
+	int port;       // Port number.
+	int maxComms;   // Maximum number of comms we can create
+} ncclNetProperties_v4_t;
+
+typedef struct {
+	// Name of the network (mainly for logs)
+	const char* name;
+	// Initialize the network.
+	ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+	// Return the number of adapters.
+	ncclResult_t (*devices)(int* ndev);
+	// Get various device properties.
+	ncclResult_t (*getProperties)(int dev, ncclNetProperties_v4_t* props);
+	// Create a receiving object and provide a handle to connect to it. The
+	// handle can be up to NCCL_NET_V4_HANDLE_MAXSIZE bytes and will be exchanged
+	// between ranks to create a connection.
+	ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+	// Connect to a handle and return a sending comm object for that peer.
+	ncclResult_t (*connect)(int dev, void* handle, void** sendComm);
+	// Finalize connection establishment after remote peer has called connectHandle
+	ncclResult_t (*accept)(void* listenComm, void** recvComm);
+	// Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+	// Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+	ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+	ncclResult_t (*deregMr)(void* comm, void* mhandle);
+	// Asynchronous send to a peer.
+	// May return request == NULL if the call cannot be performed (or would block)
+	ncclResult_t (*isend)(void* sendComm, void* data, int size, void* mhandle, void** request);
+	// Asynchronous recv from a peer.
+	// May return request == NULL if the call cannot be performed (or would block)
+	ncclResult_t (*irecv)(void* recvComm, void* data, int size, void* mhandle, void** request);
+	// Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+	// visible to the GPU
+	ncclResult_t (*iflush)(void* recvComm, void* data, int size, void* mhandle, void** request);
+	// Test whether a request is complete. If size is not NULL, it returns the
+	// number of bytes sent/received.
+	ncclResult_t (*test)(void* request, int* done, int* size);
+	// Close and free send/recv comm objects
+	ncclResult_t (*closeSend)(void* sendComm);
+	ncclResult_t (*closeRecv)(void* recvComm);
+	ncclResult_t (*closeListen)(void* listenComm);
+} ncclNet_v4_t;
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_HEADERS_NEURON_NET_V4_H

--- a/include/nccl-headers/neuron/net_v5.h
+++ b/include/nccl-headers/neuron/net_v5.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_NET_V5_H_
+#define NCCL_NET_V5_H_
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  size_t max_write_inline_size;       // Maximum size of buffer supported to be transfered via write inline RMA operation
+  size_t max_mr_key_size;          // Maximum size of the memory region remote access key in bytes
+  int rma_supported;              // Indicator whether RMA operations of NCCL Net API are supported
+} ncclNetProperties_v5_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v5_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  ncclResult_t (*connect)(int dev, void* handle, void** sendComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  ncclResult_t (*accept)(void* listenComm, void** recvComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, int size, int tag, void* mhandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, int* sizes, int* tags, void** mhandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Return remote protection key associated with memory registration of handle
+  // Function is only available if `rma_supported` flag is set in
+  // ncclNetProperties_v5_t properties.
+  ncclResult_t (*getMrKey)(void* mhandle, uint64_t* mr_key);
+  // Asynchronous RMA write to peer memory.
+  // May return request == NULL if the call cannot be performed.
+  // Function is only available if `rma_supported` flag is set in
+  // ncclNetProperties_v5_t properties.
+  ncclResult_t (*iwrite)(void* sComm, void* src, size_t size, void* src_mhandle,
+			 uint64_t dest, uint64_t mr_key, void** request);
+  // Asynchronous RMA write operation to peer memory.
+  // Maximum message size is defined by `max_write_inline_size` field in
+  // ncclNetProperties_v5_t properties.
+  // Message may be inlined.
+  // May return request == NULL if the call cannot be performed.
+  // Function is only available if `rma_supported` flag is set in properties.
+  ncclResult_t (*iwriteInline)(void* sComm, void* src, size_t size,
+			       uint64_t dest, uint64_t mr_key, void** request);
+  // Asynchronous RMA read to peer memory.
+  // May return request == NULL if the call cannot be performed.
+  // Function is only available if `rma_supported` flag is set in
+  // ncclNetProperties_v5_t properties
+  ncclResult_t (*iread)(void* rComm, void* dest, size_t size, void* dest_mhandle,
+			uint64_t src, uint64_t mr_key, void** request);
+} ncclNet_v5_t;
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
+
+#endif // end include guard

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -607,6 +607,16 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);
 
+/*
+ * @brief       Retrieve maximum size of inject RMA operations of ofi endpoint
+ *
+ * @return      0, on success
+ *              -FI_ENOPROTOOPT, in case option to retrieve size is not available
+ *              error, on others
+ */
+int get_inject_rma_size_opt(struct fid_ep *ofi_ep,
+			    size_t *max_write_inline_size);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -226,6 +226,13 @@ typedef struct nccl_ofi_properties {
 	unsigned int max_group_receives;
 	/** regMr is global if is not tied to a particular comm **/
 	int regIsGlobal;
+	/** Maximum size of buffer supported to be transfered via
+	 * RMA write inline operation **/
+	size_t max_write_inline_size;
+	/** Maximum size of the memory region remote access key in bytes **/
+	size_t max_mr_key_size;
+	/** Indicator whether RMA operations of NCCL Net API are supported **/
+	int rma_supported;
 } nccl_ofi_properties_t;
 
 /**
@@ -275,6 +282,9 @@ struct nccl_net_ofi_device {
 	 */
 	int (*get_ep)(nccl_net_ofi_device_t *base_dev,
 			       nccl_net_ofi_ep_t **ep);
+
+	int (*get_mr_key)(nccl_net_ofi_device_t *base_dev, void* mhandle,
+			  uint64_t* mr_key);
 
 	/**
 	 * destructor - releases resources associated with device
@@ -412,6 +422,11 @@ struct nccl_net_ofi_send_comm {
 			     nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **req);
 
 	int (*close)(nccl_net_ofi_send_comm_t *send_comm);
+
+	int (*write)(nccl_net_ofi_send_comm_t *send_comm, void* src, size_t size, void* src_mhandle,
+		     uint64_t dest, uint64_t mr_key, nccl_net_ofi_req_t **req);
+	int (*write_inline)(nccl_net_ofi_send_comm_t *, void* src, size_t size,
+			    uint64_t dest, uint64_t mr_key, nccl_net_ofi_req_t **request);
 };
 
 struct nccl_net_ofi_recv_comm {
@@ -453,6 +468,9 @@ struct nccl_net_ofi_recv_comm {
 			      nccl_net_ofi_mr_handle_t **mhandles, nccl_net_ofi_req_t **req);
 
 	int (*close)(nccl_net_ofi_recv_comm_t *recv_comm);
+
+	int (*read)(nccl_net_ofi_recv_comm_t *recv_comm, void* dest, size_t size, void* dest_mhandle,
+		    uint64_t src, uint64_t mr_key, nccl_net_ofi_req_t **req);
 };
 
 /**

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -42,6 +42,13 @@ ncclResult_t nccl_net_ofi_iflush_v4(void* recvComm, void* data, int size, void* 
 ncclResult_t nccl_net_ofi_closeSend(void *sendComm);
 ncclResult_t nccl_net_ofi_closeRecv(void *recvComm);
 ncclResult_t nccl_net_ofi_closeListen(void *listenComm);
+ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key);
+ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhandle,
+				 uint64_t dest, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
+					uint64_t dest, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_iread(void* rComm, void* dest, size_t size, void* mhandle,
+				uint64_t src, uint64_t mr_key, void** req);
 
 #ifdef __cplusplus
 }

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -60,6 +60,10 @@ typedef enum nccl_net_ofi_rdma_req_state {
 } nccl_net_ofi_rdma_req_state_t;
 
 typedef enum nccl_net_ofi_rdma_req_type {
+	/* Write request */
+	NCCL_OFI_RDMA_WRITE,
+	/* Read request */
+	NCCL_OFI_RDMA_READ,
 	/* Send request */
 	NCCL_OFI_RDMA_SEND,
 	/* Receive request */
@@ -220,6 +224,27 @@ typedef struct {
 } rdma_req_bounce_data_t;
 
 typedef struct {
+	/* Remote destination buffer address */
+	uint64_t remote_buff;
+	/* Remote MR key */
+	uint64_t remote_mr_key;
+	/* Number of rails where we have successfully posted the network xfer.
+	 * Used mostly when the network xfer is sliced across multiple rails */
+	uint64_t xferred_rail_id;
+	/* Application-provided local src/dst buffer */
+	void *buff;
+	/* Length of application-provided buffer */
+	size_t buff_len;
+	/* First rail descriptor from memory registration of `buff' */
+	void *desc;
+	/* Additional flags */
+	uint64_t flags;
+	/* Total number of completions. Expect one completion for receiving the
+	 * control message and one completion for each send segment. */
+	int total_num_compls;
+} rdma_req_rma_op_data_t;
+
+typedef struct {
 	/* True for eager messages */
 	bool eager;
 	/* Remote destination buffer address */
@@ -355,6 +380,7 @@ typedef struct nccl_net_ofi_rdma_req {
 	int ncompls;
 
 	union {
+		rdma_req_rma_op_data_t rma_op_data;
 		rdma_req_send_data_t send_data;
 		rdma_req_recv_data_t recv_data;
 		rdma_req_send_ctrl_data_t send_ctrl_data;

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -103,6 +103,16 @@
 	NCCL_OFI_TRACE_FLUSH_NVTX(request, nccl_req); \
 } while(0)
 
+#define NCCL_OFI_TRACE_READ(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Read, request, nccl_req); \
+	NCCL_OFI_TRACE_READ_NVTX(request, nccl_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_WRITE(request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Write, request, nccl_req); \
+	NCCL_OFI_TRACE_WRITE_NVTX(request, nccl_req); \
+} while(0)
+
 #define NCCL_OFI_TRACE_PENDING_INSERT(request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Pending_queue_insert, request); \
 	NCCL_OFI_TRACE_PENDING_INSERT_NVTX(request); \

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -234,6 +234,32 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Read,
+    LTTNG_UST_TP_ARGS(
+            void *, request,
+            void *, nccl_req
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Write,
+    LTTNG_UST_TP_ARGS(
+            void *, request,
+            void *, nccl_req
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+    )
+)
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -186,6 +186,14 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	nvtx_mark_domain(NULL, "Flush", 0xA52A2A); \
 } while(0)
 
+#define NCCL_OFI_TRACE_READ_NVTX(request, nccl_req) do { \
+	nvtx_mark_domain(NULL, "Read", 0xff00ff); \
+} while(0)
+
+#define NCCL_OFI_TRACE_WRITE_NVTX(request, nccl_req) do { \
+	nvtx_mark_domain(NULL, "Write", 0xff00ff); \
+} while(0)
+
 #define NCCL_OFI_TRACE_PENDING_INSERT_NVTX(request) do { \
 	nvtx_mark_domain(NULL, "Pending_insert", 0xFF8C00); \
 } while(0)
@@ -210,6 +218,8 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 #define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(...)
 #define NCCL_OFI_TRACE_EAGER_RECV_NVTX(...)
 #define NCCL_OFI_TRACE_FLUSH_NVTX(...)
+#define NCCL_OFI_TRACE_READ_NVTX(...)
+#define NCCL_OFI_TRACE_WRITE_NVTX(...)
 #define NCCL_OFI_TRACE_PENDING_INSERT_NVTX(...)
 #define NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(...)
 

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -56,7 +56,8 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
                   FI_OPT_EFA_SENDRECV_IN_ORDER_ALIGNED_128_BYTES,
                   FI_OPT_EFA_WRITE_IN_ORDER_ALIGNED_128_BYTES,
                   FI_OPT_MAX_MSG_SIZE,
-                  FI_OPT_SHARED_MEMORY_PERMITTED],
+                  FI_OPT_SHARED_MEMORY_PERMITTED,
+		  FI_OPT_INJECT_RMA_SIZE],
                   [], [], [AC_INCLUDES_DEFAULT
 [#include <rdma/fi_endpoint.h>
 #ifdef HAVE_RDMA_FI_EXT_H

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -508,6 +508,116 @@ ncclResult_t nccl_net_ofi_isend(void *sComm, void* data, int size,
 	return nccl_net_ofi_retval_translate(ret);
 }
 
+ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhandle,
+				 uint64_t dest, uint64_t mr_key, void** req)
+{
+	nccl_net_ofi_send_comm_t *send_comm =
+		(nccl_net_ofi_send_comm_t *)sComm;
+	nccl_net_ofi_req_t **base_req = (nccl_net_ofi_req_t **)req;
+
+	/* Validate send_comm */
+	if (OFI_UNLIKELY(send_comm == NULL)) {
+		NCCL_OFI_WARN("Invalid communicator object provided");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(send_comm->write == NULL)) {
+		NCCL_OFI_WARN("Protocol does not support iwrite API function");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(base_req == NULL)) {
+		NCCL_OFI_WARN("Invalid request provided");
+		return ncclInternalError;
+	}
+
+	int ret = send_comm->write(send_comm, src, size, mhandle, dest, mr_key, base_req);
+	return nccl_net_ofi_retval_translate(ret);
+}
+
+ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
+				      uint64_t dest, uint64_t mr_key, void** req)
+{
+	nccl_net_ofi_send_comm_t *send_comm =
+		(nccl_net_ofi_send_comm_t *)sComm;
+	nccl_net_ofi_req_t **base_req = (nccl_net_ofi_req_t **)req;
+
+	/* Validate send_comm */
+	if (OFI_UNLIKELY(send_comm == NULL)) {
+		NCCL_OFI_WARN("Invalid communicator object provided");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(send_comm->write_inline == NULL)) {
+		NCCL_OFI_WARN("Protocol does not support iwriteInline API function");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(base_req == NULL)) {
+		NCCL_OFI_WARN("Invalid request provided");
+		return ncclInternalError;
+	}
+
+	int ret = send_comm->write_inline(send_comm, src, size, dest, mr_key, base_req);
+	return nccl_net_ofi_retval_translate(ret);
+}
+
+ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key)
+{
+	int ret = 0;
+	nccl_net_ofi_device_t *device = NULL;
+
+	/* Validate plugin */
+	if (OFI_UNLIKELY(plugin == NULL)) {
+		NCCL_OFI_WARN("Error accessing plugin. Plugin has not been initialized yet.");
+		return ncclInvalidArgument;
+	}
+
+	if (OFI_UNLIKELY(plugin->p_num_devs == 0)) {
+		return ncclInvalidArgument;
+	}
+
+	device = plugin->get_device(plugin, 0);
+	if (OFI_UNLIKELY(device == NULL)) {
+		NCCL_OFI_WARN("Error accessing device %i.", 0);
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(device->get_mr_key == NULL)) {
+		NCCL_OFI_WARN("Protocol does not support getMrKey API function");
+		return ncclInternalError;
+	}
+
+	ret = device->get_mr_key(device, mhandle, mr_key);
+	return nccl_net_ofi_retval_translate(ret);
+}
+
+ncclResult_t nccl_net_ofi_iread(void* rComm, void* dest, size_t size, void* mhandle,
+				uint64_t src, uint64_t mr_key, void** req)
+{
+	nccl_net_ofi_recv_comm_t *recv_comm =
+		(nccl_net_ofi_recv_comm_t *)rComm;
+	nccl_net_ofi_req_t **base_req = (nccl_net_ofi_req_t **)req;
+
+	/* Validate recv_comm */
+	if (OFI_UNLIKELY(recv_comm == NULL)) {
+		NCCL_OFI_WARN("Invalid communicator object provided");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(recv_comm->read == NULL)) {
+		NCCL_OFI_WARN("Protocol does not support iread API function");
+		return ncclInternalError;
+	}
+
+	if (OFI_UNLIKELY(base_req == NULL)) {
+		NCCL_OFI_WARN("Invalid request provided");
+		return ncclInternalError;
+	}
+
+	int ret = recv_comm->read(recv_comm, dest, size, mhandle, src, mr_key, base_req);
+	return nccl_net_ofi_retval_translate(ret);
+}
 
 ncclResult_t nccl_net_ofi_isend_v4(void* sendComm, void* data, int size,
 			  void* mhandle, void** request)

--- a/src/nccl_ofi_interface_neuron.c
+++ b/src/nccl_ofi_interface_neuron.c
@@ -22,6 +22,91 @@ static ncclResult_t init_v4(ncclDebugLogger_t logFunction)
 	return nccl_net_ofi_init(logFunction);
 }
 
+static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v5_t* props)
+{
+	nccl_ofi_properties_t ofi_properties;
+	ncclResult_t ret = nccl_net_ofi_get_properties(dev_id, &ofi_properties);
+	if (ret != ncclSuccess) {
+		return ret;
+	}
+
+	props->name = ofi_properties.name;
+	props->pciPath = ofi_properties.pci_path;
+	props->guid = ofi_properties.guid;
+	props->ptrSupport = NCCL_PTR_HOST;
+	if (ofi_properties.hmem_support) {
+		props->ptrSupport |= NCCL_PTR_NEURON;
+	}
+
+	/**
+	 * When net-plugin returns regIsGlobal=1 to NCCL (As part of
+	 * net-plugin getProperties() API), it signals to NCCL that
+	 * registered MRs are global, in the sense that they can be
+	 * used by all communicators. In addition, it also signals to
+	 * NCCL that the net-plugin have a fast MR cache such that
+	 * calling regMr() on same buffer (address and size), will
+	 * quickly return a previously globally registered MR on same
+	 * buffer.
+	 *
+	 * When user registers a buffer with NCCL by using
+	 * ncclCommRegister() API, if net-plugin supports
+	 * regIsGlobal=1, NCCL will register the buffer globally once
+	 * (On each net device) with regMr() API. When the net
+	 * proxy-thread starts to execute a communication task on a
+	 * previously registered user buffer, it will call the
+	 * net-plugin regMr() to quickly fetch the previously globally
+	 * registered MR from the plugin managed MR cache.
+	 */
+	props->regIsGlobal = ofi_properties.regIsGlobal;
+
+	props->speed = ofi_properties.port_speed;
+	props->port = ofi_properties.port_number;
+	props->latency = ofi_properties.latency;
+	props->maxComms = ofi_properties.max_communicators;
+	props->maxRecvs = ofi_properties.max_group_receives;
+
+	props->max_write_inline_size = ofi_properties.max_write_inline_size;
+	props->max_mr_key_size = ofi_properties.max_mr_key_size;
+	props->rma_supported = ofi_properties.rma_supported;
+
+	return ret;
+}
+
+static ncclResult_t connect_v5(int dev, void* handle, void** sendComm)
+{
+	return nccl_net_ofi_connect(dev, handle, sendComm);
+}
+
+
+static ncclResult_t accept_v5(void* listenComm, void** recvComm)
+{
+	return nccl_net_ofi_accept(listenComm, recvComm);
+}
+
+NCCL_OFI_EXPORT_SYMBOL const ncclNet_v5_t ncclNetPlugin_v5 = {
+        .name = "AWS Libfabric",
+        .init = nccl_net_ofi_init,
+        .devices = nccl_net_ofi_devices,
+        .getProperties = getProperties_v5,
+        .listen = nccl_net_ofi_listen,
+        .connect = connect_v5,
+        .accept = accept_v5,
+        .regMr = nccl_net_ofi_regMr,
+        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
+        .deregMr = nccl_net_ofi_deregMr,
+        .isend = nccl_net_ofi_isend,
+        .irecv = nccl_net_ofi_irecv,
+        .iflush = nccl_net_ofi_iflush,
+        .test = nccl_net_ofi_test,
+        .closeSend = nccl_net_ofi_closeSend,
+        .closeRecv = nccl_net_ofi_closeRecv,
+        .closeListen = nccl_net_ofi_closeListen,
+	.getMrKey = nccl_net_ofi_get_mr_key,
+	.iwrite = nccl_net_ofi_iwrite,
+	.iwriteInline = nccl_net_ofi_iwrite_inline,
+	.iread = nccl_net_ofi_iread,
+};
+
 static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
 {
 	nccl_ofi_properties_t ofi_properties;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -476,6 +476,8 @@ int nccl_net_ofi_info_properties(struct fi_info *nic_prov, int dev_id, int num_d
 #endif
 	}
 
+	props->rma_supported = 0;
+
 	goto exit;
 error:
 	if (props->pci_path) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3931,6 +3931,8 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	r_comm->base.recv = recv;
 	r_comm->base.flush = flush;
 	r_comm->base.close = recv_close_deferred;
+	r_comm->base.read = NULL;
+
 	r_comm->comm_active = true;
 	r_comm->send_close_req = NULL;
 	memset(&r_comm->cleanup_list_elem, 0, sizeof(r_comm->cleanup_list_elem));
@@ -5487,6 +5489,9 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->base.deregMr = dereg_mr_send_comm;
 	ret_s_comm->base.send = send;
 	ret_s_comm->base.close = send_close_deferred;
+	ret_s_comm->base.write = NULL;
+	ret_s_comm->base.write_inline = NULL;
+
 	ret_s_comm->comm_active = true;
 	ret_s_comm->next_msg_seq_num = 0;
 	memset(&ret_s_comm->cleanup_list_elem, 0, sizeof(ret_s_comm->cleanup_list_elem));
@@ -6503,6 +6508,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	device->base.get_properties = get_properties;
 	device->base.get_ep = get_ep;
 	device->base.release = nccl_net_ofi_rdma_device_release;
+	device->base.get_mr_key = NULL;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4082,6 +4082,8 @@ static int rma_read(nccl_net_ofi_recv_comm_t *recv_comm, void* dest, size_t size
 	 */
 	(r_comm->num_inflight_reqs)++;
 
+	NCCL_OFI_TRACE_READ(req, base_req);
+
 	/* Try posting RMA read */
 
 	ret = receive_progress(req, true);
@@ -5790,6 +5792,8 @@ static int rma_write_impl(nccl_net_ofi_send_comm_t *send_comm, void* src, size_t
 	 */
 	(s_comm->num_inflight_reqs)++;
 
+	NCCL_OFI_TRACE_WRITE(req, base_req);
+
 	/* Try posting RMA write with write_inline interface */
 
 	ret = send_progress(req);
@@ -5800,6 +5804,7 @@ static int rma_write_impl(nccl_net_ofi_send_comm_t *send_comm, void* src, size_t
 			NCCL_OFI_WARN("Failed to nccl_ofi_deque_insert_back: %d", ret);
 			goto error;
 		}
+		NCCL_OFI_TRACE_PENDING_INSERT(req);
 	} else if (OFI_UNLIKELY(ret != 0)) {
 		ret = -ENOTSUP;
 		goto error;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1312,6 +1312,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 	r_comm->base.recv = recv;
 	r_comm->base.flush = flush;
 	r_comm->base.close = recv_close;
+	r_comm->base.read = NULL;
 	r_comm->tag = l_comm->tag;
 	r_comm->local_ep = l_comm->local_ep;
 	r_comm->local_ep_addr = l_comm->local_ep_addr;
@@ -1885,6 +1886,8 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->base.deregMr = dereg_mr_send_comm;
 	ret_s_comm->base.send = send;
 	ret_s_comm->base.close = send_close;
+	ret_s_comm->base.write = NULL;
+	ret_s_comm->base.write_inline = NULL;
 	ret_s_comm->tag = tag;
 	ret_s_comm->local_ep = ep->ofi_ep;
 	ret_s_comm->remote_ep = remote_addr;
@@ -2411,6 +2414,7 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 	device->base.get_properties = get_properties;
 	device->base.get_ep = get_ep;
 	device->base.release = nccl_net_ofi_sendrecv_device_release;
+	device->base.get_mr_key = NULL;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -53,6 +53,9 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 		props->max_communicators = NCCL_OFI_MIN(device->max_tag, INT_MAX);
 	}
 
+	props->rma_supported = 0;
+	props->max_write_inline_size = info->tx_attr->inject_size;
+
 	/**
 	 * TODO:
 	 * The SENDRECV protocol currently does not correctly handle the truncated


### PR DESCRIPTION
This PR contains three commits.

#### net.h: Move plugin v4 neuron API into separate file
Refactoring commit only. Move plugin v4 neuron API into separate file. This follows apprach taken for nvidia APIs.

#### Add v5 neuron API as replication of v8 NVIDIA API
Provide functionality of v8 NVIDIA API to neuron by introducing v5 neuron API with v8 NVIDA API functionality such as nonblocking connection establishment.

#### api: Add neuron v6 plugin API providing RMA operations
Add neuron v6 plugin API that extends v5 API with RMA operations `iwrite`, `iread`, and `iwrite_data`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
