### PR TITLE
fix(tree): use decltype instead of typeof for cxx

### DIFF
--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -39,7 +39,11 @@ extern "C" {
  * @param	a
  *		Must be a power of two
  */
+#ifndef __cplusplus
 #define NCCL_OFI_IS_ALIGNED(x, a) (((x) & ((typeof(x))(a) - 1)) == 0)
+#else
+#define NCCL_OFI_IS_ALIGNED(x, a) (((x) & ((decltype(x))(a) - 1)) == 0)
+#endif
 
 /*
  * @brief	Return true if and only if pointer `p` is `a`-byte aligned

--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -25,6 +25,7 @@ void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites = NULL;
 
 #define STRINGIFY(sym) # sym
 
+#ifndef __cplusplus
 #define LOAD_SYM(sym)                                                              \
 	nccl_net_ofi_##sym = (typeof(sym) *)dlsym(cudadriver_lib, STRINGIFY(sym)); \
 	if (nccl_net_ofi_##sym == NULL) {                                          \
@@ -32,6 +33,16 @@ void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites = NULL;
 		ret = -ENOTSUP;                                                    \
 		goto error;                                                        \
 	}
+#else
+#define LOAD_SYM(sym)                                                              \
+	nccl_net_ofi_##sym = (decltype(sym) *)dlsym(cudadriver_lib, STRINGIFY(sym)); \
+	if (nccl_net_ofi_##sym == NULL) {                                          \
+		NCCL_OFI_WARN("Failed to load symbol " STRINGIFY(sym));            \
+		ret = -ENOTSUP;                                                    \
+		goto error;                                                        \
+	}
+#endif
+
 
 int
 nccl_net_ofi_cuda_init(void)

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -337,7 +337,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	float(*table)[NCCL_NUM_PROTOCOLS] = (float(*)[NCCL_NUM_PROTOCOLS])collCostTable;
@@ -373,7 +373,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 
@@ -406,7 +405,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	int in_out = -1;
@@ -437,7 +436,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * __->__#565
 * #563


--- --- ---

### fix(tree): use decltype instead of typeof for cxx

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>