### PR TITLE
Combined -Wextra -Werror Commits

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -134,6 +134,14 @@ CHECK_PKG_HWLOC([],
 CHECK_PKG_VALGRIND()
 CHECK_VAR_REDZONE()
 
+NCCL_OFI_PLATFORM="none"
+AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
+
+AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
+      [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
+
+CHECK_ENABLE_MEMFD_CREATE()
+
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
 
@@ -178,15 +186,7 @@ AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Adding ${werror_flags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${werror_flags}"])
 
-NCCL_OFI_PLATFORM="none"
-AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
-
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
-
-AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
-      [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
-
-CHECK_ENABLE_MEMFD_CREATE()
 
 AC_CONFIG_FILES([Makefile
                  include/Makefile

--- a/configure.ac
+++ b/configure.ac
@@ -171,13 +171,13 @@ AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 unit test output 
 AC_ARG_ENABLE([picky-compiler],
    [AS_HELP_STRING([--disable-picky-compiler], [Disable adding picky compiler flags.])])
 AS_IF([test "${enable_picky_compiler}" != "no"],
-      [picky_compiler_flags="-Wall -Wc++-compat"
+      [picky_compiler_flags="-Wall -Wc++-compat -Wextra -Wno-unused-parameter"
        AC_MSG_NOTICE([Adding ${picky_compiler_flags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${picky_compiler_flags}"
        AS_UNSET([picky_compiler_flags])])
 
 AC_ARG_ENABLE([werror],
-   [AS_HELP_STRING([--enable-werror], [Enable setting -Werror.  Off by default, unless building from Git tree.])])
+   [AS_HELP_STRING([--enable-werror], [(Developer) Enable setting -Werror.  Off by default, unless building from Git tree.])])
 werror_flags="-Werror"
 AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CFLAGS.])

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -70,7 +70,7 @@ extern "C" {
 #define NCCL_OFI_MAX_SEND_REQUESTS (NCCL_OFI_MAX_REQUESTS * NCCL_OFI_MAX_RECVS)
 
 /* Flush read size (bytes) */
-#define NCCL_OFI_FLUSH_SIZE	4
+#define NCCL_OFI_FLUSH_SIZE             (4ULL)
 
 /* Initial number of entries in the MR cache of a device */
 #define NCCL_OFI_MR_CACHE_INIT_SIZE     128
@@ -135,7 +135,7 @@ extern int domain_per_thread;
 extern float net_latency;
 
 /* Size of system memory pages */
-extern long system_page_size;
+extern size_t system_page_size;
 
 struct nccl_net_ofi_plugin;
 struct nccl_net_ofi_device;

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -24,6 +24,12 @@
 #define PATH_MAX	4096
 #endif
 
+#if __has_attribute(__fallthrough__)
+# define fallthrough                    __attribute__((__fallthrough__))
+#else
+# define fallthrough                    do {} while (0)  /* fallthrough */
+#endif
+
 /* Copied from libfabric:rdma/fabric.h@30ec628: "libfabric: Initial commit" */
 #ifndef container_of
 #define container_of(ptr, type, field) \

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -73,7 +73,7 @@ int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool);
  * @return	0 on success
  *		non-zero on error
  */
-int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, int id);
+int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id);
 
 /*
  * @brief	Release pool of IDs and free resources

--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -39,7 +39,7 @@ extern "C" {
  * @param	a
  *		Must be a power of two
  */
-#define NCCL_OFI_IS_ALIGNED(x, a) (((x) & ((typeof(x))(a) - 1)) == 0)
+#define NCCL_OFI_IS_ALIGNED(x, a)     (((x) & ((__typeof__(x))(a) - 1)) == 0)
 
 /*
  * @brief	Return true if and only if pointer `p` is `a`-byte aligned

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -12,26 +12,28 @@
 
 static inline void nvtx_mark_domain(nvtxDomainHandle_t domain, const char* name, uint32_t color)
 {
-	const nvtxEventAttributes_t eventAttrib = {
-		.version = NVTX_VERSION,
-		.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE,
-		.colorType = NVTX_COLOR_ARGB,
-		.color = color,
-		.messageType = NVTX_MESSAGE_TYPE_ASCII,
-		.message = { .ascii = name },
-	};
+	nvtxEventAttributes_t eventAttrib = {};
+
+	eventAttrib.version = NVTX_VERSION;
+	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+	eventAttrib.colorType = NVTX_COLOR_ARGB;
+	eventAttrib.color = color;
+	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+	eventAttrib.message.ascii = name;
+
 	nvtxDomainMarkEx(domain, &eventAttrib);
 }
 
 static inline nvtxRangeId_t nvtx_start_domain(bool have_domain, nvtxDomainHandle_t domain, const char* name, uint32_t color) {
-	const nvtxEventAttributes_t eventAttrib = {
-		.version = NVTX_VERSION,
-		.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE,
-		.colorType = NVTX_COLOR_ARGB,
-		.color = color,
-		.messageType = NVTX_MESSAGE_TYPE_ASCII,
-		.message = { .ascii = name },
-	};
+	nvtxEventAttributes_t eventAttrib = {};
+
+	eventAttrib.version = NVTX_VERSION;
+	eventAttrib.size = NVTX_EVENT_ATTRIB_STRUCT_SIZE;
+	eventAttrib.colorType = NVTX_COLOR_ARGB;
+	eventAttrib.color = color;
+	eventAttrib.messageType = NVTX_MESSAGE_TYPE_ASCII;
+	eventAttrib.message.ascii = name;
+
 	if (have_domain)
 		return nvtxDomainRangeStartEx(domain, &eventAttrib);
 	else

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -365,15 +365,16 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 	const nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size);
 #endif
 
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
+
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->regMr(send_comm, &cache_key, type, mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->regMr(recv_comm, &cache_key, type, mhandle);
 		break;
 	default:
@@ -397,16 +398,16 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 	}
 
 	int ret = 0;
+	nccl_net_ofi_send_comm_t *send_comm = NULL;
+	nccl_net_ofi_recv_comm_t *recv_comm = NULL;
 
 	switch (base_comm->type) {
-	case NCCL_NET_OFI_SEND_COMM:;
-		nccl_net_ofi_send_comm_t *send_comm =
-			(nccl_net_ofi_send_comm_t *)base_comm;
+	case NCCL_NET_OFI_SEND_COMM:
+		send_comm = (nccl_net_ofi_send_comm_t *)base_comm;
 		ret = send_comm->deregMr(send_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
-	case NCCL_NET_OFI_RECV_COMM:;
-		nccl_net_ofi_recv_comm_t *recv_comm =
-			(nccl_net_ofi_recv_comm_t *)base_comm;
+	case NCCL_NET_OFI_RECV_COMM:
+		recv_comm = (nccl_net_ofi_recv_comm_t *)base_comm;
 		ret = recv_comm->deregMr(recv_comm, (nccl_net_ofi_mr_handle_t *)mhandle);
 		break;
 	default:

--- a/src/nccl_ofi_ep_addr_list.c
+++ b/src/nccl_ofi_ep_addr_list.c
@@ -134,6 +134,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 				 size_t addr_size)
 {
 	int ret = 0;
+	ep_pair_list_elem_t *new_pair = NULL;
 
 	if (addr_size > ep_list->max_addr_size) {
 		NCCL_OFI_WARN("Address size %zu > max size (%zu)", addr_size,
@@ -155,8 +156,7 @@ int nccl_ofi_ep_addr_list_insert(nccl_ofi_ep_addr_list_t *ep_list,
 	memcpy(new_addr->addr, addr_in, addr_size);
 	zero_pad_address(new_addr->addr, addr_size, ep_list->max_addr_size);
 
-	ep_pair_list_elem_t *new_pair = (ep_pair_list_elem_t *)
-		malloc(sizeof(*new_pair));
+	new_pair = (ep_pair_list_elem_t *)malloc(sizeof(*new_pair));
 	if (!new_pair) {
 		NCCL_OFI_WARN("Failed to allocate new ep list element");
 		free(new_addr);

--- a/src/nccl_ofi_interface_neuron.c
+++ b/src/nccl_ofi_interface_neuron.c
@@ -83,24 +83,24 @@ static ncclResult_t accept_v5(void* listenComm, void** recvComm)
 	return nccl_net_ofi_accept(listenComm, recvComm);
 }
 
-NCCL_OFI_EXPORT_SYMBOL const ncclNet_v5_t ncclNetPlugin_v5 = {
-        .name = "AWS Libfabric",
-        .init = nccl_net_ofi_init,
-        .devices = nccl_net_ofi_devices,
-        .getProperties = getProperties_v5,
-        .listen = nccl_net_ofi_listen,
-        .connect = connect_v5,
-        .accept = accept_v5,
-        .regMr = nccl_net_ofi_regMr,
-        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-        .deregMr = nccl_net_ofi_deregMr,
-        .isend = nccl_net_ofi_isend,
-        .irecv = nccl_net_ofi_irecv,
-        .iflush = nccl_net_ofi_iflush,
-        .test = nccl_net_ofi_test,
-        .closeSend = nccl_net_ofi_closeSend,
-        .closeRecv = nccl_net_ofi_closeRecv,
-        .closeListen = nccl_net_ofi_closeListen,
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v5_t ncclNetPlugin_v5 = {
+	.name = "AWS Libfabric",
+	.init = nccl_net_ofi_init,
+	.devices = nccl_net_ofi_devices,
+	.getProperties = getProperties_v5,
+	.listen = nccl_net_ofi_listen,
+	.connect = connect_v5,
+	.accept = accept_v5,
+	.regMr = nccl_net_ofi_regMr,
+	.regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
+	.deregMr = nccl_net_ofi_deregMr,
+	.isend = nccl_net_ofi_isend,
+	.irecv = nccl_net_ofi_irecv,
+	.iflush = nccl_net_ofi_iflush,
+	.test = nccl_net_ofi_test,
+	.closeSend = nccl_net_ofi_closeSend,
+	.closeRecv = nccl_net_ofi_closeRecv,
+	.closeListen = nccl_net_ofi_closeListen,
 	.getMrKey = nccl_net_ofi_get_mr_key,
 	.iwrite = nccl_net_ofi_iwrite,
 	.iwriteInline = nccl_net_ofi_iwrite_inline,
@@ -129,7 +129,7 @@ static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
 	return ncclSuccess;
 }
 
-NCCL_OFI_EXPORT_SYMBOL const ncclNet_v4_t ncclNetPlugin_v4 = {
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "AWS Libfabric",
 	.init = init_v4,
 	.devices = nccl_net_ofi_devices,

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -136,6 +136,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	int ret = 0;
 	const char *provider_filter = NULL;
 	nccl_net_ofi_plugin_t *plugin;
+	nccl_net_ofi_ep_t *base_ep = NULL;
+	nccl_net_ofi_device_t *device = NULL;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
 
@@ -275,8 +277,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	 * resources. This initialization happens once per process, and thus it
 	 * does not matter which device is used to create the endpoint.
 	 */
-	nccl_net_ofi_device_t *device = plugin->get_device(plugin, 0);
-	nccl_net_ofi_ep_t *base_ep = NULL;
+	device = plugin->get_device(plugin, 0);
 
 	ret = device->get_ep(device, &base_ep);
 	if (ret != 0) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1142,8 +1142,8 @@ static inline int handle_bounce_recv(nccl_net_ofi_rdma_device_t *device, int rai
 	/* The first 4 bits are the type, but we don't have a base
 	 * header type.  So cast to a control message and lookup the
 	 * type from there. */
-	nccl_ofi_rdma_msg_type_t msg_type =
-		eager ? NCCL_OFI_RDMA_MSG_EAGER : ((nccl_net_ofi_rdma_ctrl_msg_t *)&bounce_fl_item->bounce_msg)->type;
+	nccl_ofi_rdma_msg_type_t msg_type = eager ? (nccl_ofi_rdma_msg_type_t)NCCL_OFI_RDMA_MSG_EAGER
+	                                          : ((nccl_net_ofi_rdma_ctrl_msg_t *)&bounce_fl_item->bounce_msg)->type;
 
 	switch (msg_type) {
 	case NCCL_OFI_RDMA_MSG_CONN:

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4530,10 +4530,12 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_RECV_CONN;
 
+		fallthrough;
 	case COMM_RECV_CONN:
 
 		l_comm->stage = COMM_CONN_REQ_PENDING;
 
+		fallthrough;
 	case COMM_CONN_REQ_PENDING:
 		/* COMM_CONN_REQ_PENDING: Wait until connect message has been
 		 * received. Then, prepare for sending connect accept message,
@@ -4608,6 +4610,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_SEND_CONN;
 
+		fallthrough;
 	case COMM_SEND_CONN:
 
 		/* COMM_SEND_CONN: Send connect response message to remote */
@@ -4621,6 +4624,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		l_comm->stage = COMM_CONN_RESP_REQ_PENDING;
 
+		fallthrough;
 	case COMM_CONN_RESP_REQ_PENDING:
 		/* COMM_CONN_RESP_REQ_PENDING: Wait until connect
 		 * response message has been delivered. Afterwards,
@@ -6200,7 +6204,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_SEND_CONN;
-
+		fallthrough;
 	case COMM_SEND_CONN:
 
 		/* COMM_SEND_CONN: Post a connect message to send peer connections */
@@ -6215,7 +6219,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
-
+		fallthrough;
 	case COMM_CONN_REQ_PENDING:
 		/* COMM_CONN_REQ_PENDING: Wait until connect message
 		 * has been sent. Afterwards, reset previously used
@@ -6246,14 +6250,14 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		req = NULL;
 
 		comm_state->stage = COMM_RECV_CONN;
-
+		fallthrough;
 	case COMM_RECV_CONN:
 		/* COMM_RECV_CONN: Receive connect response message from remote */
 
 		assert(s_comm && s_comm->num_rails > 0);
 
 		comm_state->stage = COMM_CONN_RESP_REQ_PENDING;
-
+		fallthrough;
 	case COMM_CONN_RESP_REQ_PENDING:
 
 		/* Progress our engine to get completions. If the

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -5093,8 +5093,7 @@ static int send_progress(nccl_net_ofi_rdma_req_t *req)
 
 			ret = post_rdma_eager_send(req, comm_rail, xfer_info);
 		} else {
-			for (int rail_it = send_data->xferred_rail_id;
-			     rail_it < schedule->num_xfer_infos; rail_it++) {
+			for (size_t rail_it = send_data->xferred_rail_id; rail_it < schedule->num_xfer_infos; rail_it++) {
 				/* Get xfer information from the schedule */
 				nccl_net_ofi_xfer_info_t *xfer_info = &xfers[rail_it];
 				/* Get communicator rail information to xfer the req */
@@ -5460,8 +5459,7 @@ retry:
 
 	/* Determine if this should be sent eagerly. */
 	eager = false;
-	if ((!have_ctrl && size <= eager_max_size) ||
-		 (size == 0)) {
+	if ((!have_ctrl && (size_t)size <= eager_max_size) || (size == 0)) {
 		eager = true;
 	}
 
@@ -7196,7 +7194,7 @@ static inline int nccl_net_ofi_rdma_plugin_complete_init(nccl_net_ofi_plugin_t *
 	}
 
 	/* Allocate and initialize nccl_net devices */
-	for (int dev_id = 0 ; dev_id != rdma_plugin->base.p_num_devs ; ++dev_id) {
+	for (size_t dev_id = 0; dev_id != rdma_plugin->base.p_num_devs; ++dev_id) {
 		struct fi_info *info_list;
 
 		/* Retrieve NIC info list from topology */
@@ -7208,10 +7206,11 @@ static inline int nccl_net_ofi_rdma_plugin_complete_init(nccl_net_ofi_plugin_t *
 		}
 
 		/* Allocate device */
-		nccl_net_ofi_rdma_device_t *device =
-			nccl_net_ofi_rdma_device_create(&rdma_plugin->base, dev_id,
-							info_list, rdma_plugin->topo,
-							ofi_nccl_round_robin_threshold());
+		nccl_net_ofi_rdma_device_t *device = nccl_net_ofi_rdma_device_create(&rdma_plugin->base,
+		                                                                     (int)dev_id,
+		                                                                     info_list,
+		                                                                     rdma_plugin->topo,
+		                                                                     ofi_nccl_round_robin_threshold());
 		if (device == NULL) {
 			NCCL_OFI_WARN("Device creation failed");
 			return -ENOMEM;
@@ -7219,7 +7218,7 @@ static inline int nccl_net_ofi_rdma_plugin_complete_init(nccl_net_ofi_plugin_t *
 
 		ret = plugin->assign_device(plugin, dev_id, &device->base);
 		if (ret != 0) {
-			NCCL_OFI_WARN("Assigning device %d failed", dev_id);
+			NCCL_OFI_WARN("Assigning device %ld failed", dev_id);
 			return ret;
 		}
 	}
@@ -7338,8 +7337,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	if (ofi_nccl_eager_max_size() < 0 ||
-	    ofi_nccl_eager_max_size() > ofi_nccl_round_robin_threshold()) {
+	if (ofi_nccl_eager_max_size() > ofi_nccl_round_robin_threshold()) {
 		NCCL_OFI_WARN("Invalid value for EAGER_MAX_SIZE");
 		ret = ncclInvalidArgument;
 		goto error;

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -57,9 +57,9 @@ void nccl_net_ofi_set_multiplexing_schedule(size_t size, int num_rails,
  * @brief	Assign message round-robin
  */
 static inline int set_round_robin_schedule(nccl_net_ofi_threshold_scheduler_t *scheduler,
-					   size_t size,
-					   int num_rails,
-					   nccl_net_ofi_schedule_t *schedule)
+                                           size_t size,
+                                           size_t num_rails,
+                                           nccl_net_ofi_schedule_t *schedule)
 {
 	int rail_id;
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2392,7 +2392,7 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 	nccl_net_ofi_sendrecv_device_t *device =
 		(nccl_net_ofi_sendrecv_device_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_device_t));
 	if (device == NULL) {
-		NCCL_OFI_WARN("Unable to allocate device %i", dev_id);
+		NCCL_OFI_WARN("Unable to allocate device %d", dev_id);
 		return NULL;
 	}
 
@@ -2543,7 +2543,7 @@ static inline int nccl_net_ofi_sendrecv_plugin_complete_init(nccl_net_ofi_plugin
 {
 	nccl_net_ofi_sendrecv_plugin_t *sendrecv_plugin = (nccl_net_ofi_sendrecv_plugin_t *)plugin;
 	struct fi_info *info;
-	int dev_id = 0;
+	size_t dev_id = 0;
 	int ret;
 
 	/* Allocate and initialize nccl_net devices */
@@ -2554,16 +2554,15 @@ static inline int nccl_net_ofi_sendrecv_plugin_complete_init(nccl_net_ofi_plugin
 			return -EINVAL;
 		}
 
-		nccl_net_ofi_sendrecv_device_t *device =
-			nccl_net_ofi_sendrecv_device_create(plugin, dev_id, info);
+		nccl_net_ofi_sendrecv_device_t *device = nccl_net_ofi_sendrecv_device_create(plugin, (int)dev_id, info);
 		if (device == NULL) {
-			NCCL_OFI_WARN("Unable to allocate device %i", dev_id);
+			NCCL_OFI_WARN("Unable to allocate device %li", dev_id);
 			return -ENOMEM;
 		}
 
 		ret = plugin->assign_device(plugin, dev_id, &device->base);
 		if (ret != 0) {
-			NCCL_OFI_WARN("Assigning device %d failed", dev_id);
+			NCCL_OFI_WARN("Assigning device %li failed", dev_id);
 			return ret;
 		}
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -14,6 +14,7 @@
 
 #include <rdma/fabric.h>
 
+#include "nccl-headers/net.h"
 #include "nccl_ofi.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1410,7 +1410,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		comm_state->stage = COMM_RECV_CONN;
-
+		fallthrough;
 	case COMM_RECV_CONN:
 
 		/* Allocate memory for peer address for the first time ONLY */
@@ -1437,6 +1437,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
 
+		fallthrough;
 	case COMM_CONN_REQ_PENDING:
 
 		/* Progress NCCL OFI engine so that connection is accepted */
@@ -2047,6 +2048,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 
 		comm_state->stage = COMM_SEND_CONN;
 
+		fallthrough;
 	case COMM_SEND_CONN:
 		/* Send "connect" message to remote EP */
 		rc = send_connect_message(s_comm, device, ep, req);
@@ -2063,7 +2065,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		}
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
-
+		fallthrough;
 	case COMM_CONN_REQ_PENDING:
 		if (s_comm->conn_info->connect_to_self == 1) {
 			NCCL_OFI_TRACE(NCCL_NET, "Connect to self; short circuit cleanup");

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -1041,7 +1041,7 @@ static int get_device_property(unsigned domain, unsigned bus,
 	int ret = 0;
 	FILE *file;
 	const char *path_format = "/sys/bus/pci/devices/%04x:%02x:%02x.%01x/%s";
-	size_t path_len;
+	ssize_t path_len;
 	char *path = NULL;
 
         if ((path_len = snprintf(NULL, 0, path_format, domain, bus, dev, func, prop_name)) < 0) {

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -34,7 +34,9 @@ struct ec2_platform_data {
 	bool net_flush_required;
 	const char *default_protocol;
 	int domain_per_thread;
-} platform_data_map[] = {
+};
+
+static struct ec2_platform_data platform_data_map[] = {
 	{
 		.name = "p4d.24xlarge",
 		.topology = "p4d-24xl-topo.xml",
@@ -88,6 +90,8 @@ struct ec2_platform_data {
 	{
 		.name = "g5.48xlarge",
 		.topology = "g5.48xl-topo.xml",
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = false,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
@@ -95,6 +99,9 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1.32xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
@@ -102,6 +109,9 @@ struct ec2_platform_data {
 	},
 	{
 		.name = "trn1n.32xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
 		.gdr_required = true,
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -604,6 +604,10 @@ exit:
 
 int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	int ret = 0;
+#if HAVE_CUDA
+	const char *optname_name = "none";
+	int optname = -1;
+#endif
 
 	if (endpoint == NULL) {
 		NCCL_OFI_WARN("Unable to configure invalid endpoint");
@@ -645,8 +649,6 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep* endpoint) {
 	static bool nccl_proto_configured = false;
 	static bool need_ordering = false;
 	static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
-	int optname = -1;
-	const char *optname_name = "none";
 
 	/* During initialization, try to set
 	 * FI_OPT_EFA_{SENDRECV,WRTIE}_IN_ORDER_ALIGNED_128_BYTES to
@@ -785,6 +787,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 {
 	struct fi_info *info_list_in = *info_list;
 	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));
+	struct fi_info *info_ptr = NULL;
 
 	if (num_rails <= 0) {
 		return;
@@ -824,7 +827,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 
 	/* Update info_list references to match sorted order */
 	*info_list = sorted_info_array[0];
-	struct fi_info *info_ptr = *info_list;
+	info_ptr = *info_list;
 	for (int i = 0; i < num_rails; ++i) {
 		assert(info_ptr);
 		assert(sorted_info_array[i]);

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -550,7 +550,7 @@ int platform_init(const char **provider_filter)
 
 		ret = snprintf(topology_path, sizeof(topology_path), "%s/%s",
 			       XML_DIR, platform_data->topology);
-		if (ret < 0 || ret >= sizeof(topology_path)) {
+		if (ret < 0 || (size_t)ret >= sizeof(topology_path)) {
 			NCCL_OFI_WARN("Error occurred while forming the complete topology XML file path. RC: %d, Buffer Size: %d, XML dir: %s, Topology file: %s",
 				      ret, PATH_MAX, XML_DIR, platform_data->topology);
 			ret = -ENOMEM;

--- a/src/tuner/nccl_ofi_regions.c
+++ b/src/tuner/nccl_ofi_regions.c
@@ -140,7 +140,7 @@ int is_inside_region(nccl_ofi_tuner_point_t point, nccl_ofi_tuner_region_t *regi
 {
 	assert(region->num_vertices > 1);
 
-	int i, k;
+	size_t i, k;
 	nccl_ofi_tuner_point_t *pv;
 	double min_x, max_x, min_y, max_y;
 	const double eps = 1e-10;

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -347,7 +347,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
-	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
+	for (size_t i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
 		algorithm = nccl_ofi_tuner_ctx->regions[i].algorithm;
 		protocol = nccl_ofi_tuner_ctx->regions[i].protocol;
 		if (table[algorithm][protocol] == NCCL_ALGO_PROTO_IGNORE || algorithm >= numAlgo ||
@@ -413,7 +413,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
-	for (int i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
+	for (size_t i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
 		if (nccl_ofi_tuner_ctx->regions[i].algorithm == NCCL_ALGO_NVLS_TREE && nvlsSupport == 0) {
 			continue;
 		}

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -337,7 +337,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	float(*table)[NCCL_NUM_PROTOCOLS] = (float(*)[NCCL_NUM_PROTOCOLS])collCostTable;
@@ -373,7 +373,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 
@@ -406,7 +405,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 
 	if (nccl_ofi_tuner_ctx == NULL || nccl_ofi_tuner_ctx->regions == NULL || collType != ncclFuncAllReduce) {
 		/* Fall back to NCCL's tuner */
-		goto exit;
+		return ncclSuccess;
 	}
 
 	int in_out = -1;
@@ -437,7 +436,6 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 		NCCL_OFI_INFO(NCCL_TUNING, "Falling back to NCCL's tuner for coll %d size %ld.", collType, nBytes);
 	}
 
-exit:
 	return ncclSuccess;
 }
 

--- a/src/tuner/nccl_ofi_tuner.c
+++ b/src/tuner/nccl_ofi_tuner.c
@@ -344,7 +344,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info(void *context,
 	int in_out = -1;
 	int algorithm = NCCL_ALGO_UNDEF;
 	int protocol = NCCL_PROTO_UNDEF;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (size_t i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {
@@ -409,7 +409,7 @@ ncclResult_t nccl_ofi_tuner_get_coll_info_v2(
 	}
 
 	int in_out = -1;
-	nccl_ofi_tuner_point_t p = {.x = nBytes, .y = nccl_ofi_tuner_ctx->dims.num_ranks};
+	nccl_ofi_tuner_point_t p = {.x = (double)nBytes, .y = (double)nccl_ofi_tuner_ctx->dims.num_ranks};
 
 	/* Check all regions */
 	for (size_t i = 0; i < nccl_ofi_tuner_ctx->num_regions && in_out < 0; i++) {

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -302,7 +302,7 @@ int main(int argc, char* argv[])
 						inflight_reqs--;
 						req_completed[idx] = 1;
 
-						if (received_size !=
+						if ((size_t)received_size !=
 						    NCCL_OFI_MIN(send_sizes[szidx], recv_sizes[szidx])) {
 							NCCL_OFI_WARN(
 								"Wrong received size %d (send size: %zu recv size %zu)",

--- a/tests/unit/ep_addr_list.c
+++ b/tests/unit/ep_addr_list.c
@@ -11,8 +11,7 @@
 
 static void insert_addresses(nccl_ofi_ep_addr_list_t *ep_addr_list, size_t num_addr, int ep_num)
 {
-	for (int i = 0; i < num_addr; ++i) {
-
+	for (size_t i = 0; i < num_addr; ++i) {
 		nccl_net_ofi_ep_t *ep = NULL;
 		int ret = nccl_ofi_ep_addr_list_get(ep_addr_list, &i, sizeof(i),
 			&ep);
@@ -34,10 +33,10 @@ static void insert_addresses(nccl_ofi_ep_addr_list_t *ep_addr_list, size_t num_a
 			}
 		} else {
 			if (!ep) {
-				NCCL_OFI_WARN("No ep returned when expected. addr %d, ep_num %d", i, ep_num);
+				NCCL_OFI_WARN("No ep returned when expected. addr %ld, ep_num %d", i, ep_num);
 				exit(1);
 			}
-			if ((uintptr_t)ep != ep_num) {
+			if ((uintptr_t)ep != (uintptr_t)ep_num) {
 				NCCL_OFI_WARN("Unexpected ep returned");
 			}
 		}

--- a/tests/unit/freelist.c
+++ b/tests/unit/freelist.c
@@ -207,7 +207,7 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 
-		if ((char *)item - (char *)simple_base != item->reginfo.base_offset) {
+		if ((uintptr_t)item - (long unsigned int)simple_base != item->reginfo.base_offset) {
 			NCCL_OFI_WARN("base_offset was wrong %p %p %lu %lu",
 				      item, simple_base, (char *)item - (char *)simple_base,
 				      item->reginfo.base_offset);

--- a/tests/unit/idpool.c
+++ b/tests/unit/idpool.c
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
 	(void) ret; // Avoid unused-variable warning
 	size_t sizes[] = {0, 5, 63, 64, 65, 127, 128, 129, 255};
 
-	for (int t = 0; t < sizeof(sizes) / sizeof(size_t); t++) {
+	for (long unsigned int t = 0; t < sizeof(sizes) / sizeof(size_t); t++) {
 		size_t size = sizes[t];
 
 		/* Scale pool size to number of 64-bit uints (rounded up) */
@@ -32,7 +32,7 @@ int main(int argc, char *argv[]) {
 		assert(idpool->size == size);
 
 		/* Test that all bits are set */
-		for (int i = 0; i < num_long_elements; i++) {
+		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
 				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
 			} else {
@@ -45,7 +45,7 @@ int main(int argc, char *argv[]) {
 		(void) id; // Avoid unused-variable warning
 		for (uint64_t i = 0; i < size; i++) {
 			id = nccl_ofi_idpool_allocate_id(idpool);
-			assert(id == i);
+			assert((uint64_t)id == i);
 		}
 		id = nccl_ofi_idpool_allocate_id(idpool);
 		assert(-ENOMEM == id);
@@ -54,14 +54,14 @@ int main(int argc, char *argv[]) {
 		if (size) {
 			int holes[] = {(int)(size/3), (int)(size/2)}; // Must be in increasing order
 
-			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
 					ret = nccl_ofi_idpool_free_id(idpool, holes[i]);
 					assert(0 == ret);
 				}
 			}
 
-			for (int i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
 					id = nccl_ofi_idpool_allocate_id(idpool);
 					assert(id == holes[i]);
@@ -73,7 +73,7 @@ int main(int argc, char *argv[]) {
 		ret = nccl_ofi_idpool_free_id(idpool, (int)size);
 		assert(-EINVAL == ret);
 
-		for (int i = 0; i < size; i++) {
+		for (size_t i = 0; i < size; i++) {
 			ret = nccl_ofi_idpool_free_id(idpool, i);
 			assert(0 == ret);
 		}
@@ -84,7 +84,7 @@ int main(int argc, char *argv[]) {
 		}
 
 		/* Test that all bits are set */
-		for (int i = 0; i < num_long_elements; i++) {
+		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
 				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
 			} else {

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -64,7 +64,7 @@ int verify_schedule(nccl_net_ofi_schedule_t *schedule, nccl_net_ofi_schedule_t *
 		return 1;
 	}
 
-	for (int info_id = 0; info_id != schedule->num_xfer_infos; ++info_id) {
+	for (size_t info_id = 0; info_id != schedule->num_xfer_infos; ++info_id) {
 		ret |= verify_xfer_info(&schedule->rail_xfer_infos[info_id],
 				     &ref_schedule->rail_xfer_infos[info_id], info_id);
 	}


### PR DESCRIPTION
CI is moving too slowly, and rebasing triggers too many rebuilds, to continue to use stacked PRs. This is a single PR that is combining all of the following PRS: 
 
* b45d7e8c  (#588) (approved, marked as merged)
* 07801496  (#589) (initially unapproved, changes made as requested, approved and marked as merged)
* 247e96a9  (#595) (approved, marked as merged)
* f50eecd1  (#593) (approved, marked as merged)                  
* 2b2e91e9  (#587) (approved, marked as merged)     
* 441e1e8a  (#577) (approved, marked as merged)           
* 1040fef1  (#576) (approved, marked as merged)  
* 5faa97dc  (#586) (approved, marked as merged)  
* 1ecfffbc  (#574) (approved, marked as merged)  
* 8cb419b7  (#570) (approved, marked as merged)                 
* ab14b170  (#573) (approved, marked as merged)             
* e067641d  (#569) (approved, marked as merged)
* 4a2d0b14  (#585) (approved, marked as merged)                    
* 13a67d18  (#575) (initially unapproved, changes made as requested, approved and marked as merged)
* 24c9d4b2  (#565) (approved and marked as merged)
* 30efcbfd  (#563) ( ❌ needs reapproval, will automatically be marked as merged by the landing of this PR)

For and PR marked above as unapproved, please click and re-review it. It will land (but will not be targeting master). Once all commits are "merged" into a some non-master branch, then we can just approve this PR, containing roughly the same contents, and we can merge it to master all-together and delete the branches.

I would prefer to be able to just land directly into master by changing base branches, but it's not realistic today given the way that CI is triggering. So here we are.
 
*Description of changes:* 

Bunch of changes that bring us significantly closer to building successfully with C++, but also enables `-Werror -Wextra` going forward, and CI actions ensure that it will stay that way. I'm not sure that this is all pointless and nit-picky, a build failure caught on https://github.com/aws/aws-ofi-nccl/pull/624 very possibly can explain a segfault that was reported when initializing the plugin when less than 32 EFAs are available.

edit: needed to be rebased due to a bug introduced during rebase on the very first in the series, see comment [here](https://github.com/aws/aws-ofi-nccl/pull/563#issuecomment-2380401201).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.