### PR TITLE
fix(tuner): fix implicit conversions

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -344,7 +344,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 	int in_out = -1;
 	int algorithm = NCCL_ALGO_UNDEF;
 	int protocol = NCCL_PROTO_UNDEF;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
@@ -409,7 +409,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 	}
 
 	int in_out = -1;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * __->__#573
 * #569
 * #565
 * #563


--- --- ---

### fix(tuner): fix implicit conversions


cpp requires explicit cast to double here.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>