### PR TITLE
fix(aws): align declaration and init order

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -95,16 +95,16 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	},
 	{
 		.name = "trn1n.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	}
 };


### PR DESCRIPTION
Stacked PRs:
 * #578
 * #582
 * #568
 * #567
 * #566
 * #577
 * #576
 * #574
 * #575
 * #572
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * #560
 * #558
 * __->__#557


--- --- ---

### fix(aws): align declaration and init order


When using designated initializer lists, under C++ only, a warning will
be emitted if the declaration order does not match the initialization
order if any fields are missing in the initializer list. Reorder these
structs to initialize all fields in their declaration order.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>