### PR TITLE
feat(tree): add static_assert shim macro

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -192,8 +192,7 @@ typedef struct nccl_ofi_connection_info {
 	nccl_net_ofi_req_t* req;
 } nccl_ofi_connection_info_t;
 /* Since this is a message on the wire, check that it has the expected size */
-_Static_assert(sizeof(nccl_ofi_connection_info_t) == 80,
-	       "Wrong size for SENDRECV connect message");
+static_assert(sizeof(nccl_ofi_connection_info_t) == 80, "Wrong size for SENDRECV connect message");
 
 typedef struct nccl_net_ofi_conn_handle {
 	char ep_name[MAX_EP_ADDR];

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -11,6 +11,10 @@
 
 #define NCCL_OFI_EXPORT_SYMBOL __attribute__((visibility("default")))
 
+#ifndef __cplusplus
+#define static_assert _Static_assert
+#endif
+
 /* Maximum length of directory path */
 #ifdef HAVE_LINUX_LIMITS_H
 #include <linux/limits.h>

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -95,9 +95,9 @@ struct nccl_ofi_freelist_reginfo_t {
 };
 typedef struct nccl_ofi_freelist_reginfo_t nccl_ofi_freelist_reginfo_t;
 
-_Static_assert(offsetof(nccl_ofi_freelist_reginfo_t, elem) == 0,
+static_assert(offsetof(nccl_ofi_freelist_reginfo_t, elem) == 0,
 	       "elem is not the first member of the structure nccl_ofi_freelist_reginfo_t");
-_Static_assert(sizeof(nccl_ofi_freelist_reginfo_t) - offsetof(nccl_ofi_freelist_reginfo_t, redzone) == MEMCHECK_REDZONE_SIZE,
+static_assert(sizeof(nccl_ofi_freelist_reginfo_t) - offsetof(nccl_ofi_freelist_reginfo_t, redzone) == MEMCHECK_REDZONE_SIZE,
 	       "redzone is not the last member of the structure nccl_ofi_freelist_reginfo_t");
 
 /*

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -29,7 +29,7 @@ extern "C" {
  * MEMCHECK_REDZONE_SIZE defines the size of redzones prefixing each
  * entry. Redzones are required to be a multiple of 8 due to ASAN
  * shadow-map granularity */
-_Static_assert(MEMCHECK_REDZONE_SIZE % MEMCHECK_GRANULARITY == 0,
+static_assert(MEMCHECK_REDZONE_SIZE % MEMCHECK_GRANULARITY == 0,
 	       "Size of redzone is not a multiple of ASAN shadow-map granularity");
 
 /**

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -95,8 +95,8 @@ enum nccl_ofi_rdma_msg_type {
 	NCCL_OFI_RDMA_MSG_MAX = NCCL_OFI_RDMA_MSG_INVALID,
 };
 
-_Static_assert(NCCL_OFI_RDMA_MSG_MAX <= (0x10),
-	       "Out of space in nccl_ofi_rdma_msg_type; must fit in a nibble");
+static_assert(NCCL_OFI_RDMA_MSG_MAX <= (0x10),
+			  "Out of space in nccl_ofi_rdma_msg_type; must fit in a nibble");
 
 /* This goes on the wire, so we want the datatype
  * size to be fixed.
@@ -142,9 +142,9 @@ typedef struct nccl_net_ofi_rdma_ctrl_msg {
 	};
 } nccl_net_ofi_rdma_ctrl_msg_t;
 /* Since this is a message on the wire, check that it has the expected size */
-_Static_assert(sizeof(nccl_net_ofi_rdma_ctrl_msg_t) == 48,
+static_assert(sizeof(nccl_net_ofi_rdma_ctrl_msg_t) == 48,
               "Wrong size for RDMA Control message");
-_Static_assert(offsetof(nccl_net_ofi_rdma_ctrl_msg_t, short_buff_mr_key) +
+static_assert(offsetof(nccl_net_ofi_rdma_ctrl_msg_t, short_buff_mr_key) +
 	       sizeof( ((nccl_net_ofi_rdma_ctrl_msg_t *)0)->short_buff_mr_key) <= 32,
 	       "Short RDMA Control message larger than 32 bytes (EFA inline size)");
 
@@ -404,8 +404,8 @@ typedef struct nccl_ofi_rdma_connection_info {
 	nccl_ofi_rdma_ep_name_t ep_names[MAX_NUM_RAILS];
 } nccl_ofi_rdma_connection_info_t;
 /* Since this is a message on the wire, check that it has the expected size */
-_Static_assert(sizeof(nccl_ofi_rdma_connection_info_t) == 336,
-	       "Wrong size for RDMA connect message");
+static_assert(sizeof(nccl_ofi_rdma_connection_info_t) == 336,
+			  "Wrong size for RDMA connect message");
 
 /*
  * @brief	Send communicator rail

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -9,11 +9,11 @@
 #include "nccl_ofi_api.h"
 
 
-_Static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
+static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
 	       "Size of OFI Handle is too large");
-_Static_assert(offsetof(nccl_net_ofi_conn_handle_t, state) <= NCCL_NET_HANDLE_MAXSIZE_V4,
+static_assert(offsetof(nccl_net_ofi_conn_handle_t, state) <= NCCL_NET_HANDLE_MAXSIZE_V4,
 	       "Size of OFI Handle (without state) is too large");
-_Static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
+static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
 	       "Maximum outstanding requests for plugin is less than what NCCL requires");
 
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -479,8 +479,8 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 	 * reails have the same speed. */
 	if (ret == 0) {
 		props->port_speed *= device->num_rails;
-		_Static_assert(NCCL_OFI_RDMA_COMM_ID_BITS < 31,
-			       "NCCL_OFI_RDMA_COMM_ID_BITS must be less than 31 so max_communicators fits in an integer");
+		static_assert(NCCL_OFI_RDMA_COMM_ID_BITS < 31,
+					  "NCCL_OFI_RDMA_COMM_ID_BITS must be less than 31 so max_communicators fits in an integer");
 		props->max_communicators = NCCL_OFI_RDMA_MAX_COMMS;
 	}
 	return ret;


### PR DESCRIPTION
Stacked PRs:
 * #578
 * #568
 * #567
 * #566
 * #577
 * #576
 * #574
 * #575
 * #572
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * #560
 * #558
 * #557
 * __->__#556


--- --- ---

### feat(tree): add static_assert shim macro


static_assert is a c++ keyword, so when not using c++, create a macro
under the same name that aliases _Static_assert to static_assert. This
means static_assert can be used in both cases.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>