### PR TITLE
defaults: make dmabuf opt-in

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -272,14 +272,15 @@ OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
  * Unfortunately, the plugin needs to signal DMABUF support or lack thereof back
  * to NCCL prior to having an opportuntiy to make any any memory registrations.
  * This ultimately means that the plugin will opimistically assume DMA-BUF is
- * viable on all FI_HMEM providers beyond libfabric 1.20.
+ * viable on all FI_HMEM providers beyond libfabric 1.20, if not for this param.
  *
  * If dmabuf registrations fail, (ie: if ibv_reg_dmabuf_mr cannot be resolved),
  * the plugin has no freedom to renegotiate DMABUF support with NCCL, and so it
- * is fatal. Under those conditions, users should set this environment variable
- * to force NCCL to avoid providing dmabuf file desciptors.
+ * is fatal. Under those conditions, users should ensure that they have set this
+ * environment variable to '1' to force NCCL to avoid providing dmabuf file
+ * desciptors. This is the default, pending perf investigations.
  */
-OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
+OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 1);
 
 /*
  * Messages sized larger than this threshold will be striped across multiple rails


### PR DESCRIPTION
This commit disables dmabuf by default. Due to the current libfabric
release cadence around the 2.x release, libfabric@8708b5c is not
contained on any current libfabric upstream release. For EFA users atop
efa-installer 1.35 (libfabric 1.22), this would mean that if we make a
1.13.x release, we would be putting the default EFA user onto the
problematic dual gdr+dmabuf MR flow.

No perf or correctness issues have been seen with the dmabuf flow, and
this should be reverted as soon as libfabric makes a release or
efa-installer cherry-picks the fix.