### PR TITLE
fix: ep release in endpoint per comm

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -6719,7 +6719,7 @@ static void ep_rail_release(nccl_net_ofi_ep_rail_t *rail, int dev_id, struct fid
 		(instead of a cq per endpoint), set the rail->cq pointer to NULL
 		here so	that the cq isn't actually released in ep_release().
 		The cq will be released when the domain is cleaned up */
-		rail->cq = NULL;
+		cq = NULL;
 	}
 	nccl_ofi_ofiutils_ep_release(rail->ofi_ep, rail->av,
 				     cq, dev_id);
@@ -6807,6 +6807,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 #ifndef NDEBUG
 	if (ofi_nccl_endpoint_per_communicator() != 0) {
 		assert(ep_rail->cq != NULL);
+		assert(dev_rail->cq != NULL);
 	}
 #endif
 


### PR DESCRIPTION
In the endpoint per communicator path, we keep shared CQs in the device to be used by all endpoints, so we don't want to release the CQ when we release an endpoint. This is fixing a bug that was causing the CQ to be released in `ep_rail_release` by mistake, that resulted in a segfault when the CQ was used again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
