### PR TITLE
chore(.github/workflows): constrain push triggers to known branches

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -1,5 +1,11 @@
 name: PR CI
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+      - main
+      - v*
+  pull_request:
 env:
   APT_PACKAGES: >-
     build-essential


### PR DESCRIPTION
Stacked PRs:
 * #592
 * #578
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #564
 * #563
 * #560
 * __->__#582


--- --- ---

### chore(.github/workflows): constrain push triggers to known branches


pull_request triggers remain unchanged/unfiltered.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>