### PR TITLE
fix(build): ensure -pthread is passed

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -80,7 +80,13 @@ AC_CHECK_FUNC([memset], [], [AC_MSG_ERROR([NCCL OFI Plugin requires memset funct
 AC_CHECK_FUNC([realpath], [], [AC_MSG_ERROR([NCCL OFI Plugin requires realpath function.])])
 AC_CHECK_FUNCS([gettid])
 AC_SEARCH_LIBS([dlopen], [dl], [], [AC_MSG_ERROR([NCCL OFI Plugin requires dlopen])])
+
+dnl it is insufficient to just link against pthread with -lpthread
+dnl background: https://stackoverflow.com/a/23251828
+CPPFLAGS="${CPPFLAGS} -pthread"
+LDFLAGS="${LDFLAGS} -pthread"
 AC_SEARCH_LIBS([pthread_mutexattr_settype], [pthread], [], [AC_MSG_ERROR([NCCL OFI Plugin requires pthreads.])])
+
 AC_SEARCH_LIBS([log2], [m], [], [AC_MSG_ERROR([NCCL OFI Plugin requires the log2 library function.])])
 
 dnl Need at least glibc 2.3 or later (released 2002-10-02) , because


### PR DESCRIPTION
> Linking against pthread and adding the compiler/linker/preprocessor option for
> pthreads are different things when using a modern libc. Without the
> compiler/preprocessor options, various builtin `#define`s are not set. Notably,
> this should change the behavior around errno in a multithreaded context within
> glibc; _REENTRANT will now be defined and errno is now thread-local.
> 
> See 4e45dd8a for an example of a bug that this would have prevented.

See also:

 + Background: https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread

 + 4e45dd8a for a bug that this would have caught.

 + Why in both CFLAGS and CPPFLAGS? https://clang.llvm.org/docs/ClangCommandLineReference.html#cmdoption-clang-pthread

 + Why in LDFLAGS? https://gcc.gnu.org/onlinedocs/gcc/Link-Options.html#index-pthread-1
 
By submitting this pull request, I confirm that my contribution is made under
the terms of the Apache 2.0 license.