### PR TITLE
ci: fix efa installer caching

### DIFF
--- a/.github/workflows/cache_efa_installer.yaml
+++ b/.github/workflows/cache_efa_installer.yaml
@@ -15,8 +15,10 @@ jobs:
           - 1.25.0
     runs-on: ubuntu-latest
     steps:
-      - run: curl -s -L https://efa-installer.amazonaws.com/aws-efa-installer-${{ matrix.version }}.tar.gz | tar xvz -
-      - uses: actions/cache@v3
+      - run: curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${{ matrix.version }}.tar.gz 
+      - run: tar xvf ./aws-efa-installer*.tar.gz
+      - uses: actions/cache@v4
         with:
+          enableCrossOsArchive: true
           key: aws-efa-installer-${{ matrix.version }}
-          path: aws-efa-installer
+          path: aws-efa-installer/*


### PR DESCRIPTION
*Description of changes:*

Unfortunately, this couldn't be tested without introducing the action to the repo in the master branch so that the action appeared in the UI.  It was implemented with a script issue. This fixes that script issue, and can be tested before merging now that the initial action was introduced to the repository.

https://github.com/aws/aws-ofi-nccl/actions/runs/10604329005

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
