### PR TITLE
.ci/aws: Stop Running ofi nccl functional tests until they are fixed

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -199,7 +199,7 @@ pipeline {
                     def test_type = "--test-type pr"
                     def build_type = "--aws-ofi-nccl-build-type debug"
                     def pr_num = "--test-aws-ofi-nccl-pr $env.CHANGE_ID"
-                    def test_list = "--test-list test_nccl_test test_ofi_nccl_functional"
+                    def test_list = "--test-list test_nccl_test"
                     def base_args = "${nccl_version} ${timeout} ${cluster_type} ${test_target} ${test_type} ${build_type} ${pr_num} ${test_list}"
 
                     def num_instances = 4


### PR DESCRIPTION
We have an internal tracking ticket NCCLOFITICKET-642 which is tracking the re-enablement of the functional tests.  The functional tests are causing kernel panics on p5 on multiple OS's. Remove this testing in order to stabalize the PR CI until it is fixed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
