### PR TITLE
Add tuner region unit test to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tests/unit/show_tuner_decisions
 tests/unit/show_tuner_costs
 tests/unit/ep_addr_list
 tests/unit/mr
+tests/unit/region_based_tuner
 
 # http://www.gnu.org/software/automake
 .deps/


### PR DESCRIPTION
Add the recently added tuner region unit test binary to the list of files that git should ignore.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
