### PR TITLE
fix(sendrecv): fix a memory leak

### DIFF
--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1595,7 +1595,11 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	/* Build handle */
 	local_ep_name = get_local_address(ep->ofi_ep);
 
-	memcpy(handle->ep_name, local_ep_name, MAX_EP_ADDR);
+	if (local_ep_name != NULL) {
+		memcpy(handle->ep_name, local_ep_name, MAX_EP_ADDR);
+		free(local_ep_name);
+	}
+
 	handle->comm_id = (uint32_t)tag;
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */


### PR DESCRIPTION
get_local_address either returns NULL, in which case, this is sure to attempt to copy MAX_EP_ADDR bytes from NULL and sigsegv, or it returns an allocated string which is leaked on /every/ call to listen.

Check for NULL before copying-out of the returned address, and free the string afterwards.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
