### PR TITLE
fix(rdma): stop setting FI_ORDER_NONE

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -7100,9 +7100,6 @@ static void get_hints(struct fi_info *hints)
 
 	hints->mode = 0;
 
-	hints->tx_attr->msg_order = FI_ORDER_NONE;
-	hints->rx_attr->msg_order = FI_ORDER_NONE;
-
 	hints->ep_attr->type = FI_EP_RDM;
 
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM | FI_MR_VIRT_ADDR |


### PR DESCRIPTION
FI_ORDER_NONE (defined as 0) is deprecated. Prefer to just leave it unset to avoid deprecation warnings when building against newer libfabric. This should be zeroed out when hints are constructed, anyway, so this buys us compatibility with libfabric-git without any change in behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
