### PR TITLE
fix(freelist): use uintptr_t for pointer arithmetic

### DIFF
--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -207,20 +207,20 @@ static inline void nccl_ofi_freelist_entry_set_undefined(nccl_ofi_freelist_t *fr
 		size_t redzone_offset = offsetof(struct nccl_ofi_freelist_reginfo_t, redzone);
 
 		/* Entry after reginfo structure is accessible but undefined */
-		nccl_net_ofi_mem_undefined_unaligned(entry_p + reginfo_offset + reginfo_size,
+		nccl_net_ofi_mem_undefined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + reginfo_size),
 						     user_entry_size - reginfo_offset - reginfo_size);
 		/* Redzone at the end of the reginfo structure is
 		 * marked as not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset + redzone_offset,
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + redzone_offset),
 						    MEMCHECK_REDZONE_SIZE);
 		/* Members of reginfo structure except first and last
 		 * member are accessible and defined */
-		nccl_net_ofi_mem_defined_unaligned(entry_p + reginfo_offset + elem_size,
+		nccl_net_ofi_mem_defined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + elem_size),
 						   redzone_offset - elem_size);
 		/* First member of reginfo structure, i.e.,
 		 * nccl_ofi_freelist_elem_t structure, is marked as
 		 * not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset, elem_size);
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset), elem_size);
 		/* First part of entry until reginfo structure is
 		 * accessible but undefined */
 		nccl_net_ofi_mem_undefined(entry_p, reginfo_offset);

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -85,9 +85,9 @@ static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
  */
 static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_defined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_defined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -96,9 +96,9 @@ static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_undefined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_undefined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -107,9 +107,9 @@ static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_noaccess((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**


### PR DESCRIPTION
Stacked PRs:
 * #592
 * #578
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * __->__#560


--- --- ---

### fix(freelist): use uintptr_t for pointer arithmetic


Signed-off-by: Nicholas Sielicki <nslick@amazon.com>