### PR TITLE
ci: cache efa installer

### DIFF
--- a/.github/workflows/cache_efa_installer.yaml
+++ b/.github/workflows/cache_efa_installer.yaml
@@ -1,0 +1,22 @@
+name: Cache EFA Installer
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "20 4 * * *"
+
+jobs:
+  cache_efa_installer:
+    strategy:
+      matrix:
+        # fetch just the latest, and the oldest version that is known to work
+        # with current actions without requiring workarounds
+        version:
+          - latest
+          - 1.25.0
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -s -L https://efa-installer.amazonaws.com/aws-efa-installer-${{ matrix.version }}.tar.gz | tar xvz -
+      - uses: actions/cache@v3
+        with:
+          key: aws-efa-installer-${{ matrix.version }}
+          path: aws-efa-installer


### PR DESCRIPTION
*Description of changes:*

Once a day, download efa installer and store it in actions cache. Other actions can use this instead of downloading from network.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
