### PR TITLE
nit: deque: avoid typedef hell

### DIFF
--- a/include/nccl-headers/neuron/error.h
+++ b/include/nccl-headers/neuron/error.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_HEADERS_NEURON_ERROR_H_
 #define NCCL_HEADERS_NEURON_ERROR_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -21,7 +21,7 @@ typedef enum {
 	ncclRemoteError = 6
 } ncclResult_t;
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/include/nccl-headers/neuron/net.h
+++ b/include/nccl-headers/neuron/net.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_HEADERS_NEURON_NET_H_
 #define NCCL_HEADERS_NEURON_NET_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -100,7 +100,7 @@ typedef struct {
 	ncclResult_t (*closeListen)(void* listenComm);
 } ncclNet_v4_t;
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -192,8 +192,7 @@ typedef struct nccl_ofi_connection_info {
 	nccl_net_ofi_req_t* req;
 } nccl_ofi_connection_info_t;
 /* Since this is a message on the wire, check that it has the expected size */
-_Static_assert(sizeof(nccl_ofi_connection_info_t) == 80,
-	       "Wrong size for SENDRECV connect message");
+static_assert(sizeof(nccl_ofi_connection_info_t) == 80, "Wrong size for SENDRECV connect message");
 
 typedef struct nccl_net_ofi_conn_handle {
 	char ep_name[MAX_EP_ADDR];

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_H_
 #define NCCL_OFI_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -22,7 +23,6 @@ extern "C" {
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_mr.h"
-
 
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
@@ -590,7 +590,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -6,12 +6,13 @@
 #ifndef NET_OFI_API_H_
 #define NET_OFI_API_H_
 
-#include "nccl-headers/net.h"
-#include "nccl-headers/error.h"
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
+
+#include "nccl-headers/net.h"
+#include "nccl-headers/error.h"
 
 struct nccl_ofi_properties;
 
@@ -42,7 +43,7 @@ ncclResult_t nccl_net_ofi_closeSend(void *sendComm);
 ncclResult_t nccl_net_ofi_closeRecv(void *recvComm);
 ncclResult_t nccl_net_ofi_closeListen(void *listenComm);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif // End extern "C"
 

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -9,7 +9,11 @@
 #define OFI_LIKELY(x)   __builtin_expect((x), 1)
 #define OFI_UNLIKELY(x) __builtin_expect((x), 0)
 
+#ifdef __cplusplus
+#define NCCL_OFI_EXPORT_SYMBOL __attribute__((visibility("default"))) [[maybe_unused]]
+#else
 #define NCCL_OFI_EXPORT_SYMBOL __attribute__((visibility("default")))
+#endif
 
 #ifndef __cplusplus
 #define static_assert _Static_assert

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -11,6 +11,10 @@
 
 #define NCCL_OFI_EXPORT_SYMBOL __attribute__((visibility("default")))
 
+#ifndef __cplusplus
+#define static_assert _Static_assert
+#endif
+
 /* Maximum length of directory path */
 #ifdef HAVE_LINUX_LIMITS_H
 #include <linux/limits.h>

--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -6,7 +6,8 @@
 #ifndef NCCL_OFI_CUDA_H_
 #define NCCL_OFI_CUDA_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -41,7 +42,7 @@ extern CUresult (*nccl_net_ofi_cuFlushGPUDirectRDMAWrites)(CUflushGPUDirectRDMAW
 extern void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites;
 #endif
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_DEQUE_H
 #define NCCL_OFI_DEQUE_H
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -162,7 +163,7 @@ unlock:
 	return 0;
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -23,13 +23,12 @@ extern "C" {
  * this structure as a black box. Critically, the caller must ensure the
  * contents of this structure are not modified while it is in the deque.
  */
-struct nccl_ofi_deque_elem_t {
+struct nccl_ofi_deque_elem {
 	/* Pointer to previous element */
-	struct nccl_ofi_deque_elem_t *prev;
+	struct nccl_ofi_deque_elem *prev;
 	/* Pointer to next element */
-	struct nccl_ofi_deque_elem_t *next;
+	struct nccl_ofi_deque_elem *next;
 };
-typedef struct nccl_ofi_deque_elem_t nccl_ofi_deque_elem_t;
 
 /*
  * Deque (doubly-ended queue) structure
@@ -37,7 +36,7 @@ typedef struct nccl_ofi_deque_elem_t nccl_ofi_deque_elem_t;
  * Core deque structure.  This should be considered opaque to users
  * of the deque interface
  */
-struct nccl_ofi_deque_t {
+struct nccl_ofi_deque {
 	/* "Head" of queue.
 	 * The queue is circular. An empty queue has only this element. In an empty
 	 * queue, head.prev and head.next point to head.
@@ -46,18 +45,17 @@ struct nccl_ofi_deque_t {
 	 * front. insert_back and insert_front add elements to these respective
 	 * locations.
 	 */
-	nccl_ofi_deque_elem_t head;
+	struct nccl_ofi_deque_elem head;
 	/* Lock for deque operations */
 	pthread_mutex_t lock;
 };
-typedef struct nccl_ofi_deque_t nccl_ofi_deque_t;
 
 /*
  * Initialize deque structure.
  *
  * @return zero on success, non-zero on non-success.
  */
-int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p);
+extern int nccl_ofi_deque_init(struct nccl_ofi_deque **deque_p);
 
 /*
  * Finalize a deque
@@ -66,7 +64,7 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p);
  *
  * @return zero on success, non-zero on non-success.
  */
-int nccl_ofi_deque_finalize(nccl_ofi_deque_t *deque);
+extern int nccl_ofi_deque_finalize(struct nccl_ofi_deque *deque);
 
 /*
  * Insert an element to the back of the deque
@@ -74,7 +72,7 @@ int nccl_ofi_deque_finalize(nccl_ofi_deque_t *deque);
  * @param deque_elem	user-allocated storage space for list entry
  * @return zero on success, non-zero on error
  */
-static inline int nccl_ofi_deque_insert_back(nccl_ofi_deque_t *deque, nccl_ofi_deque_elem_t *deque_elem)
+static inline int nccl_ofi_deque_insert_back(struct nccl_ofi_deque *deque, struct nccl_ofi_deque_elem *deque_elem)
 {
 	assert(deque);
 	assert(deque_elem);
@@ -99,7 +97,7 @@ static inline int nccl_ofi_deque_insert_back(nccl_ofi_deque_t *deque, nccl_ofi_d
  * @param deque_elem	user-allocated storage space for list entry
  * @return zero on success, non-zero on error
  */
-static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_deque_elem_t *deque_elem)
+static inline int nccl_ofi_deque_insert_front(struct nccl_ofi_deque *deque, struct nccl_ofi_deque_elem *deque_elem)
 {
 	assert(deque);
 	assert(deque_elem);
@@ -123,7 +121,7 @@ static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_
  *
  * @return true if empty, false if not
  */
-static inline bool nccl_ofi_deque_isempty(nccl_ofi_deque_t *deque)
+static inline bool nccl_ofi_deque_isempty(struct nccl_ofi_deque *deque)
 {
 	return deque->head.next == &deque->head;
 }
@@ -133,7 +131,7 @@ static inline bool nccl_ofi_deque_isempty(nccl_ofi_deque_t *deque)
  * @param deque_elem  returned element; NULL if deque is empty or an error occurred
  * @return zero on success, non-zero on non-success
  */
-static inline int nccl_ofi_deque_remove_front(nccl_ofi_deque_t *deque, nccl_ofi_deque_elem_t **deque_elem)
+static inline int nccl_ofi_deque_remove_front(struct nccl_ofi_deque *deque, struct nccl_ofi_deque_elem **deque_elem)
 {
 	assert(deque);
 	assert(deque_elem);
@@ -162,6 +160,9 @@ unlock:
 
 	return 0;
 }
+
+typedef struct nccl_ofi_deque_elem nccl_ofi_deque_elem_t;
+typedef struct nccl_ofi_deque nccl_ofi_deque_t;
 
 #ifdef __cplusplus
 } // End extern "C"

--- a/include/nccl_ofi_ep_addr_list.h
+++ b/include/nccl_ofi_ep_addr_list.h
@@ -5,6 +5,10 @@
 #ifndef NCCL_OFI_EP_ADDR_LIST_H
 #define NCCL_OFI_EP_ADDR_LIST_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 struct nccl_ofi_ep_addr_list;
 typedef struct nccl_ofi_ep_addr_list nccl_ofi_ep_addr_list_t;
 
@@ -75,5 +79,9 @@ int nccl_ofi_ep_addr_list_delete(nccl_ofi_ep_addr_list_t *ep_list, nccl_net_ofi_
  * @param ep_list list to destroy
  */
 void nccl_ofi_ep_addr_list_fini(nccl_ofi_ep_addr_list_t *ep_list);
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
 
 #endif

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -207,20 +207,20 @@ static inline void nccl_ofi_freelist_entry_set_undefined(nccl_ofi_freelist_t *fr
 		size_t redzone_offset = offsetof(struct nccl_ofi_freelist_reginfo_t, redzone);
 
 		/* Entry after reginfo structure is accessible but undefined */
-		nccl_net_ofi_mem_undefined_unaligned(entry_p + reginfo_offset + reginfo_size,
+		nccl_net_ofi_mem_undefined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + reginfo_size),
 						     user_entry_size - reginfo_offset - reginfo_size);
 		/* Redzone at the end of the reginfo structure is
 		 * marked as not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset + redzone_offset,
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + redzone_offset),
 						    MEMCHECK_REDZONE_SIZE);
 		/* Members of reginfo structure except first and last
 		 * member are accessible and defined */
-		nccl_net_ofi_mem_defined_unaligned(entry_p + reginfo_offset + elem_size,
+		nccl_net_ofi_mem_defined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + elem_size),
 						   redzone_offset - elem_size);
 		/* First member of reginfo structure, i.e.,
 		 * nccl_ofi_freelist_elem_t structure, is marked as
 		 * not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset, elem_size);
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset), elem_size);
 		/* First part of entry until reginfo structure is
 		 * accessible but undefined */
 		nccl_net_ofi_mem_undefined(entry_p, reginfo_offset);

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -5,7 +5,8 @@
 #ifndef NCCL_OFI_FREELIST_H
 #define NCCL_OFI_FREELIST_H
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -313,7 +314,7 @@ static inline void nccl_ofi_freelist_entry_free(nccl_ofi_freelist_t *freelist, v
 	nccl_net_ofi_mutex_unlock(&freelist->lock);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -95,9 +95,9 @@ struct nccl_ofi_freelist_reginfo_t {
 };
 typedef struct nccl_ofi_freelist_reginfo_t nccl_ofi_freelist_reginfo_t;
 
-_Static_assert(offsetof(nccl_ofi_freelist_reginfo_t, elem) == 0,
+static_assert(offsetof(nccl_ofi_freelist_reginfo_t, elem) == 0,
 	       "elem is not the first member of the structure nccl_ofi_freelist_reginfo_t");
-_Static_assert(sizeof(nccl_ofi_freelist_reginfo_t) - offsetof(nccl_ofi_freelist_reginfo_t, redzone) == MEMCHECK_REDZONE_SIZE,
+static_assert(sizeof(nccl_ofi_freelist_reginfo_t) - offsetof(nccl_ofi_freelist_reginfo_t, redzone) == MEMCHECK_REDZONE_SIZE,
 	       "redzone is not the last member of the structure nccl_ofi_freelist_reginfo_t");
 
 /*

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -5,12 +5,12 @@
 #ifndef NCCL_OFI_IDPOOL_H_
 #define NCCL_OFI_IDPOOL_H_
 
-#ifdef _cplusplus
+
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <pthread.h>
-
 #include <stdint.h>
 
 /*
@@ -87,7 +87,7 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id);
  */
 int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_log.h
+++ b/include/nccl_ofi_log.h
@@ -6,7 +6,7 @@
 #ifndef NCCL_OFI_LOG_H_
 #define NCCL_OFI_LOG_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -33,7 +33,7 @@ extern ncclDebugLogger_t ofi_log_function;
 #define NCCL_OFI_TRACE(flags, fmt, ...)
 #endif
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MATH_H_
 #define NCCL_OFI_MATH_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -65,7 +65,7 @@ extern "C" {
  */
 #define NCCL_OFI_ROUND_UP(x, y) NCCL_OFI_ROUND_DOWN((x) + ((y) - 1), (y))
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -29,7 +29,7 @@ extern "C" {
  * MEMCHECK_REDZONE_SIZE defines the size of redzones prefixing each
  * entry. Redzones are required to be a multiple of 8 due to ASAN
  * shadow-map granularity */
-_Static_assert(MEMCHECK_REDZONE_SIZE % MEMCHECK_GRANULARITY == 0,
+static_assert(MEMCHECK_REDZONE_SIZE % MEMCHECK_GRANULARITY == 0,
 	       "Size of redzone is not a multiple of ASAN shadow-map granularity");
 
 /**

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -86,8 +86,8 @@ static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
 static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 {
 	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_defined(data - offset, size + offset);
+	size_t offset = (uintptr_t)data - (uintptr_t)aligned;
+	nccl_net_ofi_mem_defined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -97,8 +97,8 @@ static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 {
 	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_undefined(data - offset, size + offset);
+	size_t offset = (uintptr_t)data - (uintptr_t)aligned;
+	nccl_net_ofi_mem_undefined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -108,8 +108,8 @@ static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
 {
 	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
+	size_t offset = (uintptr_t)data - (uintptr_t)aligned;
+	nccl_net_ofi_mem_noaccess((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_H
 #define NCCL_OFI_MEMCHECK_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -169,7 +169,7 @@ static inline void nccl_net_ofi_mem_mempool_alloc(void *handle, void *data, size
  */
 static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_t size);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_asan.h
+++ b/include/nccl_ofi_memcheck_asan.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_ASAN_H
 #define NCCL_OFI_MEMCHECK_ASAN_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -56,7 +56,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 	nccl_net_ofi_mem_noaccess(data, size);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_nop.h
+++ b/include/nccl_ofi_memcheck_nop.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_NOP_H
 #define NCCL_OFI_MEMCHECK_NOP_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -44,7 +44,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 {
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_memcheck_valgrind.h
+++ b/include/nccl_ofi_memcheck_valgrind.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MEMCHECK_VALGRIND_H
 #define NCCL_OFI_MEMCHECK_VALGRIND_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -48,7 +48,7 @@ static inline void nccl_net_ofi_mem_mempool_free(void *handle, void *data, size_
 	VALGRIND_MEMPOOL_FREE(handle, data);
 }
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_MR_H_
 #define NCCL_OFI_MR_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -80,7 +80,7 @@ int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
  */
 int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }  // End extern "C"
 #endif
 

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -5,12 +5,11 @@
 #ifndef NCCL_OFI_MSGBUFF_H_
 #define NCCL_OFI_MSGBUFF_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
 #include <pthread.h>
-
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_OFIUTILS_H
 #define NCCL_OFI_OFIUTILS_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -43,7 +43,7 @@ void nccl_ofi_ofiutils_free_info_list(struct fi_info *info_list);
 
 int nccl_ofi_mr_keys_need_own_key(struct fi_info* provider, bool *provide_own_mr_key);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PARAM_H_
 #define NCCL_OFI_PARAM_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -240,7 +240,7 @@ OFI_NCCL_PARAM_INT(errorcheck_mutex, "ERRORCHECK_MUTEX",
  */
 OFI_NCCL_PARAM_INT(endpoint_per_communicator, "ENDPOINT_PER_COMM", 0);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PLATFORM_H_
 #define NCCL_OFI_PLATFORM_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 

--- a/include/nccl_ofi_pthread.h
+++ b/include/nccl_ofi_pthread.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_PTHREAD_H
 #define NCCL_OFI_PTHREAD_H
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -104,7 +104,7 @@ nccl_net_ofi_mutex_unlock_impl(pthread_mutex_t *mutex, const char *file, size_t 
 #define nccl_net_ofi_mutex_unlock(mutex) nccl_net_ofi_mutex_unlock_impl(mutex, __FILE__, __LINE__);
 
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_RDMA_H_
 #define NCCL_OFI_RDMA_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -761,7 +761,7 @@ typedef struct nccl_net_ofi_rdma_device {
 int nccl_net_ofi_rdma_init(const char *provider_filter,
 			   nccl_net_ofi_plugin_t **plugin_p);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_SCHEDULER_H_
 #define NCCL_OFI_SCHEDULER_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -134,7 +134,7 @@ void nccl_net_ofi_set_multiplexing_schedule(size_t size,
 					    size_t align,
 					    nccl_net_ofi_schedule_t *schedule);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_OFI_SENDRECV_H_
 #define NCCL_OFI_SENDRECV_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -226,7 +226,7 @@ typedef struct nccl_net_ofi_sendrecv_req {
 int nccl_net_ofi_sendrecv_init(const char *provider_filter,
 			       nccl_net_ofi_plugin_t **plugin_p);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 } // End extern "C"
 #endif
 

--- a/include/nccl_ofi_topo.h
+++ b/include/nccl_ofi_topo.h
@@ -5,7 +5,7 @@
 #ifndef NCCL_NET_OFI_TOPO_H_
 #define NCCL_NET_OFI_TOPO_H_
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 extern "C" {
 #endif
 
@@ -315,7 +315,7 @@ struct fi_info *nccl_ofi_topo_next_info_list(nccl_ofi_topo_data_iterator_t *iter
  */
 int nccl_ofi_topo_write_nccl_topology(nccl_ofi_topo_t *topo, FILE *file);
 
-#ifdef _cplusplus
+#ifdef __cplusplus
 }
 #endif
 

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -9,11 +9,11 @@
 #include "nccl_ofi_api.h"
 
 
-_Static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
+static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
 	       "Size of OFI Handle is too large");
-_Static_assert(offsetof(nccl_net_ofi_conn_handle_t, state) <= NCCL_NET_HANDLE_MAXSIZE_V4,
+static_assert(offsetof(nccl_net_ofi_conn_handle_t, state) <= NCCL_NET_HANDLE_MAXSIZE_V4,
 	       "Size of OFI Handle (without state) is too large");
-_Static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
+static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
 	       "Maximum outstanding requests for plugin is less than what NCCL requires");
 
 

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -11,7 +11,7 @@
 #include "nccl_ofi_deque.h"
 #include "nccl_ofi_log.h"
 
-int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
+int nccl_ofi_deque_init(struct nccl_ofi_deque **deque_p)
 {
 	nccl_ofi_deque_t *deque = (nccl_ofi_deque_t *)malloc(sizeof(nccl_ofi_deque_t));
 
@@ -36,7 +36,7 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 	return 0;
 }
 
-int nccl_ofi_deque_finalize(nccl_ofi_deque_t *deque)
+int nccl_ofi_deque_finalize(struct nccl_ofi_deque *deque)
 {
 	assert(deque);
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4259,7 +4259,7 @@ static int post_rdma_write(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post RDMA write */
-	rc = fi_writedata(comm_rail->local_ep, send_data->buff + xfer_info->offset,
+	rc = fi_writedata(comm_rail->local_ep, (void*)((uintptr_t)send_data->buff + xfer_info->offset),
 				xfer_info->msg_size, desc, send_data->wdata,
 				comm_rail->remote_addr,
 				send_data->remote_buff + xfer_info->offset,
@@ -4287,7 +4287,7 @@ static int post_rdma_eager_send(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post eager send */
-	rc = fi_senddata(comm_rail->local_ep, send_data->buff + xfer_info->offset, xfer_info->msg_size, desc,
+	rc = fi_senddata(comm_rail->local_ep, (void*)(((uintptr_t)send_data->buff) + xfer_info->offset), xfer_info->msg_size, desc,
 			 send_data->wdata, comm_rail->remote_addr, req);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2398,7 +2398,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		} else {
 			ret = nccl_ofi_idpool_free_id(key_pool, key);
 			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_WARN("Error freeing MR key %"PRIu64", leaking key", key);
+				NCCL_OFI_WARN("Error freeing MR key %" PRIu64 ", leaking key", key);
 			}
 		}
 	}
@@ -3312,7 +3312,7 @@ static int recv_close(nccl_net_ofi_recv_comm_t *recv_comm)
 	/* Release communicator ID */
 	ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", r_comm->local_comm_id);
+		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
 	}
 
 	free(r_comm);
@@ -3690,7 +3690,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_device
 		if (~0 != r_comm->local_comm_id) {
 			ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
 			if (ret != 0) {
-				NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", r_comm->local_comm_id);
+				NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
 			}
 		}
 		free(r_comm);
@@ -4047,7 +4047,7 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 	ret = nccl_ofi_idpool_free_id(get_device_from_ep((nccl_net_ofi_rdma_ep_t *)base_ep)->comm_idpool,
 				      l_comm->comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", l_comm->comm_id);
+		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, l_comm->comm_id);
 	}
 
 	free(l_comm);
@@ -4125,7 +4125,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
  error:
 	if (l_comm && ~0 != l_comm->comm_id) {
 		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, l_comm->comm_id)) {
-			NCCL_OFI_WARN("Error freeing communicator ID %"PRIu64"", l_comm->comm_id);
+			NCCL_OFI_WARN("Error freeing communicator ID %" PRIu64 "", l_comm->comm_id);
 		}
 	}
 	free(l_comm);
@@ -4788,7 +4788,7 @@ static int send_close(nccl_net_ofi_send_comm_t *send_comm)
 	/* Release communicator ID */
 	ret = nccl_ofi_idpool_free_id(device->comm_idpool, s_comm->local_comm_id);
 	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", s_comm->local_comm_id);
+		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, s_comm->local_comm_id);
 	}
 
 	/* Destroy domain */
@@ -5076,7 +5076,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
  error:
 	if (ret_s_comm && ~0 != ret_s_comm->local_comm_id) {
 		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, ret_s_comm->local_comm_id)) {
-			NCCL_OFI_WARN("Error freeing communicator ID %"PRIu32"", ret_s_comm->local_comm_id);
+			NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, ret_s_comm->local_comm_id);
 		}
 	}
 	free(ret_s_comm);

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -740,7 +740,7 @@ static int dereg_mr_base_comm(struct fid_mr *mr_handle,
 		} else {
 			ret = nccl_ofi_idpool_free_id(key_pool, key);
 			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_WARN("Error freeing MR key %"PRIu64", leaking key", key);
+				NCCL_OFI_WARN("Error freeing MR key %" PRIu64 ", leaking key", key);
 			}
 		}
 	}

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -95,16 +95,16 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	},
 	{
 		.name = "trn1n.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	}
 };


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #565
 * #564
 * #563
 * #562
 * __->__#561
 * #560
 * #559
 * #558
 * #557
 * #556
 * #555
 * #554


--- --- ---

### nit: deque: avoid typedef hell


Prefer to define the structures in vanilla C without relying on any
custom typedefs, and move the typedef to the bottom of the file for
consumers to use, if they want.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>