### PR TITLE
fix(tree): use empty brace initializers for zero-initialization

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1523,7 +1523,7 @@ exit:
 static inline int process_err_completion(nccl_net_ofi_rdma_device_t *device,
 					 struct fid_cq *cq)
 {
-	struct fi_cq_err_entry err_entry = { 0 };
+	struct fi_cq_err_entry err_entry = {};
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	int ret = 0;
 
@@ -6704,7 +6704,7 @@ static inline int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_rail_t
 
 	if (ofi_nccl_endpoint_per_communicator() != 0) {
 		/* Create device-shared completion queue */
-		struct fi_cq_attr cq_attr = {0};
+		struct fi_cq_attr cq_attr = {};
 		cq_attr.format = FI_CQ_FORMAT_DATA;
 		ret = fi_cq_open(rail_dev->domain, &cq_attr, &rail_dev->cq, NULL);
 		if (OFI_UNLIKELY(ret != 0)) {

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -185,7 +185,7 @@ static int ofi_process_cq(struct fid_cq *cq, uint64_t max_tag)
 {
 	ssize_t rc = 0;
 	int ret = 0;
-	struct fi_cq_err_entry err_buffer = { 0 };
+	struct fi_cq_err_entry err_buffer = {};
 	struct fi_cq_tagged_entry cqe_tagged_buffers[cq_read_count];
 	nccl_net_ofi_sendrecv_req_t *req = NULL;
 
@@ -1821,7 +1821,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 					    nccl_net_ofi_sendrecv_ep_t *ep,
 					    nccl_net_ofi_sendrecv_send_comm_t **s_comm)
 {
-	char remote_ep_addr[MAX_EP_ADDR] = {0};
+	char remote_ep_addr[MAX_EP_ADDR] = {};
 	uint64_t tag = 0ULL;
 	uint64_t max_tag = 0;
 	size_t req_size = sizeof(nccl_net_ofi_sendrecv_req_t);

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -702,7 +702,7 @@ static int lift_up_ofi_infos(nccl_ofi_topo_t *topo)
 	 * topology nodes that have a "NIC topology nodes" or a
 	 * "accelerator topology nodes" it their subtree, all info
 	 * structs are found. */
-	nccl_ofi_topo_data_iterator_t data_iter;
+	nccl_ofi_topo_data_iterator_t data_iter = {};
 	nccl_ofi_topo_set_to_begin(topo, &data_iter);
 	while ((source_data = nccl_ofi_get_user_data(&data_iter))) {
 		nccl_ofi_inc_user_data_iter(&data_iter);
@@ -878,7 +878,7 @@ static int create_groups_from_info_lists(nccl_ofi_topo_t *topo)
 	nccl_ofi_topo_data_t *data = NULL;
 
 	/* Iterate over user data of topology nodes */
-	nccl_ofi_topo_data_iterator_t data_iter;
+	nccl_ofi_topo_data_iterator_t data_iter = {};
 	nccl_ofi_topo_set_to_begin(topo, &data_iter);
 	while ((data = nccl_ofi_get_user_data(&data_iter))) {
 		nccl_ofi_inc_user_data_iter(&data_iter);
@@ -917,7 +917,7 @@ static int create_groups_from_info_lists(nccl_ofi_topo_t *topo)
  */
 static void print_nic_groups(nccl_ofi_topo_t *topo) {
 	nccl_ofi_topo_data_t *data = NULL;
-	nccl_ofi_topo_data_iterator_t data_iter;
+	nccl_ofi_topo_data_iterator_t data_iter = {};
 	nccl_ofi_topo_set_to_begin(topo, &data_iter);
 
 	int group_idx = 0;


### PR DESCRIPTION
Stacked PRs:
 * #624
 * __->__#594


--- --- ---

### fix(tree): use empty brace initializers for zero-initialization


prefer `struct foo bar = {}' to `struct foo bar = { 0 }' to avoid
-Wmissing-field-initializers warnings.
Signed-off-by: Nicholas Sielicki <nslick@amazon.com>