### PR TITLE
Revert "neuron: Disable rdma eager messages by default"

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -261,20 +261,8 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
 /*
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
- *
- * Neuron perf is better without the eager protocol, so we set the
- * default to 0 on Neuron platforms.  We really need to have a way to
- * tweak defaults from the platform file, but this fits our needs for
- * now.
  */
-OFI_NCCL_PARAM_UINT(eager_max_size,
-                    "EAGER_MAX_SIZE",
-#if HAVE_NEURON
-                    0
-#else
-                    8192
-#endif
-);
+OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE", 8192);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
This reverts commit bfc2e7c877f4eca2ca574cdf8c8662ede68e6e33.

Eager gets re-enabled on neuron platforms, i.e., commit above is reverted, since current neuron features benefit from sending data eagerly due to missing pre-posting feature.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
