### PR TITLE
Fix a number of duplicate definition names

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -25,6 +25,7 @@ sources = \
 	nccl_ofi_pthread.c \
 	nccl_ofi_dmabuf.c \
 	nccl_ofi_ep_addr_list.c \
+	nccl_ofi_param.c \
 	tracepoint.c
 
 if WANT_PLATFORM_AWS

--- a/src/nccl_ofi_param.c
+++ b/src/nccl_ofi_param.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+/*
+ * This is an ugly hack.  The original implementation of
+ * nccl_ofi_param created inline functions to access each environment
+ * variable, using the macros found in nccl_ofi_param.h.  However,
+ * this creates something of an ODR problem, as multiple complication
+ * units can call the same param lookup function, and that results in
+ * naming conflicts.  So instead, we have the header file act like a
+ * normal header file most of the time, and when included from
+ * nccl_ofi_param.c with OFI_NCCL_PARAM_DEFINE set to 1, stamps out
+ * the original implementations of the functions.  So now we have one
+ * copy of each function that everyone can call.
+ *
+ * This is intended to be a transient state.  We want to rewrite the
+ * entire param system once we've finished moving to C++, but need to
+ * solve the ODR problem before we move to C++.  So here lies one of
+ * the more terrible pieces of code I've ever written.
+ */
+#define OFI_NCCL_PARAM_DEFINE 1
+#include "nccl_ofi_param.h"


### PR DESCRIPTION
In preparation for moving to C++, make sure we're closer to following the [One Definition Rule](https://en.wikipedia.org/wiki/One_Definition_Rule).  There was one major offender, duplicate symbol names between the sendrecv and rdma transports.  While we still need to clean up the naming in the rdma transport, this PR prefixes every private symbol in the sendrecv transport with `sendrecv_`.

The other potential badness was the param code, if the compiler did not inline those functions.  To work around that, we do some ugly hacking to put all the param access functions in a single `nccl_ofi_param.c` file, and `nccl_ofi_param.h` only creates declarations most of the time.  The implementation is ugly, but we want to rewrite this code anyway, so let's limp until we're using C++ and can write something better.

Without this PR:
```
% nm .libs/libinternal_net_plugin.a | grep ' [tT] ' | cut -f3 -d' ' | sort | uniq -d
accept
connect
dereg_mr_recv_comm
dereg_mr_send_comm
flush
get_properties
listen
listen_close
ofi_process_cq
recv
reg_mr_recv_comm
reg_mr_send_comm
send
test
```

With this PR:
```
% nm .libs/libinternal_net_plugin.a | grep ' [tT] ' | cut -f3 -d' ' | sort | uniq -d
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
