### PR TITLE
Add Multiplexed-round-robin scheduler

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -234,9 +234,9 @@ OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
 OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
 
 /*
- * Maximum size of a message in bytes before message is multiplexed
+ * Messages sized larger than this threshold will be striped across multiple rails
  */
-OFI_NCCL_PARAM_UINT(round_robin_threshold, "ROUND_ROBIN_THRESHOLD", (256 * 1024));
+OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (64 * 1024));
 
 /*
  * Minimum bounce buffers posted per endpoint. The plugin will attempt to post

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -93,9 +93,9 @@ typedef struct nccl_net_ofi_threshold_scheduler {
 	unsigned int rr_counter;
 	/* Lock for round robin counter */
 	pthread_mutex_t rr_lock;
-	/* Maximum size of a message in bytes before message is
+	/* Minimum size of the message in bytes before message is
 	 * multiplexed */
-	size_t rr_threshold;
+	size_t min_stripe_size;
 } nccl_net_ofi_threshold_scheduler_t;
 
 /*
@@ -109,30 +109,14 @@ void nccl_net_ofi_release_schedule(nccl_net_ofi_scheduler_t *scheduler,
  *
  * @param	num_rails
  *		Number of rails
- * @param	rr_threshold
- *		Maximum size of a message in bytes before message is multiplexed
- *
+ * @param min_stripe_size
+ * 		Minimum size of a message in bytes before message is multiplexed
  * @return	Scheduler, on success
  *		NULL, on error
  * @return	0, on success
  *		non-zero, on error
  */
-int nccl_net_ofi_threshold_scheduler_init(int num_rails,
-					  size_t rr_threshold,
-					  nccl_net_ofi_scheduler_t **scheduler);
-
-/*
- * Internal: Set schedule that multiplexes messages to all rails.
- *
- * A mininal stripe size `max_stripe_size' is calculated (multiple of
- * `align') that is sufficient to assign the whole message. Rails are
- * filled from low id to large id. The last rail may get assigned less
- * data.
- */
-void nccl_net_ofi_set_multiplexing_schedule(size_t size,
-					    int num_rails,
-					    size_t align,
-					    nccl_net_ofi_schedule_t *schedule);
+int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size, nccl_net_ofi_scheduler_t **scheduler);
 
 #ifdef __cplusplus
 } // End extern "C"

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -7017,10 +7017,8 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
 /**
  * Create an rdma device object
  */
-static nccl_net_ofi_rdma_device_t *
-nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
-				int dev_id, struct fi_info *info_list,
-				nccl_ofi_topo_t *topo, size_t rr_threshold)
+static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
+	nccl_net_ofi_plugin_t *plugin, int dev_id, struct fi_info *info_list, nccl_ofi_topo_t *topo, size_t min_strip_size)
 {
 	int ret = 0;
 	bool provide_own_mr_key = false;
@@ -7063,9 +7061,7 @@ nccl_net_ofi_rdma_device_create(nccl_net_ofi_plugin_t *plugin,
 	}
 
 	/* Create scheduler */
-	ret = nccl_net_ofi_threshold_scheduler_init(length,
-						    rr_threshold,
-						    &device->scheduler);
+	ret = nccl_net_ofi_threshold_scheduler_init(length, min_strip_size, &device->scheduler);
 	if (ret != 0) {
 		goto error;
 	}
@@ -7275,7 +7271,7 @@ static inline int nccl_net_ofi_rdma_plugin_complete_init(nccl_net_ofi_plugin_t *
 		                                                                     (int)dev_id,
 		                                                                     info_list,
 		                                                                     rdma_plugin->topo,
-		                                                                     ofi_nccl_round_robin_threshold());
+		                                                                     ofi_nccl_min_stripe_size());
 		if (device == NULL) {
 			NCCL_OFI_WARN("Device creation failed");
 			return -ENOMEM;
@@ -7402,7 +7398,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	if (ofi_nccl_eager_max_size() > ofi_nccl_round_robin_threshold()) {
+	if (ofi_nccl_eager_max_size() > ofi_nccl_min_stripe_size()) {
 		NCCL_OFI_WARN("Invalid value for EAGER_MAX_SIZE");
 		ret = ncclInvalidArgument;
 		goto error;


### PR DESCRIPTION
*Description of changes:*
This change modifies the current scheduling policy such that we either round-robin on each rail or a pair of rails or a triplet of rails or a quadruplet of rails based on the min_stripe_size. Within the group of rails the message is divided by the stripe_size and multiplexed on each rail.

The num_stripes to be multiplexed is calculated using the below formula,
num_stripes = min ( ceil ( msg_size / min_stripe_size ) , num_rails )

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
