### PR TITLE
feat(build): better --enable-debug defaults

### DIFF
--- a/m4/ax_check_enable_debug.m4
+++ b/m4/ax_check_enable_debug.m4
@@ -76,11 +76,11 @@ AC_DEFUN([AX_CHECK_ENABLE_DEBUG],[
     AS_CASE([$enable_debug],
       [yes],[
         AC_MSG_RESULT(yes)
-        CFLAGS="${CFLAGS} -g -O0"
-        CXXFLAGS="${CXXFLAGS} -g -O0"
-        FFLAGS="${FFLAGS} -g -O0"
-        FCFLAGS="${FCFLAGS} -g -O0"
-        OBJCFLAGS="${OBJCFLAGS} -g -O0"
+        CFLAGS="${CFLAGS} -gdwarf -Og -fno-omit-frame-pointer"
+        CXXFLAGS="${CXXFLAGS} -gdwarf -Og -fno-omit-frame-pointer"
+        FFLAGS="${FFLAGS} -gdwarf -Og -fno-omit-frame-pointer"
+        FCFLAGS="${FCFLAGS} -gdwarf -Og -fno-omit-frame-pointer"
+        OBJCFLAGS="${OBJCFLAGS} -gdwarf -Og -fno-omit-frame-pointer"
       ],
       [info],[
         AC_MSG_RESULT(info)


### PR DESCRIPTION
prefer dwarf debug symbols for usage with nsight, don't use -O0 as it prevents the proper usage of fortify-source, don't omit frame pointers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
