### PR TITLE
Fix: access domain from ep during mr on device

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2528,7 +2528,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 		goto exit;
 	}
 
-	ret = register_rail_mr_buffer(get_device_rail(device, 0)->domain, ep->control_rail.ofi_ep,
+	ret = register_rail_mr_buffer(ep->control_rail.domain, ep->control_rail.ofi_ep,
 				      -1, type, &mr_attr,
 				      &ret_handle->control_mr);
 	if (OFI_UNLIKELY(ret != 0)) {


### PR DESCRIPTION
This commit fixes a bug introduced by commit 64d8baf "rdma: Move control messages to own endpoint".

The domain member of the plugin RDMA device struct is not available for free disposal. It only stores an actual domain in case only one domain is created per device, i.e., when the domain-per-thread feature is disabled. In this case, the domain is copied over from the device object into the plugin RDMA endpoint object. Afterwards, only the domain member of the endpoint should be accessed. Reason is that the device object does not provide an domain in case domain-per-thread feature is disabled.
However, said commit above accesses domain member of device object in any case. This commit fixes this bug by accessing the domain member of the endpoint instead.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
