### PR TITLE
Expose each libfabric NIC as one NIC device to the user in case of non-NVIDIA platforms

### DIFF
--- a/include/nccl_ofi_topo.h
+++ b/include/nccl_ofi_topo.h
@@ -133,6 +133,8 @@ void nccl_ofi_topo_free(nccl_ofi_topo_t *topo);
  * 3. For each topology node with a libfabric NIC info list in its
  * user data, search towards the root for a node with 'num_groups' > 0.
  * If such a node has been found, move the list to that node.
+ * If no said node is found, keep list stored in original node and set
+ * `num_groups` to one.
  * 4. For each topology node with a libfabric NIC info list and 'num_groups > 0',
  * split the list into 'num_groups' sub-lists (groups) and add the
  * groups to the topology nodes corresponding to their leaders (first

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -763,8 +763,21 @@ static int lift_up_ofi_infos(nccl_ofi_topo_t *topo)
 			}
 			target_obj = target_obj->parent;
 			if (!target_obj) {
-				NCCL_OFI_WARN("Unable to attach NIC to accelerator.");
-				return -EINVAL;
+				/* No accelerator found to which the
+				 * info list can be assigned to, i.e.,
+				 * neither the source node, not any
+				 * ancestor has a group count larger
+				 * than `0`. This can have two
+				 * reasons; either the topology does
+				 * not contain a known accelerator at
+				 * all, or each accelerator has a NIC
+				 * that is closer to the accelerator
+				 * than NICs of the source node. We
+				 * still want to expose those NICs,
+				 * and thus, expose each NIC as one
+				 * group. */
+				source_data->num_groups = source_data->info_list_len;
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
## This patch exposes each libfabric NIC as one NIC device to the user in case of non-NVIDIA platforms

Before, plugin would group NICs around trainium device, or error our in case of accelerator is not a NVIDIA GPU or a trainium device. This patch is implemented by applying the following two changes:

#### RDMA: Expose each NIC as a device in case of unknown accelerator

The NIC grouping code for RDMA protocol groups NICs around
accelerators. To find the accelerators, the grouping code uses
hard-coded accelerator identifies. Supported hard-coded accelerators
are for NVIDIA GPUs and trainium devices.
In case of an unknown accelerator, the grouping code would fail and
error out.
This patch modifies the code such that each libfabric NIC is exposed
as one device to the user of the plugin in case of absense of known
accelerators around which a libfabric NIC can be grouped.

#### topo: Avoid grouping of multiple NICs to trainium accelerator

Since a TRN accelerator is composed of multiple cores, the number of
trainium accelerators does not necessarily reflect the number of NIC
devices that the RDMA protocol should expose to the user. Instead,
each core should have a NIC accessible for communication if that many
NICs are available.
The best approach, for now, is to remove trainium accelerators from
the list of accelerators around which NICs are grouped. Consequently,
each libfabric NIC is exposed as on NIC device to the user. This
provides trainium maximal freedom in routing data over NICs.

In the long run, a better solution might be to expose the number of
actual cores to the plugin and take that number into account while NIC
grouping.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
