### PR TITLE
fix(m4): set redzone size to 0

### DIFF
--- a/m4/check_var_redzone.m4
+++ b/m4/check_var_redzone.m4
@@ -11,7 +11,7 @@ AC_DEFUN([CHECK_VAR_REDZONE], [
   AC_MSG_CHECKING([for MEMCHECK_REDZONE_SIZE])
   AC_ARG_VAR(MEMCHECK_REDZONE_SIZE,
              AS_HELP_STRING([Size of added redzones (in bytes). The default size is 16 bytes in case memory access checks are enabled and 0 otherwise. Is required to be a multiple of 8. @<:@default=16@:>@]))
-  AS_IF([test "${asan_enabled}" = "0" -a "${valgrind_enabled}" = "0"],[default_memcheck_redzone_size=0])
+  AS_IF([test "${enable_asan}" != "yes" -a "${valgrind_enabled}" != "1"],[default_memcheck_redzone_size=0])
   MEMCHECK_REDZONE_SIZE=${MEMCHECK_REDZONE_SIZE:=${default_memcheck_redzone_size}}
   AC_MSG_RESULT(${MEMCHECK_REDZONE_SIZE})
   AS_IF([test "$(( MEMCHECK_REDZONE_SIZE % 8 ))" != "0"],


### PR DESCRIPTION
We were mistakenly adding redzones to our freelist entries in release builds due to an incorrect check for enabled memory checkers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
