### PR TITLE
fix(cuda): avoid loading stub

### DIFF
--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -41,10 +41,10 @@ nccl_net_ofi_cuda_init(void)
 	char libcuda_path[1024];
 	char *nccl_cuda_path = getenv("NCCL_CUDA_PATH");
 	if (nccl_cuda_path == NULL) {
-		snprintf(libcuda_path, 1024, "%s", "libcuda.so");
+		snprintf(libcuda_path, 1024, "%s", "libcuda.so.1");
 	}
 	else {
-		snprintf(libcuda_path, 1024, "%s/%s", nccl_cuda_path, "libcuda.so");
+		snprintf(libcuda_path, 1024, "%s/%s", nccl_cuda_path, "libcuda.so.1");
 	}
 
 	(void) dlerror(); /* Clear any previous errors */


### PR DESCRIPTION
CTK ships `stubs/libcuda.so', which may potentially be found by dlopen depending on the environment. The stub exists only for the sake of allowing software to resolve the UMD lib at build time w/o needing to have any particular driver actually installed.

In our usage, it is better to explicitly request libcuda.so.1 to avoid ever potentially loading the stub.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
