### PR TITLE
fix: Fallback to internal tuner on NCCL-2.21.5 for PAT

### DIFF
--- a/src/tuner/nccl_ofi_regions.c
+++ b/src/tuner/nccl_ofi_regions.c
@@ -892,6 +892,10 @@ ncclResult_t region_get_coll_info_internal_v2(nccl_ofi_tuner_context_t *ctx,
 
 	/* Check all regions */
 	for (size_t i = 0; i < region_ctx->num_regions[collType] && in_out < 0; i++) {
+		/* PAT is not supported in V2 tuner, in this case revert to nccl internal tuner */
+		if (region_ctx->regions[collType][i].algorithm == NCCL_ALGO_PAT) {
+			continue;
+		}
 		if (region_ctx->regions[collType][i].algorithm == NCCL_ALGO_NVLS_TREE && nvlsSupport == 0) {
 			continue;
 		}


### PR DESCRIPTION
Since PAT is not supported on NCCL 2.21.5-1,
in this case fallback to NCCL internal tuner.

*Description of changes:*
Change the tuner v2 api to fallback to internal tuner in case the ALGO is PAT

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
