### PR TITLE
fix(platform-aws): fill all platform values

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -34,7 +34,9 @@ struct ec2_platform_data {
 	bool net_flush_required;
 	const char *default_protocol;
 	int domain_per_thread;
-} platform_data_map[] = {
+};
+
+static struct ec2_platform_data platform_data_map[] = {
 	{
 		.name = "p4d.24xlarge",
 		.topology = "p4d-24xl-topo.xml",
@@ -88,6 +90,8 @@ struct ec2_platform_data {
 	{
 		.name = "g5.48xlarge",
 		.topology = "g5.48xl-topo.xml",
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = false,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
@@ -95,6 +99,9 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
@@ -102,6 +109,9 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1n.32xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",


### PR DESCRIPTION
Stacked PRs:
 * #568
 * #567
 * #566
 * #591
 * #588
 * __->__#595
 * #594
 * #593
 * #589
 * #587
 * #577
 * #576
 * #586
 * #585
 * #574
 * #575
 * #571
 * #570
 * #573
 * #569
 * #565
 * #563


--- --- ---

### fix(platform-aws): fill all platform values


commit ce214aa rearranged fields such that the written initializers were
valid on most modern compilers, but it went unnoticed that this is
insufficient for AL2's ancient toolchain, which fails with:

> sorry, unimplemented: non-trivial designated initializers not supported

provide all members for all entries to fix this.
