### PR TITLE
fix(tree): import libfabric's container_of macro

### DIFF
--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -24,6 +24,13 @@
 #define PATH_MAX	4096
 #endif
 
+/* Copied from libfabric:rdma/fabric.h@30ec628: "libfabric: Initial commit" */
+#ifndef container_of
+#define container_of(ptr, type, field) \
+	((type *) ((char *)ptr - offsetof(type, field)))
+#endif
+/* end of copied libfabric macros */
+
 /* Workaround for platforms without memfd_create */
 #ifndef HAVE_MEMFD_CREATE
 #include <sys/syscall.h>


### PR DESCRIPTION
```
fix(tree): import libfabric's container_of macro

Newer versions of libfabric are no longer defining this in
"rdma/fabric.h", but we were relying on it transiently. Bring it in-tree
to unblock compilation against libfabric master.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
