### PR TITLE
Reduce repetitive INFO printing

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -134,6 +134,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	nccl_net_ofi_plugin_t *plugin;
 	nccl_net_ofi_ep_t *base_ep = NULL;
 	nccl_net_ofi_device_t *device = NULL;
+	nccl_ofi_properties_t properties;
 
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Initializing " PACKAGE_STRING);
 
@@ -292,6 +293,14 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	if (ret != 0) {
 		goto exit;
 	}
+	ret = device->get_properties(device, &properties);
+	if (ret != 0) {
+		goto exit;
+	}
+	NCCL_OFI_INFO(NCCL_NET | NCCL_INIT, "Support for global registrations: %s",
+		      (properties.regIsGlobal == 0) ? "false" : "true");
+	NCCL_OFI_INFO(NCCL_NET | NCCL_INIT, "Support for DMA-BUF registrations: %s",
+		      (properties.dmabuf_support == 0) ? "false" : "true");
 	ret = base_ep->release_ep(base_ep);
 	if (ret != 0) {
 		goto exit;
@@ -453,10 +462,10 @@ int nccl_net_ofi_info_properties(nccl_net_ofi_plugin_t *plugin, struct fi_info *
 	 */
 	if (nic_prov->domain_attr->mr_mode & FI_MR_ENDPOINT || plugin->domain_per_thread) {
 		props->regIsGlobal = 0;
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Global registrations are not supported");
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Global registrations are not supported");
 	} else {
 		props->regIsGlobal = 1;
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Global registrations supported");
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Global registrations supported");
 	}
 
 	/* Speed reported in Mbps */
@@ -543,7 +552,7 @@ int nccl_net_ofi_info_properties(nccl_net_ofi_plugin_t *plugin, struct fi_info *
 		nccl_ofi_dmabuf_viable()
 		;
 	if (props->dmabuf_support) {
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "DMA-BUF support is advertised in properties.");
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "DMA-BUF support is advertised in properties.");
 	}
 
 	goto exit;

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -265,7 +265,7 @@ static int configure_ep_inorder(struct fid_ep *ep, int optname, const char* optn
 			      optname_name, ret, fi_strerror(-ret));
 		return ret;
 	} else {
-		NCCL_OFI_INFO(NCCL_INIT, "Setting %s have_ordering is true.", optname_name);
+		NCCL_OFI_TRACE(NCCL_INIT, "Setting %s have_ordering is true.", optname_name);
 		*have_ordering = true;
 	}
 


### PR DESCRIPTION
Switch printing information about global registration scope, DMA-BUF support, and ordering from INFO to TRACE, as they happen for every endpoint created, and with the endpoint per communicator code, this results in hundreds of prints, even for a 32 GPU job.

Add a startup time print for the global registration and dma-buf state, since those may prove useful.

For a 4 node allreduce test, this reduces the output from 4062 lines to 2974 lines, a reduction of 26%, and was inspired by having to parse through files from our 16 node runs, where it's basically all endpoint properties prints.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
