### PR TITLE
freelist: separate out metadata from user data

### DIFF
--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -40,6 +40,9 @@ typedef struct nccl_net_ofi_schedule {
 	/* Number of transfer information entries set by the scheduler */
 	size_t num_xfer_infos;
 
+	/* Backpointer to freelist element (for cleanup) */
+	nccl_ofi_freelist_elem_t *elem;
+
 	/* Array of transfer information structs. The array has at
 	 * least 'num_xfer_infos' entries. */
 	nccl_net_ofi_xfer_info_t rail_xfer_infos[];

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -199,6 +199,9 @@ typedef struct nccl_net_ofi_sendrecv_req {
 
 	/* Direction of request */
 	nccl_net_ofi_sendrecv_req_direction_t direction;
+
+	/* Backpointer to freelist elem (for cleanup) */
+	nccl_ofi_freelist_elem_t *elem;
 } nccl_net_ofi_sendrecv_req_t;
 
 


### PR DESCRIPTION
Updates the interface of freelist to return an elem struct that contains
a buffer pointer and (optionally) memory registration info. Also updates
sendrecv, rdma, and scheduler codes to use the new interface.

This separation paves the way for storing freelist user data in GPU
memory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
