### PR TITLE
chore(build): mpi: set mpicxx, too.

### DIFF
--- a/m4/check_pkg_mpi.m4
+++ b/m4/check_pkg_mpi.m4
@@ -31,6 +31,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
          LDFLAGS="${MPI_LDFLAGS} ${LDFLAGS}"])
 
   MPICC=${mpi_bindir}mpicc
+  MPICXX=${mpi_bindir}mpicxx
 
   AC_MSG_CHECKING([for working mpicc])
   ${MPICC} --help >& AS_MESSAGE_LOG_FD
@@ -38,6 +39,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
         [AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])
          MPICC="${CC}"
+         MPICXX="${CXX}"
          AS_IF([test "${check_pkg_found}" = "yes"],
                [AC_CHECK_HEADERS([mpi.h], [], [check_pkg_found=no])])
 
@@ -49,6 +51,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
         [$2])
 
   AC_SUBST([MPICC])
+  AC_SUBST([MPICXX])
   AC_SUBST([MPI_CPPFLAGS])
   AC_SUBST([MPI_LDFLAGS])
   AC_SUBST([MPI_LIBS])

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -9,6 +9,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include $(MPI_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
 LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
 CC = $(MPICC)
+CXX = $(MPICXX)
 
 noinst_HEADERS = test-common.h
 


### PR DESCRIPTION
Stacked PRs:
 * #568
 * __->__#567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### chore(build): mpi: set mpicxx, too.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>