### PR TITLE
platform: trn1 default protocol send receive

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -97,14 +97,14 @@ struct ec2_platform_data {
 		.name = "trn1.32xlarge",
 		.gdr_required = true,
 		.net_flush_required = true,
-		.default_protocol = "RDMA",
+		.default_protocol = "SENDRECV",
 		.domain_per_thread = 1,
 	},
 	{
 		.name = "trn1n.32xlarge",
 		.gdr_required = true,
 		.net_flush_required = true,
-		.default_protocol = "RDMA",
+		.default_protocol = "SENDRECV",
 		.domain_per_thread = 1,
 	}
 };


### PR DESCRIPTION
In order to use the RDMA protocol on TRN1, users need to issue a reboot of their instance. If a reboot is not issued, the plugin will fail to initialize. Therefore, we want to set the default protocol to SEND RECEIVE so that users can use this plugin out of the box without having to reboot their instance.

*Issue #, if available:*

*Description of changes:*
- Set default protocol on TRN1 platform to be send receive


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
