### PR TITLE
util: Use FI_ENOPROTOOPT to check for a provider's support for option

### DIFF
--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -322,7 +322,7 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 		ret = fi_setopt(&(*ep)->fid, FI_OPT_ENDPOINT,
 				FI_OPT_SHARED_MEMORY_PERMITTED, &optval,
 				sizeof(optval));
-		if (ret == -FI_EOPNOTSUPP) {
+		if (ret == -FI_EOPNOTSUPP || ret == -FI_ENOPROTOOPT) {
 			/* One way we get here is running against
 			 * older libfabric builds that don't have
 			 * FI_OPT_SHARED_MEMORY_PERMITTED.  This isn't
@@ -347,7 +347,7 @@ int nccl_ofi_ofiutils_init_connection(int api_version, struct fi_info *info, str
 		ret = fi_setopt(&(*ep)->fid, FI_OPT_ENDPOINT,
 				FI_OPT_CUDA_API_PERMITTED, &optval,
 				sizeof(optval));
-		if (ret == -FI_EOPNOTSUPP) {
+		if (ret == -FI_EOPNOTSUPP || ret == -FI_ENOPROTOOPT) {
 			if (support_gdr == GDR_SUPPORTED) {
 				/* If we got here, that means we previously said
 				 * we definitely had GDR support, but now don't.


### PR DESCRIPTION
fi_endpoint(3) states that fi_setopt/_getopt calls return FI_ENOPROTOOPT when a provider does not support a requested option. Certain setopt options also return FI_EOPNOTSUPP if a particular mode forced by setting an option is not supported (such as, with FI_OPT_CUDA_API_PERMITTED being set to false when a provider requires CUDA API to support FI_HMEM_CUDA). Checking for both as we have the same error outcome in either case.

Fixes #606

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
