### PR TITLE
Simplify locking and enable FI_THREAD_DOMAIN

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -260,6 +260,15 @@ struct nccl_net_ofi_device {
 	 */
 	nccl_ofi_mr_cache_t *mr_cache;
 
+	/* do we need to use an mr rkey pool?  This is a
+	 * provider-specific behavior determined during domain
+	 * creation time.
+	 */
+	bool need_mr_rkey_pool;
+
+	/* Memory registration key pool */
+	nccl_ofi_idpool_t mr_rkey_pool;
+
 	int (*get_properties)(nccl_net_ofi_device_t *base_dev,
 			      nccl_ofi_properties_t *props);
 
@@ -559,7 +568,7 @@ int nccl_net_ofi_endpoint_fini(nccl_net_ofi_ep_t *ep);
  * Constructor for a device object
  */
 int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_t *plugin,
-			     int device_index, const char *device_name);
+			     int device_index, struct fi_info *ofi_info);
 
 /**
  * Destructor for a device object

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -132,6 +132,7 @@ extern size_t system_page_size;
 
 struct nccl_net_ofi_plugin;
 struct nccl_net_ofi_device;
+struct nccl_net_ofi_domain;
 struct nccl_net_ofi_ep;
 struct nccl_net_ofi_req;
 struct nccl_net_ofi_mr_handle;
@@ -142,6 +143,7 @@ struct nccl_net_ofi_recv_comm;
 
 typedef struct nccl_net_ofi_plugin nccl_net_ofi_plugin_t;
 typedef struct nccl_net_ofi_device nccl_net_ofi_device_t;
+typedef struct nccl_net_ofi_domain nccl_net_ofi_domain_t;
 typedef struct nccl_net_ofi_ep nccl_net_ofi_ep_t;
 typedef struct nccl_net_ofi_req nccl_net_ofi_req_t;
 typedef struct nccl_net_ofi_mr_handle nccl_net_ofi_mr_handle_t;
@@ -232,11 +234,8 @@ typedef struct nccl_ofi_properties {
  * Device Data
  *
  * A device is roughly a NIC (or a port on a NIC) or a multi-rail
- * group.  While a multi-threaded app may create multiple endpoints
- * per device, the device data should be shared across multiple
- * threads in the same process.  Sharable structures such as address
- * vectors, fabrics, and domains should be associated with a device
- * instead of an endpoint.
+ * group.  The device is the unit of bandwidth sharing and general NIC
+ * propoeries, and accessing domains (ie, groups of NIC resources).
  */
 struct nccl_net_ofi_device {
 	struct nccl_net_ofi_plugin *plugin;
@@ -251,37 +250,22 @@ struct nccl_net_ofi_device {
 	 */
 	char *name;
 
-	/*
-	 * Protocol-agnostic MR cache for this device. Note that Registrations
-	 * are tied to domains in libfabric, but we do not have a
-	 * domain-specific object today, so stashing it in the device itself.
-	 * This should change if we were to break up nccl_net_ofi_device into
-	 * separate device and domain objects.
-	 */
-	nccl_ofi_mr_cache_t *mr_cache;
-
 	/* do we need to use an mr rkey pool?  This is a
 	 * provider-specific behavior determined during domain
 	 * creation time.
 	 */
 	bool need_mr_rkey_pool;
 
-	/* Memory registration key pool */
-	nccl_ofi_idpool_t mr_rkey_pool;
-
 	int (*get_properties)(nccl_net_ofi_device_t *base_dev,
 			      nccl_ofi_properties_t *props);
 
-	/*
-	 * @brief	Get nccl_ofi_ep for given
-	 * 		nccl_ofi_device.  Create if it does not exist. Store
-	 * 		in pthread key. Increase reference counter. Must be
-	 * 		protected by lock stored in device.
-	 *
-	 * 		During the plugin initialization, this function will be
-	 * 		called once per process using one of the instantiated device structs
-	 * 		to create and configure the endpoint of the initializing thread.
+	/* Retrieve a domain associated with this device.  There may
+	 * be more than one domain per device, depending on a number
+	 * of performance tradeoffs (be sure to read the domain
+	 * description below).
 	 */
+	nccl_net_ofi_domain_t *(*get_domain)(nccl_net_ofi_device_t *dev);
+
 	int (*get_ep)(nccl_net_ofi_device_t *base_dev,
 		      nccl_net_ofi_ep_t **ep);
 
@@ -293,24 +277,92 @@ struct nccl_net_ofi_device {
 	 */
 	int (*release)(nccl_net_ofi_device_t *device);
 
-	/* Lock for concurrency since endpoints can be shared by
+	/* Lock for concurrency since domains can be shared by
 	 * multiple entities. */
 	pthread_mutex_t device_lock;
 
 /* private */
-	/**
-	 * Create a new endpoint
+	/*
+	 * create a new domain.  This funcion is a private pure
+	 * virtual function, which is called from the base
+	 * implementation of get_domain() and should not be called
+	 * from the more general case.
+	 */
+	nccl_net_ofi_domain_t *(*create_domain)(nccl_net_ofi_device_t *dev);
+
+	/*
+	 * hash table indexed by thread id of active domains.
+	 */
+	nccl_net_ofi_domain_t *domain_table;
+};
+
+
+/**
+ * Domain Object - Represents a protection and thread safety domain
+ *
+ * A domain is a weird combination of a Libfabric domain (and related
+ * resources like an AV and CQ) as well as a general thread boundary.
+ * Transports are free to implement fine grained threads, but
+ * generally it is expected that calls into resources that share the
+ * same domain will share the same lock.
+ */
+struct nccl_net_ofi_domain {
+	/* Backpointer to the device associated with this domain. */
+	nccl_net_ofi_device_t *device;
+
+        /*
+	 * Retrieve an endpoint for this domain.  If a suitable
+	 * endpoint does not exist, call create_endpoint() to create
+	 * one and return that endpoint.  This function is a pure
+	 * virtual function that must be implemented by inheriting
+	 * classes.
+	 */
+	int (*get_ep)(nccl_net_ofi_domain_t *domain,
+		      nccl_net_ofi_ep_t **endpoint);
+
+	/*
+	 * Destructor - release resources associated with the domain
+	 */
+	int (*release)(nccl_net_ofi_domain_t *domain);
+
+	/*
+	 * Protocol-agnostic MR cache for this device.
+	 */
+	nccl_ofi_mr_cache_t *mr_cache;
+
+	/* Memory registration key pool */
+	nccl_ofi_idpool_t mr_rkey_pool;
+
+
+	pthread_mutex_t domain_lock;
+
+/* Private */
+	/* pure virtual function called when resources associated with
+	 * the ep should be destroyed.  Device lock will be held when
+	 * this function is called.
+	 */
+	int (*free)(nccl_net_ofi_domain_t *domain);
+
+	/* Create a new endpoint
 	 *
 	 * Pure virtual function to allocate a new endpoint structure
 	 */
-	int (*create_endpoint)(nccl_net_ofi_device_t *device,
+	int (*create_endpoint)(nccl_net_ofi_domain_t *domain,
 			       nccl_net_ofi_ep_t **ep);
 
 	/* hash table of active endpoints.  We reuse endpoints based
 	 * on the thread that calls get_ep().
 	 */
 	nccl_net_ofi_ep_t *endpoint_table;
+
+	/* thread id of the thread that called get_domain().  Used as
+	   the hash key for the domain hash */
+	long creating_thread_id;
+
+	/* hash table handle */
+	UT_hash_handle hh;
 };
+
 
 /**
  * Endpoint - A per-Proxy Thread device abstraction
@@ -328,8 +380,8 @@ struct nccl_net_ofi_device {
  * implementation.
  */
 struct nccl_net_ofi_ep {
-	/* Backpointer to the device associated with this ep. */
-	nccl_net_ofi_device_t *device;
+	/* Backpointer to the domain associated with this ep. */
+	nccl_net_ofi_domain_t *domain;
 
 	/* Create a receiving object and provide a handle to it.
 	 *
@@ -558,11 +610,32 @@ struct nccl_net_ofi_plugin {
  */
 int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p);
 
+/* base implementation of endpoint release.  endpoint_init() will set
+ * the release pointer to this function, although transports can
+ * override that function pointer and later call this function
+ * directly.
+ */
 int nccl_net_ofi_endpoint_release(nccl_net_ofi_ep_t *ep);
 
-int nccl_net_ofi_endpoint_init(nccl_net_ofi_device_t *device, nccl_net_ofi_ep_t *ep);
+/* initialize resources associated with the endpoint base class.
+ * Expectation is that this will be called by a transport's endpoint
+ * creation function */
+int nccl_net_ofi_endpoint_init(nccl_net_ofi_domain_t *domain, nccl_net_ofi_ep_t *ep);
 
+/* free resources associated with the endpoint base class.
+ * Expectation is that this will be called by a transport's endpoint
+ * free function. */
 int nccl_net_ofi_endpoint_fini(nccl_net_ofi_ep_t *ep);
+
+/* initialize resources associated with the domain base class.
+ * Expectation is that this will be called by a transport's domain
+ * creation routine */
+int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_t *domain);
+
+/* free resources associated with the domain base class.  Expectation
+ * is that this will be called by a transport's domain free
+ * function. */
+int nccl_net_ofi_domain_fini(nccl_net_ofi_domain_t *domain);
 
 /**
  * Constructor for a device object

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -23,9 +23,6 @@ typedef struct nccl_ofi_idpool {
 	/* ID pool bit array. A bit set in the array indicates
 	   that the ID corresponding to its index is available.*/
 	uint64_t *ids;
-
-	/* Lock for concurrency */
-	pthread_mutex_t lock;
 } nccl_ofi_idpool_t;
 
 /*

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -87,6 +87,16 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id);
  */
 int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
 
+
+/*
+ * @brief        Check if an idpool has been initialized with a size
+ *               other than 0.
+ */
+static inline bool nccl_ofi_idpool_active(nccl_ofi_idpool_t *idpool) {
+	return (idpool->size != 0);
+}
+
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -160,7 +160,6 @@ typedef struct nccl_ofi_mr_cache {
 	size_t used;
 	uint32_t hit_count;
 	uint32_t miss_count;
-	pthread_mutex_t lock;
 } nccl_ofi_mr_cache_t;
 
 /**

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -99,8 +99,6 @@ typedef struct {
 	uint16_t msg_last_incomplete;
 	// Points to the message after the inserted message with highest sequence number.
 	uint16_t msg_next;
-	// Mutex for this msg buffer -- locks all non-init operations
-	pthread_mutex_t lock;
 } nccl_ofi_msgbuff_t;
 
 /**

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -119,6 +119,7 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
 	struct fid_mr *control_mr;
+	struct nccl_net_ofi_rdma_device *device;
 
 	int num_rails;
 
@@ -396,12 +397,6 @@ typedef struct nccl_net_ofi_rdma_req {
 	/* Size of completed request */
 	size_t size;
 
-	/*
-	 * Protect updating critical fields such as size and ncompls when
-	 * network xfer happened over multiple rails
-	 */
-	pthread_mutex_t req_lock;
-
 	/* State of request */
 	nccl_net_ofi_rdma_req_state_t state;
 
@@ -531,7 +526,6 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 
 	nccl_ofi_deque_elem_t cleanup_list_elem;
 
-	pthread_mutex_t ctrl_recv_lock;
 	bool received_close_message;
 	/* Counters for total sent and received control messages */
 	uint64_t n_ctrl_received;
@@ -612,7 +606,6 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	nccl_ofi_deque_elem_t cleanup_list_elem;
 
 	/* Counters for total sent and received control messages */
-	pthread_mutex_t ctrl_counter_lock;
 	uint64_t n_ctrl_sent;
 	uint64_t n_ctrl_delivered;
 
@@ -686,8 +679,6 @@ struct nccl_net_ofi_ep_rail {
 	size_t min_bounce_posted;
 	/* Maximum posted bounce buffers (see RDMA_MAX_POSTED_BOUNCE_BUFFERS) */
 	size_t max_bounce_posted;
-	/* Mutex for bounce buffer operations */
-	pthread_mutex_t bounce_mutex;
 };
 
 /*

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -750,12 +750,6 @@ typedef struct nccl_net_ofi_rdma_device_rail {
 
 	/* Fabric handle */
 	struct fid_fabric *fabric;
-
-	/* Access domain handles */
-	struct fid_domain *domain;
-
-	/* Completion Queue handle */
-	struct fid_cq *cq;
 } nccl_net_ofi_rdma_device_rail_t;
 
 /*
@@ -806,13 +800,32 @@ typedef struct nccl_net_ofi_rdma_device {
 
 	bool use_long_rkeys;
 
-	/* List of endpoints and set of addresses they have connections to */
-	nccl_ofi_ep_addr_list_t *ep_addr_list;
-
 #if HAVE_NVTX_TRACING
 	nvtxDomainHandle_t nvtx_domain[MAX_NUM_RAILS];
 #endif
 } nccl_net_ofi_rdma_device_t;
+
+
+typedef struct nccl_net_ofi_rdma_domain_rail {
+	/* Access domain handles */
+	struct fid_domain *domain;
+
+	struct fid_cq *cq;
+} nccl_net_ofi_rdma_domain_rail_t;
+
+
+typedef struct nccl_net_ofi_rdma_domain {
+	nccl_net_ofi_domain_t base;
+
+	int num_rails;
+	nccl_net_ofi_rdma_domain_rail_t *domain_rails;
+
+	/* Memory registration key pool */
+	nccl_ofi_idpool_t key_pool;
+
+	/* List of endpoints and set of addresses they have connections to */
+	nccl_ofi_ep_addr_list_t *ep_addr_list;
+} nccl_net_ofi_rdma_domain_t;
 
 
 struct nccl_net_ofi_rdma_plugin {

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -804,9 +804,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	   lookup of comms in the RDMA protocol. */
 	nccl_net_ofi_comm_t **comms;
 
-	/* Memory registration key pool */
-	nccl_ofi_idpool_t key_pool;
-
 	bool use_long_rkeys;
 
 	/* List of endpoints and set of addresses they have connections to */

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -91,8 +91,7 @@ typedef struct nccl_net_ofi_threshold_scheduler {
 	nccl_net_ofi_scheduler_t base;
 	/* Round robin counter */
 	unsigned int rr_counter;
-	/* Lock for round robin counter */
-	pthread_mutex_t rr_lock;
+
 	/* Minimum size of the message in bytes before message is
 	 * multiplexed */
 	size_t min_stripe_size;

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -111,15 +111,26 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Endpoint handle to communicate to */
 	struct fid_ep *ofi_ep;
 
-	/* Access Domain handle */
-	struct fid_domain *domain;
-
 	/* Address vector handle */
 	struct fid_av *av;
 
 	/* Completion Queue handle */
 	struct fid_cq *cq;
 } nccl_net_ofi_sendrecv_ep_t;
+
+
+/*
+ * Domain - container for the libfabric domain, which is the threading
+ * boundary for most Libfabric providers, given how the util cq
+ * implementation works.
+ */
+typedef struct nccl_net_ofi_sendrecv_domain {
+	nccl_net_ofi_domain_t base;
+
+	/* Access Domain handle */
+	struct fid_domain *domain;
+} nccl_net_ofi_sendrecv_domain_t;
+
 
 /**
  * @brief	Sendrecv Device
@@ -163,9 +174,6 @@ typedef struct nccl_net_ofi_sendrecv_device {
 
 	/* Fabric handle */
 	struct fid_fabric *fabric;
-
-	/* Access Domain handle */
-	struct fid_domain *domain;
 } nccl_net_ofi_sendrecv_device_t;
 	
 typedef struct nccl_net_ofi_sendrecv_req {

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -108,6 +108,9 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Current available tag ID */
 	uint64_t tag;
 
+	/* copy of device's max_tag to reading device information */
+	uint64_t max_tag;
+
 	/* Endpoint handle to communicate to */
 	struct fid_ep *ofi_ep;
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -14,7 +14,6 @@ extern "C" {
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_log.h"
-#include "nccl_ofi_idpool.h"
 
 typedef enum nccl_net_ofi_sendrecv_req_state {
 	NCCL_OFI_SENDRECV_REQ_CREATED = 0,
@@ -167,9 +166,6 @@ typedef struct nccl_net_ofi_sendrecv_device {
 
 	/* Access Domain handle */
 	struct fid_domain *domain;
-
-	/* Memory registration key pool */
-	nccl_ofi_idpool_t key_pool;
 } nccl_net_ofi_sendrecv_device_t;
 	
 typedef struct nccl_net_ofi_sendrecv_req {

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -58,6 +58,7 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
                   FI_OPT_MAX_MSG_SIZE,
                   FI_OPT_SHARED_MEMORY_PERMITTED,
                   FI_MR_DMABUF,
+		  FI_PROGRESS_CONTROL_UNIFIED,
 		  FI_OPT_INJECT_RMA_SIZE],
                   [], [], [AC_INCLUDES_DEFAULT
 [#include <rdma/fi_endpoint.h>

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -23,13 +23,6 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 	deque->head.prev = &deque->head;
 	deque->head.next = &deque->head;
 
-	int ret = pthread_mutex_init(&deque->lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to initialize deque mutex.");
-		free(deque);
-		return -ret;
-	}
-
 	assert(deque_p);
 	*deque_p = deque;
 
@@ -39,14 +32,6 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 int nccl_ofi_deque_finalize(nccl_ofi_deque_t *deque)
 {
 	assert(deque);
-
-	/* Since user allocates all memory used for deque elements, we don't need to
-	   deallocate any entries here. :D */
-	int ret = pthread_mutex_destroy(&deque->lock);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to destroy deque mutex.");
-		return -ret;
-	}
 
 	free(deque);
 	return 0;

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -96,17 +96,9 @@ static int freelist_init_internal(size_t entry_size,
 	freelist->regmr_opaque = regmr_opaque;
 	freelist->reginfo_offset = reginfo_offset;
 
-	ret = pthread_mutex_init(&freelist->lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
-		free(freelist);
-		return -ret;
-	}
-
 	ret = nccl_ofi_freelist_add(freelist, initial_entry_count);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Allocating initial freelist entries failed: %d", ret);
-		pthread_mutex_destroy(&freelist->lock);
 		free(freelist);
 		return ret;
 
@@ -197,8 +189,6 @@ int nccl_ofi_freelist_fini(nccl_ofi_freelist_t *freelist)
 
 	freelist->entry_size = 0;
 	freelist->entries = NULL;
-
-	pthread_mutex_destroy(&freelist->lock);
 
 	free(freelist);
 

--- a/src/nccl_ofi_mr.c
+++ b/src/nccl_ofi_mr.c
@@ -37,10 +37,6 @@ nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
 		goto error;
 	}
 
-	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
-		goto error;
-	}
-
 	ret_cache->system_page_size = system_page_size;
 	ret_cache->size = init_num_entries;
 	ret_cache->used = 0;
@@ -67,8 +63,6 @@ void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache)
 		      "MR cache %d hits %d misses",
 		      cache->hit_count,
 		      cache->miss_count);
-
-	nccl_net_ofi_mutex_destroy(&cache->lock);
 
 	free(cache->slots);
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -684,40 +684,81 @@ int nccl_net_ofi_plugin_fini(nccl_net_ofi_plugin_t *plugin)
 }
 
 
-static int nccl_net_ofi_device_get_ep(nccl_net_ofi_device_t *device,
-				      nccl_net_ofi_ep_t **ep_p)
+/*
+ * implementation of retreiving a domain from a device.  This code
+ * assumes the device lock is already held, because in the case of
+ * get_domain() we only need to worry about the device lock, but in
+ * the device->get_ep call, hold the lock while we're also creating
+ * the ep.
+ */
+static nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain_impl(nccl_net_ofi_device_t *device)
 {
-	int ret = 0;
-	long thread_id;
-	nccl_net_ofi_ep_t *ep = NULL;
+	nccl_net_ofi_plugin_t *plugin = NULL;
+	nccl_net_ofi_domain_t *domain = NULL;
+	long lookup_key = 0;
 
-	nccl_net_ofi_mutex_lock(&device->device_lock);
+	assert(device != NULL);
 
-	thread_id = nccl_net_ofi_gettid();
-	HASH_FIND(hh, device->endpoint_table, &thread_id,
-		  sizeof(ep->creating_thread_id), ep);
+	plugin = device->plugin;
+	assert(plugin != NULL);
 
-	if (ep == NULL) {
-		ret = device->create_endpoint(device, &ep);
-		if (ret != 0) {
-			NCCL_OFI_WARN("Creating new endpoint for device %s failed: %s",
-				      device->name, fi_strerror(-ret));
-			goto unlock;
+	if (plugin->domain_per_thread) {
+		lookup_key = nccl_net_ofi_gettid();
+	}
+
+	HASH_FIND(hh, device->domain_table, &lookup_key,
+		  sizeof(domain->creating_thread_id), domain);
+
+	if (domain == NULL) {
+		domain = device->create_domain(device);
+		if (domain == NULL) {
+			NCCL_OFI_WARN("Initializing a new domain for device %s failed",
+				      device->name);
+			return NULL;
 		}
 
-		ep->creating_thread_id = thread_id;
+		domain->creating_thread_id = lookup_key;
 
-		HASH_ADD(hh, device->endpoint_table, creating_thread_id,
-			 sizeof(ep->creating_thread_id), ep);
+		HASH_ADD(hh, device->domain_table, creating_thread_id,
+			 sizeof(domain->creating_thread_id), domain);
 
-		NCCL_OFI_TRACE(NCCL_NET, "Eendpoint %p for device #%d (%s) is created",
-			       ep,
+		NCCL_OFI_TRACE(NCCL_NET, "Domain %p for device #%d (%s) is created",
+			       domain,
 			       device->dev_id,
 			       device->name);
 	}
 
-	ep->ref_cnt++;
-	*ep_p = ep;
+	return domain;
+}
+
+
+static nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain(nccl_net_ofi_device_t *device)
+{
+	nccl_net_ofi_domain_t *domain;
+
+	nccl_net_ofi_mutex_lock(&device->device_lock);
+	domain = nccl_net_ofi_device_get_domain_impl(device);
+	nccl_net_ofi_mutex_unlock(&device->device_lock);
+
+	return domain;
+}
+
+
+static int nccl_net_ofi_device_get_ep(nccl_net_ofi_device_t *device,
+				      nccl_net_ofi_ep_t **ep_p)
+{
+	int ret;
+	nccl_net_ofi_domain_t *domain = NULL;
+
+	nccl_net_ofi_mutex_lock(&device->device_lock);
+
+	domain = nccl_net_ofi_device_get_domain_impl(device);
+	if (domain == NULL) {
+		ret = -EINVAL;
+		goto unlock;
+	}
+
+	ret = domain->get_ep(domain, ep_p);
 
 unlock:
 	nccl_net_ofi_mutex_unlock(&device->device_lock);
@@ -740,18 +781,8 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 		goto exit;
 	}
 
-	device->mr_cache = NULL;
-	if (!ofi_nccl_mr_cache_disable()) {
-		device->mr_cache =
-			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
-					       system_page_size);
-		if (!device->mr_cache) {
-			ret = -ENOMEM;
-			goto exit;
-		}
-	}
-
 	device->get_properties = NULL;
+	device->get_domain = nccl_net_ofi_device_get_domain;
 	device->get_ep = nccl_net_ofi_device_get_ep;
 	device->get_mr_key = NULL;
 	device->release = nccl_net_ofi_device_fini;
@@ -772,6 +803,129 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 			      strerror(-ret));
 		return -ret;
 	}
+
+	device->create_domain = NULL;
+	device->domain_table = NULL;
+
+exit:
+
+	return ret;
+}
+
+
+int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
+{
+
+	if (device == NULL) {
+		return 0;
+	}
+
+	if (device->name != NULL) {
+		free(device->name);
+	}
+
+	return 0;
+}
+
+
+static int nccl_net_ofi_domain_get_ep(nccl_net_ofi_domain_t *domain,
+				      nccl_net_ofi_ep_t **ep_p)
+{
+	int ret = 0;
+	long thread_id;
+	nccl_net_ofi_ep_t *ep = NULL;
+
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
+
+	thread_id = nccl_net_ofi_gettid();
+	HASH_FIND(hh, domain->endpoint_table, &thread_id,
+		  sizeof(ep->creating_thread_id), ep);
+
+	if (ep == NULL) {
+		ret = domain->create_endpoint(domain, &ep);
+		if (ret != 0) {
+			NCCL_OFI_WARN("Creating new endpoint for domain %p failed: %s",
+				      domain, fi_strerror(-ret));
+			goto unlock;
+		}
+
+		ep->creating_thread_id = thread_id;
+
+		HASH_ADD(hh, domain->endpoint_table, creating_thread_id,
+			 sizeof(ep->creating_thread_id), ep);
+
+		NCCL_OFI_TRACE(NCCL_NET, "Eendpoint %p for domain %p is created",
+			       ep, domain);
+	}
+
+	ep->ref_cnt++;
+	*ep_p = ep;
+
+unlock:
+	nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+	return ret;
+}
+
+
+static int nccl_net_ofi_domain_release(nccl_net_ofi_domain_t *domain)
+{
+	int ret = 0;
+	nccl_net_ofi_device_t *device;
+
+	assert(domain != NULL);
+	device = domain->device;
+
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
+
+	if (HASH_COUNT(domain->endpoint_table) == 0) {
+		nccl_net_ofi_mutex_lock(&device->device_lock);
+		HASH_DEL(device->domain_table, domain);
+
+		ret = domain->free(domain);
+		nccl_net_ofi_mutex_unlock(&device->device_lock);
+		if (ret != 0) {
+			NCCL_OFI_WARN("Freeing domain failed: %d", ret);
+			goto cleanup;
+		}
+	}
+
+cleanup:
+	nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+	return ret;
+}
+
+
+int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_t *domain)
+{
+	int ret;
+
+	domain->device = device;
+
+	ret = nccl_net_ofi_mutex_init(&domain->domain_lock, NULL);
+	if (ret != 0) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+			       "Unable to initialize domain mutex");
+		return -ret;
+	}
+
+	domain->get_ep = nccl_net_ofi_domain_get_ep;
+	domain->release = nccl_net_ofi_domain_release;
+	domain->endpoint_table = NULL;
+	domain->creating_thread_id = 0;
+
+	domain->mr_cache = NULL;
+	if (!ofi_nccl_mr_cache_disable()) {
+		domain->mr_cache =
+			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
+					       system_page_size);
+		if (!domain->mr_cache) {
+			ret = -ENOMEM;
+			goto exit;
+		}
+	}
+
 	if (device->need_mr_rkey_pool) {
 		/* The provider may return support for a larger key size. Use
 		 * the size requested by the user to allow them to limit the
@@ -785,10 +939,10 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 				size_t_bits);
 			return -EINVAL;
 		}
-		ret = nccl_ofi_idpool_init(&device->mr_rkey_pool, 1 << shift);
+		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 1 << shift);
 	} else {
 		/* Mark key pool as not in use */
-		ret = nccl_ofi_idpool_init(&device->mr_rkey_pool, 0);
+		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 0);
 	}
 	if (ret != 0) {
 		NCCL_OFI_WARN("Creating MR id pool failed: %s",
@@ -796,30 +950,18 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 		return -ret;
 	}
 
-	device->create_endpoint = NULL;
-	device->endpoint_table = NULL;
-
 exit:
 	return ret;
 }
 
 
-int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
+int nccl_net_ofi_domain_fini(nccl_net_ofi_domain_t *domain)
 {
-
-	if (device == NULL) {
-		return 0;
+	if (domain->mr_cache != NULL) {
+		nccl_ofi_mr_cache_finalize(domain->mr_cache);
 	}
 
-	if (device->mr_cache != NULL) {
-		nccl_ofi_mr_cache_finalize(device->mr_cache);
-	}
-
-	if (device->name != NULL) {
-		free(device->name);
-	}
-
-	nccl_ofi_idpool_fini(&device->mr_rkey_pool);
+	nccl_ofi_idpool_fini(&domain->mr_rkey_pool);
 
 	return 0;
 }
@@ -828,17 +970,17 @@ int nccl_net_ofi_device_fini(nccl_net_ofi_device_t *device)
 int nccl_net_ofi_endpoint_release(nccl_net_ofi_ep_t *ep)
 {
 	int ret = 0;
-	nccl_net_ofi_device_t *device;
+	nccl_net_ofi_domain_t *domain;
 
 	assert(ep != NULL);
-	device = ep->device;
+	domain = ep->domain;
 
-	nccl_net_ofi_mutex_lock(&device->device_lock);
+	nccl_net_ofi_mutex_lock(&domain->domain_lock);
 
 	ep->ref_cnt--;
 
 	if (ep->ref_cnt == 0) {
-		HASH_DEL(device->endpoint_table, ep);
+		HASH_DEL(domain->endpoint_table, ep);
 
 		ret = ep->free_ep(ep);
 		if (ret != 0) {
@@ -848,20 +990,23 @@ int nccl_net_ofi_endpoint_release(nccl_net_ofi_ep_t *ep)
 	}
 
 cleanup:
-	nccl_net_ofi_mutex_unlock(&device->device_lock);
+	nccl_net_ofi_mutex_unlock(&domain->domain_lock);
+
+	if (ret == 0) {
+		ret = domain->release(domain);
+	}
 
 	return ret;
-
 }
 
 
-int nccl_net_ofi_endpoint_init(nccl_net_ofi_device_t *device,
+int nccl_net_ofi_endpoint_init(nccl_net_ofi_domain_t *domain,
 			       nccl_net_ofi_ep_t *ep)
 {
-	assert(device != NULL);
+	assert(domain != NULL);
 	assert(ep != NULL);
 
-	ep->device = device;
+	ep->domain = domain;
 	ep->release_ep = nccl_net_ofi_endpoint_release;
 
 	ep->creating_thread_id = 0;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2638,9 +2638,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret = nccl_ofi_mr_cache_del_entry(mr_cache, mr_handle);
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -2780,7 +2778,6 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 		 * MR cache is locked between lookup and insert, to be sure we
 		 * insert a missing entry
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = (nccl_net_ofi_rdma_mr_handle_t *)
 			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey);
 
@@ -2811,10 +2808,6 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 	}
 
 exit:
-	if (mr_cache) {
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
-	}
-
 	*mhandle = ret_handle;
 	return ret;
 }

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -130,15 +130,21 @@ static inline int free_base_req(uint64_t *num_inflight_reqs,
 static inline int check_post_bounce_req(nccl_net_ofi_rdma_req_t *bounce_req);
 
 
-static nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device(nccl_net_ofi_rdma_ep_t *ep)
+static nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain(nccl_net_ofi_rdma_ep_t *ep)
 {
-	return (nccl_net_ofi_rdma_device_t*)ep->base.device;
+	return (nccl_net_ofi_rdma_domain_t*)ep->base.domain;
 }
 
 
-static nccl_net_ofi_rdma_plugin_t *rdma_endpoint_get_plugin(nccl_net_ofi_rdma_ep_t *ep)
+static nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device(nccl_net_ofi_rdma_ep_t *ep)
 {
-	return (nccl_net_ofi_rdma_plugin_t*)ep->base.device->plugin;
+	return (nccl_net_ofi_rdma_device_t*)rdma_endpoint_get_domain(ep)->base.device;
+}
+
+
+static nccl_net_ofi_rdma_device_t *rdma_domain_get_device(nccl_net_ofi_rdma_domain_t *domain)
+{
+	return (nccl_net_ofi_rdma_device_t*)domain->base.device;
 }
 
 
@@ -156,7 +162,7 @@ static nccl_net_ofi_rdma_ep_t *rdma_req_get_ep(nccl_net_ofi_rdma_req_t *req)
 
 static nccl_net_ofi_rdma_device_t *rdma_req_get_device(nccl_net_ofi_rdma_req_t *req)
 {
-	return (nccl_net_ofi_rdma_device_t *)rdma_req_get_ep(req)->base.device;
+	return (nccl_net_ofi_rdma_device_t *)rdma_req_get_ep(req)->base.domain->device;
 }
 
 /*
@@ -284,6 +290,16 @@ static inline nccl_net_ofi_rdma_device_rail_t *rdma_device_get_rail(nccl_net_ofi
 	assert(rail_id < device->num_rails);
 	return &device->device_rails[rail_id];
 }
+
+
+static inline nccl_net_ofi_rdma_domain_rail_t *rdma_domain_get_rail(nccl_net_ofi_rdma_domain_t *domain,
+								    int rail_id)
+{
+	assert(domain->domain_rails);
+	assert(rail_id < domain->num_rails);
+	return &domain->domain_rails[rail_id];
+}
+
 
 /*
  * @brief Return endpoint rail with index `rail_id`
@@ -2724,7 +2740,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	*mhandle = NULL;
-	struct fid_domain *domain;
+	struct fid_domain *ofi_domain;
 	struct fi_mr_attr mr_attr = {};
 	uint64_t regattr_flags = 0;
 
@@ -2732,9 +2748,12 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
 
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	int dev_id = device->base.dev_id;
 	int num_rails = device->num_rails;
-	nccl_ofi_idpool_t *key_pool = &device->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 
 	/* Allocate rdma memory registration handle */
 	ret_handle = calloc_rdma_mr_handle(num_rails);
@@ -2767,9 +2786,9 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	ret_handle->num_rails = num_rails;
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
 		nccl_net_ofi_ep_rail_t *rail = rdma_endpoint_get_rail(ep, rail_id);
-		domain = rdma_endpoint_get_ofi_domain(ep, rail_id);
+		ofi_domain = rdma_endpoint_get_ofi_domain(ep, rail_id);
 
-		ret = register_rail_mr_buffer(domain, rail->ofi_ep,
+		ret = register_rail_mr_buffer(ofi_domain, rail->ofi_ep,
 					      dev_id, type, &mr_attr, regattr_flags,
 					      &ret_handle->mr[rail_id]);
 		if (OFI_UNLIKELY(ret != 0)) {
@@ -2813,11 +2832,11 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 
 	assert(ep);
 
-	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
-	assert(device != NULL);
+	/* Retrieve and validate domain */
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
-	nccl_ofi_idpool_t *key_pool = &device->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 	if (mr_cache) {
 		/*
 		 * MR cache is locked between lookup and insert, to be sure we
@@ -2932,13 +2951,13 @@ static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 			    int type, void **mhandle)
 {
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)send_comm->base.ep;
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
-	assert(device != NULL);
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	return reg_mr_ep(ep,
 			 ckey,
 			 type,
-			 device->base.mr_cache,
+			 domain->base.mr_cache,
 			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
@@ -2947,13 +2966,13 @@ static int reg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 			    int type, void **mhandle)
 {
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)recv_comm->base.ep;
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
-	assert(device != NULL);
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	return reg_mr_ep(ep,
 			 ckey,
 			 type,
-			 device->base.mr_cache,
+			 domain->base.mr_cache,
 			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
@@ -2992,7 +3011,7 @@ static int freelist_regmr_host_fn(void *ep_void_ptr, void *data, size_t size, vo
 	}
 
 	freelist_handle->mr_handle = mr_handle;
-	freelist_handle->key_pool = &(rdma_endpoint_get_device(ep))->base.mr_rkey_pool;
+	freelist_handle->key_pool = &(rdma_endpoint_get_domain(ep))->base.mr_rkey_pool;
 	*handle = (void *)freelist_handle;
 	return 0;
 }
@@ -3022,12 +3041,12 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)recv_comm->base.ep;
 	assert(ep != NULL);
 
-	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
-	assert(device != NULL);
+	/* Retrieve and validate domain */
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &device->base.mr_rkey_pool, device->base.mr_cache);
+	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 /*
@@ -3485,13 +3504,13 @@ static inline bool is_flush_buff_enabled(void)
  * 		error, on others
  */
 static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm,
-							nccl_net_ofi_rdma_device_t *device)
+							nccl_net_ofi_rdma_domain_t *domain)
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = r_comm->flush_buff.mr_handle;
 
 	if (mr_handle) {
-		ret = dereg_mr_ep(mr_handle, &device->base.mr_rkey_pool, NULL);
+		ret = dereg_mr_ep(mr_handle, &domain->key_pool, NULL);
 	}
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
@@ -3572,6 +3591,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 {
 	nccl_net_ofi_rdma_device_t *device = NULL;
+	nccl_net_ofi_rdma_domain_t *domain = NULL;
 	int ret = 0;
 
 	/* Retrieve and validate endpoint */
@@ -3581,6 +3601,9 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return ret;
 	}
+
+	domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
@@ -3593,7 +3616,7 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 	}
 
 	if (is_flush_buff_enabled()) {
-		ret = dealloc_and_dereg_flush_buff(r_comm, device);
+		ret = dealloc_and_dereg_flush_buff(r_comm, domain);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to deregister ctrl buffer pool");
 			return ret;
@@ -4255,7 +4278,7 @@ static int rma_read(nccl_net_ofi_recv_comm_t *recv_comm, void* dest, size_t size
  * 		NULL, on error
  */
 static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen_comm_t *l_comm,
-							nccl_net_ofi_rdma_device_t *device,
+							nccl_net_ofi_rdma_domain_t *domain,
 							nccl_net_ofi_rdma_ep_t *l_comm_ep,
 							nccl_ofi_rdma_connection_info_t *conn_msg)
 {
@@ -4264,6 +4287,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	int comm_id = 0;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = NULL;
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
 	int dev_id = device->base.dev_id;
 	int num_rails = l_comm_ep->num_rails;
 
@@ -4324,7 +4348,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 	{
 		nccl_ofi_rdma_ep_name_t *remote_rail0_ep_name = &conn_msg->ep_names[0];
 		nccl_net_ofi_ep_t *ep_for_addr = NULL;
-		ret = nccl_ofi_ep_addr_list_get(device->ep_addr_list, remote_rail0_ep_name->ep_name,
+		ret = nccl_ofi_ep_addr_list_get(domain->ep_addr_list, remote_rail0_ep_name->ep_name,
 			remote_rail0_ep_name->ep_name_len, &ep_for_addr);
 		if (ret != 0) {
 			goto error;
@@ -4332,7 +4356,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 
 		if (ep_for_addr == NULL) {
 			nccl_net_ofi_ep_t *new_base_ep;
-			ret = device->base.create_endpoint(&device->base, &new_base_ep);
+			ret = domain->base.create_endpoint(&domain->base, &new_base_ep);
 			if (ret != 0) {
 				NCCL_OFI_WARN("Failed to allocate new ep: %s", strerror(-ret));
 				goto error;
@@ -4343,7 +4367,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_listen
 
 			ep_for_addr = &new_ep->base;
 
-			ret = nccl_ofi_ep_addr_list_insert(device->ep_addr_list, ep_for_addr,
+			ret = nccl_ofi_ep_addr_list_insert(domain->ep_addr_list, ep_for_addr,
 				remote_rail0_ep_name->ep_name, remote_rail0_ep_name->ep_name_len);
 			if (ret != 0) {
 				goto error;
@@ -4629,7 +4653,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	}
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(l_comm_ep);
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(l_comm_ep);
+	assert(domain != NULL);
+	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
 	assert(device != NULL);
 
 	int dev_id = device->base.dev_id;
@@ -4695,7 +4721,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		/* Prepare receive communicator object for the received peer connection */
-		r_comm = prepare_recv_comm(l_comm, device, l_comm_ep, conn_msg);
+		r_comm = prepare_recv_comm(l_comm, domain, l_comm_ep, conn_msg);
 		if (OFI_UNLIKELY(r_comm == NULL)) {
 			ret = -EINVAL;
 			goto exit;
@@ -4716,9 +4742,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_lock(&(domain->base.domain_lock));
 		ep->base.ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_unlock(&(domain->base.domain_lock));
 
 		/* Reset request state for connect response message */
 		prepare_send_conn_resp_req(l_comm);
@@ -4931,13 +4957,13 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)send_comm->base.ep;
 	assert(ep != NULL);
 
-	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
-	assert(device != NULL);
+	/* Retrieve and validate domain */
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle =
 		(nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &device->base.mr_rkey_pool, device->base.mr_cache);
+	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 static int alloc_rdma_write_req(nccl_net_ofi_rdma_send_comm_t *s_comm,
@@ -6283,7 +6309,7 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		(nccl_net_ofi_rdma_send_comm_t *)comm_state->comm;
 
 	/* Retrieve and validate devices */
-	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)base_ep->device;
+	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)base_ep->domain->device;
 	assert(device != NULL);
 
 	/* Connection establishment is not done yet */
@@ -6498,24 +6524,13 @@ static inline int set_local_address(struct fid_ep *ep, nccl_net_ofi_ep_rail_t *r
 static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 			int dev_id, int rail_id,
 			nccl_net_ofi_rdma_device_rail_t *dev_rail,
+			nccl_net_ofi_rdma_domain_rail_t *domain_rail,
 			nccl_net_ofi_ep_rail_t *ep_rail)
 {
 	int ret = 0;
-	nccl_net_ofi_rdma_plugin_t *plugin = rdma_endpoint_get_plugin(ep);
 
-	if (plugin->base.domain_per_thread) {
-		ret = fi_domain(dev_rail->fabric, dev_rail->info,
-			&ep_rail->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				ret, fi_strerror(-ret));
-			return ret;
-		}
-	} else {
-		ep_rail->domain = dev_rail->domain;
-	}
-
-	ep_rail->cq = dev_rail->cq;
+	ep_rail->domain = domain_rail->domain;
+	ep_rail->cq = domain_rail->cq;
 
 #ifndef NDEBUG
 	if (ofi_nccl_endpoint_per_communicator() != 0) {
@@ -6550,6 +6565,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
  * @brief	Initialize libfabric resources of endpoint rails
  */
 static int init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *device,
+				   nccl_net_ofi_rdma_domain_t *domain,
 					    nccl_net_ofi_rdma_ep_t *ep)
 {
 	int ret = 0;
@@ -6559,9 +6575,11 @@ static int init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *device,
 	for (int rail_id = 0; rail_id != device->num_rails; ++rail_id) {
 		nccl_net_ofi_rdma_device_rail_t *rail_dev =
 			rdma_device_get_rail(device, rail_id);
+		nccl_net_ofi_rdma_domain_rail_t *domain_rail =
+			rdma_domain_get_rail(domain, rail_id);
 		nccl_net_ofi_ep_rail_t *rail = rdma_endpoint_get_rail(ep, rail_id);
 
-		ret = ep_rail_init(ep, dev_id, rail_id, rail_dev, rail);
+		ret = ep_rail_init(ep, dev_id, rail_id, rail_dev, domain_rail, rail);
 		if (ret != 0) {
 			goto exit;
 		}
@@ -6594,19 +6612,19 @@ static int nccl_net_ofi_rdma_endpoint_release(nccl_net_ofi_ep_t *base_ep)
 	 * type.  Otherwise, we use the base code release function.
 	 */
 	if (ep->is_endpoint_per_communicator_ep) {
-		nccl_net_ofi_rdma_device_t *device = NULL;
+		nccl_net_ofi_rdma_domain_t *domain = NULL;
 
 		/* Validate device */
-		device = rdma_endpoint_get_device(ep);
-		if (OFI_UNLIKELY(device == NULL)) {
-			NCCL_OFI_WARN("Invalid device provided");
+		domain = rdma_endpoint_get_domain(ep);
+		if (OFI_UNLIKELY(domain == NULL)) {
+			NCCL_OFI_WARN("Invalid domain provided");
 			return -EINVAL;
 		}
 
-		nccl_net_ofi_mutex_lock(&device->base.device_lock);
+		nccl_net_ofi_mutex_lock(&domain->base.domain_lock);
 
 		if ((--ep->base.ref_cnt) == 0) {
-			ret = nccl_ofi_ep_addr_list_delete(device->ep_addr_list, &ep->base);
+			ret = nccl_ofi_ep_addr_list_delete(domain->ep_addr_list, &ep->base);
 			if (ret != 0) {
 				NCCL_OFI_WARN("delete ep for addr failed: %d", ret);
 				goto unlock;
@@ -6620,7 +6638,7 @@ static int nccl_net_ofi_rdma_endpoint_release(nccl_net_ofi_ep_t *base_ep)
 		}
 
  unlock:
-		nccl_net_ofi_mutex_unlock(&device->base.device_lock);
+		nccl_net_ofi_mutex_unlock(&domain->base.domain_lock);
 	} else {
 		ret = nccl_net_ofi_endpoint_release(&ep->base);
 	}
@@ -6642,7 +6660,7 @@ static int nccl_net_ofi_rdma_endpoint_free(nccl_net_ofi_ep_t *base_ep)
 		return -EINVAL;
 	}
 
-	device = (nccl_net_ofi_rdma_device_t *)ep->base.device;
+	device = rdma_endpoint_get_device(ep);
 
 	/* Ideally we would "un-post" the bounce buffers, but this
 	   should be accomplished by closing the endpoint. */
@@ -6690,19 +6708,23 @@ static inline int init_max_write_inline_size_if_not_initialized(nccl_net_ofi_rdm
 
 
 /* Caller must hold the device lock */
-static int nccl_net_ofi_rdma_device_create_endpoint(nccl_net_ofi_device_t *base_dev,
+static int nccl_net_ofi_rdma_domain_create_endpoint(nccl_net_ofi_domain_t *base_domain,
 						    nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_domain_t *domain = NULL;
 	nccl_net_ofi_rdma_device_t *device = NULL;
 
-	/* Retrieve and validate device */
-	device = (nccl_net_ofi_rdma_device_t *)base_dev;
-	if (OFI_UNLIKELY(device == NULL)) {
-		NCCL_OFI_WARN("Invalid device provided");
+	/* Retrieve and validate domain */
+	domain = (nccl_net_ofi_rdma_domain_t *)base_domain;
+	if (OFI_UNLIKELY(domain == NULL)) {
+		NCCL_OFI_WARN("Invalid domain provided");
 		return -EINVAL;
 	}
+
+	device = rdma_domain_get_device(domain);
+	assert(device != NULL);
 
 	/* Allocate endpoint */
 	ep = (nccl_net_ofi_rdma_ep_t *)calloc(1, sizeof(nccl_net_ofi_rdma_ep_t));
@@ -6711,7 +6733,7 @@ static int nccl_net_ofi_rdma_device_create_endpoint(nccl_net_ofi_device_t *base_
 		return -ENOMEM;
 	}
 
-	ret = nccl_net_ofi_endpoint_init(&device->base, &ep->base);
+	ret = nccl_net_ofi_endpoint_init(&domain->base, &ep->base);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Initializing endpoint base failed");
 		goto error;
@@ -6726,7 +6748,8 @@ static int nccl_net_ofi_rdma_device_create_endpoint(nccl_net_ofi_device_t *base_
 	 * that any lookups based on railid in the domain find
 	 * the right domain */
 	memset(&ep->control_rail, 0, sizeof(ep->control_rail));
-	ret = ep_rail_init(ep, device->base.dev_id, 0, &device->device_rails[0], &ep->control_rail);
+	ret = ep_rail_init(ep, device->base.dev_id, 0, &device->device_rails[0],
+			   &domain->domain_rails[0], &ep->control_rail);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Initializing control rail failed");
 		goto error;
@@ -6754,7 +6777,7 @@ static int nccl_net_ofi_rdma_device_create_endpoint(nccl_net_ofi_device_t *base_
 
 	ep->is_endpoint_per_communicator_ep = false;
 
-	ret = init_rail_ofi_resources(device, ep);
+	ret = init_rail_ofi_resources(device, domain, ep);
 	if (ret != 0) {
 		goto error;
 	}
@@ -6796,6 +6819,121 @@ error:
 	return ret;
 }
 
+
+static int
+nccl_net_ofi_rdma_domain_free(nccl_net_ofi_domain_t *base_domain)
+{
+	int ret;
+	nccl_net_ofi_rdma_domain_t *domain = (nccl_net_ofi_rdma_domain_t *)base_domain;
+
+	if (domain->ep_addr_list) {
+		nccl_ofi_ep_addr_list_fini(domain->ep_addr_list);
+		domain->ep_addr_list = NULL;
+	}
+
+	ret = nccl_net_ofi_domain_fini(&domain->base);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed to delete domain");
+		goto cleanup;
+	}
+
+cleanup:
+	free(domain);
+
+	return 0;
+}
+
+
+static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_ofi_device_t *base_dev)
+{
+	int ret = 0;
+	nccl_net_ofi_rdma_domain_t *domain = NULL;
+	nccl_net_ofi_rdma_device_t *device = NULL;
+
+	/* Retrieve and validate device */
+	device = (nccl_net_ofi_rdma_device_t *)base_dev;
+	if (OFI_UNLIKELY(device == NULL)) {
+		NCCL_OFI_WARN("Invalid device provided");
+		return NULL;
+	}
+
+	/* Allocate endpoint */
+	domain = (nccl_net_ofi_rdma_domain_t *)calloc(1, sizeof(nccl_net_ofi_rdma_domain_t));
+	if (!domain) {
+		NCCL_OFI_WARN("Unable to allocate rdma domain");
+		return NULL;
+	}
+
+	ret = nccl_net_ofi_domain_init(&device->base, &domain->base);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Initializing base domain failed: %d", ret);
+		goto error;
+	}
+
+	domain->base.free = nccl_net_ofi_rdma_domain_free;
+	domain->base.create_endpoint = nccl_net_ofi_rdma_domain_create_endpoint;
+
+	domain->num_rails = device->num_rails;
+
+	if (ofi_nccl_endpoint_per_communicator() != 0) {
+		domain->ep_addr_list = nccl_ofi_ep_addr_list_init(MAX_EP_ADDR);
+		if (domain->ep_addr_list == NULL) {
+			NCCL_OFI_WARN("Failed to init ep addr list");
+			ret = -ENOMEM;
+			goto error;
+		}
+	} else {
+		domain->ep_addr_list = NULL;
+	}
+
+	domain->domain_rails = (nccl_net_ofi_rdma_domain_rail_t *)calloc(domain->num_rails,
+									 sizeof(nccl_net_ofi_rdma_domain_rail_t));
+	if (domain->domain_rails == NULL) {
+		NCCL_OFI_WARN("Unable to allocate rdma rails");
+		ret = -ENOMEM;
+		goto error;
+	}
+
+	for (int i = 0; i < domain->num_rails ; i++) {
+		nccl_net_ofi_rdma_device_rail_t *device_rail = rdma_device_get_rail(device, i);
+		nccl_net_ofi_rdma_domain_rail_t *domain_rail = rdma_domain_get_rail(domain, i);
+
+		ret = fi_domain(device_rail->fabric, device_rail->info,
+				&domain_rail->domain, NULL);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
+				      ret, fi_strerror(-ret));
+			goto error;
+		}
+
+		/* need the shared CQ here as well */
+		if (ofi_nccl_endpoint_per_communicator() != 0) {
+			/* Create device-shared completion queue */
+			struct fi_cq_attr cq_attr = {};
+			cq_attr.format = FI_CQ_FORMAT_DATA;
+			ret = fi_cq_open(domain_rail->domain, &cq_attr, &domain_rail->cq, NULL);
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
+					      ret, fi_strerror(-ret));
+				goto error;
+			}
+			assert(domain_rail->cq != NULL);
+		} else {
+			domain_rail->cq = NULL;
+		}
+	}
+
+
+error:
+	if (ret != 0) {
+		domain->base.release(&(domain->base));
+		domain = NULL;
+	}
+
+	return (nccl_net_ofi_domain_t *)domain;
+}
+
+
 /*
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric and domain to make device rail ready for rail creation.
@@ -6804,10 +6942,6 @@ static inline int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_t *dev
 						 nccl_net_ofi_rdma_device_rail_t *rail_dev)
 {
 	int ret = 0;
-	nccl_net_ofi_rdma_plugin_t *plugin;
-
-	plugin = rdma_device_get_plugin(device);
-	assert(plugin != NULL);
 
 	/* Create fabric */
 	ret = fi_fabric(rail_dev->info->fabric_attr, &rail_dev->fabric, NULL);
@@ -6817,45 +6951,9 @@ static inline int init_device_rail_ofi_resources(nccl_net_ofi_rdma_device_t *dev
 		goto error;
 	}
 
-	/*
-         * In the domain-per-thread case, create the domain in the endpoint structure.  In the
-         * domain-per-process case, keep it in the device structure.  This is because, on some
-         * platforms, libfabric locks when accessing the domain, so retaining separate domains
-         * per thread and per endpoint reduces contention for that lock.
-         */
-	if (!plugin->base.domain_per_thread) {
-		/* Create domain */
-		ret = fi_domain(rail_dev->fabric, rail_dev->info,
-				&rail_dev->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			goto error;
-		}
-	}
-
-	if (ofi_nccl_endpoint_per_communicator() != 0) {
-		/* Create device-shared completion queue */
-		struct fi_cq_attr cq_attr = {};
-		cq_attr.format = FI_CQ_FORMAT_DATA;
-		ret = fi_cq_open(rail_dev->domain, &cq_attr, &rail_dev->cq, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
-					ret, fi_strerror(-ret));
-			goto error;
-		}
-		assert(rail_dev->cq != NULL);
-	} else {
-		rail_dev->cq = NULL;
-	}
 
 	return ret;
  error:
-	if (rail_dev->domain) {
-		fi_close((fid_t)rail_dev->domain);
-		rail_dev->domain = NULL;
-	}
-
 	if (rail_dev->fabric) {
 		fi_close((fid_t)rail_dev->fabric);
 		rail_dev->fabric = NULL;
@@ -6894,21 +6992,11 @@ static void release_device_ofi_resources(nccl_net_ofi_rdma_device_t *device)
 	nccl_net_ofi_rdma_device_rail_t *end = device->device_rails + device->num_rails;
 
 	for (; begin != end; ++begin) {
-		if (begin->domain) {
-			fi_close(&begin->domain->fid);
-		}
 		if (begin->fabric) {
 			fi_close(&begin->fabric->fid);
 		}
 		if (begin->info) {
 			fi_freeinfo(begin->info);
-		}
-		if (begin->cq) {
-			assert(ofi_nccl_endpoint_per_communicator() != 0);
-			int r = fi_close(&begin->cq->fid);
-			if (r) {
-				NCCL_OFI_WARN("Failed to close cq: %d", r);
-			}
 		}
 	}
 }
@@ -6983,9 +7071,9 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
 		return 0;
 	}
 
-	unsigned num_endpoints = HASH_COUNT(device->base.endpoint_table);
-	if (num_endpoints > 0) {
-		NCCL_OFI_INFO(NCCL_NET, "%u endpoints still active at close", num_endpoints);
+	unsigned num_domains = HASH_COUNT(device->base.domain_table);
+	if (num_domains > 0) {
+		NCCL_OFI_INFO(NCCL_NET, "%u domains still active at close", num_domains);
 	}
 
 	if (device->device_rails != NULL) {
@@ -7017,11 +7105,6 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
 		}
 		free(device->comm_idpool);
 		device->comm_idpool = NULL;
-	}
-
-	if (device->ep_addr_list) {
-		nccl_ofi_ep_addr_list_fini(device->ep_addr_list);
-		device->ep_addr_list = NULL;
 	}
 
 	ret = nccl_net_ofi_device_fini(base_device);
@@ -7062,9 +7145,9 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	}
 
 	device->base.get_properties = get_properties;
-	device->base.create_endpoint = nccl_net_ofi_rdma_device_create_endpoint;
-	device->base.release = nccl_net_ofi_rdma_device_release;
 	device->base.get_mr_key = get_mr_key;
+	device->base.release = nccl_net_ofi_rdma_device_release;
+	device->base.create_domain = nccl_net_ofi_rdma_device_create_domain;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */
@@ -7099,17 +7182,6 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	}
 
 	device->num_comm_ids = (uint32_t)NCCL_OFI_RDMA_MAX_COMMS;
-
-	if (ofi_nccl_endpoint_per_communicator() != 0) {
-		device->ep_addr_list = nccl_ofi_ep_addr_list_init(MAX_EP_ADDR);
-		if (!device->ep_addr_list) {
-			NCCL_OFI_WARN("Failed to init ep addr list");
-			ret = -ENOMEM;
-			goto error;
-		}
-	} else {
-		device->ep_addr_list = NULL;
-	}
 
 	/* Initialize libfabric resources of rdma device */
 	ret = device_prepare_for_connection(device);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -7199,14 +7199,22 @@ static void get_hints(struct fi_info *hints)
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM | FI_MR_VIRT_ADDR |
 		FI_MR_ALLOCATED | FI_MR_PROV_KEY;
 	hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
-	hints->domain_attr->threading = FI_THREAD_SAFE;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
-	/* Set progress mode to unspec to use the provider's default
-	 * mode.  We hard poll for completion, but if a provider is
-	 * faster with async progress, then we don't really care and
-	 * should let it do that. */
+	/* If libfabric is new enough to support
+	 * FI_PROGRESS_CONTROL_UNIFIED, specify MANUAL /
+	 * CONTROL_UNIFIED progress, to remove the domain lock from
+	 * the completion queue polling.  Otherwise, set
+	 * PROGRESS_UNSPEC to allow the provider to pick what it
+	 * thinks will go fastsest.
+	 */
+#if HAVE_DECL_FI_PROGRESS_CONTROL_UNIFIED
+	hints->domain_attr->control_progress = FI_PROGRESS_CONTROL_UNIFIED;
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+#else
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;;
+#endif
 }
 
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -471,7 +471,7 @@ static int set_mr_req_attr(nccl_ofi_idpool_t *key_pool, int dev_id,
 		goto exit;
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		int key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
@@ -2697,7 +2697,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		}
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		uint64_t key = fi_mr_key(mr_handle->mr[0]);
 		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			ret = -ENOENT;

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -49,14 +49,11 @@ static inline int set_schedule_by_threshold(nccl_net_ofi_threshold_scheduler_t *
 	assert(num_stripes <= num_rails);
 
 	int curr_rail_id, next_rail_id;
-	nccl_net_ofi_mutex_lock(&scheduler->rr_lock);
 
 	/* Retieve and increment multiplex-round-robin counter; wrap around if required */
 	curr_rail_id = scheduler->rr_counter;
 	next_rail_id = (curr_rail_id + num_stripes) % num_rails;
 	scheduler->rr_counter = next_rail_id;
-
-	nccl_net_ofi_mutex_unlock(&scheduler->rr_lock);
 
 	/* Number of bytes left to assign */
 	size_t left = size;
@@ -180,12 +177,6 @@ static int threshold_scheduler_fini(nccl_net_ofi_scheduler_t *scheduler_p)
 	assert(scheduler_p);
 	assert(scheduler_p->schedule_fl);
 
-	ret = nccl_net_ofi_mutex_destroy(&scheduler->rr_lock);
-	if (ret) {
-		NCCL_OFI_WARN("Could not destroy threshold scheduler pthread mutex");
-		return -ret;
-	}
-
 	ret = scheduler_fini(scheduler_p);
 	if (ret) {
 		NCCL_OFI_WARN("Could not destroy threshold scheduler");
@@ -245,14 +236,6 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size,
 	scheduler->base.fini = threshold_scheduler_fini;
 	scheduler->rr_counter = 0;
 	scheduler->min_stripe_size = min_stripe_size;
-
-	ret = nccl_net_ofi_mutex_init(&scheduler->rr_lock, NULL);
-	if (ret) {
-		NCCL_OFI_WARN("Could not initialize mutex for round robin counter");
-		scheduler_fini(&scheduler->base);
-		free(scheduler);
-		return -ret;
-	}
 
 	*scheduler_p = &scheduler->base;
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -30,9 +30,21 @@
 #include "nccl_ofi_mr.h"
 
 
+static nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain(nccl_net_ofi_sendrecv_ep_t *ep)
+{
+	return (nccl_net_ofi_sendrecv_domain_t*)ep->base.domain;
+}
+
+
 static nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device(nccl_net_ofi_sendrecv_ep_t *ep)
 {
-	return (nccl_net_ofi_sendrecv_device_t*)ep->base.device;
+	return (nccl_net_ofi_sendrecv_device_t*)sendrecv_endpoint_get_domain(ep)->base.device;
+}
+
+
+static nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device(nccl_net_ofi_sendrecv_domain_t *domain)
+{
+	return (nccl_net_ofi_sendrecv_device_t *)domain->base.device;
 }
 
 
@@ -191,6 +203,7 @@ static const char *nccl_net_ofi_req_str(nccl_net_ofi_sendrecv_req_t *req)
 		);
 	return buf;
 }
+
 
 /*
  * @brief	Process completion entries for the given completion quque.
@@ -514,7 +527,8 @@ static int post_recv_conn(nccl_net_ofi_sendrecv_listen_comm_t *l_comm,
 
 static inline struct fid_domain* get_domain_from_endpoint(nccl_net_ofi_sendrecv_ep_t *ep)
 {
-	return ep->domain;
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	return domain->domain;
 }
 
 /*
@@ -791,10 +805,14 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
 	}
+
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	int dev_id = device->base.dev_id;
 
 	int ret = 0;
-	nccl_ofi_mr_cache_t *mr_cache = device->base.mr_cache;
+	nccl_ofi_mr_cache_t *mr_cache = domain->base.mr_cache;
 	void *ret_handle = NULL;
 
 	if (skip_local_mr_buffer_registration(type)) {
@@ -816,10 +834,10 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 		/* Cache miss */
 	}
 
-	key_pool = &device->base.mr_rkey_pool;
-	struct fid_domain *domain;
-	domain = get_domain_from_endpoint(ep);
-	ret = reg_mr_base(domain, ep->ofi_ep, key_pool,
+	key_pool = &domain->base.mr_rkey_pool;
+	struct fid_domain *ofi_domain;
+	ofi_domain = get_domain_from_endpoint(ep);
+	ret = reg_mr_base(ofi_domain, ep->ofi_ep, key_pool,
 			   dev_id, ckey, type, &ret_handle);
 	if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
 		ret_handle = NULL;
@@ -877,8 +895,12 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 		NCCL_OFI_WARN("Invalid device provided");
 		return -EINVAL;
 	}
+
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
-	return dereg_mr_base_comm(mr_handle, &device->base.mr_rkey_pool, device->base.mr_cache);
+	return dereg_mr_base_comm(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 /*
@@ -1285,15 +1307,16 @@ static int alloc_and_reg_flush_buff(struct fid_domain *domain, struct fid_ep *ep
  */
 static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrecv_listen_comm_t *l_comm,
 							    nccl_net_ofi_sendrecv_device_t *device,
+							    nccl_net_ofi_sendrecv_domain_t *domain,
 							    nccl_net_ofi_sendrecv_ep_t *ep,
 							    char *remote_ep_addr)
 {
 	int ret = 0;
 	fi_addr_t remote_ep;
-	struct fid_domain *domain;
+	struct fid_domain *ofi_domain;
 	nccl_net_ofi_sendrecv_recv_comm_t *r_comm = NULL;
 	size_t req_size = sizeof(nccl_net_ofi_sendrecv_req_t);
-	nccl_ofi_idpool_t *key_pool = &device->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 	int dev_id = device->base.dev_id;
 
 	/* Insert remote EP address to AV */
@@ -1340,7 +1363,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 		return NULL;
 	}
 
-	domain = get_domain_from_endpoint(ep);
+	ofi_domain = get_domain_from_endpoint(ep);
 
 	/*
 	 * Setup flush resources if using GPUDirect RDMA unless user disables
@@ -1348,7 +1371,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *prepare_recv_comm(nccl_net_ofi_sendrec
 	 */
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
 		r_comm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
-		ret = alloc_and_reg_flush_buff(domain, ep->ofi_ep, key_pool,
+		ret = alloc_and_reg_flush_buff(ofi_domain, ep->ofi_ep, key_pool,
 					       &r_comm->flush_buff, dev_id);
 		if (OFI_UNLIKELY(ret != 0)) {
 			free(r_comm);
@@ -1392,6 +1415,15 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		return ret;
 	}
 
+	/* Retrieve and validate domain */
+	nccl_net_ofi_sendrecv_domain_t *domain =
+		sendrecv_endpoint_get_domain(ep);
+	if (OFI_UNLIKELY(domain == NULL)) {
+		ret = -EINVAL;
+		NCCL_OFI_WARN("Invalid domain provided");
+		return ret;
+	}
+
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
 		sendrecv_endpoint_get_device(ep);
@@ -1421,9 +1453,9 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_lock(&(domain->base.domain_lock));
 		ep->base.ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(device->base.device_lock));
+		nccl_net_ofi_mutex_unlock(&(domain->base.domain_lock));
 
 		/* Prepare receive request to accept connections */
 		req = prepare_recv_req(l_comm);
@@ -1502,7 +1534,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	}
 
 	/* Prepare receive communicator object for the received peer connection */
-	r_comm = prepare_recv_comm(l_comm, device, ep, conn_info->ep_name);
+	r_comm = prepare_recv_comm(l_comm, device, domain, ep, conn_info->ep_name);
 	if (OFI_UNLIKELY(r_comm == NULL)) {
 		return -ENOMEM;
 	}
@@ -1664,9 +1696,12 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 		return -EINVAL;
 	}
 
+	nccl_net_ofi_sendrecv_domain_t *domain = sendrecv_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	struct fid_mr *mr_handle = (struct fid_mr *)mhandle;
-	return dereg_mr_base_comm(mr_handle, &device->base.mr_rkey_pool,
-				  device->base.mr_cache);
+	return dereg_mr_base_comm(mr_handle, &domain->base.mr_rkey_pool,
+				  domain->base.mr_cache);
 }
 
 static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
@@ -2165,23 +2200,23 @@ static int nccl_net_ofi_sendrecv_endpoint_free(nccl_net_ofi_ep_t *base_ep)
 }
 
 
-static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *base_dev,
+static int nccl_net_ofi_sendrecv_domain_create_endpoint(nccl_net_ofi_domain_t *base_domain,
 							nccl_net_ofi_ep_t **base_ep)
 {
 	int ret = 0;
 	nccl_net_ofi_sendrecv_ep_t *ep = NULL;
-	nccl_net_ofi_sendrecv_plugin_t *plugin;
+	nccl_net_ofi_sendrecv_device_t *device;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_sendrecv_device_t *device =
-		(nccl_net_ofi_sendrecv_device_t*)base_dev;
-	if (OFI_UNLIKELY(device == NULL)) {
-		NCCL_OFI_WARN("Invalid device provided");
+	nccl_net_ofi_sendrecv_domain_t *domain =
+		(nccl_net_ofi_sendrecv_domain_t*)base_domain;
+	if (OFI_UNLIKELY(domain == NULL)) {
+		NCCL_OFI_WARN("Invalid domain provided");
 		return -EINVAL;
 	}
 
-	plugin = sendrecv_device_get_plugin(device);
-	assert(plugin != NULL);
+	device = sendrecv_domain_get_device(domain);
+	assert(device != NULL);
 
 	/* Allocate endpoint */
 	ep = (nccl_net_ofi_sendrecv_ep_t *)calloc(1, sizeof(nccl_net_ofi_sendrecv_ep_t));
@@ -2191,23 +2226,10 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 		return -ENOMEM;
 	}
 
-	ret = nccl_net_ofi_endpoint_init(&device->base, &ep->base);
+	ret = nccl_net_ofi_endpoint_init(&domain->base, &ep->base);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Initializing endpoint base failed");
 		return ret;
-	}
-
-	if (plugin->base.domain_per_thread) {
-		ret = fi_domain(device->fabric, device->info,
-				&ep->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			free(ep);
-			return ret;
-		}
-	} else {
-		ep->domain = device->domain;
 	}
 
 	/* Initialize base endpoint */
@@ -2218,9 +2240,9 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 	/* Initialize endpoint tag */
 	ep->tag = 0;
 
-	struct fid_domain *domain = get_domain_from_endpoint(ep);
+	struct fid_domain *ofi_domain = get_domain_from_endpoint(ep);
 	ret = nccl_ofi_ofiutils_init_connection(device->info,
-						domain,
+						ofi_domain,
 						&ep->ofi_ep,
 						&ep->av, &ep->cq);
 	if (ret != 0) {
@@ -2232,6 +2254,64 @@ static int nccl_net_ofi_sendrecv_device_create_endpoint(nccl_net_ofi_device_t *b
 	return ret;
 }
 
+
+static int nccl_net_ofi_sendrecv_domain_free(nccl_net_ofi_domain_t *base_domain)
+{
+	int ret;
+	nccl_net_ofi_sendrecv_domain_t *domain = (nccl_net_ofi_sendrecv_domain_t *)base_domain;
+
+	ret = nccl_net_ofi_domain_fini(base_domain);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed to cleanup base domain: %d", ret);
+	}
+
+	if (domain->domain)
+		fi_close((fid_t)domain->domain);
+
+	free(base_domain);
+
+	return 0;
+}
+
+
+static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_net_ofi_device_t *base_device)
+{
+	int ret;
+	nccl_net_ofi_sendrecv_device_t *device = (nccl_net_ofi_sendrecv_device_t *)base_device;
+	nccl_net_ofi_sendrecv_domain_t *domain = NULL;
+
+	domain = (nccl_net_ofi_sendrecv_domain_t*)calloc(1, sizeof(nccl_net_ofi_sendrecv_domain_t));
+	if (domain == NULL) {
+		return NULL;
+	}
+
+	domain->base.free = nccl_net_ofi_sendrecv_domain_free;
+	domain->base.create_endpoint = nccl_net_ofi_sendrecv_domain_create_endpoint;
+
+	ret = nccl_net_ofi_domain_init(base_device, &domain->base);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Creating domain failed: %d", ret);
+		goto exit;
+	}
+
+	ret = fi_domain(device->fabric, device->info,
+			&domain->domain, NULL);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		goto exit;
+	}
+
+exit:
+	if (ret != 0) {
+		domain->base.free(&domain->base);
+		domain = NULL;
+	}
+
+	return (nccl_net_ofi_domain_t*)domain;
+}
+
+
 /*
  * @brief	Allocates and initialises various libfabric resources like
  *		fabric and domain to make sendrecv device ready for endpoint creation.
@@ -2240,10 +2320,6 @@ static int device_prepare_for_connection(nccl_net_ofi_sendrecv_device_t *device)
 {
 	int ret = 0;
 	int ofi_tag_leading_zeroes = 0, ofi_tag_bits_for_ring_id = 64;
-	nccl_net_ofi_sendrecv_plugin_t *plugin;
-
-	plugin = sendrecv_device_get_plugin(device);
-	assert(plugin != NULL);
 
 	/* Determine if any tag bits are used by provider */
 	while (!((device->info->ep_attr->mem_tag_format << ofi_tag_leading_zeroes++) &
@@ -2257,45 +2333,12 @@ static int device_prepare_for_connection(nccl_net_ofi_sendrecv_device_t *device)
 			      device->info->fabric_attr->prov_name,
 			      ofi_tag_bits_for_ring_id,
 			      MIN_TAG_BITS_FOR_RING_ID);
-		ret = -EINVAL;
-		goto exit;
+		return -EINVAL;
 	}
 
 	/* Set maximum tag information; Reserving 1 bit for control information */
 	device->max_tag = (uint64_t)((1ULL << (ofi_tag_bits_for_ring_id - 1)) - 1);
 
-	/* Create fabric */
-	ret = fi_fabric(device->info->fabric_attr, &device->fabric, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Couldn't open a fabric provider. RC: %d, ERROR: %s",
-			      ret, fi_strerror(-ret));
-		goto error;
-	}
-
-	/*
-	 * In the domain-per-thread case, create the domain in the endpoint structure.  In the
-	 * domain-per-process case, keep it in the device structure.  This is because, on some
-	 * platforms, libfabric locks when accessing the domain, so retaining separate domains
-	 * per thread and per endpoint reduces contention for that lock.
-	 */
-	if (!plugin->base.domain_per_thread) {
-		/* Create domain */
-		ret = fi_domain(device->fabric, device->info,
-				&device->domain, NULL);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Couldn't open a fabric access domain. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			goto error;
-		}
-	}
-
-	return ret;
- error:
-	if (device->domain)
-		fi_close((fid_t)device->domain);
-	if (device->fabric)
-		fi_close((fid_t)device->fabric);
- exit:
 	return ret;
 }
 
@@ -2313,9 +2356,13 @@ nccl_net_ofi_sendrecv_device_release(nccl_net_ofi_device_t *base_device)
 		return 0;
 	}
 
-	unsigned num_endpoints = HASH_COUNT(device->base.endpoint_table);
-	if (num_endpoints > 0) {
-		NCCL_OFI_INFO(NCCL_NET, "%u endpoints still active at close", num_endpoints);
+	unsigned num_domains = HASH_COUNT(device->base.domain_table);
+	if (num_domains > 0) {
+		NCCL_OFI_INFO(NCCL_NET, "%u domains still active at close", num_domains);
+	}
+
+	if (device->fabric) {
+		fi_close((fid_t)device->fabric);
 	}
 
 	if (device->info != NULL) {
@@ -2361,9 +2408,9 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 
 
 	device->base.get_properties = get_properties;
-	device->base.create_endpoint = nccl_net_ofi_sendrecv_device_create_endpoint;
 	device->base.release = nccl_net_ofi_sendrecv_device_release;
 	device->base.get_mr_key = NULL;
+	device->base.create_domain = nccl_net_ofi_sendrecv_device_create_domain;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */
@@ -2375,6 +2422,14 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 		goto error;
 	}
 	device->prov_name = device->info->fabric_attr->prov_name;
+
+	/* Create fabric */
+	ret = fi_fabric(device->info->fabric_attr, &device->fabric, NULL);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Couldn't open a fabric provider. RC: %d, ERROR: %s",
+			      ret, fi_strerror(-ret));
+		goto error;
+	}
 
 	ret = device_prepare_for_connection(device);
 	if (ret != 0) {

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -598,7 +598,7 @@ static int register_mr_buffers(struct fid_domain *domain,
 		goto exit;
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		int key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
@@ -749,7 +749,7 @@ static int dereg_mr_base_comm(struct fid_mr *mr_handle,
 		}
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		uint64_t key = fi_mr_key(mr_handle);
 		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			NCCL_OFI_WARN("Error retrieving MR key, leaking key");

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2545,11 +2545,22 @@ static void get_hints(struct fi_info *hints, int req_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->threading = FI_THREAD_SAFE;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
-	/* Set progress mode to unspec to use the provider's default mode. */
+	/* If libfabric is new enough to support
+	 * FI_PROGRESS_CONTROL_UNIFIED, specify MANUAL /
+	 * CONTROL_UNIFIED progress, to remove the domain lock from
+	 * the completion queue polling.  Otherwise, set
+	 * PROGRESS_UNSPEC to allow the provider to pick what it
+	 * thinks will go fastsest.
+	 */
+#if HAVE_DECL_FI_PROGRESS_CONTROL_UNIFIED
+	hints->domain_attr->control_progress = FI_PROGRESS_CONTROL_UNIFIED;
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+#else
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;;
+#endif
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -762,9 +762,7 @@ static int dereg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 		 * cache itself, this call would either just decrement the
 		 * refcnt, or delete the entry for this handle.
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret = nccl_ofi_mr_cache_del_entry(mr_cache, (void *)mr_handle);
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -839,7 +837,6 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 		 * MR cache is locked between lookup and insert, to be sure we
 		 * insert a missing entry
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey);
 		if (ret_handle) {
 			/* Cache hit */
@@ -874,10 +871,6 @@ static int reg_mr_base_comm(nccl_net_ofi_comm_t *base_comm,
 	}
 
 unlock:
-	if (mr_cache) {
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
-	}
-
 	nccl_net_ofi_mutex_unlock(&domain->base.domain_lock);
 
 	*mhandle = ret_handle;


### PR DESCRIPTION
This patch series switches from a fine grained locking scheme (that creates thousands of locks in the rdma transport case) to a simple device and domain locking scheme, where the lock is held for the majority of the communication calls.  This allows us to disable most of the locking in Libfabric by supporting FI_THREAD_DOMAIN.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
