### PR TITLE
fix(rdma): send periodic control messages to sync sender/receiver

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -530,7 +530,7 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 
 	nccl_ofi_deque_elem_t cleanup_list_elem;
 
-	pthread_mutex_t receive_close_lock;
+	pthread_mutex_t ctrl_recv_lock;
 	bool received_close_message;
 	/* Counters for total sent and received control messages */
 	uint64_t n_ctrl_received;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -535,6 +535,7 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	/* Counters for total sent and received control messages */
 	uint64_t n_ctrl_received;
 	uint64_t n_ctrl_expected;
+	uint16_t last_ctrl_received;
 
 	bool comm_active;
 
@@ -614,6 +615,8 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	pthread_mutex_t ctrl_counter_lock;
 	uint64_t n_ctrl_sent;
 	uint64_t n_ctrl_delivered;
+
+	uint16_t last_ctrl_sent;
 
 	/* Number of rails */
 	int num_rails;


### PR DESCRIPTION
We hit a bug where the sender sends a long run of eager messages and
ends up outpacing the receiver by more than the width of the message
buffer, causing an error.

In this patch, receiver will send a control message to sender at least
every `msgbuff_size - max_requests` messages, and sender will pause if
it hasn't received a control message within this duration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
