### PR TITLE
fix(param): move some parameters to unsigned

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -156,7 +156,7 @@ OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
  * Specify the memory registration key size in bytes when using a libfabric
  * provider that supports application-selected memory registration keys.
  */
-OFI_NCCL_PARAM_INT(mr_key_size, "MR_KEY_SIZE", 2);
+OFI_NCCL_PARAM_UINT(mr_key_size, "MR_KEY_SIZE", 2);
 
 /*
  * Disable the MR cache. The MR cache is used to keep track of registered
@@ -244,7 +244,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * tweak defaults from the platform file, but this fits our needs for
  * now.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE",
+OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE",
 #if HAVE_NEURON
 		   0
 #else


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * __->__#571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### fix(param): move some parameters to unsigned


mr_key_size and eager_max_size are positive integers, avoid sign
comparison issues by treating them as such.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>