### PR TITLE
Separate endpoint for control messages

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -238,10 +238,6 @@ typedef struct {
 typedef struct {
 	/* Pointer to the allocated control buffer from freelist */
 	nccl_net_ofi_rdma_ctrl_fl_item_t *ctrl_fl_item;
-	/* Schedule used to transfer the control buffer. We save the
-	 * pointer to reference it when transferring the buffer over
-	 * network. */
-	nccl_net_ofi_schedule_t *ctrl_schedule;
 	/* Pointer to recv parent request */
 	nccl_net_ofi_rdma_req_t *recv_req;
 #if HAVE_NVTX_TRACING

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -111,6 +111,8 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  * allocate a rdma memory registration handle with `num_rails' rails.
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
+	struct fid_mr *control_mr;
+
 	int num_rails;
 
 	/* Array of size `num_rails' */
@@ -394,13 +396,15 @@ typedef struct nccl_ofi_rdma_connection_info {
 	 * on the receiver side */
 	uint32_t remote_comm_id;
 
+	nccl_ofi_rdma_ep_name_t control_ep_name;
+
 	/* Array of `MAX_NUM_RAILS` `nccl_ofi_rdma_ep_name_t`
 	 * structs. The member `num_rails` indicates the number of
 	 * entries that are in use. */
 	nccl_ofi_rdma_ep_name_t ep_names[MAX_NUM_RAILS];
 } nccl_ofi_rdma_connection_info_t;
 /* Since this is a message on the wire, check that it has the expected size */
-_Static_assert(sizeof(nccl_ofi_rdma_connection_info_t) == 272,
+_Static_assert(sizeof(nccl_ofi_rdma_connection_info_t) == 336,
 	       "Wrong size for RDMA connect message");
 
 /*
@@ -451,6 +455,8 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	uint16_t next_msg_seq_num;
 
 	nccl_ofi_msgbuff_t *msgbuff;
+
+	nccl_net_ofi_rdma_send_comm_rail_t control_rail;
 
 	/* Number of rails */
 	int num_rails;
@@ -534,6 +540,7 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 #if HAVE_NVTX_TRACING
 	nvtxDomainHandle_t nvtx_domain[NCCL_OFI_N_NVTX_DOMAIN_PER_COMM];
 #endif
+	nccl_net_ofi_rdma_recv_comm_rail_t control_rail;
 
 	/* Number of rails */
 	int num_rails;
@@ -625,6 +632,8 @@ struct nccl_net_ofi_rdma_ep {
 	 * struct. This allows casting between pointers of this struct
 	 * and its base struct. */
 	nccl_net_ofi_ep_t base;
+
+	nccl_net_ofi_ep_rail_t control_rail;
 
 	/* Number of rails */
 	int num_rails;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1677,6 +1677,11 @@ static int ofi_process_cq(nccl_net_ofi_rdma_ep_t *ep)
 		}
 	}
 
+	ret = ofi_process_cq_rail(ep, &ep->control_rail);
+	if (ret != 0) {
+		goto exit;
+	}
+
 	/* Process any pending requests */
 	ret = process_pending_reqs(ep);
 	if (OFI_UNLIKELY(ret != 0 && ret != -FI_EAGAIN)) {
@@ -2012,6 +2017,12 @@ static inline int post_bounce_buffs(nccl_net_ofi_rdma_ep_t *ep)
 		}
 	}
 
+	ret = post_bounce_buffs_on_rail(ep, &ep->control_rail);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed call to post_bounce_buffs_on_rail(control_rail)");
+		goto exit;
+	}
+
 exit:
 	return ret;
 }
@@ -2304,14 +2315,23 @@ static int prepare_recv_conn_req(nccl_net_ofi_rdma_listen_comm_t *l_comm)
  */
 static int dereg_rails(nccl_net_ofi_rdma_mr_handle_t *handle)
 {
-	/* Cleanup memory registration */
 	int ret = 0;
+	int rc = 0;
 	int num_rails = handle->num_rails;
 
+	/* Cleanup memory registration for control */
+	rc = fi_close(&handle->control_mr->fid);
+	if (OFI_UNLIKELY(rc != 0)) {
+		NCCL_OFI_WARN("Unable to de-register memory on control mr. RC: %d, Error: %s",
+			      rc, fi_strerror(-rc));
+		ret = rc;
+	}
+
+	/* Cleanup memory registration for data rails */
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
 		/* No memory registration available for this rail */
 		if (!handle->mr[rail_id]) continue;
-		int rc = fi_close(&handle->mr[rail_id]->fid);
+		rc = fi_close(&handle->mr[rail_id]->fid);
 		if (OFI_UNLIKELY(rc != 0)) {
 			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
 				      rc, fi_strerror(-rc));
@@ -2361,7 +2381,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		return -EINVAL;
 	}
 
-	if (OFI_UNLIKELY(mr_handle->num_rails < 1)) {
+	if (OFI_UNLIKELY(mr_handle->num_rails < 0)) {
 		NCCL_OFI_WARN("Unexpected number of rails in rdma memory registration handle");
 		return -EINVAL;
 	}
@@ -2439,6 +2459,15 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not set registration request attributes, dev: %d",
 			dev_id);
+		free(ret_handle);
+		ret_handle = NULL;
+		goto exit;
+	}
+
+	ret = register_rail_mr_buffer(get_device_rail(device, 0)->domain, ep->control_rail.ofi_ep,
+				      -1, type, &mr_attr,
+				      &ret_handle->control_mr);
+	if (OFI_UNLIKELY(ret != 0)) {
 		free(ret_handle);
 		ret_handle = NULL;
 		goto exit;
@@ -2743,7 +2772,8 @@ cleanup:
 }
 
 /**
- * @brief	Allocate a new send ctrl req from freelist
+ * @brief	Allocate a new control message that the receiver will
+ *		send to the sender describing the recv buffer.
  */
 static inline int insert_send_ctrl_req(
 				nccl_net_ofi_rdma_recv_comm_t *r_comm,
@@ -3481,7 +3511,8 @@ static inline nccl_net_ofi_rdma_recv_comm_t *calloc_rdma_recv_comm(int num_rails
  * @return	Receive communicator object, on success
  * 		NULL, on error
  */
-static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device_t *device,
+static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen_comm_t *l_comm,
+							nccl_net_ofi_rdma_device_t *device,
 							nccl_net_ofi_rdma_ep_t *l_comm_ep,
 							nccl_ofi_rdma_connection_info_t *conn_msg)
 {
@@ -3577,6 +3608,25 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 
 	/* Add ourselves to ep's lookup array */
 	set_comm(device, r_comm->local_comm_id, &r_comm->base.base);
+
+	r_comm->control_rail.local_ep = ep->control_rail.ofi_ep;;
+	ret = fi_av_insert(ep->control_rail.av, (void *)conn_msg->control_ep_name.ep_name, 1,
+			   &r_comm->control_rail.remote_addr, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert remote address into address vector "
+			      "for device %d. RC: %d",
+			      dev_id, fi_strerror(-ret));
+		goto error;
+	}
+
+	ret = fi_av_insert(ep->control_rail.av, (void *)ep->control_rail.local_ep_name, 1,
+			   &r_comm->control_rail.local_addr, 0, NULL);
+	if (OFI_UNLIKELY(ret != 1)) {
+		NCCL_OFI_WARN("Unable to insert local address into address vector "
+			      "for device %d. RC: %d",
+			      dev_id, fi_strerror(-ret));
+		goto error;
+	}
 
 	/* Allocate array of communicator rails */
 	r_comm->num_rails = num_rails;
@@ -3750,7 +3800,7 @@ static int post_send_conn_resp(nccl_net_ofi_rdma_recv_comm_t *r_comm,
 			       nccl_net_ofi_rdma_req_t *req)
 {
 	ssize_t rc = 0;
-	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = get_recv_comm_rail(r_comm, 0);
+	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = &r_comm->control_rail;;
 
 	req->state = NCCL_OFI_RDMA_REQ_PENDING;
 	rc = fi_send(comm_rail->local_ep, (void *)conn_resp, sizeof(nccl_ofi_rdma_connection_info_t), NULL,
@@ -3890,7 +3940,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		/* Prepare receive communicator object for the received peer connection */
-		r_comm = prepare_recv_comm(device, l_comm_ep, conn_msg);
+		r_comm = prepare_recv_comm(l_comm, device, l_comm_ep, conn_msg);
 		if (OFI_UNLIKELY(r_comm == NULL)) {
 			ret = -EINVAL;
 			goto exit;
@@ -4044,7 +4094,6 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	nccl_net_ofi_rdma_listen_comm_t *l_comm = NULL;
 	nccl_net_ofi_rdma_ep_t *ep =
 		(nccl_net_ofi_rdma_ep_t *)base_ep;
-	nccl_net_ofi_ep_rail_t *first_rail = get_rail(ep, 0);
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
@@ -4054,14 +4103,14 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 
 	/* Build handle */
 	memset(handle, 0, sizeof(nccl_net_ofi_conn_handle_t));
-	assert(sizeof(handle->ep_name) == sizeof(first_rail->local_ep_name));
-	memcpy(handle->ep_name, first_rail->local_ep_name,
-	       first_rail->local_ep_name_len);
+	assert(sizeof(handle->ep_name) == sizeof(ep->control_rail.local_ep_name));
+	memcpy(handle->ep_name, ep->control_rail.local_ep_name,
+	       ep->control_rail.local_ep_name_len);
 	/* We don't copy the size here since the handle doesn't have a size field.
 	   The size will be distributed later by the connect response message.
 	   Instead, zero the unused bytes here. */
-	memset(handle->ep_name + first_rail->local_ep_name_len, 0,
-		sizeof(handle->ep_name) - first_rail->local_ep_name_len);
+	memset(handle->ep_name + ep->control_rail.local_ep_name_len, 0,
+		sizeof(handle->ep_name) - ep->control_rail.local_ep_name_len);
 
 	/* Build listen_comm */
 	l_comm = (nccl_net_ofi_rdma_listen_comm_t *)calloc(1,
@@ -4078,7 +4127,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	l_comm->base.base.dev_id = dev_id;
 	l_comm->base.accept = accept;
 	l_comm->base.close = listen_close;
-	l_comm->leader_local_ep = first_rail->ofi_ep;
+	l_comm->leader_local_ep = ep->control_rail.ofi_ep;
 
 	/* Allocate listen communicator ID */
 	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
@@ -4383,11 +4432,9 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req_t *req)
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 	rdma_req_send_ctrl_data_t *send_ctrl_data = get_send_ctrl_data(req);
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
-	const int control_rail_id = 0;
 
 	// Get communicator rail information to xfer the req
-	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail;
-	comm_rail = get_recv_comm_rail(r_comm, control_rail_id);
+	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = &r_comm->control_rail;
 
 	nccl_net_ofi_rdma_ctrl_fl_item_t *ctrl_fl_item = send_ctrl_data->ctrl_fl_item;
 
@@ -4396,9 +4443,9 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req_t *req)
 		(freelist_regmr_fn_handle_t *)ctrl_fl_item->fl_reginfo.mr_handle;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = fl_handle->mr_handle;
 
-	void *desc = fi_mr_desc(mr_handle->mr[control_rail_id]);
+	void *desc = fi_mr_desc(mr_handle->control_mr);
 
-	NCCL_OFI_TRACE_SEND_CTRL_START(req->dev_id, xfer_info->rail_id, req->comm, req, req->msg_seq_num);
+	NCCL_OFI_TRACE_SEND_CTRL_START(req->dev_id, ep->control_rail.rail_id, req->comm, req, req->msg_seq_num);
 
 	size_t ctrl_msg_len = nccl_net_ofi_rdma_ctrl_msg_size(ep->num_rails, ep->use_long_rkeys);
 
@@ -4810,6 +4857,14 @@ static void prepare_send_connect_message(nccl_net_ofi_rdma_ep_t *ep, int dev_id,
 	/* Set number of rails to be sent back to remote for verification */
 	conn_msg->num_rails = num_rails;
 
+	/* Set libfabric endpoint name for control rail */
+	memcpy(conn_msg->control_ep_name.ep_name,
+	       ep->control_rail.local_ep_name,
+	       ep->control_rail.local_ep_name_len);
+	conn_msg->control_ep_name.ep_name_len =
+		ep->control_rail.local_ep_name_len;
+
+
 	/* Set libfabric endpoint names for each rail */
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
 		memcpy(conn_msg->ep_names[rail_id].ep_name,
@@ -4868,6 +4923,21 @@ static inline int init_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 		return ret;
 	}
 
+	/*
+	 * The *_bounce_posted limits are used in the progress engine to
+	 * determine if the receive queue is hydrated with sufficient buffers.
+	 * The parameters account for all the rails, so scale down bounds to
+	 * what a single rail would need for the control endpoint.
+	 */
+	ep->control_rail.min_bounce_posted = NCCL_OFI_DIV_CEIL(
+		ofi_nccl_rdma_min_posted_bounce_buffers(), ep->num_rails
+		);
+	ep->control_rail.max_bounce_posted = NCCL_OFI_DIV_CEIL(
+		ofi_nccl_rdma_max_posted_bounce_buffers(), ep->num_rails
+		);
+	ep->control_rail.num_bounce_posted = 0;
+	ret = nccl_net_ofi_mutex_init(&ep->control_rail.bounce_mutex, NULL);
+
 	for (int rail_id = 0; rail_id < ep->num_rails; ++rail_id) {
 		nccl_net_ofi_ep_rail_t *rail = get_rail(ep, rail_id);
 		rail->min_bounce_posted = NCCL_OFI_DIV_CEIL(
@@ -4911,6 +4981,8 @@ static inline int fini_bounce_buffers(nccl_net_ofi_rdma_ep_t *ep)
 		nccl_net_ofi_mutex_destroy(&rail->bounce_mutex);
 	}
 
+	nccl_net_ofi_mutex_destroy(&ep->control_rail.bounce_mutex);
+
 	return ret;
 }
 
@@ -4943,7 +5015,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	nccl_net_ofi_rdma_send_comm_t *ret_s_comm = NULL;
 	int num_rails = ep->num_rails;
 	int rail_id = 0;
-	nccl_net_ofi_ep_rail_t *first_rail = get_rail(ep, 0);
+	nccl_net_ofi_ep_rail_t *control_rail = &ep->control_rail;
 	*s_comm = NULL;
 
 	/* Retrieve and validate device */
@@ -4996,7 +5068,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->num_rails = num_rails;
 
 	/* Insert remote name into AV of first rail */
-	ret = fi_av_insert(first_rail->av,
+	ret = fi_av_insert(control_rail->av,
 			   (void *)handle->ep_name, 1,
 			   &remote_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
@@ -5007,11 +5079,11 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	}
 
 	/* Store remote address of first rail in communicator */
-	ret_s_comm->rails[0].remote_addr = remote_addr;
+	ret_s_comm->control_rail.remote_addr = remote_addr;
 
-	/* Store local libfabric endpoint of first rail */
-	ret_s_comm->rails[0].local_ep = first_rail->ofi_ep;
-	ret_s_comm->num_init_rails = 1;
+	/* Store local libfabric endpoint of control rail */
+	ret_s_comm->control_rail.local_ep = control_rail->ofi_ep;
+	ret_s_comm->num_init_rails = 0;
 
 	/* Allocate request free list */
 	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t), 16, 16,
@@ -5129,7 +5201,7 @@ static int post_send_conn(nccl_net_ofi_rdma_send_comm_t *s_comm,
 			      nccl_net_ofi_rdma_req_t *req)
 {
 	ssize_t rc = 0;
-	nccl_net_ofi_rdma_send_comm_rail_t *comm_rail = get_send_comm_rail(s_comm, 0);
+	nccl_net_ofi_rdma_send_comm_rail_t *comm_rail = &s_comm->control_rail;
 
 	/*
 	 * TODO: replace it with API of FI_INJECT type when most of
@@ -5351,6 +5423,7 @@ static void ep_rail_release(nccl_net_ofi_ep_rail_t *rail, int dev_id)
  */
 static void release_rdma_ep_resources(nccl_net_ofi_rdma_ep_t *ep, int dev_id)
 {
+	ep_rail_release(&ep->control_rail, dev_id);
 	for (int rail_id = 0; rail_id != ep->num_rails; ++rail_id) {
 		ep_rail_release(get_rail(ep, rail_id), dev_id);
 	}
@@ -5585,6 +5658,16 @@ static int create_ep(nccl_net_ofi_rdma_device_t *device,
 	}
 
 	ep->use_long_rkeys = device->use_long_rkeys;
+
+	/* we pass 0 as the railid for the control rail, so
+	 * that any lookups based on railid in the domain find
+	 * the right domain */
+	memset(&ep->control_rail, 0, sizeof(ep->control_rail));
+	ret = ep_rail_init(ep, device->base.dev_id, 0, &device->device_rails[0], &ep->control_rail);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Initializing control rail failed");
+		goto error;
+	}
 
 	ret = init_rail_ofi_resources(device, ep);
 	if (ret != 0) {


### PR DESCRIPTION
Rebased and reworked https://github.com/aws/aws-ofi-nccl/pull/321 on master.

The commits are largely the same with adaptations to recent changes around MR (with the addition of the cache) and fix for a bug that was causing an fi_av_insert() on the control QP's address to fail (as the conn message did not carry the correct address).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
