### PR TITLE
rdma: remove "request completed with error" message

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2496,7 +2496,6 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 		assert(req->free);
 		req->free(req, true);
 	} else if (OFI_UNLIKELY(req->state == NCCL_OFI_RDMA_REQ_ERROR)) {
-		NCCL_OFI_WARN("Request completed with error");
 		ret = -EINVAL;
 		goto exit;
 	}


### PR DESCRIPTION
In case a request completes with an error, a more detailed error message has already been logged elsewhere. Remove this useless additional error message, which (for reasons we don't understand) can end up being printed infinitely in case of an error

fixes #611

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
