### PR TITLE
feat(build): disable semantic interposition

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,8 +52,17 @@ AC_C_INLINE
 dnl ac_check_enable_debug will make sure AC_PROG_CC doesn't add a
 dnl bunch of debugging flags, so there's no ordering requirement
 dnl between this and AC_PROG_CC.
-AS_IF([test "${ax_enable_debug}" = "no"], [CFLAGS="${CFLAGS} -O3"])
+AS_IF([test "${ax_enable_debug}" = "no"], [
+             dnl Enable O3 optimization
+             CFLAGS="${CFLAGS} -O3"
 
+             dnl dead code elim
+             CFLAGS="${CFLAGS} -ffunction-sections -fdata-sections"
+
+             dnl https://maskray.me/blog/2021-05-09-fno-semantic-interposition
+             CFLAGS="${CFLAGS} -fno-semantic-interposition -fvisibility=hidden"
+             LDFLAGS="${LDFLAGS} -Bsymbolic"
+            ])
 CHECK_ENABLE_SANITIZER()
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ dnl the risk of silently enabling system extensions is minimal.
 AC_USE_SYSTEM_EXTENSIONS
 dnl AM_PROG_AR must be called before LT_INIT
 AM_PROG_AR
+AC_PROG_RANLIB
 LT_INIT([shared disable-static pic-only])
 
 NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS=

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,10 @@ AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset funct
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
 AC_CHECK_FUNCS([gettid])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
+dnl it is insufficient to merely link against pthread
+dnl -pthread must be passed in cflags: https://stackoverflow.com/a/23251828
+CFLAGS="${CFLAGS} -pthread"
+CPPFLAGS="${CPPFLAGS} -pthread"
 AC_SEARCH_LIBS([pthread_mutexattr_settype], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
 AC_SEARCH_LIBS([log2], [m], [], [AC_MSG_ERROR([NCCL OFI Plugin requires the log2 library function.])])
 


### PR DESCRIPTION
*Description of changes:*

```
feat(build): disable semantic interposition

Tell the compiler to treat symbols marked explicitly as
NCCL_OFI_EXPORT_SYMBOL as preemptible, but not others. This gives the
compiler the freedom to assume that no external LD_PRELOAD'd library can
inject itself as an implementation of any given function in the library,
which means the compiler has the freedom to optimize across function.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>

1 file changed, 10 insertions(+), 1 deletion(-)
configure.ac | 11 ++++++++++-
```

```
fix(build): add missing AC_PROG_RANLIB

Automake manual:

> This is required if any libraries are built in the package. See
> Particular Program Checks in The Autoconf Manual.

add this for correctness.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>

1 file changed, 1 insertion(+)
configure.ac | 1 +
```

```
fix(build): ensure -pthread is passed

Linking against pthread and adding the compiler option for pthread are
two different things. Without the compiler option, various builtin
'#define's are not set. Notably, this should change the behavior around
errno in a multithreaded context within glibc; _REENTRANT will now be
defined and errno is now thread-local.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>

1 file changed, 3 insertions(+)
configure.ac | 3 +++
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
