### PR TITLE
fix(tuner): don't choose NVLSTree if nRanks==nNodes

### DIFF
--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -269,7 +269,7 @@ ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugLogger_t
 				      {9999360, 64},
 				      {2367488, 16},
 				      {0, 16}}},
-			{.algorithm = NCCL_ALGO_NVLS_TREE,
+			{.algorithm = NCCL_ALGO_RING,
 			 .protocol = NCCL_PROTO_SIMPLE,
 			 .num_vertices = 4,
 			 .vertices = {{4736000, 2}, {TUNER_MAX_SIZE, 2}, extended_ring_ll128, {269484032, 128}}}};


### PR DESCRIPTION
When `nRanks==nNodes` (`SPLIT_MASK=0x7` in NCCL-tests) NCCL is telling the tuner that NVLS is not supported, because it is only doing inter node communication and NVLS doesn't works across nodes.
So the region that chooses NVLSTree+Simple is ignored by the tuner, and so it falls back to NCCL's tuner. The best choice there is `Ring+Simple`, so this is updating that region.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
