### PR TITLE
platform-aws: bump libfabric requirement to 1.22

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -56,6 +56,12 @@ jobs:
           - latest
           - 1.25.0
         include:
+          - efainstaller: latest
+            platform-aws: enable
+
+          - efainstaller: 1.25.0
+            platform-aws: disable
+
           - container: public.ecr.aws/amazonlinux/amazonlinux:2023
             displayname: al2023
             efainstallerdir: ALINUX2023
@@ -110,7 +116,7 @@ jobs:
                         --enable-tests=yes \
                         --enable-werror=yes \
                         --enable-picky-compiler=yes \
-                        --enable-platform-aws \
+                        --${{ matrix.platform-aws }}-platform-aws \
                         --enable-neuron
           else
             ./configure --with-mpi=/opt/amazon/openmpi \
@@ -118,7 +124,7 @@ jobs:
                         --enable-tests=yes \
                         --enable-werror=yes \
                         --enable-picky-compiler=yes \
-                        --enable-platform-aws \
+                        --${{ matrix.platform-aws }}-platform-aws \
                         --with-cuda=/usr/local/cuda/
           fi
 

--- a/m4/ax_platform_aws.m4
+++ b/m4/ax_platform_aws.m4
@@ -21,17 +21,17 @@ AC_DEFUN([AX_CHECK_PLATFORM_AWS],[
   AM_CONDITIONAL([WANT_PLATFORM_AWS], [test "${want_platform_aws}" = "yes"])
   AS_IF([test "${want_platform_aws}" = "yes"],
         [NCCL_OFI_PLATFORM="AWS"
-         AC_MSG_CHECKING([for Libfabric 1.18.0 or later])
+         AC_MSG_CHECKING([for Libfabric 1.22.0 or greater])
          AC_COMPILE_IFELSE([AC_LANG_PROGRAM(
 [[#include <rdma/fabric.h>
 ]],
 [[#if !defined(FI_MAJOR_VERSION)
 #error "we cannot check the version -- sad panda"
-#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION(1,18))
+#elif FI_VERSION_LT(FI_VERSION(FI_MAJOR_VERSION, FI_MINOR_VERSION), FI_VERSION(1,22))
 #error "version is too low -- nopes"
 #endif
 ]])],
              [AC_MSG_RESULT([yes])],
              [AC_MSG_RESULT([no])
-	      AC_MSG_ERROR([On AWS platforms, Libfabric 1.18.0 or later is required])])
+	      AC_MSG_ERROR([On AWS platforms, Libfabric 1.22.0 or later is required])])
         NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --enable-platform-aws=${enable_platform_aws}"])])

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -608,15 +608,9 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s (found %d nics)",
 		      selected_provider->fabric_attr->prov_name, num_providers);
 
-	/* Prior to Libfabric 1.18.0, there was no way to disable
-	 * Libfabric from making CUDA calls.  While the EFA path was
-	 * CUDA clean, it could use the shm provider, which did make
-	 * CUDA calls.  Rather than muck with side channel ways of
-	 * disabling CUDA in old Libfabric, just require newer
-	 * Libfabric. */
 	if (strncmp("efa", selected_provider->fabric_attr->prov_name, strlen("efa")) == 0) {
-		if (FI_VERSION_LT(fi_version(), FI_VERSION(1, 18))) {
-			NCCL_OFI_WARN("EFA provider requires at least libfabric version 1.18.0.");
+		if (FI_VERSION_LT(fi_version(), FI_VERSION(1, 22))) {
+			NCCL_OFI_WARN("EFA provider requires at least libfabric version 1.22.0.");
 			return -ENOTSUP;
 		}
 	}

--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -353,8 +353,16 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 #endif
 
-	/* Set Libfabric endpoint option FI_OPT_CUDA_API_PERMITTED to false if
-	 * using the Libfabric 1.18 API with HMEM support.
+	/*
+	 * Set Libfabric endpoint option FI_OPT_CUDA_API_PERMITTED to false if using
+	 * the Libfabric 1.18 API with HMEM support, and the device supports GDR.
+	 *
+	 * Prior to Libfabric 1.18.0, there was no way to disable
+	 * Libfabric from making CUDA calls.  While the EFA path was
+	 * CUDA clean, it could use the shm provider, which did make
+	 * CUDA calls.  Rather than muck with side channel ways of
+	 * disabling CUDA in old Libfabric, just require newer
+	 * Libfabric.
 	 */
 	if (FI_VERSION_GE(info->fabric_attr->api_version,
 			  FI_VERSION(1, 18)) && support_gdr != GDR_UNSUPPORTED) {


### PR DESCRIPTION
p5en bring-up has exposed a set of interconnected bugs across libfabric
and the plugin to the point that it's become difficult to reason about
how fixes apply retroactively to older libfabric releases. Bump the
required version to 1.22 when building with platform-aws for our 1.13.x
series to enforce that users aren't running a mixture of versions that
developers haven't tested.

Signed-off-by: Nicholas Sielicki <nslick@amazon.com>