### PR TITLE
Improve protocol selection logic

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -484,6 +484,19 @@ struct nccl_net_ofi_recv_comm {
  */
 struct nccl_net_ofi_plugin {
 /* public */
+
+	/**
+	 * Complete initialization of plugin
+	 *
+	 * When a plugin is first created, it should not create any
+	 * network resources -- create is called to understand the
+	 * configuration of the network and see which transports can
+	 * run.  The base code will pick one and call complete_init,
+	 * at which point devices and network resources can be
+	 * created.
+	 */
+	int (*complete_init)(nccl_net_ofi_plugin_t *plugin);
+
 	int (*assign_device)(nccl_net_ofi_plugin_t *plugin,
 			     size_t device_index, nccl_net_ofi_device_t *device);
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -834,11 +834,21 @@ typedef struct nccl_net_ofi_rdma_device {
 #endif
 } nccl_net_ofi_rdma_device_t;
 
+
+struct nccl_net_ofi_rdma_plugin {
+	nccl_net_ofi_plugin_t base;
+
+	nccl_ofi_topo_t *topo;
+};
+typedef struct nccl_net_ofi_rdma_plugin nccl_net_ofi_rdma_plugin_t;
+
+
 /*
  * @brief	Initialize plugin with rdma protocol structures
  */
 int nccl_net_ofi_rdma_init(const char *provider_filter,
-			   nccl_net_ofi_plugin_t **plugin_p);
+			   nccl_net_ofi_plugin_t **plugin_p,
+			   bool *found_multi_rail);
 
 #ifdef __cplusplus
 } // End extern "C"

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -220,6 +220,15 @@ typedef struct nccl_net_ofi_sendrecv_req {
 	nccl_net_ofi_sendrecv_req_direction_t direction;
 } nccl_net_ofi_sendrecv_req_t;
 
+
+struct nccl_net_ofi_sendrecv_plugin {
+	nccl_net_ofi_plugin_t base;
+
+	struct fi_info *provider_list;
+};
+typedef struct nccl_net_ofi_sendrecv_plugin nccl_net_ofi_sendrecv_plugin_t;
+
+
 /*
  * @brief	Initialize plugin with sendrecv protocol structures
  */


### PR DESCRIPTION
Change the protocol selection logic when the platform file does not specify a protocol.  Instead of always defaulting to sendrecv if the user / platform file didn't specify a protocol, try to figure out when rdma is a good default.  We still are conservative with enabling the rdma protocol, to avoid changing the default in as many places as posible.

With the change, the protocol selection order is:

  1. if the user set NCCL_OFI_PROTOCOL, use that.
  2. if the platform init set nccl_ofi_selected_protocol, use that.
  3. If the rdma protocol reports multiple nics per device and initialized successfully, use that.
  4. If the sendrecv protocol initialized successfully, use that.
  5. If the rdma protocol initialized successfully, use that.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
