### PR TITLE
fix(rdma): endpont_per_comm: NULL ptr bug

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3578,6 +3578,8 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 
 			new_ep->thread_local_ep = false;
 
+			ep_for_addr = &new_ep->base;
+
 			ret = nccl_ofi_ep_addr_list_insert(device->ep_addr_list, ep_for_addr,
 				remote_rail0_ep_name->ep_name, remote_rail0_ep_name->ep_name_len);
 			if (ret != 0) {


### PR DESCRIPTION
A later revision of PR #438 introduced a NULL ptr bug in the `endpoint_per_comm = 1` code. Since this option isn't enabled by default, we weren't testing it.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
