### PR TITLE
rdma: add option to round robin the ctrl msg, and use shared CQs for control and data endpoints

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -301,6 +301,12 @@ OFI_NCCL_PARAM_INT(rdma_min_posted_bounce_buffers, "RDMA_MIN_POSTED_BOUNCE_BUFFE
 OFI_NCCL_PARAM_INT(rdma_max_posted_bounce_buffers, "RDMA_MAX_POSTED_BOUNCE_BUFFERS", 128);
 
 /*
+ * Whether to spread the control message across multiple rails in round robin fashion or
+ * send it consistenly on one rail.
+ */
+OFI_NCCL_PARAM_INT(rdma_rr_ctrl_msg, "RR_CTRL_MSG", 0);
+
+/*
  * Internode network latency reported to NCCL. Defaults to 0, unless the configured
  * platform sets a specific value.
  */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -633,7 +633,6 @@ typedef struct nccl_net_ofi_rdma_listen_comm {
 
 	/* Comm ID provided by local endpoint */
 	uint32_t comm_id;
-	struct fid_ep *leader_local_ep;
 
 	/* Communicator created while accept routine is executed */
 	nccl_net_ofi_rdma_recv_comm_t *r_comm;


### PR DESCRIPTION
PR #543 has moved the control message to its own dedicated
endpoint on a single rail. As a result, the control message is not sent on
all rails in a round-robin fashion anymore. This has impacted performance
in some cases, so we want the option to still distribute the control messages
across all rails.
This PR is providing an environment variable to choose between a) using a
single dedicated endpoint for control messages, sharing the CQ with the data
endpoint on rail 0; or b) use as many additional endpoints for the control
messages as the number of rails, sharing the CQs with the data endpoints, and
use the scheduler to round robin the control messages across all rails.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
