### PR TITLE
fix(tree): add fallthrough switch markers

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4546,10 +4546,12 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_RECV_CONN;
 
+		/* fall through */
 	case COMM_RECV_CONN:
 
 		l_comm->stage = COMM_CONN_REQ_PENDING;
 
+		/* fall through */
 	case COMM_CONN_REQ_PENDING:
 		/* COMM_CONN_REQ_PENDING: Wait until connect message has been
 		 * received. Then, prepare for sending connect accept message,
@@ -4624,6 +4626,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_SEND_CONN;
 
+		/* fall through */
 	case COMM_SEND_CONN:
 
 		/* COMM_SEND_CONN: Send connect response message to remote */
@@ -4637,6 +4640,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_CONN_RESP_REQ_PENDING;
 
+		/* fall through */
 	case COMM_CONN_RESP_REQ_PENDING:
 		/* COMM_CONN_RESP_REQ_PENDING: Wait until connect
 		 * response message has been delivered. Afterwards,
@@ -4670,6 +4674,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		break;
 
 	case COMM_CONNECTED:
+		/* fall through */
 	default:
 		NCCL_OFI_WARN("Invalid state of receive communicator object: %d",
 			      l_comm->stage);
@@ -6219,6 +6224,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_SEND_CONN;
+		/* fall through */
 
 	case COMM_SEND_CONN:
 
@@ -6234,6 +6240,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
+		/* fall through */
 
 	case COMM_CONN_REQ_PENDING:
 		/* COMM_CONN_REQ_PENDING: Wait until connect message
@@ -6265,6 +6272,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		req = NULL;
 
 		comm_state->stage = COMM_RECV_CONN;
+		/* fall through */
 
 	case COMM_RECV_CONN:
 		/* COMM_RECV_CONN: Receive connect response message from remote */
@@ -6272,6 +6280,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		assert(s_comm && s_comm->num_rails > 0);
 
 		comm_state->stage = COMM_CONN_RESP_REQ_PENDING;
+		/* fall through */
 
 	case COMM_CONN_RESP_REQ_PENDING:
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1142,7 +1142,7 @@ static inline int handle_bounce_recv(nccl_net_ofi_rdma_device_t *device, int rai
 	 * header type.  So cast to a control message and lookup the
 	 * type from there. */
 	nccl_ofi_rdma_msg_type_t msg_type =
-		eager ? NCCL_OFI_RDMA_MSG_EAGER : ((nccl_net_ofi_rdma_ctrl_msg_t *)&bounce_fl_item->bounce_msg)->type;
+		eager ? (nccl_ofi_rdma_msg_type_t)NCCL_OFI_RDMA_MSG_EAGER : ((nccl_net_ofi_rdma_ctrl_msg_t *)&bounce_fl_item->bounce_msg)->type;
 
 	switch (msg_type) {
 	case NCCL_OFI_RDMA_MSG_CONN:

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1425,6 +1425,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		comm_state->stage = COMM_RECV_CONN;
+		/* fall through */
 
 	case COMM_RECV_CONN:
 
@@ -1452,6 +1453,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
 
+		/* fall through */
 	case COMM_CONN_REQ_PENDING:
 
 		/* Progress NCCL OFI engine so that connection is accepted */
@@ -1485,8 +1487,11 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		break;
 
 	case COMM_SEND_CONN:
+		/* fall through */
 	case COMM_CONN_RESP_REQ_PENDING:
+		/* fall through */
 	case COMM_CONNECTED:
+		/* fall through */
 	default:
 		NCCL_OFI_WARN("Invalid state of receive communicator object: %d",
 			      stage);
@@ -2063,6 +2068,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 
 		comm_state->stage = COMM_SEND_CONN;
 
+		/* fall through */
 	case COMM_SEND_CONN:
 		/* Send "connect" message to remote EP */
 		rc = send_connect_message(s_comm, device, ep, req);
@@ -2079,6 +2085,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
+		/* fall through */
 
 	case COMM_CONN_REQ_PENDING:
 		if (s_comm->conn_info->connect_to_self == 1) {
@@ -2111,8 +2118,11 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		break;
 
 	case COMM_RECV_CONN:
+		/* fall through */
 	case COMM_CONN_RESP_REQ_PENDING:
+		/* fall through */
 	case COMM_CONNECTED:
+		/* fall through */
 	default:
 		NCCL_OFI_WARN("Invalid state of send communicator object: %d", stage);
 		return -EINVAL;


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * __->__#585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### fix(tree): add fallthrough switch markers


Signed-off-by: Nicholas Sielicki <nslick@amazon.com>
