### PR TITLE
fix(rdma): fi_{send,write}data: do arithmetic on uintptr

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4288,7 +4288,7 @@ static int post_rdma_write(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post RDMA write */
-	rc = fi_writedata(comm_rail->local_ep, send_data->buff + xfer_info->offset,
+	rc = fi_writedata(comm_rail->local_ep, (void*)((uintptr_t)send_data->buff + xfer_info->offset),
 				xfer_info->msg_size, desc, send_data->wdata,
 				comm_rail->remote_addr,
 				send_data->remote_buff + xfer_info->offset,
@@ -4316,7 +4316,7 @@ static int post_rdma_eager_send(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post eager send */
-	rc = fi_senddata(comm_rail->local_ep, send_data->buff + xfer_info->offset, xfer_info->msg_size, desc,
+	rc = fi_senddata(comm_rail->local_ep, (void*)(((uintptr_t)send_data->buff) + xfer_info->offset), xfer_info->msg_size, desc,
 			 send_data->wdata, comm_rail->remote_addr, req);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {


### PR DESCRIPTION
Stacked PRs:
 * __->__#558


--- --- ---

### fix(rdma): fi_{send,write}data: do arithmetic on uintptr


void pointer arithmetic is illegal in c++; cast to uintptr, do the
offset, then cast to void* to pass to libfabric.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>