### PR TITLE
rdma: Set LOW_LATENCY traffic class for control

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -380,6 +380,13 @@ OFI_NCCL_PARAM_INT(tuner_net_latency, "TUNER_NET_LATENCY", 20);
  */
 OFI_NCCL_PARAM_INT(tuner_net_comp_overhead, "TUNER_NET_COMP_OVERHEAD", 3);
 
+/*
+ * Do we want to set the LOW_LATENCY traffic class for control
+ * messages?  This generally improves performance for platforms that
+ * support TCs, unless the prioritization over-reacts on the given network.
+ */
+OFI_NCCL_PARAM_INT(use_low_lat_tc, "USE_LOW_LATENCY_TC", 1);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif


### PR DESCRIPTION
Set a priority traffic class (LOW_LATENCY) for the control queue pair. Providers should silently fall back to TC_UNSPEC in the case that LOW_LATENCY is not available, so there's no fallback in this code. The traffic class interface was added in Libfabric 1.9.0 and configure requires at least Libfabric 1.11.0, so there's no need to add backward compatibility #ifdefs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
