### PR TITLE
Cleanups from adding a domain interface

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -260,6 +260,15 @@ struct nccl_net_ofi_device {
 	 */
 	nccl_ofi_mr_cache_t *mr_cache;
 
+	/* do we need to use an mr rkey pool?  This is a
+	 * provider-specific behavior determined when providers are
+	 * selected.
+	 */
+	bool need_mr_rkey_pool;
+
+	/* Memory registration key pool */
+	nccl_ofi_idpool_t mr_rkey_pool;
+
 	int (*get_properties)(nccl_net_ofi_device_t *base_dev,
 			      nccl_ofi_properties_t *props);
 
@@ -559,7 +568,7 @@ int nccl_net_ofi_endpoint_fini(nccl_net_ofi_ep_t *ep);
  * Constructor for a device object
  */
 int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_t *plugin,
-			     int device_index, const char *device_name);
+			     int device_index, struct fi_info *ofi_info);
 
 /**
  * Destructor for a device object

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -87,6 +87,16 @@ int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id);
  */
 int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
 
+
+/*
+ * @brief        Check if an idpool has been initialized with a size
+ *               other than 0.
+ */
+static inline bool nccl_ofi_idpool_active(nccl_ofi_idpool_t *idpool) {
+	return (idpool->size != 0);
+}
+
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -804,9 +804,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	   lookup of comms in the RDMA protocol. */
 	nccl_net_ofi_comm_t **comms;
 
-	/* Memory registration key pool */
-	nccl_ofi_idpool_t key_pool;
-
 	bool use_long_rkeys;
 
 	/* List of endpoints and set of addresses they have connections to */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -14,7 +14,6 @@ extern "C" {
 #include "nccl_ofi.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_log.h"
-#include "nccl_ofi_idpool.h"
 
 typedef enum nccl_net_ofi_sendrecv_req_state {
 	NCCL_OFI_SENDRECV_REQ_CREATED = 0,
@@ -167,9 +166,6 @@ typedef struct nccl_net_ofi_sendrecv_device {
 
 	/* Access Domain handle */
 	struct fid_domain *domain;
-
-	/* Memory registration key pool */
-	nccl_ofi_idpool_t key_pool;
 } nccl_net_ofi_sendrecv_device_t;
 	
 typedef struct nccl_net_ofi_sendrecv_req {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -471,7 +471,7 @@ static int set_mr_req_attr(nccl_ofi_idpool_t *key_pool, int dev_id,
 		goto exit;
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		int key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
@@ -2697,7 +2697,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		}
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		uint64_t key = fi_mr_key(mr_handle->mr[0]);
 		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			ret = -ENOENT;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -598,7 +598,7 @@ static int register_mr_buffers(struct fid_domain *domain,
 		goto exit;
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		int key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
@@ -749,7 +749,7 @@ static int dereg_mr_base_comm(struct fid_mr *mr_handle,
 		}
 	}
 
-	if (key_pool->ids) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		uint64_t key = fi_mr_key(mr_handle);
 		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			NCCL_OFI_WARN("Error retrieving MR key, leaking key");


### PR DESCRIPTION
Pull out the cleanup patches from https://github.com/aws/aws-ofi-nccl/pull/665.  I'm not convinced that 665 is a real failure, but want something simple enough we can get some CI confidence.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
