### PR TITLE
rdma: Revert commits eliminating eager waits

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -282,7 +282,8 @@ typedef struct {
 typedef struct {
 	/* Pointer to the allocated control buffer from freelist */
 	nccl_net_ofi_rdma_ctrl_fl_item_t *ctrl_fl_item;
-
+	/* Pointer to recv parent request */
+	nccl_net_ofi_rdma_req_t *recv_req;
 #if HAVE_NVTX_TRACING
 	nvtxRangeId_t trace_id;
 #endif
@@ -325,6 +326,8 @@ typedef struct {
 	size_t dst_len;
 	/* Mr handle for destination buffer */
 	nccl_net_ofi_rdma_mr_handle_t *dest_mr_handle;
+	/* Pointer to send control message child request */
+	nccl_net_ofi_rdma_req_t *send_ctrl_req;
 	/* Pointer to receive segments child request */
 	nccl_net_ofi_rdma_req_t *recv_segms_req;
 	/* (Eager messages) pointer to eager local copy request */
@@ -533,7 +536,6 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	/* Counters for total sent and received control messages */
 	uint64_t n_ctrl_received;
 	uint64_t n_ctrl_expected;
-	uint16_t last_ctrl_received;
 
 	bool comm_active;
 
@@ -613,8 +615,6 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	pthread_mutex_t ctrl_counter_lock;
 	uint64_t n_ctrl_sent;
 	uint64_t n_ctrl_delivered;
-
-	uint16_t last_ctrl_sent;
 
 	/* Number of rails */
 	int num_rails;


### PR DESCRIPTION
Eliminating the waits for eager messages can cause the sender and
receiver to go out-of-sync during a long run of eager messages. For
example, at an extreme, the sender could send 1024 eager messages, which
are queued by Libfabric and marked complete. Then if the sender received
a control message for message 0 from the receiver, it couldn't be
unambiguously associated with the first message or the 1024th message,
which both have the same sequence number, since the sequence number is
only 10 bits.

A patch intended to keep them in sync (2479540) also did not resolve the
issue. Without `FI_ORDER_SAS` semantics (which the plugin does not
request), the completions can be reordered, and the receipt of of sync
ctrl message does not guarantee that previous ctrl messages have
completed, which can lead to the same problem.

A proper design fix is still in progress; this PR re-enables the eager
waits in the interim.

The supporting refactoring commits of
https://github.com/aws/aws-ofi-nccl/pull/553 are retained so we
can re-enable this feature later. Only the last commit is reverted. The
sync patch is also reverted.

This reverts commits 2479540e332afb9fbf6efbd90c057d09386f109e and
7a0fa83daad9d01c14b2895439e1dd5615cb6ebd.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
