### PR TITLE
fix(tree): use correct __cplusplus guards

### DIFF
--- a/include/nccl-headers/neuron/error.h
+++ b/include/nccl-headers/neuron/error.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_HEADERS_NEURON_ERROR_H_
 #define NCCL_HEADERS_NEURON_ERROR_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -21,7 +21,7 @@ typedef enum {
 	ncclRemoteError = 6
 } ncclResult_t;
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/nccl-headers/neuron/net.h
+++ b/include/nccl-headers/neuron/net.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_HEADERS_NEURON_NET_H_
 #define NCCL_HEADERS_NEURON_NET_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -100,7 +100,7 @@ typedef struct {
 	ncclResult_t (*closeListen)(void* listenComm);
 } ncclNet_v4_t;
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_H_
 #define NCCL_OFI_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -22,7 +23,6 @@ extern "C" {
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_mr.h"
-
 
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
@@ -590,7 +590,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -6,12 +6,13 @@
 #ifndef NET_OFI_API_H_
 #define NET_OFI_API_H_
 
-#include "nccl-headers/net.h"
-#include "nccl-headers/error.h"
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "nccl-headers/net.h"
+#include "nccl-headers/error.h"
 
 struct nccl_ofi_properties;
 
@@ -42,7 +43,7 @@ ncclResult_t nccl_net_ofi_closeSend(void *sendComm);
 ncclResult_t nccl_net_ofi_closeRecv(void *recvComm);
 ncclResult_t nccl_net_ofi_closeListen(void *listenComm);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif // End extern "C"
 

--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -6,7 +6,8 @@
 #ifndef NCCL_OFI_CUDA_H_
 #define NCCL_OFI_CUDA_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -41,7 +42,7 @@ extern CUresult (*nccl_net_ofi_cuFlushGPUDirectRDMAWrites)(CUflushGPUDirectRDMAW
 extern void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites;
 #endif
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_DEQUE_H
 #define NCCL_OFI_DEQUE_H
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -162,7 +163,7 @@ unlock:
 	return 0;
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_ep_addr_list.h
+++ b/include/nccl_ofi_ep_addr_list.h
@@ -5,6 +5,10 @@
 #ifndef NCCL_OFI_EP_ADDR_LIST_H
 #define NCCL_OFI_EP_ADDR_LIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct nccl_ofi_ep_addr_list;
 typedef struct nccl_ofi_ep_addr_list nccl_ofi_ep_addr_list_t;
 
@@ -75,5 +79,9 @@ int nccl_ofi_ep_addr_list_delete(nccl_ofi_ep_addr_list_t *ep_list, nccl_net_ofi_
  * @param ep_list list to destroy
  */
 void nccl_ofi_ep_addr_list_fini(nccl_ofi_ep_addr_list_t *ep_list);
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
 
 #endif

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_FREELIST_H
 #define NCCL_OFI_FREELIST_H
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -313,7 +314,7 @@ static inline void nccl_ofi_freelist_entry_free(nccl_ofi_freelist_t *freelist, v
 	nccl_net_ofi_mutex_unlock(&freelist->lock);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -5,12 +5,12 @@
 #ifndef NCCL_OFI_IDPOOL_H_
 #define NCCL_OFI_IDPOOL_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <pthread.h>
-
 #include <stdint.h>
 
 /*
@@ -87,7 +87,7 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id);
  */
 int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_log.h
+++ b/include/nccl_ofi_log.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_OFI_LOG_H_
 #define NCCL_OFI_LOG_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -33,7 +33,7 @@ extern ncclDebugLogger_t ofi_log_function;
 #define NCCL_OFI_TRACE(flags, fmt, ...)
 #endif
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MATH_H_
 #define NCCL_OFI_MATH_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -65,7 +65,7 @@ extern "C" {
  */
 #define NCCL_OFI_ROUND_UP(x, y) NCCL_OFI_ROUND_DOWN((x) + ((y) - 1), (y))
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_H
 #define NCCL_OFI_MEMCHECK_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -169,7 +169,7 @@ static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size
  */
 static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_asan.h
+++ b/include/nccl_ofi_memcheck_asan.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_ASAN_H
 #define NCCL_OFI_MEMCHECK_ASAN_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -56,7 +56,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 	nccl_net_ofi_mem_noaccess(data, size);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_nop.h
+++ b/include/nccl_ofi_memcheck_nop.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_NOP_H
 #define NCCL_OFI_MEMCHECK_NOP_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -44,7 +44,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 {
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_valgrind.h
+++ b/include/nccl_ofi_memcheck_valgrind.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_VALGRIND_H
 #define NCCL_OFI_MEMCHECK_VALGRIND_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -48,7 +48,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 	VALGRIND_MEMPOOL_FREE(handle, data);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MR_H_
 #define NCCL_OFI_MR_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -80,7 +80,7 @@ int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
  */
 int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }  // End extern "C"
 #endif
 

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -5,12 +5,11 @@
 #ifndef NCCL_OFI_MSGBUFF_H_
 #define NCCL_OFI_MSGBUFF_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <pthread.h>
-
 #include <stdbool.h>
 #include <stdint.h>
 
@@ -183,7 +182,7 @@ nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
 nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
 		uint16_t msg_index, nccl_ofi_msgbuff_status_t *msg_idx_status);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_OFIUTILS_H
 #define NCCL_OFI_OFIUTILS_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -43,7 +43,7 @@ void nccl_ofi_ofiutils_free_info_list(struct fi_info *info_list);
 
 int nccl_ofi_mr_keys_need_own_key(struct fi_info* provider, bool *provide_own_mr_key);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PARAM_H_
 #define NCCL_OFI_PARAM_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -240,7 +240,7 @@ OFI_NCCL_PARAM_INT(errorcheck_mutex, "ERRORCHECK_MUTEX",
  */
 OFI_NCCL_PARAM_INT(endpoint_per_communicator, "ENDPOINT_PER_COMM", 0);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PLATFORM_H_
 #define NCCL_OFI_PLATFORM_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -34,5 +34,9 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribut
  * @param num_rails: number of rails
  */
 void platform_sort_rails(struct fi_info **info_list, int num_rails) __attribute__((weak));
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif // End NCCL_OFI_PLATFORM_H_

--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PTHREAD_H
 #define NCCL_OFI_PTHREAD_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -104,7 +104,7 @@ nccl_net_ofi_mutex_unlock_impl(pthread_mutex_t *mutex, const char *file, size_t 
 #define nccl_net_ofi_mutex_unlock(mutex) nccl_net_ofi_mutex_unlock_impl(mutex, __FILE__, __LINE__);
 
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_RDMA_H_
 #define NCCL_OFI_RDMA_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -761,7 +761,7 @@ typedef struct nccl_net_ofi_rdma_device {
 int nccl_net_ofi_rdma_init(const char *provider_filter,
 			   nccl_net_ofi_plugin_t **plugin_p);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_SCHEDULER_H_
 #define NCCL_OFI_SCHEDULER_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -134,7 +134,7 @@ void nccl_net_ofi_set_multiplexing_schedule(size_t size,
 					    size_t align,
 					    nccl_net_ofi_schedule_t *schedule);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_SENDRECV_H_
 #define NCCL_OFI_SENDRECV_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -226,7 +226,7 @@ typedef struct nccl_net_ofi_sendrecv_req {
 int nccl_net_ofi_sendrecv_init(const char *provider_filter,
 			       nccl_net_ofi_plugin_t **plugin_p);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_topo.h
+++ b/include/nccl_ofi_topo.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_NET_OFI_TOPO_H_
 #define NCCL_NET_OFI_TOPO_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -315,7 +315,7 @@ struct fi_info *nccl_ofi_topo_next_info_list(nccl_ofi_topo_data_iterator_t *iter
  */
 int nccl_ofi_topo_write_nccl_topology(nccl_ofi_topo_t *topo, FILE *file);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 


### PR DESCRIPTION
Stacked PRs:
 * #578
 * #568
 * #567
 * #566
 * #577
 * #576
 * #574
 * #575
 * #572
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * #560
 * #558
 * #557
 * #556
 * #555
 * __->__#554


--- --- ---

### fix(tree): use correct __cplusplus guards


the canonical token is __cplusplus not _cplusplus. When this is
incorrect, linkage fails as cxx will perform name mangling when
including these headers, resulting in a function with that mangle not
existing.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>