### PR TITLE
fix(build): add missing AC_PROG_RANLIB

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,6 +38,7 @@ dnl the risk of silently enabling system extensions is minimal.
 AC_USE_SYSTEM_EXTENSIONS
 dnl AM_PROG_AR must be called before LT_INIT
 AM_PROG_AR
+AC_PROG_RANLIB
 LT_INIT([shared disable-static pic-only])
 
 NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS=


### PR DESCRIPTION
``` text
Automake manual:

> This is required if any libraries are built in the package. See
> Particular Program Checks in The Autoconf Manual.

add this for correctness.
```

Ranlib is already being used, but this just adds the automake hook to ensure
that it can be resolved..

By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.