### PR TITLE
MR: Enforce page-aligned buffer registration for iovec and add corresponding test case

### DIFF
--- a/include/nccl_ofi_log.h
+++ b/include/nccl_ofi_log.h
@@ -34,8 +34,15 @@ extern nccl_ofi_logger_t ofi_log_function;
 	(*ofi_log_function)(NCCL_LOG_TRACE, flags,		\
 	__PRETTY_FUNCTION__, __LINE__, "NET/OFI " fmt,		\
 	##__VA_ARGS__)
+#define NCCL_OFI_TRACE_WHEN(criteria, flags, fmt, ...)			\
+	do {								\
+		if (OFI_UNLIKELY(criteria)) {				\
+			NCCL_OFI_TRACE(flags, fmt, ##__VA_ARGS__);	\
+		}							\
+	} while (0)
 #else
 #define NCCL_OFI_TRACE(flags, fmt, ...)
+#define NCCL_OFI_TRACE_WHEN(criteria, flags, fmt, ...)
 #endif
 
 #ifdef __cplusplus

--- a/src/nccl_ofi_mr.c
+++ b/src/nccl_ofi_mr.c
@@ -11,7 +11,7 @@
 #include "nccl_ofi_pthread.h"
 
 nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
-					    size_t system_page_size)
+					    size_t mr_cache_page_size)
 {
 	nccl_ofi_mr_cache_t *ret_cache = NULL;
 
@@ -20,7 +20,7 @@ nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
 		goto error;
 	}
 
-	if (system_page_size == 0) {
+	if (mr_cache_page_size == 0) {
 		NCCL_OFI_WARN("MR cache: system page size must be positive");
 		goto error;
 	}
@@ -40,8 +40,11 @@ nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
 	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
 		goto error;
 	}
-
-	ret_cache->system_page_size = system_page_size;
+	/*
+	 * System page size isn't reflective of the GDR mappings. We're not trying to map a
+	 * whole page, but just to find an interval that makes an array-based cache manageable.
+	 */
+	ret_cache->system_page_size = mr_cache_page_size;
 	ret_cache->size = init_num_entries;
 	ret_cache->used = 0;
 	ret_cache->hit_count = 0;

--- a/tests/functional/nccl_message_transfer.c
+++ b/tests/functional/nccl_message_transfer.c
@@ -51,11 +51,11 @@ int main(int argc, char* argv[])
 	/* Data sizes. We want to check send size greater, equal
 	   and smaller than recv size. And check values 1. below
 	   the eager threshold, 2. between eager and rr threshold,
-	   and 3. above the rr threshold. */
-	size_t send_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
+	   3. above the rr threshold, and 4. fraction of page size. */
+	size_t send_sizes[] = {512, 4 * 1024, 16 * 1024, 1024 * 1024,
 	                       5 * 1024, 17 * 1024, 2 * 1024 * 1024,
 	                       4 * 1024, 16 * 1024, 1024 * 1024};
-	size_t recv_sizes[] = {4 * 1024, 16 * 1024, 1024 * 1024,
+	size_t recv_sizes[] = {512, 4 * 1024, 16 * 1024, 1024 * 1024,
 	                       4 * 1024, 16 * 1024, 1024 * 1024,
 	                       5 * 1024, 17 * 1024, 2 * 1024 * 1024};
 


### PR DESCRIPTION
When a user registers multiple small buffers within same system page, current logic of MR cache results in only the first buffer registered, and the registered handle of the first buffer is returned for all other small buffers registrations.
Later when the handle is used for send / recv operations of actually unregistered small buffer regions, EFA device
returns errors regarding invalid local key. 

The changes include:
- Register iovec memory regions aligned to system page size, by using aligned base and bound when creating mr keys.
- Make cache->system_page_size min of reported system page size and cache page size.
- Add unit test for new mr key creation behavior.
- Adjust message transfer test to trigger the error case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
