### PR TITLE
Couple of accessor function / code cleanups

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -124,15 +124,6 @@ extern bool virt_addr_mr;
  */
 extern const char *nccl_ofi_selected_protocol;
 
-/*
- * Determine whether to allocate the domain per process or per
- * thread.
- * 0: allocate domain per process
- * 1: allocate domain per thread
- */
-
-extern int domain_per_thread;
-
 /* Internode network latency reported to NCCL. */
 extern float net_latency;
 
@@ -531,6 +522,14 @@ struct nccl_net_ofi_plugin {
 
 	int (*release_plugin)(nccl_net_ofi_plugin_t *plugin);
 
+	/*
+	 * Determine whether to allocate the domain per process or per
+	 * thread.
+	 * false: allocate domain per process
+	 * true: allocate domain per thread
+	 */
+	bool domain_per_thread;
+
 /* private */
 	/* Array of devices */
 	nccl_net_ofi_device_t **p_devs;
@@ -589,7 +588,8 @@ int nccl_net_ofi_plugin_fini(nccl_net_ofi_plugin_t *plugin);
  *
  * @return	Populated props structure
  */
-int nccl_net_ofi_info_properties(struct fi_info *nic_prov, int dev_id, int num_devices, nccl_ofi_properties_t *props);
+int nccl_net_ofi_info_properties(nccl_net_ofi_plugin_t *plugin, struct fi_info *nic_prov,
+				 int dev_id, int num_devices, nccl_ofi_properties_t *props);
 
 /*
  * @brief	Allocate memory region for memory registration

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -35,6 +35,12 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribut
  */
 void platform_sort_rails(struct fi_info **info_list, int num_rails) __attribute__((weak));
 
+
+/*
+ * does the platform have an opinion on domain_per_thread configuration?
+ */
+bool platform_default_domain_per_thread(void) __attribute__((weak));
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -325,7 +325,7 @@ static inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_rail(nccl_net_ofi_rdma_e
 /*
  * @brief return the domain for the endpoint and rail.
  */
-static inline struct fid_domain *get_domain_from_endpoint(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
+static inline struct fid_domain *rdma_endpoint_get_ofi_domain(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
 {
 	return rdma_endpoint_get_rail(ep, rail_id)->domain;
 }
@@ -2753,7 +2753,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	ret_handle->num_rails = num_rails;
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
 		nccl_net_ofi_ep_rail_t *rail = rdma_endpoint_get_rail(ep, rail_id);
-		domain = get_domain_from_endpoint(ep, rail_id);
+		domain = rdma_endpoint_get_ofi_domain(ep, rail_id);
 
 		ret = register_rail_mr_buffer(domain, rail->ofi_ep,
 					      dev_id, type, &mr_attr, regattr_flags,

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -181,6 +181,17 @@ static nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin(nccl_net_ofi_rdma_devi
 }
 
 
+static nccl_net_ofi_rdma_ep_t *rdma_req_get_ep(nccl_net_ofi_rdma_req_t *req)
+{
+	return (nccl_net_ofi_rdma_ep_t *)req->comm->ep;
+}
+
+
+static nccl_net_ofi_rdma_device_t *rdma_req_get_device(nccl_net_ofi_rdma_req_t *req)
+{
+	return (nccl_net_ofi_rdma_device_t *)rdma_req_get_ep(req)->base.device;
+}
+
 /*
  * @brief	Get endpoint communicator with given ID
  */
@@ -2022,7 +2033,7 @@ static inline int free_send_req(nccl_net_ofi_rdma_req_t *req,
 	send_data = get_send_data(req);
 
 	if (send_data->schedule) {
-		nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)req->comm->ep->device;
+		nccl_net_ofi_rdma_device_t *device = rdma_req_get_device(req);
 		nccl_net_ofi_release_schedule(device->scheduler, send_data->schedule);
 		send_data->schedule = NULL;
 	}
@@ -2111,7 +2122,7 @@ static inline int free_send_close_req(nccl_net_ofi_rdma_req_t *req,
 	rdma_req_send_close_data_t *send_close_data = req_get_send_close_data(req);
 
 	if (send_close_data->ctrl_schedule) {
-		nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)req->comm->ep->device;
+		nccl_net_ofi_rdma_device_t *device = rdma_req_get_device(req);
 		nccl_net_ofi_release_schedule(device->scheduler, send_close_data->ctrl_schedule);
 		send_close_data->ctrl_schedule = NULL;
 	}

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -30,6 +30,12 @@
 #include "nccl_ofi_mr.h"
 
 
+static nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device(nccl_net_ofi_sendrecv_ep_t *ep)
+{
+	return (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+}
+
+
 static nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin(nccl_net_ofi_sendrecv_device_t *device)
 {
 	return (nccl_net_ofi_sendrecv_plugin_t*)device->base.plugin;
@@ -392,7 +398,7 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	}
 
 	/* Retrieve and validate device */
-	device = (nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -780,7 +786,7 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+		sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
@@ -860,8 +866,7 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	}
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	nccl_net_ofi_sendrecv_device_t *device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
@@ -918,7 +923,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	}
 
 	/* Retrieve and validate device */
-	device = (nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -1168,8 +1173,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 			}
 
 			/* Retrieve and validate device */
-			nccl_net_ofi_sendrecv_device_t *device =
-				(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+			nccl_net_ofi_sendrecv_device_t *device = sendrecv_endpoint_get_device(ep);
 			if (OFI_UNLIKELY(device == NULL)) {
 				ret = -EINVAL;
 				NCCL_OFI_WARN("Invalid device provided");
@@ -1384,7 +1388,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+		sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -1571,8 +1575,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 		(nccl_net_ofi_sendrecv_ep_t *)base_ep;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	nccl_net_ofi_sendrecv_device_t *device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
@@ -1649,7 +1652,7 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+		sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
@@ -1683,7 +1686,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	}
 
 	/* Retrieve and validate device */
-	device = (nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");
@@ -1835,7 +1838,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	int ret = 0;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device = (nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	nccl_net_ofi_sendrecv_device_t *device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Error accessing device.");
 		return -EINVAL;
@@ -2009,7 +2012,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		(nccl_net_ofi_sendrecv_ep_t *)base_ep;
 
 	/* Retrieve and validate devices */
-	nccl_net_ofi_sendrecv_device_t *device = (nccl_net_ofi_sendrecv_device_t *)base_ep->device;
+	nccl_net_ofi_sendrecv_device_t *device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Error accessing devices array. Devices array has not been initialized.");
 		return -EINVAL;
@@ -2136,7 +2139,7 @@ static int nccl_net_ofi_sendrecv_endpoint_free(nccl_net_ofi_ep_t *base_ep)
 	}
 
 	/* Validate device */
-	device = (nccl_net_ofi_sendrecv_device_t *)ep->base.device;
+	device = sendrecv_endpoint_get_device(ep);
 	if (OFI_UNLIKELY(device == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid device provided");

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -613,16 +613,6 @@ int platform_init(const char **provider_filter)
 		nccl_ofi_selected_protocol = platform_data->default_protocol;
 	}
 
-	domain_per_thread = ofi_nccl_domain_per_thread();
-	if (domain_per_thread == -1) {
-		if (platform_data != NULL) {
-			domain_per_thread = platform_data->domain_per_thread;
-		} else {
-			domain_per_thread = 0;
-		}
-	}
-	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Creating one domain per %s", domain_per_thread ? "thread" : "process");
-
 exit:
 	return ret;
 }
@@ -891,4 +881,14 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails)
 
 error:
 	return;
+}
+
+
+bool platform_default_domain_per_thread(void)
+{
+	struct ec2_platform_data *platform_data = get_platform_data();
+	if (platform_data != NULL && platform_data->domain_per_thread != 0) {
+		return true;
+	}
+	return false;
 }


### PR DESCRIPTION
Posting a couple patches that I've had in a branch trying to clean up domain / threading logic.  Add some accessor functions for looking up one object type from another.  Also move the domain_per_thread field into the plugin, trying to remove the number of unnecessary global variables.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
