### PR TITLE
cuda: build flag for dynamically or statically linking cudart

### DIFF
--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -60,9 +60,9 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
         #include <cuda.h>
         _Static_assert(CUDA_VERSION >= 11030, "cudart>=11030 required for cuFlushGPUDirectRDMAWrites");
-        ])],[ check_cuda_gdr_flush_define=1 ],
-            [ check_cuda_gdr_flush_define=0 ])
-        AC_MSG_RESULT(${check_cuda_gdr_flush_define})
+        ])],[ check_cuda_gdr_flush_define=1 chk_result=yes ],
+            [ check_cuda_gdr_flush_define=0 chk_result=no ])
+        AC_MSG_RESULT(${chk_result})
         ])
 
   check_cuda_dmabuf_define=0
@@ -72,9 +72,9 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
         #include <cuda.h>
         _Static_assert(CUDA_VERSION >= 11070, "cudart>=11070 required for DMABUF");
-        ])],[ check_cuda_dmabuf_define=1 ],
-            [ check_cuda_dmabuf_define=0 ])
-        AC_MSG_RESULT(${check_cuda_dmabuf_define})
+        ])],[ check_cuda_dmabuf_define=1 chk_result=yes ],
+            [ check_cuda_dmabuf_define=0 chk_result=no ])
+        AC_MSG_RESULT(${chk_result})
         ])
 
   AS_IF([test "${check_pkg_found}" = "yes"],


### PR DESCRIPTION
```
595ec88d cuda: add stubs/ to search path
b0d7e8a2 cuda: support dynamically linking libcudart
```

```
1 file changed, 14 insertions(+), 2 deletions(-)
m4/check_pkg_cuda.m4 | 16 ++++++++++++++--

modified   m4/check_pkg_cuda.m4
@@ -15,6 +15,17 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   AC_ARG_WITH([cuda],
      [AS_HELP_STRING([--with-cuda=PATH], [Path to non-standard CUDA installation])])
 
+  AC_ARG_ENABLE([cudart-dynamic],
+    [AS_HELP_STRING([--enable-cudart-dynamic],
+                    [link cudart dynamically (default=link statically)])],
+    [],
+    [enable_cudart_static=no])
+
+  cudartlib="-lcudart_static"
+  if test "x${enable_cudart_static}" != "xyes"; then
+     cudartlib="-lcudart"
+  fi
+
   AS_IF([test -n "${with_cuda}"], [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-cuda=${with_cuda}"])
 
   AS_IF([test -z "${with_cuda}" -o "${with_cuda}" = "yes"],
@@ -23,8 +34,9 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [check_pkg_found=no],
         [AS_IF([test -d $(realpath ${with_cuda})/lib64], [check_pkg_libdir="lib64"], [check_pkg_libdir="lib"])
          CUDA_LDFLAGS="-L$(realpath ${with_cuda})/${check_pkg_libdir}"
+         CUDA_LDFLAGS="${CUDA_LDFLAGS} ${CUDA_LDFLAGS}/stubs"
          CUDA_CPPFLAGS="-isystem $(realpath $(realpath ${with_cuda})/include)"
-         CUDA_LIBS="-lcudart_static -lrt -ldl"
+         CUDA_LIBS="${cudartlib} -lrt -ldl"
          LDFLAGS="${CUDA_LDFLAGS} ${LDFLAGS}"
          LIBS="${CUDA_LIBS} ${LIBS}"
          CPPFLAGS="${CUDA_CPPFLAGS} ${CPPFLAGS}"
@@ -33,7 +45,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   AS_IF([test "${check_pkg_found}" = "yes"],
         [AC_SEARCH_LIBS(
          [cudaGetDriverEntryPoint],
-         [cudart_static],
+         [${cudartlib}],
          [],
          [check_pkg_found=no],
          [-ldl -lrt])])
```

testing: built and ran with both.