### PR TITLE
Fully destroy endpoints when refcount is 0

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -78,8 +78,9 @@ AC_TYPE_UINT64_T
 AC_FUNC_MALLOC
 AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset function.])])
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
+AC_CHECK_FUNCS([gettid])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
-AC_SEARCH_LIBS([pthread_getspecific], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
+AC_SEARCH_LIBS([pthread_mutexattr_settype], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
 AC_SEARCH_LIBS([log2], [m], [], [AC_MSG_ERROR([NCCL OFI Plugin requires the log2 library function.])])
 
 # Checks for external packages

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -630,6 +630,12 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 int get_inject_rma_size_opt(struct fid_ep *ofi_ep,
 			    size_t *max_write_inline_size);
 
+/*
+ * @brief       gettid() wrapper
+ * return       thread id of the current thread (always succeeds)
+ */
+long nccl_net_ofi_gettid(void);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -11,6 +11,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include -DXML_DIR=\"${pkgdatadir}/xml\"
 #
 sources = \
 	nccl_ofi_api.c \
+	nccl_ofi_compat.c \
 	nccl_ofi_net.c \
 	nccl_ofi_sendrecv.c \
 	nccl_ofi_rdma.c \

--- a/src/nccl_ofi_compat.c
+++ b/src/nccl_ofi_compat.c
@@ -1,0 +1,20 @@
+#include "config.h"
+
+#ifdef HAVE_GETTID
+#include <sys/types.h>
+#else
+#include <sys/syscall.h>
+#include <stdlib.h>
+#endif
+
+#include "nccl_ofi.h"
+
+
+long nccl_net_ofi_gettid(void)
+{
+#ifdef HAVE_GETTID
+     return (long)gettid();
+#else
+     return syscall(SYS_gettid);
+#endif
+}


### PR DESCRIPTION
Previous to this patch, endpoints were never freed, but just had most resources released when the ref count reached zero.  This was because the use of pthread thread specific data store meant that only the thread that created the ep could remove it from the thread specific data store.  Since we couldn't guarantee that, we never actually removed data from the store.

This patch switches from pthread thread specific storage to using a hash table indexed by the thread id.  Note that we use gettid() instead of pthread_self(), because pthread_t is a opaque structure that is not comparable and so can't really be used as a hash key.  If we want to support OSes other than Linux, then we can add more ways to get the unique thread id.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
