### PR TITLE
fix(api): avoid mid-function initiializers

### DIFF
--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -207,20 +207,20 @@ static inline void nccl_ofi_freelist_entry_set_undefined(nccl_ofi_freelist_t *fr
 		size_t redzone_offset = offsetof(struct nccl_ofi_freelist_reginfo_t, redzone);
 
 		/* Entry after reginfo structure is accessible but undefined */
-		nccl_net_ofi_mem_undefined_unaligned(entry_p + reginfo_offset + reginfo_size,
+		nccl_net_ofi_mem_undefined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + reginfo_size),
 						     user_entry_size - reginfo_offset - reginfo_size);
 		/* Redzone at the end of the reginfo structure is
 		 * marked as not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset + redzone_offset,
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + redzone_offset),
 						    MEMCHECK_REDZONE_SIZE);
 		/* Members of reginfo structure except first and last
 		 * member are accessible and defined */
-		nccl_net_ofi_mem_defined_unaligned(entry_p + reginfo_offset + elem_size,
+		nccl_net_ofi_mem_defined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + elem_size),
 						   redzone_offset - elem_size);
 		/* First member of reginfo structure, i.e.,
 		 * nccl_ofi_freelist_elem_t structure, is marked as
 		 * not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset, elem_size);
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset), elem_size);
 		/* First part of entry until reginfo structure is
 		 * accessible but undefined */
 		nccl_net_ofi_mem_undefined(entry_p, reginfo_offset);

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -85,9 +85,9 @@ static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
  */
 static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_defined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_defined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -96,9 +96,9 @@ static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_undefined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_undefined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -107,9 +107,9 @@ static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_noaccess((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -318,15 +318,16 @@ ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, size_t size, int type,
 		return ncclInternalError;
 	}
 
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
+
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->regMr(send_comm, data, size, type, mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->regMr(recv_comm, data, size, type, mhandle);
 		break;
 	default:
@@ -350,16 +351,16 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 	}
 
 	int ret = 0;
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
 
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->deregMr(send_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->deregMr(recv_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
 	default:
@@ -386,17 +387,17 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 	}
 
 	int ret = 0;
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
 	nccl_net_ofi_mr_handle_t **handle = (nccl_net_ofi_mr_handle_t **)mhandle;
 
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->regMrDmaBuf(send_comm, data, size, type, offset, fd, handle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->regMrDmaBuf(recv_comm, data, size, type, offset, fd, handle);
 		break;
 	default:

--- a/src/nccl_ofi_ep_addr_list.c
+++ b/src/nccl_ofi_ep_addr_list.c
@@ -134,6 +134,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 				 size_t addr_size)
 {
 	int ret = 0;
+	ep_pair_list_elem_t *new_pair = NULL;
 
 	if (addr_size > ep_list->max_addr_size) {
 		NCCL_OFI_WARN("Address size %zu > max size (%zu)", addr_size,
@@ -155,7 +156,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 	memcpy(new_addr->addr, addr_in, addr_size);
 	zero_pad_address(new_addr->addr, addr_size, ep_list->max_addr_size);
 
-	ep_pair_list_elem_t *new_pair = (ep_pair_list_elem_t *)
+	new_pair = (ep_pair_list_elem_t*)
 		malloc(sizeof(*new_pair));
 	if (!new_pair) {
 		NCCL_OFI_WARN("Failed to allocate new ep list element");

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -134,6 +134,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 {
 	int ret = 0;
 	const char *provider_filter = NULL;
+	nccl_net_ofi_ep_t *base_ep = NULL;
+	nccl_net_ofi_device_t *device = NULL;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
 
@@ -230,8 +232,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	 * resources. This initialization happens once per process, and thus it
 	 * does not matter which device is used to create the endpoint.
 	 */
-	nccl_net_ofi_device_t *device = (*plugin_p)->get_device(*plugin_p, 0);
-	nccl_net_ofi_ep_t *base_ep = NULL;
+	device = (*plugin_p)->get_device(*plugin_p, 0);
 
 	ret = device->get_ep(device, &base_ep);
 	if (ret != 0) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3071,7 +3071,13 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	int ret = 0;
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
+	rdma_req_recv_data_t *recv_data = NULL;
+	nccl_net_ofi_rdma_ep_t * ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	int dev_id = 0;
 	nccl_net_ofi_rdma_mr_handle_t **mr_handles = (nccl_net_ofi_rdma_mr_handle_t **)mhandles;
+	uint16_t msg_seq_num = 0;
+	bool eager = false;
 
 	assert(r_comm != NULL);
 
@@ -3088,12 +3094,12 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	int dev_id = r_comm->base.base.dev_id;
+	dev_id = r_comm->base.base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t * ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 	assert(ep != NULL);
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	assert(device != NULL);
 
 	ret = process_cq_if_pending(ep);
@@ -3102,13 +3108,14 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		*base_req = NULL;
 		ret = 0;
 		goto error;
-	} else if (ret != 0) {
+	}
+	if (ret != 0) {
 		goto error;
 	}
 
-	uint16_t msg_seq_num = r_comm->next_msg_seq_num;
+	msg_seq_num = r_comm->next_msg_seq_num;
 
-	bool eager = false;
+	eager = false;
 	void *elem;
 	nccl_ofi_msgbuff_elemtype_t type;
 	nccl_ofi_msgbuff_status_t msg_stat;
@@ -3147,7 +3154,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	rdma_req_recv_data_t *recv_data = get_recv_data(req);
+	recv_data = get_recv_data(req);
 
 	if (eager) {
 		nccl_net_ofi_rdma_req_t *bounce_req = (nccl_net_ofi_rdma_req_t *)elem;
@@ -3334,6 +3341,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 
 static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 {
+	nccl_net_ofi_rdma_device_t *device = NULL;
 	int ret = 0;
 
 	/* Retrieve and validate endpoint */
@@ -3344,7 +3352,7 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 		return ret;
 	}
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t*)base_ep->device;
+	device = (nccl_net_ofi_rdma_device_t*)base_ep->device;
 
 	if (r_comm->send_close_req != NULL) {
 		ret = r_comm->send_close_req->free(r_comm->send_close_req, false);
@@ -3717,6 +3725,12 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 				   nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
+	int flush_n = 0;
+	bool network_busy = false;
+	int dev_id = 0;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	nccl_net_ofi_scheduler_t *scheduler = NULL;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm =
 		(nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
 
@@ -3733,19 +3747,19 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	int dev_id = recv_comm->base.dev_id;
+	dev_id = recv_comm->base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 	assert(ep != NULL);
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	assert(device != NULL);
 
-	nccl_net_ofi_scheduler_t *scheduler = device->scheduler;
+	scheduler = device->scheduler;
 	assert(scheduler != NULL);
 
 	/* Process any pending requests */
-	bool network_busy = false;
+	network_busy = false;
 	rc = process_cq_if_pending(ep);
 	if (rc == -EAGAIN) {
 		/* Network is still busy. */
@@ -3781,7 +3795,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	 * Find the non-zero request for which we will issue flush.
 	 * A single operation can flush all request at once.
 	 */
-	int flush_n = -1;
+	flush_n = -1;
 	for (int recv_n = 0; recv_n < n; recv_n++) {
 		if (sizes[recv_n] != 0) {
 			flush_n = recv_n;
@@ -3900,7 +3914,9 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 {
 	int ret = 0;
 
+	int comm_id = 0;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = NULL;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 	int dev_id = device->base.dev_id;
 	int num_rails = l_comm_ep->num_rails;
 
@@ -3938,7 +3954,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	r_comm->n_ctrl_delivered = 0;
 
 	/* Allocate recv communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		r_comm->local_comm_id = ~0;
 		goto error;
@@ -3997,7 +4013,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 		r_comm->base.base.ep = &l_comm_ep->base;
 	}
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 
 	/* Add ourselves to ep's lookup array */
 	set_comm(device, r_comm->local_comm_id, &r_comm->base.base);
@@ -4490,6 +4506,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_listen_comm_t *l_comm = NULL;
+	int comm_id = 0;
 	nccl_net_ofi_rdma_ep_t *ep =
 		(nccl_net_ofi_rdma_ep_t *)base_ep;
 
@@ -4528,7 +4545,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	l_comm->leader_local_ep = ep->control_rail.ofi_ep;
 
 	/* Allocate listen communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		l_comm->comm_id = ~0;
 		ret = comm_id;
@@ -5050,10 +5067,13 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	int ret = 0;
 	nccl_net_ofi_rdma_send_comm_t *s_comm = (nccl_net_ofi_rdma_send_comm_t *)send_comm;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	uint16_t msg_seq_num = s_comm->next_msg_seq_num;
 	bool polled_cq = false;
 	bool have_ctrl = false;
+	bool eager = false;
+	int dev_id = 0;
 
 	assert(s_comm != NULL);
 
@@ -5071,9 +5091,9 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		goto error;
 	}
 
-	int dev_id = s_comm->base.base.dev_id;
+	dev_id = s_comm->base.base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)s_comm->base.base.ep;
 	assert(ep != NULL);
 
 	ret = process_cq_if_pending(ep);
@@ -5082,7 +5102,8 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		*base_req = NULL;
 		ret = 0;
 		goto error;
-	} else if (ret != 0) {
+	}
+	if (ret != 0) {
 		goto error;
 	}
 
@@ -5090,6 +5111,10 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	 * TODO: Use NCCL provided tags when using grouped receives aka
 	 * props->maxRecvs > 1.
 	 */
+
+	have_ctrl = false;
+	msg_seq_num = s_comm->next_msg_seq_num;
+
 	void *elem;
 	nccl_ofi_msgbuff_elemtype_t type;
 	nccl_ofi_msgbuff_status_t msg_stat;
@@ -5144,7 +5169,7 @@ retry:
 	}
 
 	/* Determine if this should be sent eagerly. */
-	bool eager = false;
+	eager = false;
 	if ((!have_ctrl && size <= eager_max_size) ||
 		 (size == 0)) {
 		eager = true;
@@ -5451,6 +5476,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 				   nccl_net_ofi_rdma_send_comm_t **s_comm)
 {
 	int ret = 0;
+	int comm_id = 0;
 	fi_addr_t remote_addr;
 	nccl_net_ofi_rdma_send_comm_t *ret_s_comm = NULL;
 	int num_rails = ep->num_rails;
@@ -5505,7 +5531,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->remote_comm_id = handle->comm_id;
 
 	/* Allocate send communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		ret_s_comm->local_comm_id = ~0;
 		ret = comm_id;
@@ -5700,6 +5726,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 			    nccl_net_ofi_send_comm_t **send_comm)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_req_state_t conn_resp_req_state;
 	nccl_net_ofi_rdma_req_state_t conn_msg_state;
 	*send_comm = NULL;
 	nccl_net_ofi_rdma_ep_t *ep =
@@ -5827,7 +5854,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		nccl_net_ofi_mutex_lock(&s_comm->conn_resp_req->req_lock);
-		nccl_net_ofi_rdma_req_state_t conn_resp_req_state = s_comm->conn_resp_req->state;
+		conn_resp_req_state = s_comm->conn_resp_req->state;
 		nccl_net_ofi_mutex_unlock(&s_comm->conn_resp_req->req_lock);
 
 		/* Wait until conn resp message is received */
@@ -6000,10 +6027,11 @@ static int init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *device,
 static int release_ep(nccl_net_ofi_ep_t *base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
 
 	/* Validate device */
-	nccl_net_ofi_rdma_ep_t *ep =
-		(nccl_net_ofi_rdma_ep_t*)base_ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)base_ep;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -6011,8 +6039,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 	}
 
 	/* Validate device */
-	nccl_net_ofi_rdma_device_t *device =
-		(nccl_net_ofi_rdma_device_t*)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -6168,10 +6195,11 @@ error:
 static inline int get_ep(nccl_net_ofi_device_t *base_dev, nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device =
-		(nccl_net_ofi_rdma_device_t*)base_dev;
+	device = (nccl_net_ofi_rdma_device_t*)base_dev;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -6183,7 +6211,7 @@ static inline int get_ep(nccl_net_ofi_device_t *base_dev, nccl_net_ofi_ep_t **ba
 
 	/* Obtain thread-local rdma endpoint. Allocate and
 	 * initialize endpoint if necessary. */
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)pthread_getspecific(device->ep_key);
+	ep = (nccl_net_ofi_rdma_ep_t*)pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */
 		ep = (nccl_net_ofi_rdma_ep_t *)calloc(1, sizeof(nccl_net_ofi_rdma_ep_t));
@@ -6484,8 +6512,9 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 				int dev_id, struct fi_info *info_list,
 				nccl_ofi_topo_t *topo, size_t rr_threshold)
 {
-	int ret;
-
+	int ret = 0;
+	bool provide_own_mr_key = false;
+	int length = 0;
 	nccl_net_ofi_rdma_device_t *device =
 		(nccl_net_ofi_rdma_device_t *)calloc(1, sizeof(nccl_net_ofi_rdma_device_t));
 	if (device == NULL) {
@@ -6515,7 +6544,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Ensure that number of rails are the same across devices */
-	int length = ofi_info_list_length(info_list);
+	length = ofi_info_list_length(info_list);
 	if (topo->max_group_size != length) {
 		NCCL_OFI_WARN("Wrong number of NICs for device %i. Expected %i but got %i",
 			      dev_id, topo->max_group_size, length);
@@ -6592,7 +6621,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Initialize mr key pool */
-	bool provide_own_mr_key = true;
+	provide_own_mr_key = true;
 	ret = nccl_ofi_mr_keys_need_own_key(info_list, &provide_own_mr_key);
 	if (ret != 0) {
 		NCCL_OFI_WARN("MR key config parsing failed: %s",

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -358,6 +358,8 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 {
 	int ret = 0;
 	nccl_net_ofi_sendrecv_req_t *req = (nccl_net_ofi_sendrecv_req_t *)base_req;
+	nccl_net_ofi_sendrecv_device_t *device = NULL;
+	nccl_net_ofi_sendrecv_ep_t *ep = NULL;
 
 	/* Retrieve and validate comm */
 	nccl_net_ofi_comm_t *base_comm = req->comm;
@@ -368,8 +370,7 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	}
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_sendrecv_ep_t *ep =
-		(nccl_net_ofi_sendrecv_ep_t *)base_comm->ep;
+	ep = (nccl_net_ofi_sendrecv_ep_t *)base_comm->ep;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -377,8 +378,7 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	}
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	device = (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -761,6 +761,7 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm, void *data,
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *ep =
 		(nccl_net_ofi_sendrecv_ep_t *)base_comm->ep;
+	nccl_ofi_idpool_t *key_pool = NULL;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -796,7 +797,7 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm, void *data,
 	}
 	/* Cache miss */
 
-	nccl_ofi_idpool_t *key_pool = &device->key_pool;
+	key_pool = &device->key_pool;
 	struct fid_domain *domain;
 	domain = get_domain_from_endpoint(ep);
 	ret = reg_mr_base(domain, ep->ofi_ep, key_pool,
@@ -894,14 +895,15 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	int ret = 0;
 	ssize_t rc = 0;
 	nccl_net_ofi_sendrecv_req_t *req = NULL;
+	nccl_net_ofi_sendrecv_ep_t * ep = NULL;
+	nccl_net_ofi_sendrecv_device_t *device = NULL;
 	nccl_net_ofi_sendrecv_recv_comm_t *r_comm =
 		(nccl_net_ofi_sendrecv_recv_comm_t *)recv_comm;
 	int dev_id = r_comm->base.base.dev_id;
 	struct fid_mr **mr_handles = (struct fid_mr **)mhandles;
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_sendrecv_ep_t * ep =
-		(nccl_net_ofi_sendrecv_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_sendrecv_ep_t *)r_comm->base.base.ep;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -909,8 +911,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	}
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	device = (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -1056,6 +1057,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	void *data = NULL;
 	void *flush_mr_desc = NULL;
 	int dev_id = recv_comm->base.dev_id;
+	int flush_n = -1;
 	struct fid_mr **mr_handles = (struct fid_mr **)mhandles;
 
 	if (ofi_nccl_gdr_flush_disable() || support_gdr == GDR_UNSUPPORTED)
@@ -1084,7 +1086,6 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	 * Find the non-zero request for which we will issue flush.
 	 * A single operation can flush all request at once.
 	 */
-	int flush_n = -1;
 	for (int recv_n = 0; recv_n < n; recv_n++) {
 		if (sizes[recv_n] != 0) {
 			flush_n = recv_n;
@@ -1563,6 +1564,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	fi_addr_t local_ep_addr;
 	nccl_net_ofi_sendrecv_listen_comm_t *l_comm = NULL;
 	uint64_t tag;
+	int dev_id = 0;
 	int num_addrs;
 	nccl_net_ofi_sendrecv_ep_t *ep =
 		(nccl_net_ofi_sendrecv_ep_t *)base_ep;
@@ -1576,7 +1578,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 		goto exit;
 	}
 
-	int dev_id = device->base.dev_id;
+	dev_id = device->base.dev_id;
 
 	/* Zero-out the handle */
 	memset(handle, 0, sizeof(nccl_net_ofi_conn_handle_t));
@@ -1677,6 +1679,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	ssize_t rc = 0;
 	nccl_net_ofi_sendrecv_req_t *req = NULL;
 	void *desc = NULL;
+	nccl_net_ofi_sendrecv_device_t *device = NULL;
 	int dev_id = s_comm->base.base.dev_id;
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
 
@@ -1690,8 +1693,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	}
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	device = (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -2124,6 +2126,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 static int release_ep(nccl_net_ofi_ep_t *base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_sendrecv_device_t *device = NULL;
 
 	/* Validate device */
 	nccl_net_ofi_sendrecv_ep_t *ep =
@@ -2135,8 +2138,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 	}
 
 	/* Validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	device = (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -2183,6 +2185,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 				    nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_sendrecv_ep_t *ep = NULL;
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
@@ -2198,8 +2201,7 @@ static int get_ep(nccl_net_ofi_device_t *base_dev,
 
 	/* Obtain thread-local sendrecv endpoint. Allocate and
 	 * initialize endpoint if necessary. */
-	nccl_net_ofi_sendrecv_ep_t *ep =
-		(nccl_net_ofi_sendrecv_ep_t *)pthread_getspecific(device->ep_key);
+	ep = (nccl_net_ofi_sendrecv_ep_t *)pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */
 		ep = (nccl_net_ofi_sendrecv_ep_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));
@@ -2392,6 +2394,7 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 				int dev_id, struct fi_info *info)
 {
 	int ret;
+	bool provide_own_mr_key = true;
 
 	nccl_net_ofi_sendrecv_device_t *device =
 		(nccl_net_ofi_sendrecv_device_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_device_t));
@@ -2439,7 +2442,6 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Indicates if the provider selects MR keys */
-	bool provide_own_mr_key = true;
 	ret = nccl_ofi_mr_keys_need_own_key(info, &provide_own_mr_key);
 	if (ret != 0) {
 		NCCL_OFI_WARN("MR key config parsing failed: %s",

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -604,6 +604,10 @@ exit:
 
 int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	int ret = 0;
+#if HAVE_CUDA
+	const char *optname_name = "none";
+	int optname = -1;
+#endif
 
 	if (endpoint == NULL) {
 		NCCL_OFI_WARN("Unable to configure invalid endpoint");
@@ -645,8 +649,6 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	static bool nccl_proto_configured = false;
 	static bool need_ordering = false;
 	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-	int optname = -1;
-	const char *optname_name = "none";
 
 	/* During initialization, try to set
 	 * FI_OPT_EFA_{SENDRECV,WRTIE}_IN_ORDER_ALIGNED_128_BYTES to
@@ -785,6 +787,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 {
 	struct fi_info *info_list_in = *info_list;
 	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));
+	struct fi_info *info_ptr = NULL;
 
 	if (num_rails <= 0) {
 		return;
@@ -824,7 +827,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 
 	/* Update info_list references to match sorted order */
 	*info_list = sorted_info_array[0];
-	struct fi_info *info_ptr = *info_list;
+	info_ptr = *info_list;
 	for (int i = 0; i < num_rails; ++i) {
 		assert(info_ptr);
 		assert(sorted_info_array[i]);


### PR DESCRIPTION
Stacked PRs:
 * #592
 * #578
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * __->__#564
 * #563
 * #560


--- --- ---

### fix(api): avoid mid-function initiializers


c++ suppoorts initializers anywhere in the function, but one must not
jump over an initializer with any goto usage. Given the lack of RAII in
C, this becomes a significant painpoint.

Avoid naming these casts, such that the jmp's are acceptable in both cxx
and c.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>