### PR TITLE
add `--enable-cpp` build flag

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -85,7 +85,7 @@ jobs:
 
       - name: Install hwloc, utilities.
         run: |
-          yum -y install hwloc-devel autoconf automake libtool gcc g++ git make
+          yum -y install hwloc-devel autoconf automake libtool gcc gcc-c++ git make
 
       - name: Install CUDA
         if: matrix.sdk == 'cuda'

--- a/configure.ac
+++ b/configure.ac
@@ -46,6 +46,7 @@ NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS=
 # Checks for programs
 AC_PROG_CC
 AM_PROG_CC_C_O
+AC_PROG_CXX
 m4_version_prereq([2.70], [], [AC_PROG_CC_STDC])
 AC_C_INLINE
 
@@ -55,12 +56,18 @@ dnl between this and AC_PROG_CC.
 AS_IF([test "${ax_enable_debug}" = "no"], [
              dnl Enable O3 optimization
              CFLAGS="${CFLAGS} -O3"
+             CXXFLAGS="${CXXFLAGS} -O3"
+
+             dnl use C++17, disable exceptions, and disable runtime type information
+             CXXFLAGS="-std=c++17 -fno-rtti -fno-exceptions"
 
              dnl dead code elim
              CFLAGS="${CFLAGS} -ffunction-sections -fdata-sections"
+             CXXFLAGS="${CXXFLAGS} -ffunction-sections -fdata-sections"
 
              dnl https://maskray.me/blog/2021-05-09-fno-semantic-interposition
              CFLAGS="${CFLAGS} -fno-semantic-interposition -fvisibility=hidden"
+             CXXFLAGS="${CXXFLAGS} -fno-semantic-interposition -fvisibility=hidden "
              LDFLAGS="${LDFLAGS} -Bsymbolic"
             ])
 CHECK_ENABLE_SANITIZER()
@@ -175,9 +182,14 @@ AS_IF([test "${enable_trace}" = "yes" ],
 AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 unit test output should include TRACE level])
 
 picky_cflags=""
+picky_cxxflags=""
 AC_DEFUN([ADD_PICKY_FLAGS],[
     AC_LANG_PUSH([C])
     AX_CHECK_COMPILE_FLAG([$1], [picky_cflags="${picky_cflags} $1"], [], [-Werror])
+    AC_LANG_POP()
+
+    AC_LANG_PUSH([C++])
+    AX_CHECK_COMPILE_FLAG([$1], [picky_cxxflags="${picky_cxxflags} $1"], [], [-Werror -x c++])
     AC_LANG_POP()
     ])
 
@@ -220,6 +232,8 @@ AC_ARG_ENABLE([picky-compiler],
 AS_IF([test "${enable_picky_compiler}" != "no"],
       [AC_MSG_NOTICE([Adding ${picky_cflags} to CFLAGS.])
        CFLAGS="${CFLAGS} ${picky_cflags}"
+       CXXFLAGS="${CXXFLAGS} ${picky_cxxflags}"
+       AS_UNSET([picky_cxxflags])
        AS_UNSET([picky_cflags])])
 
 werror_flags="-Werror"
@@ -227,10 +241,12 @@ AC_ARG_ENABLE([werror],
    [AS_HELP_STRING([--enable-werror], [(Developer) Enable setting -Werror.  Off by default, unless building from Git tree.])])
 AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CFLAGS.])
-       CFLAGS="${werror_flags} ${CFLAGS}"],
+       CXXFLAGS="${werror_flags} ${CXXFLAGS} "
+       CFLAGS="${werror_flags} ${CFLAGS} "],
       [test "${enable_werror}" = "yes"],
       [AC_MSG_NOTICE([Adding ${werror_flags} to CFLAGS.])
-       CFLAGS="${werror_flags} ${CFLAGS}"])
+       CXXFLAGS="${werror_flags} ${CXXFLAGS} "
+       CFLAGS="${werror_flags} ${CFLAGS} "])
 
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
 

--- a/include/nccl_ofi_config_bottom.h
+++ b/include/nccl_ofi_config_bottom.h
@@ -5,6 +5,8 @@
 #ifndef NCCL_OFI_CONFIG_BOTTOM_H
 #define NCCL_OFI_CONFIG_BOTTOM_H
 
+#define NCCL_OFI_N_NVTX_DOMAIN_PER_COMM 8
+
 /* configure aborts if __buildin_expect() isn't available */
 #define OFI_LIKELY(x)   __builtin_expect((x), 1)
 #define OFI_UNLIKELY(x) __builtin_expect((x), 0)

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -33,14 +33,15 @@ enum nccl_ofi_mr_ckey_type {
 typedef enum nccl_ofi_mr_ckey_type nccl_ofi_mr_ckey_type_t;
 
 struct nccl_ofi_mr_ckey {
-	const union {
-		const struct iovec iovec;
+	union {
+		struct iovec iovec;
 #if HAVE_DECL_FI_MR_DMABUF
-		const struct fi_mr_dmabuf fi_mr_dmabuf;
+		struct fi_mr_dmabuf fi_mr_dmabuf;
 #endif
 	};
-	const enum nccl_ofi_mr_ckey_type type;
+	enum nccl_ofi_mr_ckey_type type;
 };
+
 typedef struct nccl_ofi_mr_ckey nccl_ofi_mr_ckey_t;
 typedef struct nccl_ofi_mr_ckey const *const nccl_ofi_mr_ckey_ref;
 
@@ -118,30 +119,24 @@ static inline void nccl_ofi_mr_ckey_round(size_t *len, void **base_addr, const c
 #if HAVE_DECL_FI_MR_DMABUF
 static inline nccl_ofi_mr_ckey_t nccl_ofi_mr_ckey_mk_dmabuf(int fd, uint64_t offset, size_t len, void *base_addr)
 {
-	return (nccl_ofi_mr_ckey_t){
-		.fi_mr_dmabuf =
-			{
-				.fd = fd,
-				.offset = offset,
-				.len = len,
-				.base_addr = base_addr,
-			},
-		.type = NCCL_OFI_MR_CKEY_DMABUF,
-	};
+	nccl_ofi_mr_ckey_t cache_key = {};
+	cache_key.fi_mr_dmabuf.fd = fd;
+	cache_key.fi_mr_dmabuf.offset = offset;
+	cache_key.fi_mr_dmabuf.len = len;
+	cache_key.fi_mr_dmabuf.base_addr = base_addr;
+	cache_key.type = NCCL_OFI_MR_CKEY_DMABUF;
+	return cache_key;
 }
 #endif
 
 static inline nccl_ofi_mr_ckey_t nccl_ofi_mr_ckey_mk_vec(void *iov_base, size_t iov_len)
 {
 	nccl_ofi_mr_ckey_round(&iov_len, &iov_base, "iovec");
-	return (nccl_ofi_mr_ckey_t){
-		.iovec =
-			{
-				.iov_base = iov_base,
-				.iov_len = iov_len,
-			},
-		.type = NCCL_OFI_MR_CKEY_IOVEC,
-	};
+	nccl_ofi_mr_ckey_t cache_key = {};
+	cache_key.iovec.iov_base = iov_base;
+	cache_key.iovec.iov_len = iov_len;
+	cache_key.type = NCCL_OFI_MR_CKEY_IOVEC;
+	return cache_key;
 }
 
 static inline void nccl_ofi_mr_ckey_fill_mr_attrs(nccl_ofi_mr_ckey_ref ckey, struct fi_mr_attr *attrs, uint64_t *flags)

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -9,18 +9,22 @@
 extern "C" {
 #endif
 
+#include "config.h"
+
 #include <rdma/fabric.h>
 
 #include "nccl_ofi.h"
-#include "nccl_ofi_log.h"
-#include "nccl_ofi_scheduler.h"
-#include "nccl_ofi_msgbuff.h"
-#include "nccl_ofi_topo.h"
 #include "nccl_ofi_deque.h"
+#include "nccl_ofi_ep_addr_list.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_idpool.h"
-#include "nccl_ofi_tracepoint.h"
-#include "nccl_ofi_ep_addr_list.h"
+#include "nccl_ofi_log.h"
+#include "nccl_ofi_msgbuff.h"
+#include "nccl_ofi_scheduler.h"
+#include "nccl_ofi_topo.h"
+#if HAVE_NVTX_TRACING
+#include <nvtx3/nvToolsExt.h>
+#endif
 
 /* Maximum number of rails supported. This defines the size of
  * messages exchanged during connection establishment (linear

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -8,8 +8,6 @@
 #if HAVE_NVTX_TRACING
 #include <nvtx3/nvToolsExt.h>
 
-#define NCCL_OFI_N_NVTX_DOMAIN_PER_COMM 8
-
 static inline void nvtx_mark_domain(nvtxDomainHandle_t domain, const char* name, uint32_t color)
 {
 	nvtxEventAttributes_t eventAttrib = {};

--- a/m4/check_pkg_mpi.m4
+++ b/m4/check_pkg_mpi.m4
@@ -31,6 +31,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
          LDFLAGS="${MPI_LDFLAGS} ${LDFLAGS}"])
 
   MPICC=${mpi_bindir}mpicc
+  MPICXX=${mpi_bindir}mpicxx
 
   AC_MSG_CHECKING([for working mpicc])
   ${MPICC} --help >& AS_MESSAGE_LOG_FD
@@ -38,6 +39,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
         [AC_MSG_RESULT([yes])],
         [AC_MSG_RESULT([no])
          MPICC="${CC}"
+         MPICXX="${CXX}"
          AS_IF([test "${check_pkg_found}" = "yes"],
                [AC_CHECK_HEADERS([mpi.h], [], [check_pkg_found=no])])
 
@@ -49,6 +51,7 @@ AC_DEFUN([CHECK_PKG_MPI], [
         [$2])
 
   AC_SUBST([MPICC])
+  AC_SUBST([MPICXX])
   AC_SUBST([MPI_CPPFLAGS])
   AC_SUBST([MPI_LDFLAGS])
   AC_SUBST([MPI_LIBS])

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -12,6 +12,7 @@ AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
 LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
 CC = $(MPICC)
+CXX = $(MPICXX)
 
 if ENABLE_FUNC_TESTS
 noinst_HEADERS = test-common.h

--- a/tests/unit/scheduler.c
+++ b/tests/unit/scheduler.c
@@ -86,12 +86,12 @@ static inline int set_ref_schedule(nccl_net_ofi_schedule_t *schedule, size_t ind
 }
 
 static inline int test_multiplexer(nccl_net_ofi_scheduler_t *scheduler,
-								   int num_rails,
-								   size_t msg_size,
-								   size_t num_stripes,
-								   int *rail_id,
-								   int *offset,
-								   size_t *msg_size_per_stripe)
+				   int num_rails,
+				   size_t msg_size,
+				   size_t num_stripes,
+				   int *rail_id,
+				   size_t *offset,
+				   size_t *msg_size_per_stripe)
 {
 	int ret = 0;
 	nccl_net_ofi_schedule_t *ref_schedule;
@@ -158,7 +158,7 @@ static inline int test_threshold_scheduler()
 	size_t msg_size_per_stripe_1[6][1] =
 		{{msg_sizes_1[0]}, {msg_sizes_1[1]}, {msg_sizes_1[2]}, {msg_sizes_1[3]}, {msg_sizes_1[4]}, {msg_sizes_1[5]}};
 	int rail_ids_1[6][1] = {{0}, {1}, {2}, {3}, {0}, {1}}; /* In round-robin for each iteration a new rail-id is used */
-	int offsets_1[6][1] = {{0}, {0}, {0}, {0}, {0}, {0}};  /* Offset remaines 0 in round robin */
+	size_t offsets_1[6][1] = {{0}, {0}, {0}, {0}, {0}, {0}}; /* Offset remaines 0 in round robin */
 	for (int iter = 0; iter < 6; iter++) {
 		ret = test_multiplexer(scheduler,
 		                       num_rails,
@@ -192,12 +192,12 @@ static inline int test_threshold_scheduler()
 	/* For each message ensure that two rails are used. Also ensure that the rail-id pairs
 	 * are round-robin between each schedule */
 	int rail_ids_2[6][2] = {{2, 3}, {0, 1}, {2, 3}, {0, 1}, {2, 3}, {0, 1}};
-	int offsets_2[6][2] = {{0, stripe_size[0]},
-	                       {0, stripe_size[1]},
-	                       {0, stripe_size[2]},
-	                       {0, stripe_size[3]},
-	                       {0, stripe_size[4]},
-	                       {0, stripe_size[5]}};
+	size_t offsets_2[6][2] = {{0, stripe_size[0]},
+				  {0, stripe_size[1]},
+				  {0, stripe_size[2]},
+				  {0, stripe_size[3]},
+				  {0, stripe_size[4]},
+				  {0, stripe_size[5]}};
 	size_t msg_size_per_stripe_2[6][2] = {{stripe_size[0], remaining_stripe_size[0]},
 	                                      {stripe_size[1], remaining_stripe_size[1]},
 	                                      {stripe_size[2], remaining_stripe_size[2]},
@@ -234,12 +234,12 @@ static inline int test_threshold_scheduler()
 	/* For each message ensure that three rails are used. Also ensure that the rail-id triplets
 	 * are round-robin between each schedule */
 	int rail_ids_3[6][2] = {{2, 3}, {0, 1}, {2, 3}, {0, 1}, {2, 3}, {0, 1}};
-	int offsets_3[6][2] = {{0, (stripe_size[0] * 2) / 2},
-	                       {0, (stripe_size[1] * 2) / 2},
-	                       {0, (stripe_size[2] * 2) / 2},
-	                       {0, (stripe_size[3] * 2) / 2},
-	                       {0, (stripe_size[4] * 2) / 2},
-	                       {0, (stripe_size[5] * 2) / 2}};
+	size_t offsets_3[6][2] = {{0, (stripe_size[0] * 2) / 2},
+				  {0, (stripe_size[1] * 2) / 2},
+				  {0, (stripe_size[2] * 2) / 2},
+				  {0, (stripe_size[3] * 2) / 2},
+				  {0, (stripe_size[4] * 2) / 2},
+				  {0, (stripe_size[5] * 2) / 2}};
 	size_t msg_size_per_stripe_3[6][2] = {{(stripe_size[0] * 2) / 2, remaining_stripe_size[0]},
 	                                      {(stripe_size[1] * 2) / 2, remaining_stripe_size[1]},
 	                                      {(stripe_size[2] * 2) / 2, remaining_stripe_size[2]},
@@ -275,12 +275,12 @@ static inline int test_threshold_scheduler()
 	}
 	/* For each message ensure that all four rails are used. */
 	int rail_ids_4[6][4] = {{2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}};
-	int offsets_4[6][4] = {{0, stripe_size[0], stripe_size[0] * 2, stripe_size[0] * 3},
-	                       {0, stripe_size[1], stripe_size[1] * 2, stripe_size[1] * 3},
-	                       {0, stripe_size[2], stripe_size[2] * 2, stripe_size[2] * 3},
-	                       {0, stripe_size[3], stripe_size[3] * 2, stripe_size[3] * 3},
-	                       {0, stripe_size[4], stripe_size[4] * 2, stripe_size[4] * 3},
-	                       {0, stripe_size[5], stripe_size[5] * 2, stripe_size[5] * 3}};
+	size_t offsets_4[6][4] = {{0, stripe_size[0], stripe_size[0] * 2, stripe_size[0] * 3},
+				  {0, stripe_size[1], stripe_size[1] * 2, stripe_size[1] * 3},
+				  {0, stripe_size[2], stripe_size[2] * 2, stripe_size[2] * 3},
+				  {0, stripe_size[3], stripe_size[3] * 2, stripe_size[3] * 3},
+				  {0, stripe_size[4], stripe_size[4] * 2, stripe_size[4] * 3},
+				  {0, stripe_size[5], stripe_size[5] * 2, stripe_size[5] * 3}};
 	size_t msg_size_per_stripe_4[6][4] = {{stripe_size[0], stripe_size[0], stripe_size[0], remaining_stripe_size[0]},
 	                                      {stripe_size[1], stripe_size[1], stripe_size[1], remaining_stripe_size[1]},
 	                                      {stripe_size[2], stripe_size[2], stripe_size[2], remaining_stripe_size[2]},


### PR DESCRIPTION
> feat(build): Add full C++ build mode
> 
> Rather than relying on -Wc++-compat, add a full build flag that uses all
CXXFLAGS and parses the source truly as C++.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
