### PR TITLE
Fix use of uninitialized lock

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -789,10 +789,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	/* Message scheduler */
 	nccl_net_ofi_scheduler_t *scheduler;
 
-	/* Lock for concurrency since endpoints can be shared by
-	 * multiple entities. */
-	pthread_mutex_t device_lock;
-
 	/* Number of rails */
 	int num_rails;
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -4676,9 +4676,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(device->device_lock));
+		nccl_net_ofi_mutex_lock(&(device->base.device_lock));
 		ep->base.ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(device->device_lock));
+		nccl_net_ofi_mutex_unlock(&(device->base.device_lock));
 
 		/* Reset request state for connect response message */
 		prepare_send_conn_resp_req(l_comm);


### PR DESCRIPTION
Commit 840769e8 moved the device lock from the rdma/sendrecv classes to the base device class.  Somehow, I missed removing the device lock field from the rdma device and missed updating one use.  This commit fixes both of those problems.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
