### PR TITLE
tuner: Enable tuner init msg on INFO logs

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -291,7 +291,7 @@ exit:
 	*context = (void *)nccl_ofi_tuner_ctx;
 	nccl_net_ofi_mutex_unlock(&nccl_ofi_tuner_ctx_lock);
 
-	NCCL_OFI_TRACE(NCCL_TUNING, "Tuner init: comm with %ld ranks and %ld nodes.", nRanks, nNodes);
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING, "Tuner init: comm with %ld ranks and %ld nodes.", nRanks, nNodes);
 	return ret;
 }
 


### PR DESCRIPTION
*Description of changes:*
Enable tuner initialization message to be displayed on all NCCL_DEBUG=INFO and display the logs as part of the default subsystem (INIT)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
