### PR TITLE
core: Leave endpoint created during init

### DIFF
--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -302,7 +302,14 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		      (properties.regIsGlobal == 0) ? "false" : "true");
 	NCCL_OFI_INFO(NCCL_NET | NCCL_INIT, "Support for DMA-BUF registrations: %s",
 		      (properties.dmabuf_support == 0) ? "false" : "true");
+	/* Cause release to not actually free the resources, to speed
+	 * up initialization, since the very same resources will be
+	 * recreated by NCCL soon after initialization to do real
+	 * communication.
+	 */
+	base_ep->ref_cnt++;
 	ret = base_ep->release_ep(base_ep);
+	base_ep->ref_cnt--;
 	if (ret != 0) {
 		goto exit;
 	}


### PR DESCRIPTION
During initialization, the code creates an endpoint to populate the properties structure and test features of Libfabric.  Rather than destroy that endpoint and create a new one during NCCL communicator creation, edit the reference counting so that we end up with an endpoint with refcount 0 that hasn't been destroyed.  It will be found in the hash table during communicator creation and then will operate as a normal endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
