### PR TITLE
fix(neuron): remove const from ncclNetPlugin_v{4,5} syms

### DIFF
--- a/src/nccl_ofi_interface_neuron.c
+++ b/src/nccl_ofi_interface_neuron.c
@@ -83,7 +83,7 @@ static ncclResult_t accept_v5(void* listenComm, void** recvComm)
 	return nccl_net_ofi_accept(listenComm, recvComm);
 }
 
-NCCL_OFI_EXPORT_SYMBOL const ncclNet_v5_t ncclNetPlugin_v5 = {
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v5_t ncclNetPlugin_v5 = {
         .name = "AWS Libfabric",
         .init = nccl_net_ofi_init,
         .devices = nccl_net_ofi_devices,
@@ -129,7 +129,7 @@ static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
 	return ncclSuccess;
 }
 
-NCCL_OFI_EXPORT_SYMBOL const ncclNet_v4_t ncclNetPlugin_v4 = {
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "AWS Libfabric",
 	.init = init_v4,
 	.devices = nccl_net_ofi_devices,

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -51,12 +51,12 @@ int main(int argc, char* argv[])
 	   and smaller than recv size. And check values 1. below
 	   the eager threshold, 2. between eager and rr threshold,
 	   and 3. above the rr threshold. */
-	size_t send_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
-	                       5 * 1024, 17 * 1024, 2 * 1024 * 1024,
-	                       4 * 1024, 16 * 1024, 1024 * 1024};
-	size_t recv_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
-	                       4 * 1024, 16 * 1024, 1024 * 1024,
-	                       5 * 1024, 17 * 1024, 2 * 1024 * 1024};
+	int send_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
+	                    5 * 1024, 17 * 1024, 2 * 1024 * 1024,
+	                    4 * 1024, 16 * 1024, 1024 * 1024};
+	int recv_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
+	                    4 * 1024, 16 * 1024, 1024 * 1024,
+	                    5 * 1024, 17 * 1024, 2 * 1024 * 1024};
 
 	/* For grouped recvs */
 	int tag = 1;

--- a/tests/unit/ep_addr_list.c
+++ b/tests/unit/ep_addr_list.c
@@ -11,7 +11,7 @@
 
 static void insert_addresses(nccl_ofi_ep_addr_list_t *ep_addr_list, size_t num_addr, int ep_num)
 {
-	for (int i = 0; i < num_addr; ++i) {
+	for (size_t i = 0; i < num_addr; ++i) {
 
 		nccl_net_ofi_ep_t *ep = NULL;
 		int ret = nccl_ofi_ep_addr_list_get(ep_addr_list, &i, sizeof(i),
@@ -37,7 +37,7 @@ static void insert_addresses(nccl_ofi_ep_addr_list_t *ep_addr_list, size_t num_a
 				NCCL_OFI_WARN("No ep returned when expected. addr %d, ep_num %d", i, ep_num);
 				exit(1);
 			}
-			if ((uintptr_t)ep != ep_num) {
+			if ((uintptr_t)ep != (uintptr_t)ep_num) {
 				NCCL_OFI_WARN("Unexpected ep returned");
 			}
 		}

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 
-		if ((char *)item - (char *)simple_base != item->reginfo.base_offset) {
+		if ((uintptr_t)item - (long unsigned int)simple_base != item->reginfo.base_offset) {
 			NCCL_OFI_WARN("base_offset was wrong %p %p %lu %lu",
 				      item, simple_base, (char *)item - (char *)simple_base,
 				      item->reginfo.base_offset);

--- a/tests/unit/idpool.c
+++ b/tests/unit/idpool.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 	(void) ret; // Avoid unused-variable warning
 	size_t sizes[] = {0, 5, 63, 64, 65, 127, 128, 129, 255};
 
-	for (int t = 0; t < sizeof(sizes) / sizeof(size_t); t++) {
+	for (long unsigned int t = 0; t < sizeof(sizes) / sizeof(size_t); t++) {
 		size_t size = sizes[t];
 
 		/* Scale pool size to number of 64-bit uints (rounded up) */
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
 		assert(idpool->size == size);
 
 		/* Test that all bits are set */
-		for (int i = 0; i < num_long_elements; i++) {
+		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
 				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
 			} else {
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 		(void) id; // Avoid unused-variable warning
 		for (uint64_t i = 0; i < size; i++) {
 			id = nccl_ofi_idpool_allocate_id(idpool);
-			assert(id == i);
+			assert((uint64_t)id == i);
 		}
 		id = nccl_ofi_idpool_allocate_id(idpool);
 		assert(-ENOMEM == id);
@@ -54,14 +54,14 @@ int main(int argc, char *argv[]) {
 		if (size) {
 			int holes[] = {(int)(size/3), (int)(size/2)}; // Must be in increasing order
 
-			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
 					ret = nccl_ofi_idpool_free_id(idpool, holes[i]);
 					assert(0 == ret);
 				}
 			}
 
-			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
 					id = nccl_ofi_idpool_allocate_id(idpool);
 					assert(id == holes[i]);
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
 		ret = nccl_ofi_idpool_free_id(idpool, (int)size);
 		assert(-EINVAL == ret);
 
-		for (int i = 0; i < size; i++) {
+		for (size_t i = 0; i < size; i++) {
 			ret = nccl_ofi_idpool_free_id(idpool, i);
 			assert(0 == ret);
 		}
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		/* Test that all bits are set */
-		for (int i = 0; i < num_long_elements; i++) {
+		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
 				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
 			} else {

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -64,7 +64,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 		return 1;
 	}
 
-	for (int info_id = 0; info_id != schedule->num_xfer_infos; ++info_id) {
+	for (size_t info_id = 0; info_id != schedule->num_xfer_infos; ++info_id) {
 		ret |= verify_xfer_info(&schedule->rail_xfer_infos[info_id],
 				     &ref_schedule->rail_xfer_infos[info_id], info_id);
 	}


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * __->__#577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### fix(neuron): remove const from ncclNetPlugin_v{4,5} syms


const variables have internal linkage by default under c++; nvidia
interface requires it not be const because its modified during init.
Remove const for neuron, too.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>