### PR TITLE
Fix log format string behavior

### DIFF
--- a/include/nccl_ofi_log.h
+++ b/include/nccl_ofi_log.h
@@ -12,8 +12,13 @@ extern "C" {
 
 #include "nccl-headers/net.h"
 
+// GCC is happy with this hint to identify printf string code
+// mismatches.  Clang does not seem to want to apply the hint, but
+// also doesn't complain, so this is better than nothing.
+typedef ncclDebugLogger_t nccl_ofi_logger_t __attribute__ ((format (printf, 5, 6)));
+
 // Logger Function
-extern ncclDebugLogger_t ofi_log_function;
+extern nccl_ofi_logger_t ofi_log_function;
 
 #define NCCL_OFI_WARN(fmt, ...)							\
 	(*ofi_log_function)(NCCL_LOG_WARN, NCCL_ALL, __PRETTY_FUNCTION__,	\

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -19,7 +19,7 @@ static_assert(NCCL_NET_MAX_REQUESTS <= NCCL_OFI_MAX_REQUESTS,
 
 /* nccl_net_ofi plugin */
 nccl_net_ofi_plugin_t *plugin = NULL;
-ncclDebugLogger_t ofi_log_function = NULL;
+nccl_ofi_logger_t ofi_log_function = NULL;
 
 
 static ncclResult_t nccl_net_ofi_retval_translate(int retval)

--- a/src/nccl_ofi_idpool.c
+++ b/src/nccl_ofi_idpool.c
@@ -158,7 +158,7 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
 	}
 
 	if (OFI_UNLIKELY(id >= idpool->size)) {
-		NCCL_OFI_WARN("ID value %lu out of range (max: %lu)", id, idpool->size);
+		NCCL_OFI_WARN("ID value %d out of range (max: %lu)", id, idpool->size);
 		return -EINVAL;
 	}
 
@@ -169,7 +169,7 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id)
 
 	/* Check if bit is 1 already */
 	if (idpool->ids[i] & (1ULL << entry_index)) {
-		NCCL_OFI_WARN("Attempted to free an ID that's not in use (%lu)", id);
+		NCCL_OFI_WARN("Attempted to free an ID that's not in use (%d)", id);
 
 		nccl_net_ofi_mutex_unlock(&idpool->lock);
 		return -ENOTSUP;

--- a/src/nccl_ofi_mr.c
+++ b/src/nccl_ofi_mr.c
@@ -136,7 +136,7 @@ void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache,
 			cache->hit_count++;
 			NCCL_OFI_TRACE(
 				NCCL_NET,
-				"Found MR handle %p for %p in cache slot %d",
+				"Found MR handle %p for %p in cache slot %zu",
 				cache->slots[slot]->handle,
 				addr,
 				slot);
@@ -200,7 +200,7 @@ int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
 			cache->used++;
 			NCCL_OFI_TRACE(
 				NCCL_NET,
-				"Inserted MR handle %p for %p in cache slot %d",
+				"Inserted MR handle %p for %p in cache slot %zu",
 				handle,
 				addr,
 				slot);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1506,7 +1506,7 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 				ret = -EINVAL;
 			}
 		} else {
-			NCCL_OFI_WARN("Unexpected comp_flags on cq event 0x%016X", comp_flags);
+			NCCL_OFI_WARN("Unexpected comp_flags on cq event 0x%016" PRIX64, comp_flags);
 			ret = -EINVAL;
 		}
 
@@ -1691,7 +1691,7 @@ static int process_pending_reqs(nccl_net_ofi_rdma_ep_t *ep)
 	while (true) {
 		rc = nccl_ofi_deque_remove_front(pending_reqs_queue, &deque_elem);
 		if (OFI_UNLIKELY(rc != 0)) {
-			NCCL_OFI_WARN("Failed to nccl_ofi_deque_remove_front: %zd", rc);
+			NCCL_OFI_WARN("Failed to nccl_ofi_deque_remove_front: %d", rc);
 			return rc;
 		}
 
@@ -1719,7 +1719,7 @@ static int process_pending_reqs(nccl_net_ofi_rdma_ep_t *ep)
 		}
 
 		if ((rc != 0) && (rc != -FI_EAGAIN)) {
-			NCCL_OFI_WARN("Unable to post request; RC: %zd", rc);
+			NCCL_OFI_WARN("Unable to post request; RC: %d", rc);
 			break;
 		} else if (rc == -FI_EAGAIN) {
 			/* Put the request in the front of the queue and try again later */
@@ -1804,7 +1804,7 @@ static int ofi_process_cq(nccl_net_ofi_rdma_ep_t *ep)
 	/* Process any pending requests */
 	ret = process_pending_reqs(ep);
 	if (OFI_UNLIKELY(ret != 0 && ret != -FI_EAGAIN)) {
-		NCCL_OFI_WARN("Failed call to process_pending_reqs: %zd", ret);
+		NCCL_OFI_WARN("Failed call to process_pending_reqs: %d", ret);
 	}
 
  exit:
@@ -2253,7 +2253,7 @@ static int init_send_comm_rails(nccl_net_ofi_rdma_send_comm_t *s_comm,
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
-				      "for device %d. RC: %d",
+				      "for device %d. RC: %s",
 				      dev_id, fi_strerror(-ret));
 			return -EINVAL;
 		}
@@ -3935,7 +3935,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	if (!network_busy) {
 		rc = receive_progress(req, true);
 		if (OFI_UNLIKELY(rc != 0)) {
-			NCCL_OFI_WARN("Call to receive_progress failed: %zd", rc);
+			NCCL_OFI_WARN("Call to receive_progress failed: %zu", rc);
 			ret = rc;
 			goto error;
 		}
@@ -4178,8 +4178,8 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 
 	/* Validate received comm ID */
 	if (OFI_UNLIKELY(conn_msg->local_comm_id >= device->num_comm_ids)) {
-		NCCL_OFI_WARN("Received an invalid communicator ID %lu for device %d", conn_msg->local_comm_id,
-					  dev_id);
+		NCCL_OFI_WARN("Received an invalid communicator ID %" PRIu32 " for device %d",
+			      conn_msg->local_comm_id, dev_id);
 		goto error;
 	}
 
@@ -4238,7 +4238,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 			   &r_comm->control_rail.remote_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert remote address into address vector "
-			      "for device %d. RC: %d",
+			      "for device %d. RC: %s",
 			      dev_id, fi_strerror(-ret));
 		goto error;
 	}
@@ -4247,7 +4247,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 			   &r_comm->control_rail.local_addr, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
 		NCCL_OFI_WARN("Unable to insert local address into address vector "
-			      "for device %d. RC: %d",
+			      "for device %d. RC: %s",
 			      dev_id, fi_strerror(-ret));
 		goto error;
 	}
@@ -4268,7 +4268,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 				   &comm_rail->remote_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert remote address into address vector "
-				      "for device %d. RC: %d",
+				      "for device %d. RC: %s",
 				      dev_id, fi_strerror(-ret));
 			goto error;
 		}
@@ -4277,7 +4277,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 				   &comm_rail->local_addr, 0, NULL);
 		if (OFI_UNLIKELY(ret != 1)) {
 			NCCL_OFI_WARN("Unable to insert local address into address vector "
-				      "for device %d. RC: %d",
+				      "for device %d. RC: %s",
 				      dev_id, fi_strerror(-ret));
 			goto error;
 		}
@@ -4783,7 +4783,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
  error:
 	if (l_comm && ~0 != l_comm->comm_id) {
 		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, l_comm->comm_id)) {
-			NCCL_OFI_WARN("Error freeing communicator ID %" PRIu64, l_comm->comm_id);
+			NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, l_comm->comm_id);
 		}
 	}
 	free(l_comm);
@@ -5925,7 +5925,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 
 	/* Store communicator ID from handle in communicator */
 	if (OFI_UNLIKELY(handle->comm_id >= device->num_comm_ids)) {
-		NCCL_OFI_WARN("Received an invalid communicator ID %lu for device %d", handle->comm_id,
+		NCCL_OFI_WARN("Received an invalid communicator ID %" PRIu32 " for device %d", handle->comm_id,
 			      dev_id);
 		ret = -EINVAL;
 		goto error;
@@ -6336,7 +6336,7 @@ static inline int set_local_address(struct fid_ep *ep, nccl_net_ofi_ep_rail_t *r
 			 (void *)rail->local_ep_name,
 			 &rail->local_ep_name_len);
 	if (res == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+		NCCL_OFI_WARN("Endpoint's address length (%zu) is larger than supplied buffer length (%d)",
 			      rail->local_ep_name_len, MAX_EP_ADDR);
 		return -EINVAL;
 	} else if (res != 0) {

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1291,7 +1291,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 	ret = fi_av_insert(ep->av, (void *)remote_ep_addr, 1,
 			   &remote_ep, 0, NULL);
 	if (OFI_UNLIKELY(ret != 1)) {
-		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %s",
 			      dev_id, fi_strerror(-ret));
 		return NULL;
 	}
@@ -1544,7 +1544,7 @@ static inline char *get_local_address(struct fid_ep *ep)
 			 (void *)local_ep_addr,
 			 &namelen);
 	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+		NCCL_OFI_WARN("Endpoint's address length (%zu) is larger than supplied buffer length (%d)",
 			      namelen, MAX_EP_ADDR);
 		free(local_ep_addr);
 		return NULL;
@@ -1608,7 +1608,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 
 	/* Only 1 address should be inserted into the AV */
 	if (OFI_UNLIKELY(num_addrs != 1)) {
-		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %d",
+		NCCL_OFI_WARN("Unable to insert remote address into address vector for device %d. RC: %s",
 			      dev_id, fi_strerror(-ret));
 		ret = -EINVAL;
 		goto error;
@@ -1908,7 +1908,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 			 (void *)ret_s_comm->conn_info->ep_name,
 			 &ret_s_comm->conn_info->ep_namelen);
 	if (ret == -FI_ETOOSMALL) {
-		NCCL_OFI_WARN("Endpoint's address length (%d) is larger than supplied buffer length (%d)",
+		NCCL_OFI_WARN("Endpoint's address length (%zu) is larger than supplied buffer length (%d)",
 			      ret_s_comm->conn_info->ep_namelen, MAX_EP_ADDR);
 		goto out;
 	} else if (ret != 0) {

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -381,19 +381,19 @@ int configure_nvls_option(void)
 				return -ENOTSUP;
 			}
 
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "ncclGetVersion results = %lu", version);
+			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "ncclGetVersion results = %d", version);
 		}
 
 		/* 2.18.5 */
 		if (version < 21805) {
-			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Disabling NVLS support due to NCCL version %lu", version);
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Disabling NVLS support due to NCCL version %d", version);
 			ret = setenv("NCCL_NVLS_ENABLE", "0", 1);
 			if (ret != 0) {
 				NCCL_OFI_WARN("Unable to set NCCL_NVLS_ENABLE");
 				return -errno;
 			}
 		} else {
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Not disabling NVLS support due to NCCL version %lu", version);
+			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Not disabling NVLS support due to NCCL version %d", version);
 		}
 	}
 

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -427,7 +427,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 				      "Choosing algo %d proto %d with cost %.8f µsecs for coll %d size %ld.",
 				      *algorithm,
 				      *protocol,
-				      0,
+				      0.0,
 				      collType,
 				      nBytes);
 		}

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -311,7 +311,7 @@ int main(int argc, char* argv[])
 						if (received_size !=
 						    NCCL_OFI_MIN(send_sizes[szidx], recv_sizes[szidx])) {
 							NCCL_OFI_WARN(
-								"Wrong received size %d (send size: %d recv size %d)",
+								"Wrong received size %d (send size: %zu recv size %zu)",
 								received_size, send_sizes[szidx], recv_sizes[szidx]);
 							res = ncclInternalError;
 							goto exit;

--- a/tests/functional/test-common.h
+++ b/tests/functional/test-common.h
@@ -93,7 +93,7 @@ void print_dev_props(int dev, test_nccl_properties_t *props)
         NCCL_OFI_TRACE(NCCL_NET, "****************** Device %d Properties ******************", dev);
         NCCL_OFI_TRACE(NCCL_NET, "%s: PCIe Path: %s", props->name, props->pciPath);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Plugin Support: %d", props->name, props->ptrSupport);
-        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %d", props->name, props->guid);
+        NCCL_OFI_TRACE(NCCL_NET, "%s: Device GUID: %zu", props->name, props->guid);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Speed: %d", props->name, props->speed);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Port: %d", props->name, props->port);
         NCCL_OFI_TRACE(NCCL_NET, "%s: Device Maximum Communicators: %d", props->name, props->maxComms);

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -162,7 +162,7 @@ int main(int argc, char *argv[])
 
 		if (last_buff) {
 			if (last_buff - (char *)entry != 1024 + MEMCHECK_REDZONE_SIZE) {
-				NCCL_OFI_WARN("bad spacing %ul", (char *)entry - last_buff);
+				NCCL_OFI_WARN("bad spacing %zu", (char *)entry - last_buff);
 				exit(1);
 			}
 		}

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -59,7 +59,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 	}
 
 	if (schedule->num_xfer_infos != ref_schedule->num_xfer_infos) {
-		NCCL_OFI_WARN("Wrong number of xfer infos. Expected %i, but got %i",
+		NCCL_OFI_WARN("Wrong number of xfer infos. Expected %zu, but got %zu",
 			      ref_schedule->num_xfer_infos, schedule->num_xfer_infos);
 		return 1;
 	}


### PR DESCRIPTION
GCC is willing to enforce printf-style format checks if the typedef for the log function pointer is tagged with the appropriate attribute. Clang behaves oddly, only generating warnings in the tests.  Which is weird, but at least get warnings for GCC is a huge win.

With printf warning checks, we find many issues that are also fixed in this patch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
