### PR TITLE
tree: cleanup "gdr_support" variable

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -81,15 +81,11 @@ extern "C" {
 /* Initial number of entries in the MR cache of a device */
 #define NCCL_OFI_MR_CACHE_INIT_SIZE     128
 
-/* Indicates if GPUDirect is supported by libfabric provider */
-enum gdr_support_level_t {GDR_UNKNOWN, GDR_SUPPORTED, GDR_UNSUPPORTED};
-extern enum gdr_support_level_t support_gdr;
-
-
 /* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
  * to flush data to the GPU. Note, CUDA flush support is not supported on all
  * platforms and should be disabled by default */
 extern bool cuda_flush;
+extern bool gdr_flush_disabled;
 
 /* number of duplicate providers to create for each discovered
  * provider, including renaming to cause NCCL to create additional

--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -66,6 +66,23 @@ bool nccl_net_ofi_cuda_have_dma_buf_attr(void);
  */
 bool nccl_net_ofi_cuda_have_gdr_support_attr(void);
 
+/*
+ * @brief	query CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_FLUSH_WRITES_OPTIONS
+
+ * @return	true if attr is fetched successfully and true.
+ *		    false otherwise
+ */
+bool nccl_net_ofi_cuda_have_gdr_flush_support_attr(void);
+
+/*
+ * @brief test whether gdrcopy can possibly be supported, depending on the
+ * linked libfabric version and the properties exposed by cuda.
+ *
+ * @return	true if attr is fetched successfully and true.
+ *		    false otherwise
+ */
+bool nccl_net_ofi_cuda_gdr_viable(void);
+
 #ifdef __cplusplus
 }  // End extern "C"
 #endif

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -281,6 +281,9 @@ OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
  */
 OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
 
+/* Largely exists for parity with DISABLE_DMABUF, but usage of this is discouraged. */
+OFI_NCCL_PARAM_INT(disable_gdrcopy, "DISABLE_GDRCOPY", 0);
+
 /*
  * Messages sized larger than this threshold will be striped across multiple rails
  */

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -53,15 +53,15 @@ AC_DEFUN([CHECK_PKG_CUDA], [
          [check_pkg_found=no],
          [-ldl -lrt])])
 
-  check_cuda_gdr_flush_define=0
+  check_cuda_gdr_define=0
   AS_IF([test "${check_pkg_found}" = "yes"],
         [
-        AC_MSG_CHECKING([if CUDA 11.3+ is available for GDR Write Flush support])
+        AC_MSG_CHECKING([if CUDA 11.3+ is available for GDR + GDR Write Flush support])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
         #include <cuda.h>
         _Static_assert(CUDA_VERSION >= 11030, "cudart>=11030 required for cuFlushGPUDirectRDMAWrites");
-        ])],[ check_cuda_gdr_flush_define=1 chk_result=yes ],
-            [ check_cuda_gdr_flush_define=0 chk_result=no ])
+        ])],[ check_cuda_gdr_define=1 chk_result=yes ],
+            [ check_cuda_gdr_define=0 chk_result=no ])
         AC_MSG_RESULT(${chk_result})
         ])
 
@@ -85,7 +85,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
 
   AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
   AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF_SUPPORT], [${check_cuda_dmabuf_define}], [Defined to 1 if CUDA DMA-BUF support is available])
-  AC_DEFINE_UNQUOTED([HAVE_CUDA_GDRFLUSH_SUPPORT], [${check_cuda_gdr_flush_define}], [Defined to 1 if CUDA cuFlushGPUDirectRDMAWrites support is available])
+  AC_DEFINE_UNQUOTED([HAVE_CUDA_GDR_SUPPORT], [${check_cuda_gdr_define}], [Defined to 1 if CUDA cuFlushGPUDirectRDMAWrites support is available])
   AM_CONDITIONAL([HAVE_CUDA], [test "${check_pkg_found}" = "yes"])
 
   AC_SUBST([CUDA_LDFLAGS])


### PR DESCRIPTION
In the default case, we lazily create all fabric resources at the time of communicator creation, such that they end up owned by the correct thread and/or are resident on the correct cpu socket and memory domain.

previously, there existed an ugly dependency chain in our init: while the large majority of the provider properties that we care about can be extracted from fi_getinfo responses, some can only be effectively queried by attempting mutations against an existing endpoint/domain/etc and seeing if it failed or not. A further subset of these properties need to be exposed back by nccl-net-ofi to nccl, at the time of getProperties, and prior to communicator instantiation.

to work around this, late in init we pick a device, instantiate it, query the attributes we need for getProperties, and then tear it all down. This is expensive and delays our init, as well as exposing us to bugs from incomplete teardown.

The sole case in the codebase today where this is necessary today is around detecting gdr support for FI_HMEM_CUDA. With dmabuf now as the default, it's relatively safe to just avoid the call and optimistically assume support when both cuda properties are true and when FI_HMEM is available in the provider.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
