### PR TITLE
Fix device sorting on aws platforms

### DIFF
--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -27,13 +27,31 @@ int platform_init(const char **provider_filter) __attribute__((weak));
  */
 int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribute__((weak));
 
-/* Platform-specific hook to sort in the multi-rail protocol of the plugin. Some
- * providers rely on having a consistent ordering of rail indices for best
- * performance.
+/* Platform-specific hook to sort in the multi-rail protocol of the
+ * plugin
+ *
+ * Rail-oriented networks or traffic flows are a common performance
+ * optimization for ML networks.  Generally, Libfabric providers sort
+ * their provider list by BDFs, which are indicitive of physical
+ * ordering and good enough.  However, on some platforms (especially
+ * virtualized platforms), this might not actually be sufficient and
+ * another sorting mechanism may be required to properly group NICs.
+ *
+ * This interface is called in the topology initialization code to
+ * order NICs that are behind the same PCIe root complex / switch.
+ * The info_list will have num_rails providers listed, and will later
+ * be split into num_groups groups (based on the number of
+ * accelerators that are also behind the PCIe switch).
+ *
+ * Providers of this interface should sort the provided info_list such
+ * that the Nth provider on this node will be assumed to talk to the
+ * Nth provider on remote nodes (ie, identify the "rail id" and sort
+ * by that).
+ *
  * @param info_list: pointer to list of `num_rails` info objects
  * @param num_rails: number of rails
  */
-void platform_sort_rails(struct fi_info **info_list, int num_rails) __attribute__((weak));
+void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_groups) __attribute__((weak));
 
 
 /*

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -51,7 +51,7 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribut
  * @param info_list: pointer to list of `num_rails` info objects
  * @param num_rails: number of rails
  */
-void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_groups) __attribute__((weak));
+void platform_sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups) __attribute__((weak));
 
 
 /*

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -25,7 +25,6 @@
 #include "nccl_ofi_memcheck.h"
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_pthread.h"
-#include "nccl_ofi_platform.h"
 #include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_mr.h"
 
@@ -6933,10 +6932,6 @@ static nccl_net_ofi_rdma_device_rail_t *create_device_rail_array(struct fi_info 
 							  sizeof(nccl_net_ofi_rdma_device_rail_t));
 	if (device_rails == NULL) {
 		return NULL;
-	}
-
-	if (platform_sort_rails != NULL) {
-		platform_sort_rails(&info_list, num_infos);
 	}
 
 	for (int i = 0 ; i < num_infos ; i++) {

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -812,7 +812,7 @@ static int create_groups_from_info_list(nccl_ofi_topo_t *topo,
 	 * consistency
 	 */
 	if (platform_sort_rails != NULL) {
-		platform_sort_rails(info_list, num_infos, (size_t)group_size);
+		platform_sort_rails(info_list, (size_t)num_infos, (size_t)group_size);
 	}
 
 	for (; group_idx < num_groups; ++group_idx) {

--- a/src/nccl_ofi_topo.c
+++ b/src/nccl_ofi_topo.c
@@ -16,6 +16,7 @@
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_ofiutils.h"
+#include "nccl_ofi_platform.h"
 
 static const uint8_t target_class_id = 0x03;		/* Display controller class */
 static const unsigned short target_vendor_id = 0x10de;	/* NVIDIA */
@@ -804,6 +805,15 @@ static int create_groups_from_info_list(nccl_ofi_topo_t *topo,
 	 * groups */
 	const int num_large_groups = num_infos % num_groups;
 	int group_size = num_infos / num_groups + 1;
+
+	/* sort the provider list to match network rail ordering.  See
+	 * the documentation comment for platform_sort_rails() for
+	 * more information.  We do this here so that there is
+	 * consistency
+	 */
+	if (platform_sort_rails != NULL) {
+		platform_sort_rails(info_list, num_infos, (size_t)group_size);
+	}
 
 	for (; group_idx < num_groups; ++group_idx) {
 		hwloc_obj_t obj;

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -759,7 +759,7 @@ static int get_rail_vf_idx(struct fi_info *info)
 	return vf_idx;
 }
 
-void platform_sort_rails(struct fi_info **info_list, int num_rails)
+void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_groups)
 {
 	struct fi_info *info_list_in = *info_list;
 	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -759,7 +759,7 @@ static int get_rail_vf_idx(struct fi_info *info)
 	return vf_idx;
 }
 
-void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_groups)
+void platform_sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups)
 {
 	struct fi_info *info_list_in = *info_list;
 	struct fi_info **sorted_info_array = (struct fi_info **)alloca(num_rails*sizeof(struct fi_info *));
@@ -769,13 +769,13 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_g
 		return;
 	}
 
-	for (int i = 0; i < num_rails; ++i) {
+	for (size_t i = 0; i < num_rails; ++i) {
 		sorted_info_array[i] = NULL;
 	}
 
-	int rail_map[2] = {0, 2};
+	size_t rail_map[2] = {0, 2};
 
-	for (int i = 0; i < num_rails; ++i) {
+	for (size_t i = 0; i < num_rails; ++i) {
 		if (info_list_in == NULL) {
 			goto error;
 		}
@@ -786,7 +786,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_g
 			goto error;
 		}
 
-		int rail_idx = rail_map[vf_idx];
+		size_t rail_idx = rail_map[vf_idx];
 		rail_map[vf_idx]++;
 
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Assigning rail index %d to info list idx %d",
@@ -804,7 +804,7 @@ void platform_sort_rails(struct fi_info **info_list, int num_rails, size_t num_g
 	/* Update info_list references to match sorted order */
 	*info_list = sorted_info_array[0];
 	info_ptr = *info_list;
-	for (int i = 0; i < num_rails; ++i) {
+	for (size_t i = 0; i < num_rails; ++i) {
 		assert(info_ptr);
 		assert(sorted_info_array[i]);
 		if (i == num_rails - 1) {


### PR DESCRIPTION
The device sorting code in the aws platform code for mrail groups  would cause NCCL to abort / run slowly because the sorting happened too late in the code, and the leader nic in the generated topology file didn't match the new leader after sorting, which is the one returned in getProperties.  This patch pulls the sorting logic up into the topology grouping logic so that we avoid that bug, and also cleans up some other issues found while auditing that code.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
