### PR TITLE
lttng: tracepoints for eager and ctrl messages

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -39,12 +39,12 @@
 } while(0)
 
 #define NCCL_OFI_TRACE_EAGER_SEND_START(dev, rail_id, size, comm, msg_seq_num, request) do { \
-	/* TODO: use a better (LTTNG) trace for eager send? */ \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send_write_segment_start, dev, rail_id, size, comm, msg_seq_num, request); \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_eager_start, dev, rail_id, size, comm, msg_seq_num, request); \
 	NCCL_OFI_TRACE_EAGER_SEND_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request); \
 } while(0)
 
 #define NCCL_OFI_TRACE_EAGER_SEND_COMPLETE(dev, rail_id, comm, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_eager_complete, dev, rail_id, comm, msg_seq_num, request); \
 	NCCL_OFI_TRACE_EAGER_SEND_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request); \
 } while (0)
 
@@ -54,10 +54,12 @@
 } while (0)
 
 #define NCCL_OFI_TRACE_SEND_CTRL_START(dev, rail_id, comm, req, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_start, dev, rail_id, comm, req, msg_seq_num); \
 	NCCL_OFI_TRACE_SEND_CTRL_START_NVTX(dev, rail_id, comm, req, msg_seq_num); \
 } while (0);
 
 #define NCCL_OFI_TRACE_SEND_CTRL_END(dev, rail_id, comm, req, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send_ctrl_end, dev, rail_id, comm, req, msg_seq_num); \
 	NCCL_OFI_TRACE_SEND_CTRL_END_NVTX(dev, rail_id, comm, req, msg_seq_num); \
 } while (0);
 
@@ -80,13 +82,9 @@
 	NCCL_OFI_TRACE_RECV_END_NVTX(request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_CTRL_SEND_COMPLETE(request) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_ctrl_send_complete, request); \
-} while(0)
-
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request); \
-	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request); \
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request, msg_seq_num); \
+	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request, msg_seq_num); \
 } while(0)
 
 #define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) do { \

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -89,6 +89,47 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 
 
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Send_ctrl_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, rail_id,
+            void *, comm,
+            void *, request,
+            uint16_t, msg_seq_num
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+    )
+)
+
+
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Send_ctrl_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, rail_id,
+            void *, comm,
+            void *, request,
+            uint16_t, msg_seq_num
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+    )
+)
+
+
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -136,6 +177,50 @@ LTTNG_UST_TRACEPOINT_EVENT(
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
+    Send_eager_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, rail_id,
+            size_t, size,
+            void *, comm,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, rail_id, rail_id)
+            lttng_ust_field_integer(size_t, size, size)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    Send_eager_complete,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            int, rail_id,
+            void *, comm,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
     Recv,
     LTTNG_UST_TP_ARGS(
             int, dev,
@@ -154,20 +239,6 @@ LTTNG_UST_TRACEPOINT_EVENT(
 )
 
 
-
-LTTNG_UST_TRACEPOINT_EVENT(
-    nccl_ofi_plugin,
-    Recv_ctrl_send_complete,
-    LTTNG_UST_TP_ARGS(
-            void *, request
-    ),
-    LTTNG_UST_TP_FIELDS(
-            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
-    )
-)
-
-
-
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
     Recv_segment_complete,
@@ -175,13 +246,15 @@ LTTNG_UST_TRACEPOINT_EVENT(
             int, dev,
             int, rail_id,
             size_t, size,
-            void *, request
+            void *, request,
+            uint16_t, msg_seq_num
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(int, rail_id, rail_id)
             lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
     )
 )
 

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -168,10 +168,10 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request) do { \
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
 	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
-		handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm)->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \


### PR DESCRIPTION
This PR adds:

- a separate lttng tracepoint for eager send instead of using the same one used for write
- an lttng tracepoint for the eager send completion
- tracepoints for ctrl send and its completion event

Plus it adds as parameters the device to the event for recv completion of ctrl message and the sequence number for recv completion event of a write message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
