### PR TITLE
feat(ci): add workflow_dispatch to distcheck

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -1,5 +1,6 @@
 name: PR CI
 on:
+  workflow_dispatch:
   push:
     branches:
       - master


### PR DESCRIPTION
Allow manually triggering the distcheck build matrix on a specific branch. This is mostly useful on our forks, where it's possible through the "actions" tab to select the PR-CI job and submit a run request against your branch, without requiring creating a draft PR that sends clogs emails and spawns jenkins ci jobs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
