### PR TITLE
Add domain object to transports

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -763,12 +763,6 @@ typedef struct nccl_net_ofi_rdma_device_rail {
 
 	/* Fabric handle */
 	struct fid_fabric *fabric;
-
-	/* Access domain handles */
-	struct fid_domain *domain;
-
-	/* Completion Queue handle */
-	struct fid_cq *cq;
 } nccl_net_ofi_rdma_device_rail_t;
 
 /*
@@ -819,13 +813,29 @@ typedef struct nccl_net_ofi_rdma_device {
 
 	bool use_long_rkeys;
 
-	/* List of endpoints and set of addresses they have connections to */
-	nccl_ofi_ep_addr_list_t *ep_addr_list;
-
 #if HAVE_NVTX_TRACING
 	nvtxDomainHandle_t nvtx_domain[MAX_NUM_RAILS];
 #endif
 } nccl_net_ofi_rdma_device_t;
+
+
+typedef struct nccl_net_ofi_rdma_domain_rail {
+	/* Access domain handles */
+	struct fid_domain *domain;
+
+	struct fid_cq *cq;
+} nccl_net_ofi_rdma_domain_rail_t;
+
+
+typedef struct nccl_net_ofi_rdma_domain {
+	nccl_net_ofi_domain_t base;
+
+	int num_rails;
+	nccl_net_ofi_rdma_domain_rail_t *domain_rails;
+
+	/* List of endpoints and set of addresses they have connections to */
+	nccl_ofi_ep_addr_list_t *ep_addr_list;
+} nccl_net_ofi_rdma_domain_t;
 
 
 struct nccl_net_ofi_rdma_plugin {

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -111,15 +111,26 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Endpoint handle to communicate to */
 	struct fid_ep *ofi_ep;
 
-	/* Access Domain handle */
-	struct fid_domain *domain;
-
 	/* Address vector handle */
 	struct fid_av *av;
 
 	/* Completion Queue handle */
 	struct fid_cq *cq;
 } nccl_net_ofi_sendrecv_ep_t;
+
+
+/*
+ * Domain - container for the libfabric domain, which is the threading
+ * boundary for most Libfabric providers, given how the util cq
+ * implementation works.
+ */
+typedef struct nccl_net_ofi_sendrecv_domain {
+	nccl_net_ofi_domain_t base;
+
+	/* Access Domain handle */
+	struct fid_domain *domain;
+} nccl_net_ofi_sendrecv_domain_t;
+
 
 /**
  * @brief	Sendrecv Device
@@ -163,9 +174,6 @@ typedef struct nccl_net_ofi_sendrecv_device {
 
 	/* Fabric handle */
 	struct fid_fabric *fabric;
-
-	/* Access Domain handle */
-	struct fid_domain *domain;
 } nccl_net_ofi_sendrecv_device_t;
 	
 typedef struct nccl_net_ofi_sendrecv_req {

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -721,40 +721,81 @@ int nccl_net_ofi_plugin_fini(nccl_net_ofi_plugin_t *plugin)
 }
 
 
-static int nccl_net_ofi_device_get_ep(nccl_net_ofi_device_t *device,
-				      nccl_net_ofi_ep_t **ep_p)
+/*
+ * implementation of retreiving a domain from a device.  This code
+ * assumes the device lock is already held, because in the case of
+ * get_domain() we only need to worry about the device lock, but in
+ * the device->get_ep call, hold the lock while we're also creating
+ * the ep.
+ */
+static nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain_impl(nccl_net_ofi_device_t *device)
 {
-	int ret = 0;
-	long thread_id;
-	nccl_net_ofi_ep_t *ep = NULL;
+	nccl_net_ofi_plugin_t *plugin = NULL;
+	nccl_net_ofi_domain_t *domain = NULL;
+	long lookup_key = 0;
 
-	nccl_net_ofi_mutex_lock(&device->device_lock);
+	assert(device != NULL);
 
-	thread_id = nccl_net_ofi_gettid();
-	HASH_FIND(hh, device->endpoint_table, &thread_id,
-		  sizeof(ep->creating_thread_id), ep);
+	plugin = device->plugin;
+	assert(plugin != NULL);
 
-	if (ep == NULL) {
-		ret = device->create_endpoint(device, &ep);
-		if (ret != 0) {
-			NCCL_OFI_WARN("Creating new endpoint for device %s failed: %s",
-				      device->name, fi_strerror(-ret));
-			goto unlock;
+	if (plugin->domain_per_thread) {
+		lookup_key = nccl_net_ofi_gettid();
+	}
+
+	HASH_FIND(hh, device->domain_table, &lookup_key,
+		  sizeof(domain->creating_thread_id), domain);
+
+	if (domain == NULL) {
+		domain = device->create_domain(device);
+		if (domain == NULL) {
+			NCCL_OFI_WARN("Initializing a new domain for device %s failed",
+				      device->name);
+			return NULL;
 		}
 
-		ep->creating_thread_id = thread_id;
+		domain->creating_thread_id = lookup_key;
 
-		HASH_ADD(hh, device->endpoint_table, creating_thread_id,
-			 sizeof(ep->creating_thread_id), ep);
+		HASH_ADD(hh, device->domain_table, creating_thread_id,
+			 sizeof(domain->creating_thread_id), domain);
 
-		NCCL_OFI_TRACE(NCCL_NET, "Eendpoint %p for device #%d (%s) is created",
-			       ep,
+		NCCL_OFI_TRACE(NCCL_NET, "Domain %p for device #%d (%s) is created",
+			       domain,
 			       device->dev_id,
 			       device->name);
 	}
 
-	ep->ref_cnt++;
-	*ep_p = ep;
+	return domain;
+}
+
+
+static nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain(nccl_net_ofi_device_t *device)
+{
+	nccl_net_ofi_domain_t *domain;
+
+	nccl_net_ofi_mutex_lock(&device->device_lock);
+	domain = nccl_net_ofi_device_get_domain_impl(device);
+	nccl_net_ofi_mutex_unlock(&device->device_lock);
+
+	return domain;
+}
+
+
+static int nccl_net_ofi_device_get_ep(nccl_net_ofi_device_t *device,
+				      nccl_net_ofi_ep_t **ep_p)
+{
+	int ret;
+	nccl_net_ofi_domain_t *domain = NULL;
+
+	nccl_net_ofi_mutex_lock(&device->device_lock);
+
+	domain = nccl_net_ofi_device_get_domain_impl(device);
+	if (domain == NULL) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	ret = domain->get_ep(domain, ep_p);
 
 unlock:
 	nccl_net_ofi_mutex_unlock(&device->device_lock);
@@ -777,18 +818,8 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 		goto exit;
 	}
 
-	device->mr_cache = NULL;
-	if (!ofi_nccl_mr_cache_disable()) {
-		device->mr_cache =
-			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
-					       mr_cache_alignment);
-		if (!device->mr_cache) {
-			ret = -ENOMEM;
-			goto exit;
-		}
-	}
-
 	device->get_properties = NULL;
+	device->get_domain = nccl_net_ofi_device_get_domain;
 	device->get_ep = nccl_net_ofi_device_get_ep;
 	device->get_mr_key = NULL;
 	device->release = nccl_net_ofi_device_fini;
@@ -809,6 +840,134 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 			      strerror(-ret));
 		return -ret;
 	}
+
+	device->create_domain = NULL;
+	device->domain_table = NULL;
+
+exit:
+
+	return ret;
+}
+
+
+int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
+{
+
+	if (device == NULL) {
+		return 0;
+	}
+
+	if (device->name != NULL) {
+		free(device->name);
+	}
+
+	return 0;
+}
+
+
+static int nccl_net_ofi_domain_get_ep(nccl_net_ofi_domain_t *domain,
+				      nccl_net_ofi_ep_t **ep_p)
+{
+	int ret = 0;
+	long thread_id;
+	nccl_net_ofi_ep_t *ep = NULL;
+
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
+
+	thread_id = nccl_net_ofi_gettid();
+	HASH_FIND(hh, domain->endpoint_table, &thread_id,
+		  sizeof(ep->creating_thread_id), ep);
+
+	if (ep == NULL) {
+		ret = domain->create_endpoint(domain, &ep);
+		if (ret != 0) {
+			NCCL_OFI_WARN("Creating new endpoint for domain %p failed: %s",
+				      domain, fi_strerror(-ret));
+			goto unlock;
+		}
+
+		ep->creating_thread_id = thread_id;
+
+		HASH_ADD(hh, domain->endpoint_table, creating_thread_id,
+			 sizeof(ep->creating_thread_id), ep);
+
+		NCCL_OFI_TRACE(NCCL_NET, "Eendpoint %p for domain %p is created",
+			       ep, domain);
+	}
+
+	ep->ref_cnt++;
+	*ep_p = ep;
+
+unlock:
+	nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+	return ret;
+}
+
+
+static int nccl_net_ofi_domain_release(nccl_net_ofi_domain_t *domain)
+{
+	int ret = 0;
+	nccl_net_ofi_device_t *device;
+
+	assert(domain != NULL);
+	device = domain->device;
+
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
+
+	if (HASH_COUNT(domain->endpoint_table) == 0) {
+		nccl_net_ofi_mutex_lock(&device->device_lock);
+		HASH_DEL(device->domain_table, domain);
+
+		// domain->free below is going to free the domain lock
+		// and we've removed the domain from the hash table,
+		// so no one should have a reference to the domain at
+		// this point and we can release the mutex.
+		nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+		ret = domain->free(domain);
+		nccl_net_ofi_mutex_unlock(&device->device_lock);
+		if (ret != 0) {
+			NCCL_OFI_WARN("Freeing domain failed: %d", ret);
+			return ret;
+		}
+	} else {
+		nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+	}
+
+	return 0;
+}
+
+
+int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_t *domain)
+{
+	int ret;
+
+	domain->device = device;
+
+	ret = nccl_net_ofi_mutex_init(&domain->domain_lock, NULL);
+	if (ret != 0) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			       "Unable to initialize domain mutex");
+		return -ret;
+	}
+
+	domain->get_ep = nccl_net_ofi_domain_get_ep;
+	domain->release = nccl_net_ofi_domain_release;
+	domain->endpoint_table = NULL;
+	domain->creating_thread_id = 0;
+
+	domain->mr_cache = NULL;
+	if (!ofi_nccl_mr_cache_disable()) {
+		domain->mr_cache =
+			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
+					       system_page_size);
+		if (!domain->mr_cache) {
+			ret = -ENOMEM;
+			goto exit;
+		}
+	}
+
 	if (device->need_mr_rkey_pool) {
 		/* The provider may return support for a larger key size. Use
 		 * the size requested by the user to allow them to limit the
@@ -822,10 +981,10 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 				size_t_bits);
 			return -EINVAL;
 		}
-		ret = nccl_ofi_idpool_init(&device->mr_rkey_pool, 1 << shift);
+		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 1 << shift);
 	} else {
 		/* Mark key pool as not in use */
-		ret = nccl_ofi_idpool_init(&device->mr_rkey_pool, 0);
+		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 0);
 	}
 	if (ret != 0) {
 		NCCL_OFI_WARN("Creating MR id pool failed: %s",
@@ -833,30 +992,18 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 		return -ret;
 	}
 
-	device->create_endpoint = NULL;
-	device->endpoint_table = NULL;
-
 exit:
 	return ret;
 }
 
 
-int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
+int nccl_net_ofi_domain_fini(nccl_net_ofi_domain_t *domain)
 {
-
-	if (device == NULL) {
-		return 0;
+	if (domain->mr_cache != NULL) {
+		nccl_ofi_mr_cache_finalize(domain->mr_cache);
 	}
 
-	if (device->mr_cache != NULL) {
-		nccl_ofi_mr_cache_finalize(device->mr_cache);
-	}
-
-	if (device->name != NULL) {
-		free(device->name);
-	}
-
-	nccl_ofi_idpool_fini(&device->mr_rkey_pool);
+	nccl_ofi_idpool_fini(&domain->mr_rkey_pool);
 
 	return 0;
 }
@@ -865,17 +1012,17 @@ int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
 int nccl_net_ofi_endpoint_release(nccl_net_ofi_ep_t *ep)
 {
 	int ret = 0;
-	nccl_net_ofi_device_t *device;
+	nccl_net_ofi_domain_t *domain;
 
 	assert(ep != NULL);
-	device = ep->device;
+	domain = ep->domain;
 
-	nccl_net_ofi_mutex_lock(&device->device_lock);
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
 
 	ep->ref_cnt--;
 
 	if (ep->ref_cnt == 0) {
-		HASH_DEL(device->endpoint_table, ep);
+		HASH_DEL(domain->endpoint_table, ep);
 
 		ret = ep->free_ep(ep);
 		if (ret != 0) {
@@ -885,20 +1032,23 @@ int nccl_net_ofi_endpoint_release(nccl_net_ofi_ep_t *ep)
 	}
 
 cleanup:
-	nccl_net_ofi_mutex_unlock(&device->device_lock);
+	nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+	if (ret == 0) {
+		ret = domain->release(domain);
+	}
 
 	return ret;
-
 }
 
 
-int nccl_net_ofi_endpoint_init(nccl_net_ofi_device_t *device,
+int nccl_net_ofi_endpoint_init(nccl_net_ofi_domain_t *domain,
 			       nccl_net_ofi_ep_t *ep)
 {
-	assert(device != NULL);
+	assert(domain != NULL);
 	assert(ep != NULL);
 
-	ep->device = device;
+	ep->domain = domain;
 	ep->release_ep = nccl_net_ofi_endpoint_release;
 
 	ep->creating_thread_id = 0;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -30,9 +30,21 @@
 #include "nccl_ofi_mr.h"
 
 
+static nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain(nccl_net_ofi_sendrecv_ep_t *ep)
+{
+	return (nccl_net_ofi_sendrecv_domain_t*)ep->base.domain;
+}
+
+
 static nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device(nccl_net_ofi_sendrecv_ep_t *ep)
 {
-	return (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	return (nccl_net_ofi_sendrecv_device_t*)sendrecv_endpoint_get_domain(ep)->base.device;
+}
+
+
+static nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device(nccl_net_ofi_sendrecv_domain_t *domain)
+{
+	return (nccl_net_ofi_sendrecv_device_t *)domain->base.device;
 }
 
 
@@ -191,6 +203,7 @@ static const char *nccl_net_ofi_req_str(nccl_net_ofi_sendrecv_req_t *req)
 		);
 	return buf;
 }
+
 
 /*
  * @brief	Process completion entries for the given completion quque.
@@ -514,7 +527,8 @@ static int sendrecv_recv_conn_post(nccl_net_ofi_sendrecv_listen_comm_t *l_comm,
 
 static inline struct fid_domain* sendrecv_endpoint_get_ofi_domain(nccl_net_ofi_sendrecv_ep_t *ep)
 {
-	return ep->domain;
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	return domain->domain;
 }
 
 /*
@@ -791,10 +805,14 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
 	}
+
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	int dev_id = device->base.dev_id;
 
 	int ret = 0;
-	nccl_ofi_mr_cache_t *mr_cache = device->base.mr_cache;
+	nccl_ofi_mr_cache_t *mr_cache = domain->base.mr_cache;
 	void *ret_handle = NULL;
 
 	if (sendrecv_mr_buffer_skip_local_registration(type)) {
@@ -816,10 +834,10 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 		/* Cache miss */
 	}
 
-	key_pool = &device->base.mr_rkey_pool;
-	struct fid_domain *domain;
-	domain = sendrecv_endpoint_get_ofi_domain(ep);
-	ret = sendrecv_mr_base_register(domain, ep->ofi_ep, key_pool,
+	key_pool = &domain->base.mr_rkey_pool;
+	struct fid_domain *ofi_domain;
+	ofi_domain = sendrecv_endpoint_get_ofi_domain(ep);
+	ret = sendrecv_mr_base_register(ofi_domain, ep->ofi_ep, key_pool,
 					dev_id, ckey, type, &ret_handle);
 	if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
 		ret_handle = NULL;
@@ -877,8 +895,12 @@ static int sendrecv_recv_comm_dereg_mr(nccl_net_ofi_recv_comm_t *recv_comm,
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
 	}
+
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
-	return sendrecv_comm_mr_base_dereg(mr_handle, &device->base.mr_rkey_pool, device->base.mr_cache);
+	return sendrecv_comm_mr_base_dereg(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 /*
@@ -1286,15 +1308,16 @@ static int sendrecv_recv_comm_alloc_and_reg_flush_buff(struct fid_domain *domain
  */
 static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_ofi_sendrecv_listen_comm_t *l_comm,
 								     nccl_net_ofi_sendrecv_device_t *device,
+								     nccl_net_ofi_sendrecv_domain_t *domain,
 								     nccl_net_ofi_sendrecv_ep_t *ep,
 								     char *remote_ep_addr)
 {
 	int ret = 0;
 	fi_addr_t remote_ep;
-	struct fid_domain *domain;
+	struct fid_domain *ofi_domain;
 	nccl_net_ofi_sendrecv_recv_comm_t *r_comm = NULL;
 	size_t req_size = sizeof(nccl_net_ofi_sendrecv_req_t);
-	nccl_ofi_idpool_t *key_pool = &device->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 	int dev_id = device->base.dev_id;
 
 	/* Insert remote EP address to AV */
@@ -1341,7 +1364,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 		return NULL;
 	}
 
-	domain = sendrecv_endpoint_get_ofi_domain(ep);
+	ofi_domain = sendrecv_endpoint_get_ofi_domain(ep);
 
 	/*
 	 * Setup flush resources if using GPUDirect RDMA unless user disables
@@ -1349,7 +1372,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 	 */
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
 		r_comm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
-		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(domain, ep->ofi_ep, key_pool,
+		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(ofi_domain, ep->ofi_ep, key_pool,
 								  &r_comm->flush_buff, dev_id);
 		if (OFI_UNLIKELY(ret != 0)) {
 			free(r_comm);
@@ -1393,6 +1416,10 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		return ret;
 	}
 
+	nccl_net_ofi_sendrecv_domain_t *domain =
+		sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
 		sendrecv_endpoint_get_device(ep);
@@ -1422,9 +1449,9 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_lock(&(domain->base.domain_lock));
 		ep->base.ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_unlock(&(domain->base.domain_lock));
 
 		/* Prepare receive request to accept connections */
 		req = sendrecv_recv_req_prepare(l_comm);
@@ -1503,7 +1530,7 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	}
 
 	/* Prepare receive communicator object for the received peer connection */
-	r_comm = sendrecv_recv_comm_prepare(l_comm, device, ep, conn_info->ep_name);
+	r_comm = sendrecv_recv_comm_prepare(l_comm, device, domain, ep, conn_info->ep_name);
 	if (OFI_UNLIKELY(r_comm == NULL)) {
 		return -ENOMEM;
 	}
@@ -1665,9 +1692,12 @@ static int sendrecv_send_comm_dereg_mr(nccl_net_ofi_send_comm_t *send_comm,
 		return -EINVAL;
 	}
 
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
-	return sendrecv_comm_mr_base_dereg(mr_handle, &device->base.mr_rkey_pool,
-				  device->base.mr_cache);
+	return sendrecv_comm_mr_base_dereg(mr_handle, &domain->base.mr_rkey_pool,
+				  domain->base.mr_cache);
 }
 
 static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
@@ -2166,23 +2196,23 @@ static int nccl_net_ofi_sendrecv_endpoint_free(nccl_net_ofi_ep_t *base_ep)
 }
 
 
-static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *base_dev,
+static int nccl_net_ofi_sendrecv_domain_create_endpoint(nccl_net_ofi_domain_t *base_domain,
 							nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
 	nccl_net_ofi_sendrecv_ep_t *ep = NULL;
-	nccl_net_ofi_sendrecv_plugin_t *plugin;
+	nccl_net_ofi_sendrecv_device_t *device;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)base_dev;
-	if (OFI_UNLIKELY(device == NULL)) {
-		NCCL_OFI_WARN("Invalid device provided");
+	nccl_net_ofi_sendrecv_domain_t *domain =
+		(nccl_net_ofi_sendrecv_domain_t*)base_domain;
+	if (OFI_UNLIKELY(domain == NULL)) {
+		NCCL_OFI_WARN("Invalid domain provided");
 		return -EINVAL;
 	}
 
-	plugin = sendrecv_device_get_plugin(device);
-	assert(plugin != NULL);
+	device = sendrecv_domain_get_device(domain);
+	assert(device != NULL);
 
 	/* Allocate endpoint */
 	ep = (nccl_net_ofi_sendrecv_ep_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));
@@ -2192,23 +2222,10 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 		return -ENOMEM;
 	}
 
-	ret = nccl_net_ofi_endpoint_init(&device->base, &ep->base);
+	ret = nccl_net_ofi_endpoint_init(&domain->base, &ep->base);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Initializing endpoint base failed");
 		return ret;
-	}
-
-	if (plugin->base.domain_per_thread) {
-		ret = fi_domain(device->fabric, device->info,
-				&ep->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			free(ep);
-			return ret;
-		}
-	} else {
-		ep->domain = device->domain;
 	}
 
 	/* Initialize base endpoint */
@@ -2219,9 +2236,9 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 	/* Initialize endpoint tag */
 	ep->tag = 0;
 
-	struct fid_domain *domain = sendrecv_endpoint_get_ofi_domain(ep);
+	struct fid_domain *ofi_domain = sendrecv_endpoint_get_ofi_domain(ep);
 	ret = nccl_ofi_ofiutils_init_connection(device->info,
-						domain,
+						ofi_domain,
 						&ep->ofi_ep,
 						&ep->av, &ep->cq);
 	if (ret != 0) {
@@ -2233,6 +2250,64 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 	return ret;
 }
 
+
+static int nccl_net_ofi_sendrecv_domain_free(nccl_net_ofi_domain_t *base_domain)
+{
+	int ret;
+	nccl_net_ofi_sendrecv_domain_t *domain = (nccl_net_ofi_sendrecv_domain_t *)base_domain;
+
+	ret = nccl_net_ofi_domain_fini(base_domain);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed to cleanup base domain: %d", ret);
+	}
+
+	if (domain->domain)
+		fi_close((fid_t)domain->domain);
+
+	free(base_domain);
+
+	return 0;
+}
+
+
+static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_net_ofi_device_t *base_device)
+{
+	int ret;
+	nccl_net_ofi_sendrecv_device_t *device = (nccl_net_ofi_sendrecv_device_t *)base_device;
+	nccl_net_ofi_sendrecv_domain_t *domain = NULL;
+
+	domain = (nccl_net_ofi_sendrecv_domain_t*)calloc(1, sizeof(nccl_net_ofi_sendrecv_domain_t));
+	if (domain == NULL) {
+		return NULL;
+	}
+
+	domain->base.free = nccl_net_ofi_sendrecv_domain_free;
+	domain->base.create_endpoint = nccl_net_ofi_sendrecv_domain_create_endpoint;
+
+	ret = nccl_net_ofi_domain_init(base_device, &domain->base);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Creating domain failed: %d", ret);
+		goto exit;
+	}
+
+	ret = fi_domain(device->fabric, device->info,
+			&domain->domain, NULL);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		goto exit;
+	}
+
+exit:
+	if (ret != 0) {
+		domain->base.free(&domain->base);
+		domain = NULL;
+	}
+
+	return (nccl_net_ofi_domain_t*)domain;
+}
+
+
 /*
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric and domain to make sendrecv device ready for endpoint creation.
@@ -2241,10 +2316,6 @@ static int sendrecv_device_prepare_for_connection(nccl_net_ofi_sendrecv_device_t
 {
 	int ret = 0;
 	int ofi_tag_leading_zeroes = 0, ofi_tag_bits_for_ring_id = 64;
-	nccl_net_ofi_sendrecv_plugin_t *plugin;
-
-	plugin = sendrecv_device_get_plugin(device);
-	assert(plugin != NULL);
 
 	/* Determine if any tag bits are used by provider */
 	while (!((device->info->ep_attr->mem_tag_format << ofi_tag_leading_zeroes++) &
@@ -2258,45 +2329,12 @@ static int sendrecv_device_prepare_for_connection(nccl_net_ofi_sendrecv_device_t
 			      device->info->fabric_attr->prov_name,
 			      ofi_tag_bits_for_ring_id,
 			      MIN_TAG_BITS_FOR_RING_ID);
-		ret = -EINVAL;
-		goto exit;
+		return -EINVAL;
 	}
 
 	/* Set maximum tag information; Reserving 1 bit for control information */
 	device->max_tag = (uint64_t)((1ULL << (ofi_tag_bits_for_ring_id - 1)) - 1);
 
-	/* Create fabric */
-	ret = fi_fabric(device->info->fabric_attr, &device->fabric, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Couldn't open a fabric provider. RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
-		goto error;
-	}
-
-	/*
-	 * In the domain-per-thread case, create the domain in the endpoint structure.  In the
-	 * domain-per-process case, keep it in the device structure.  This is because, on some
-	 * platforms, libfabric locks when accessing the domain, so retaining separate domains
-	 * per thread and per endpoint reduces contention for that lock.
-	 */
-	if (!plugin->base.domain_per_thread) {
-		/* Create domain */
-		ret = fi_domain(device->fabric, device->info,
-				&device->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			goto error;
-		}
-	}
-
-	return ret;
- error:
-	if (device->domain)
-		fi_close((fid_t)device->domain);
-	if (device->fabric)
-		fi_close((fid_t)device->fabric);
- exit:
 	return ret;
 }
 
@@ -2314,9 +2352,13 @@ nccl_net_ofi_sendrecv_device_release(nccl_net_ofi_device_t *base_device)
 		return 0;
 	}
 
-	unsigned num_endpoints = HASH_COUNT(device->base.endpoint_table);
-	if (num_endpoints > 0) {
-		NCCL_OFI_INFO(NCCL_NET, "%u endpoints still active at close", num_endpoints);
+	unsigned num_domains = HASH_COUNT(device->base.domain_table);
+	if (num_domains > 0) {
+		NCCL_OFI_INFO(NCCL_NET, "%u domains still active at close", num_domains);
+	}
+
+	if (device->fabric) {
+		fi_close((fid_t)device->fabric);
 	}
 
 	if (device->info != NULL) {
@@ -2362,9 +2404,9 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 
 
 	device->base.get_properties = sendrecv_get_properties;
-	device->base.create_endpoint = nccl_net_ofi_sendrecv_device_create_endpoint;
 	device->base.release = nccl_net_ofi_sendrecv_device_release;
 	device->base.get_mr_key = NULL;
+	device->base.create_domain = nccl_net_ofi_sendrecv_device_create_domain;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */
@@ -2376,6 +2418,14 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 		goto error;
 	}
 	device->prov_name = device->info->fabric_attr->prov_name;
+
+	/* Create fabric */
+	ret = fi_fabric(device->info->fabric_attr, &device->fabric, NULL);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't open a fabric provider. RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		goto error;
+	}
 
 	ret = sendrecv_device_prepare_for_connection(device);
 	if (ret != 0) {


### PR DESCRIPTION
Add a domain object to the transport interface, to reflect the need for fi_domain (and the related MR cache / rkey pool) to either be a single domain per process or a domain per initializing thread, depending on platform.  Previously, this was kind of hacked into the code, with extra fi_domain pointers in various structs.  Cut a bunch of that out, and move a bunch of the logic into one place, so that the two protocols behave the same.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
