### PR TITLE
fix(build): check features before mangling CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -125,6 +125,14 @@ CHECK_PKG_HWLOC([],
 CHECK_PKG_VALGRIND()
 CHECK_VAR_REDZONE()
 
+NCCL_OFI_PLATFORM="none"
+AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
+
+AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
+      [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
+
+CHECK_ENABLE_MEMFD_CREATE()
+
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
 
@@ -169,15 +177,7 @@ AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Adding ${werror_flags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${werror_flags}"])
 
-NCCL_OFI_PLATFORM="none"
-AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
-
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
-
-AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
-      [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
-
-CHECK_ENABLE_MEMFD_CREATE()
 
 AC_CONFIG_FILES([Makefile
                  include/Makefile


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * #595
 * #594
 * #593
 * __->__#589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### fix(build): check features before mangling CFLAGS


Yet another autotools fix: If any warning/devel CFLAGS would invoke
warnings in headers used to detect dependencies, those dependencies will
fail with a highly misleading/confusing error message:

> configure: Found .git directory.  Adding -Werror to CFLAGS.
> checking if running on EC2 instance... yes
> checking if want AWS platform optimizations... yes
> checking for Libfabric 1.18.0 or later... no
> configure: error: On AWS platforms, Libfabric 1.18.0 or later is required

ie: it is not that Libfabric 1.18 was not found, it was that its headers
produced warnings. Fix this by resolving all dependencies before
modifying CFLAGS.
