### PR TITLE
Add platform data settings for TRN2N

### DIFF
--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -116,6 +116,16 @@ static struct ec2_platform_data platform_data_map[] = {
 		.net_flush_required = true,
 		.default_protocol = "SENDRECV",
 		.domain_per_thread = 1,
+	},
+	{
+		.name = "trn2n.48xlarge",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
+		.gdr_required = true,
+		.net_flush_required = true,
+		.default_protocol = "RDMA",
+		.domain_per_thread = 1,
 	}
 };
 


### PR DESCRIPTION
Platform TRN2N requires platform settings, e.g., to enable RDMA protocol which is not the default for cases when plugin is used with one rail.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
