### PR TITLE
feat(build): add -fanalyzer when --enable-werror

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,9 +176,14 @@ AS_IF([test "${enable_picky_compiler}" != "no"],
        CFLAGS="${CFLAGS} ${picky_compiler_flags}"
        AS_UNSET([picky_compiler_flags])])
 
+static_analysis_flags=""
+gcc_fanalyzer_flags="-fanalyzer"
+AX_CHECK_COMPILE_FLAG([${gcc_fanalyzer_flags}], [static_analysis_flags="${gcc_fanalyzer_flags}"], [], [-Werror])
+dnl todo: clang-sa flags
+werror_flags="${static_analysis_flags} -Werror"
+
 AC_ARG_ENABLE([werror],
    [AS_HELP_STRING([--enable-werror], [(Developer) Enable setting -Werror.  Off by default, unless building from Git tree.])])
-werror_flags="-Werror"
 AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${werror_flags}"],

--- a/m4/ax_check_compile_flag.m4
+++ b/m4/ax_check_compile_flag.m4
@@ -1,0 +1,53 @@
+# ===========================================================================
+#  https://www.gnu.org/software/autoconf-archive/ax_check_compile_flag.html
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   AX_CHECK_COMPILE_FLAG(FLAG, [ACTION-SUCCESS], [ACTION-FAILURE], [EXTRA-FLAGS], [INPUT])
+#
+# DESCRIPTION
+#
+#   Check whether the given FLAG works with the current language's compiler
+#   or gives an error.  (Warnings, however, are ignored)
+#
+#   ACTION-SUCCESS/ACTION-FAILURE are shell commands to execute on
+#   success/failure.
+#
+#   If EXTRA-FLAGS is defined, it is added to the current language's default
+#   flags (e.g. CFLAGS) when the check is done.  The check is thus made with
+#   the flags: "CFLAGS EXTRA-FLAGS FLAG".  This can for example be used to
+#   force the compiler to issue an error when a bad flag is given.
+#
+#   INPUT gives an alternative input source to AC_COMPILE_IFELSE.
+#
+#   NOTE: Implementation based on AX_CFLAGS_GCC_OPTION. Please keep this
+#   macro in sync with AX_CHECK_{PREPROC,LINK}_FLAG.
+#
+# LICENSE
+#
+#   Copyright (c) 2008 Guido U. Draheim <guidod@gmx.de>
+#   Copyright (c) 2011 Maarten Bosmans <mkbosmans@gmail.com>
+#
+#   Copying and distribution of this file, with or without modification, are
+#   permitted in any medium without royalty provided the copyright notice
+#   and this notice are preserved.  This file is offered as-is, without any
+#   warranty.
+
+#serial 6
+
+AC_DEFUN([AX_CHECK_COMPILE_FLAG],
+[AC_PREREQ(2.64)dnl for _AC_LANG_PREFIX and AS_VAR_IF
+AS_VAR_PUSHDEF([CACHEVAR],[ax_cv_check_[]_AC_LANG_ABBREV[]flags_$4_$1])dnl
+AC_CACHE_CHECK([whether _AC_LANG compiler accepts $1], CACHEVAR, [
+  ax_check_save_flags=$[]_AC_LANG_PREFIX[]FLAGS
+  _AC_LANG_PREFIX[]FLAGS="$[]_AC_LANG_PREFIX[]FLAGS $4 $1"
+  AC_COMPILE_IFELSE([m4_default([$5],[AC_LANG_PROGRAM()])],
+    [AS_VAR_SET(CACHEVAR,[yes])],
+    [AS_VAR_SET(CACHEVAR,[no])])
+  _AC_LANG_PREFIX[]FLAGS=$ax_check_save_flags])
+AS_VAR_IF(CACHEVAR,yes,
+  [m4_default([$2], :)],
+  [m4_default([$3], :)])
+AS_VAR_POPDEF([CACHEVAR])dnl
+])dnl AX_CHECK_COMPILE_FLAGS

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -1587,6 +1587,9 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 
 	/* Build handle */
 	local_ep_name = get_local_address(ep->ofi_ep);
+	if (local_ep_name == NULL) {
+		return -EINVAL;
+	}
 
 	memcpy(handle->ep_name, local_ep_name, MAX_EP_ADDR);
 	handle->comm_id = (uint32_t)tag;
@@ -1937,6 +1940,10 @@ static inline nccl_net_ofi_sendrecv_req_t *prepare_send_req(nccl_net_ofi_sendrec
 {
 	nccl_net_ofi_sendrecv_req_t *req = NULL;
 
+	if (OFI_UNLIKELY(s_comm == NULL)) {
+		return NULL;
+	}
+
 	req = allocate_req(s_comm->nccl_ofi_reqs_fl);
 	if (OFI_UNLIKELY(req == NULL)) {
 		NCCL_OFI_WARN("Unable to get NCCL OFI request for device %d",
@@ -2036,7 +2043,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 
 		/* Build send_comm */
 		ret = create_send_comm(handle, ep, &s_comm);
-		if (OFI_UNLIKELY(ret != 0)) {
+		if (OFI_UNLIKELY(ret != 0 || s_comm == NULL)) {
 			return ret;
 		}
 

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -175,7 +175,12 @@ static const char* get_platform_type(void)
 	while ((feof(fd) == 0) && (ferror(fd) == 0) && ((ch = fgetc(fd)) != '\n')) {
 		platform_type[len++] = ch;
 		if (len >= platform_type_len) {
-			platform_type = (char*)realloc(platform_type, len + platform_type_len);
+			char *new_platform_type = (char *)realloc(platform_type, len + platform_type_len);
+			if (new_platform_type == NULL) {
+				NCCL_OFI_WARN("Unable to (re)allocate platform type");
+				goto error;
+			}
+			platform_type = new_platform_type;
 		}
 	}
 


### PR DESCRIPTION
*Description of changes:*

Fix GCC static analyzer warnings, then enable -fanalyzer in our distcheck builds.

```
* 5995ec0e origin/fanalyzer-fixes feat(build): add -fanalyzer when --enable-werror
| 
| Steal ax_check_compile_flag from autoconf archive, then use it to check
| if we're building with a compiler that accepts -fanalyzer. If so, enable
| it when --enable-werror is active.
| 
| 
|  configure.ac                |  7 +++++-
|  m4/ax_check_compile_flag.m4 | 53 +++++++++++++++++++++++++++++++++++++++++++
|  2 files changed, 59 insertions(+), 1 deletion(-)
|


* b13cd735 fix: sendrecv/listen: silence leak warning.
| 
| gcc14 incorrectly flagged this as a leak as it was unable to reason
| about the way that we are storing into a listen_comm_t, but have
| allocated a sendrecv_listen_comm_t.
| 
| This function can be rewritten to be much more clear, though, and doing
| so silences the warning. Cast to the base struct when assigning into the
| inout ptr, Stop calling fi_strerror(-ret) as ret was never set to any
| error code. gotos are unnecessary in this function, there is no valid
| path where we allocate memory and do not return 0, so just return errors
| directly.
|
|  src/nccl_ofi_sendrecv.c | 29 +++++++----------------------
|  1 file changed, 7 insertions(+), 22 deletions(-)
|


* e62f54a9 fix: sendrecv/listen: add NULL checks
| 
| gcc13's -fanalyzer has two problems with this function:
| 
| 1. get_local_address can possibly return NULL, but it is passed into
| memcpy without first checking for NULL, and memcpy requires that neither
| argument is NULL. Adds a check for NULL and bail if it is.
| 
| 2. it believes that the inout ptr arg of create_send_comm can possibly
| be null and wants a check for NULL before using it. This is probably a
| false positive, because it's incapable of reasoning about the fact that
| if ret==0, s_comm must not be NULL. Regardless, add NULL checks here.
| This is not a critical path for us, and it's easier to err on the side
| of caution.
| 
|  src/nccl_ofi_sendrecv.c | 9 ++++++++-
|  1 file changed, 8 insertions(+), 1 deletion(-)
|  


* d0f725e8 fix: util/get_providers: fix null deref
| 
| gcc14 -fanalyzer correctly flags a potential null deref here. Cleanup
| the logic when filtering for a specific provider, and ensure that in the
| case that we filter all providers, that we do not deref a NULL list
| head.
| 
|  src/nccl_ofi_ofiutils.c | 50 ++++++++++++++++++++++++++++++++++-------------
|  1 file changed, 36 insertions(+), 14 deletions(-)
|  


* 513338ce fix: prevent realloc leak
| 
| both gcc14's -fanalyzer flag and clang-static-analyzer flag this as a
| potential leak. See docs for `bugprone-suspicious-realloc-usage` for
| details. Fix the leak.
|
|  src/platform-aws.c | 7 ++++++-
|  1 file changed, 6 insertions(+), 1 deletion(-)
|  
```

Opened as draft pull request atop #627, which is blocked on false-positive CI failures. Only the top 5 commits are meant for this PR; github should automatically detect when #627 lands and when that occurs it will be ready for review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
