### PR TITLE
fix(idpool): avoid sign comparison issues

### DIFF
--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -207,20 +207,20 @@ static inline void nccl_ofi_freelist_entry_set_undefined(nccl_ofi_freelist_t *fr
 		size_t redzone_offset = offsetof(struct nccl_ofi_freelist_reginfo_t, redzone);
 
 		/* Entry after reginfo structure is accessible but undefined */
-		nccl_net_ofi_mem_undefined_unaligned(entry_p + reginfo_offset + reginfo_size,
+		nccl_net_ofi_mem_undefined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + reginfo_size),
 						     user_entry_size - reginfo_offset - reginfo_size);
 		/* Redzone at the end of the reginfo structure is
 		 * marked as not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset + redzone_offset,
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + redzone_offset),
 						    MEMCHECK_REDZONE_SIZE);
 		/* Members of reginfo structure except first and last
 		 * member are accessible and defined */
-		nccl_net_ofi_mem_defined_unaligned(entry_p + reginfo_offset + elem_size,
+		nccl_net_ofi_mem_defined_unaligned((void*)((uintptr_t)entry_p + reginfo_offset + elem_size),
 						   redzone_offset - elem_size);
 		/* First member of reginfo structure, i.e.,
 		 * nccl_ofi_freelist_elem_t structure, is marked as
 		 * not accessible */
-		nccl_net_ofi_mem_noaccess_unaligned(entry_p + reginfo_offset, elem_size);
+		nccl_net_ofi_mem_noaccess_unaligned((void*)((uintptr_t)entry_p + reginfo_offset), elem_size);
 		/* First part of entry until reginfo structure is
 		 * accessible but undefined */
 		nccl_net_ofi_mem_undefined(entry_p, reginfo_offset);

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -73,7 +73,7 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool);
  * @return	0 on success
  *		non-zero on error
  */
-int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id);
+int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id);
 
 /*
  * @brief	Release pool of IDs and free resources

--- a/include/nccl_ofi_memcheck.h
+++ b/include/nccl_ofi_memcheck.h
@@ -85,9 +85,9 @@ static inline void nccl_net_ofi_mem_noaccess(void *data, size_t size);
  */
 static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_defined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_defined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -96,9 +96,9 @@ static inline void nccl_net_ofi_mem_defined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_undefined(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_undefined((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**
@@ -107,9 +107,9 @@ static inline void nccl_net_ofi_mem_undefined_unaligned(void *data, size_t size)
  */
 static inline void nccl_net_ofi_mem_noaccess_unaligned(void *data, size_t size)
 {
-	void *aligned = (void *)NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
-	size_t offset = data - aligned;
-	nccl_net_ofi_mem_noaccess(data - offset, size + offset);
+	uintptr_t aligned = NCCL_OFI_ROUND_DOWN((uintptr_t)data, MEMCHECK_GRANULARITY);
+	size_t offset = (uintptr_t)data - aligned;
+	nccl_net_ofi_mem_noaccess((void*)((uintptr_t)data - offset), size + offset);
 }
 
 /**

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -156,7 +156,7 @@ OFI_NCCL_PARAM_INT(cuda_flush_enable, "CUDA_FLUSH_ENABLE", 0);
  * Specify the memory registration key size in bytes when using a libfabric
  * provider that supports application-selected memory registration keys.
  */
-OFI_NCCL_PARAM_INT(mr_key_size, "MR_KEY_SIZE", 2);
+OFI_NCCL_PARAM_UINT(mr_key_size, "MR_KEY_SIZE", 2);
 
 /*
  * Disable the MR cache. The MR cache is used to keep track of registered
@@ -244,7 +244,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * tweak defaults from the platform file, but this fits our needs for
  * now.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE",
+OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE",
 #if HAVE_NEURON
 		   0
 #else

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -318,15 +318,16 @@ ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, size_t size, int type,
 		return ncclInternalError;
 	}
 
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
+
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->regMr(send_comm, data, size, type, mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->regMr(recv_comm, data, size, type, mhandle);
 		break;
 	default:
@@ -350,16 +351,16 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 	}
 
 	int ret = 0;
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
 
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->deregMr(send_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->deregMr(recv_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
 	default:
@@ -386,17 +387,17 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 	}
 
 	int ret = 0;
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
 	nccl_net_ofi_mr_handle_t **handle = (nccl_net_ofi_mr_handle_t **)mhandle;
 
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->regMrDmaBuf(send_comm, data, size, type, offset, fd, handle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->regMrDmaBuf(recv_comm, data, size, type, offset, fd, handle);
 		break;
 	default:

--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -25,6 +25,7 @@ void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites = NULL;
 
 #define STRINGIFY(sym) # sym
 
+#ifndef __cplusplus
 #define LOAD_SYM(sym)                                                              \
 	nccl_net_ofi_##sym = (typeof(sym) *)dlsym(cudadriver_lib, STRINGIFY(sym)); \
 	if (nccl_net_ofi_##sym == NULL) {                                          \
@@ -32,6 +33,16 @@ void *nccl_net_ofi_cuFlushGPUDirectRDMAWrites = NULL;
 		ret = -ENOTSUP;                                                    \
 		goto error;                                                        \
 	}
+#else
+#define LOAD_SYM(sym)                                                              \
+	nccl_net_ofi_##sym = (decltype(sym) *)dlsym(cudadriver_lib, STRINGIFY(sym)); \
+	if (nccl_net_ofi_##sym == NULL) {                                          \
+		NCCL_OFI_WARN("Failed to load symbol " STRINGIFY(sym));            \
+		ret = -ENOTSUP;                                                    \
+		goto error;                                                        \
+	}
+#endif
+
 
 int
 nccl_net_ofi_cuda_init(void)

--- a/src/nccl_ofi_ep_addr_list.c
+++ b/src/nccl_ofi_ep_addr_list.c
@@ -134,6 +134,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 				 size_t addr_size)
 {
 	int ret = 0;
+	ep_pair_list_elem_t *new_pair = NULL;
 
 	if (addr_size > ep_list->max_addr_size) {
 		NCCL_OFI_WARN("Address size %zu > max size (%zu)", addr_size,
@@ -155,7 +156,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 	memcpy(new_addr->addr, addr_in, addr_size);
 	zero_pad_address(new_addr->addr, addr_size, ep_list->max_addr_size);
 
-	ep_pair_list_elem_t *new_pair = (ep_pair_list_elem_t *)
+	new_pair = (ep_pair_list_elem_t*)
 		malloc(sizeof(*new_pair));
 	if (!new_pair) {
 		NCCL_OFI_WARN("Failed to allocate new ep list element");

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -6,6 +6,7 @@
 
 #include <errno.h>
 #include <stdlib.h>
+#include <stdbool.h>
 
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_math.h"
@@ -103,7 +104,9 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
 	nccl_net_ofi_mutex_lock(&idpool->lock);
 
 	int entry_index = 0;
-	int id = -1;
+
+	bool found = false;
+	size_t id;
 	for (size_t i = 0; i < num_long_elements; i++) {
 		entry_index = __builtin_ffsll(idpool->ids[i]);
 		if (0 != entry_index) {
@@ -113,14 +116,15 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
 			idpool->ids[i] &= ~(1ULL << (entry_index - 1));
 
 			/* Store the ID we found */
-			id = (int)((i * sizeof(uint64_t) * 8) + entry_index - 1);
+			id = (size_t)((i * sizeof(uint64_t) * 8) + entry_index - 1);
+			found = true;
 			break;
 		}
 	}
 
 	nccl_net_ofi_mutex_unlock(&idpool->lock);
 
-	if (-1 == id || id >= idpool->size) {
+	if (!found || id >= idpool->size) {
 		NCCL_OFI_WARN("No IDs available (max: %lu)", idpool->size);
 		return -ENOMEM;
 	}
@@ -142,10 +146,9 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool)
  * @return	0 on success
  *		non-zero on error
  */
-int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
+int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id)
 {
 	assert(NULL != idpool);
-	assert(id >= 0);
 
 	if (0 == idpool->size) {
 		NCCL_OFI_WARN("Cannot free an ID from a 0-sized pool");

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -134,6 +134,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 {
 	int ret = 0;
 	const char *provider_filter = NULL;
+	nccl_net_ofi_ep_t *base_ep = NULL;
+	nccl_net_ofi_device_t *device = NULL;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
 
@@ -230,8 +232,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	 * resources. This initialization happens once per process, and thus it
 	 * does not matter which device is used to create the endpoint.
 	 */
-	nccl_net_ofi_device_t *device = (*plugin_p)->get_device(*plugin_p, 0);
-	nccl_net_ofi_ep_t *base_ep = NULL;
+	device = (*plugin_p)->get_device(*plugin_p, 0);
+	base_ep = NULL;
 
 	ret = device->get_ep(device, &base_ep);
 	if (ret != 0) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4288,7 +4288,7 @@ static int post_rdma_write(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post RDMA write */
-	rc = fi_writedata(comm_rail->local_ep, send_data->buff + xfer_info->offset,
+	rc = fi_writedata(comm_rail->local_ep, (void*)((uintptr_t)send_data->buff + xfer_info->offset),
 				xfer_info->msg_size, desc, send_data->wdata,
 				comm_rail->remote_addr,
 				send_data->remote_buff + xfer_info->offset,
@@ -4316,7 +4316,7 @@ static int post_rdma_eager_send(nccl_net_ofi_rdma_req_t *req,
 
 	ssize_t rc;
 	/* Post eager send */
-	rc = fi_senddata(comm_rail->local_ep, send_data->buff + xfer_info->offset, xfer_info->msg_size, desc,
+	rc = fi_senddata(comm_rail->local_ep, (void*)(((uintptr_t)send_data->buff) + xfer_info->offset), xfer_info->msg_size, desc,
 			 send_data->wdata, comm_rail->remote_addr, req);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3019,7 +3019,13 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	int ret = 0;
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
+	rdma_req_recv_data_t *recv_data = NULL;
+	nccl_net_ofi_rdma_ep_t * ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	int dev_id = 0;
 	nccl_net_ofi_rdma_mr_handle_t **mr_handles = (nccl_net_ofi_rdma_mr_handle_t **)mhandles;
+	uint16_t msg_seq_num = 0;
+	bool eager = false;
 
 	assert(r_comm != NULL);
 
@@ -3030,12 +3036,12 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	int dev_id = r_comm->base.base.dev_id;
+	dev_id = r_comm->base.base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t * ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 	assert(ep != NULL);
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	assert(device != NULL);
 
 	ret = process_cq_if_pending(ep);
@@ -3044,13 +3050,14 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		*base_req = NULL;
 		ret = 0;
 		goto error;
-	} else if (ret != 0) {
+	}
+	if (ret != 0) {
 		goto error;
 	}
 
-	uint16_t msg_seq_num = r_comm->next_msg_seq_num;
+	msg_seq_num = r_comm->next_msg_seq_num;
 
-	bool eager = false;
+	eager = false;
 	void *elem;
 	nccl_ofi_msgbuff_elemtype_t type;
 	nccl_ofi_msgbuff_status_t msg_stat;
@@ -3089,7 +3096,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	rdma_req_recv_data_t *recv_data = get_recv_data(req);
+	recv_data = get_recv_data(req);
 
 	if (eager) {
 		nccl_net_ofi_rdma_req_t *bounce_req = (nccl_net_ofi_rdma_req_t *)elem;
@@ -3262,6 +3269,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 
 static int recv_close(nccl_net_ofi_recv_comm_t *recv_comm)
 {
+	nccl_net_ofi_rdma_device_t *device = NULL;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm =
 		(nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
 	int ret = 0;
@@ -3274,7 +3282,7 @@ static int recv_close(nccl_net_ofi_recv_comm_t *recv_comm)
 		goto exit;
 	}
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t*)base_ep->device;
+	device = (nccl_net_ofi_rdma_device_t*)base_ep->device;
 
 	/* Make sure all requests are finished */
 	if (r_comm->num_inflight_reqs > 0) {
@@ -3335,6 +3343,12 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 				   nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
+	int flush_n = 0;
+	bool network_busy = false;
+	int dev_id = 0;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	nccl_net_ofi_scheduler_t *scheduler = NULL;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm =
 		(nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
 
@@ -3351,19 +3365,19 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		goto error;
 	}
 
-	int dev_id = recv_comm->base.dev_id;
+	dev_id = recv_comm->base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 	assert(ep != NULL);
 
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	assert(device != NULL);
 
-	nccl_net_ofi_scheduler_t *scheduler = device->scheduler;
+	scheduler = device->scheduler;
 	assert(scheduler != NULL);
 
 	/* Process any pending requests */
-	bool network_busy = false;
+	network_busy = false;
 	rc = process_cq_if_pending(ep);
 	if (rc == -EAGAIN) {
 		/* Network is still busy. */
@@ -3399,7 +3413,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	 * Find the non-zero request for which we will issue flush.
 	 * A single operation can flush all request at once.
 	 */
-	int flush_n = -1;
+	flush_n = -1;
 	for (int recv_n = 0; recv_n < n; recv_n++) {
 		if (sizes[recv_n] != 0) {
 			flush_n = recv_n;
@@ -3518,7 +3532,9 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 {
 	int ret = 0;
 
+	int comm_id = 0;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = NULL;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 	int dev_id = device->base.dev_id;
 	int num_rails = l_comm_ep->num_rails;
 
@@ -3545,7 +3561,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	r_comm->base.close = recv_close;
 
 	/* Allocate recv communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		r_comm->local_comm_id = ~0;
 		goto error;
@@ -3604,7 +3620,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 		r_comm->base.base.ep = &l_comm_ep->base;
 	}
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)r_comm->base.base.ep;
 
 	/* Add ourselves to ep's lookup array */
 	set_comm(device, r_comm->local_comm_id, &r_comm->base.base);
@@ -4092,6 +4108,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_listen_comm_t *l_comm = NULL;
+	int comm_id = 0;
 	nccl_net_ofi_rdma_ep_t *ep =
 		(nccl_net_ofi_rdma_ep_t *)base_ep;
 
@@ -4130,7 +4147,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	l_comm->leader_local_ep = ep->control_rail.ofi_ep;
 
 	/* Allocate listen communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		l_comm->comm_id = ~0;
 		ret = comm_id;
@@ -4613,10 +4630,13 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	int ret = 0;
 	nccl_net_ofi_rdma_send_comm_t *s_comm = (nccl_net_ofi_rdma_send_comm_t *)send_comm;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	uint16_t msg_seq_num = s_comm->next_msg_seq_num;
 	bool polled_cq = false;
 	bool have_ctrl = false;
+	bool eager = false;
+	int dev_id = 0;
 
 	assert(s_comm != NULL);
 
@@ -4628,9 +4648,9 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		goto error;
 	}
 
-	int dev_id = s_comm->base.base.dev_id;
+	dev_id = s_comm->base.base.dev_id;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->base.base.ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)s_comm->base.base.ep;
 	assert(ep != NULL);
 
 	ret = process_cq_if_pending(ep);
@@ -4639,7 +4659,8 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 		*base_req = NULL;
 		ret = 0;
 		goto error;
-	} else if (ret != 0) {
+	}
+	if (ret != 0) {
 		goto error;
 	}
 
@@ -4647,6 +4668,10 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	 * TODO: Use NCCL provided tags when using grouped receives aka
 	 * props->maxRecvs > 1.
 	 */
+
+	have_ctrl = false;
+	msg_seq_num = s_comm->next_msg_seq_num;
+
 	void *elem;
 	nccl_ofi_msgbuff_elemtype_t type;
 	nccl_ofi_msgbuff_status_t msg_stat;
@@ -4701,7 +4726,7 @@ retry:
 	}
 
 	/* Determine if this should be sent eagerly. */
-	bool eager = false;
+	eager = false;
 	if ((!have_ctrl && size <= eager_max_size) ||
 		 (size == 0)) {
 		eager = true;
@@ -4783,6 +4808,8 @@ retry:
 static int send_close(nccl_net_ofi_send_comm_t *send_comm)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
 
 	nccl_net_ofi_rdma_send_comm_t *s_comm =
 		(nccl_net_ofi_rdma_send_comm_t *)send_comm;
@@ -4813,8 +4840,8 @@ static int send_close(nccl_net_ofi_send_comm_t *send_comm)
 		goto exit;
 	}
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *) s_comm->base.base.ep;
-	nccl_net_ofi_rdma_device_t *device = get_device_from_ep(ep);
+	ep = (nccl_net_ofi_rdma_ep_t*)s_comm->base.base.ep;
+	device = get_device_from_ep(ep);
 	set_comm(device, s_comm->local_comm_id, NULL);
 
 	/* Release communicator ID */
@@ -5022,6 +5049,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 				   nccl_net_ofi_rdma_send_comm_t **s_comm)
 {
 	int ret = 0;
+	int comm_id = 0;
 	fi_addr_t remote_addr;
 	nccl_net_ofi_rdma_send_comm_t *ret_s_comm = NULL;
 	int num_rails = ep->num_rails;
@@ -5064,7 +5092,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->remote_comm_id = handle->comm_id;
 
 	/* Allocate send communicator ID */
-	int comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
+	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		ret_s_comm->local_comm_id = ~0;
 		ret = comm_id;
@@ -5256,6 +5284,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 			    nccl_net_ofi_send_comm_t **send_comm)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_req_state_t conn_resp_req_state;
 	nccl_net_ofi_rdma_req_state_t conn_msg_state;
 	*send_comm = NULL;
 	nccl_net_ofi_rdma_ep_t *ep =
@@ -5383,7 +5412,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		nccl_net_ofi_mutex_lock(&s_comm->conn_resp_req->req_lock);
-		nccl_net_ofi_rdma_req_state_t conn_resp_req_state = s_comm->conn_resp_req->state;
+		conn_resp_req_state = s_comm->conn_resp_req->state;
 		nccl_net_ofi_mutex_unlock(&s_comm->conn_resp_req->req_lock);
 
 		/* Wait until conn resp message is received */
@@ -5552,10 +5581,11 @@ static int init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *device,
 static int release_ep(nccl_net_ofi_ep_t *base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
 
 	/* Validate device */
-	nccl_net_ofi_rdma_ep_t *ep =
-		(nccl_net_ofi_rdma_ep_t*)base_ep;
+	ep = (nccl_net_ofi_rdma_ep_t*)base_ep;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -5563,8 +5593,7 @@ static int release_ep(nccl_net_ofi_ep_t *base_ep)
 	}
 
 	/* Validate device */
-	nccl_net_ofi_rdma_device_t *device =
-		(nccl_net_ofi_rdma_device_t*)ep->base.device;
+	device = (nccl_net_ofi_rdma_device_t*)ep->base.device;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -5720,10 +5749,11 @@ error:
 static inline int get_ep(nccl_net_ofi_device_t *base_dev, nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+	nccl_net_ofi_rdma_ep_t *ep = NULL;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device =
-		(nccl_net_ofi_rdma_device_t*)base_dev;
+	device = (nccl_net_ofi_rdma_device_t*)base_dev;
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -5735,7 +5765,7 @@ static inline int get_ep(nccl_net_ofi_device_t *base_dev, nccl_net_ofi_ep_t **ba
 
 	/* Obtain thread-local rdma endpoint. Allocate and
 	 * initialize endpoint if necessary. */
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)pthread_getspecific(device->ep_key);
+	ep = (nccl_net_ofi_rdma_ep_t*)pthread_getspecific(device->ep_key);
 	if (!ep) {
 		/* Allocate endpoint */
 		ep = (nccl_net_ofi_rdma_ep_t *)calloc(1, sizeof(nccl_net_ofi_rdma_ep_t));
@@ -6036,8 +6066,9 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 				int dev_id, struct fi_info *info_list,
 				nccl_ofi_topo_t *topo, size_t rr_threshold)
 {
-	int ret;
-
+	int ret = 0;
+	bool provide_own_mr_key = false;
+	int length = 0;
 	nccl_net_ofi_rdma_device_t *device =
 		(nccl_net_ofi_rdma_device_t *)calloc(1, sizeof(nccl_net_ofi_rdma_device_t));
 	if (device == NULL) {
@@ -6067,7 +6098,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Ensure that number of rails are the same across devices */
-	int length = ofi_info_list_length(info_list);
+	length = ofi_info_list_length(info_list);
 	if (topo->max_group_size != length) {
 		NCCL_OFI_WARN("Wrong number of NICs for device %i. Expected %i but got %i",
 			      dev_id, topo->max_group_size, length);
@@ -6144,7 +6175,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Initialize mr key pool */
-	bool provide_own_mr_key = true;
+	provide_own_mr_key = true;
 	ret = nccl_ofi_mr_keys_need_own_key(info_list, &provide_own_mr_key);
 	if (ret != 0) {
 		NCCL_OFI_WARN("MR key config parsing failed: %s",

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -604,6 +604,10 @@ exit:
 
 int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	int ret = 0;
+#if HAVE_CUDA
+	const char *optname_name = "none";
+	int optname = -1;
+#endif
 
 	if (endpoint == NULL) {
 		NCCL_OFI_WARN("Unable to configure invalid endpoint");
@@ -645,8 +649,6 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	static bool nccl_proto_configured = false;
 	static bool need_ordering = false;
 	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-	int optname = -1;
-	const char *optname_name = "none";
 
 	/* During initialization, try to set
 	 * FI_OPT_EFA_{SENDRECV,WRTIE}_IN_ORDER_ALIGNED_128_BYTES to
@@ -785,6 +787,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 {
 	struct fi_info *info_list_in = *info_list;
 	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));
+	struct fi_info *info_ptr = NULL;
 
 	if (num_rails <= 0) {
 		return;
@@ -824,7 +827,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 
 	/* Update info_list references to match sorted order */
 	*info_list = sorted_info_array[0];
-	struct fi_info *info_ptr = *info_list;
+	info_ptr = *info_list;
 	for (int i = 0; i < num_rails; ++i) {
 		assert(info_ptr);
 		assert(sorted_info_array[i]);

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -95,16 +95,16 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	},
 	{
 		.name = "trn1n.32xlarge",
-		.default_protocol = "RDMA",
 		.gdr_required = true,
 		.net_flush_required = true,
+		.default_protocol = "RDMA",
 		.domain_per_thread = 1,
 	}
 };

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -337,7 +337,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	float(*table)[NCCL_NUM_PROTOCOLS] = (float(*)[NCCL_NUM_PROTOCOLS])collCostTable;
@@ -373,7 +373,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 
@@ -406,7 +405,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	int in_out = -1;
@@ -437,7 +436,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -344,7 +344,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 	int in_out = -1;
 	int algorithm = NCCL_ALGO_UNDEF;
 	int protocol = NCCL_PROTO_UNDEF;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
@@ -409,7 +409,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 	}
 
 	int in_out = -1;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {


### PR DESCRIPTION
Stacked PRs:
 * #578
 * #582
 * #568
 * #567
 * #566
 * #577
 * #576
 * #574
 * #575
 * __->__#572
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * #560
 * #558
 * #557


--- --- ---

### fix(idpool): avoid sign comparison issues


fixes compilation issues with -wsign-compare
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>