### PR TITLE
fix(valgrind): fix autotools mistake

### DIFF
--- a/m4/check_pkg_valgrind.m4
+++ b/m4/check_pkg_valgrind.m4
@@ -34,14 +34,15 @@ AC_DEFUN([CHECK_PKG_VALGRIND], [
          AC_MSG_CHECKING([for VALGRIND_MAKE_MEM_NOACCESS])
          AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
                             [[
-                              #include "valgrind/memcheck.h"
+                              #include <valgrind/memcheck.h>
                             ]],
                             [[#if !defined(VALGRIND_MAKE_MEM_NOACCESS)
                               #error Failed not defined $define
+                              return 1;
+                              #else
+                              return 0;
                               #endif
-                              int main(void) {
-                                return 0;
-                              }]])],
+                              ]])],
                            [AC_MSG_RESULT([yes])],
                            [AC_MSG_RESULT([no])
                             AC_MSG_ERROR([Need valgrind version 3.2.0 or later.])])])


### PR DESCRIPTION
AC_LANG_PROGRAM creates main for you, so putting `int main(void) {}` inside of another `int main(void){}` can fail the check due to warnings, even when the header is available.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
