### PR TITLE
fix(cuda): delete broken using directives

### DIFF
--- a/src/nccl_ofi_cuda.c
+++ b/src/nccl_ofi_cuda.c
@@ -83,10 +83,6 @@ int nccl_net_ofi_cuda_flush_gpudirect_rdma_writes(void)
 {
 #if HAVE_CUDA_GDRFLUSH_SUPPORT
 	static_assert(CUDA_VERSION >= 11030, "Requires cudart>=11.3");
-#ifdef __cplusplus
-	using cudaFlushGPUDirectRDMAWritesTarget::*;
-	using cudaFlushGPUDirectRDMAWritesScope::*;
-#endif
 	cudaError_t ret = cudaDeviceFlushGPUDirectRDMAWrites(cudaFlushGPUDirectRDMAWritesTargetCurrentDevice,
 	                                                     cudaFlushGPUDirectRDMAWritesToOwner);
 	return (ret == cudaSuccess) ? 0 : -EPERM;


### PR DESCRIPTION
This was missed in review. It doesn't work this way. In C++20, the following is legal:

```cpp
enum foo { bar, baz };
using enum foo;
```

But it does not support the glob syntax done here, and this is also missing the `enum` specifier required, and it also doesn't work with C++17. It's unnecessary in this file, anyway, we can just use the bare names here. Delete it so that this file can be parsed with `-x c++` without causing build failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
