### PR TITLE
[v1.13.x-aws] nvtx: associate eager recv with NVTX domain

### DIFF
--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -181,7 +181,15 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 } while(0)
 
 #define NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num) do { \
-	nvtx_mark_domain(NULL, "Eager_recv", 0x0000FF); \
+	nvtxDomainHandle_t handle; \
+	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+		handle = comm->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
+	} \
+	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+		handle = ((nccl_net_ofi_rdma_device_t*)(r_comm->base.base.ep->device))->nvtx_domain[rail_id]; \
+		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
+	} \
 } while(0)
 
 #define NCCL_OFI_TRACE_FLUSH_NVTX(request, nccl_req) do { \


### PR DESCRIPTION
Event was previously associated with NULL domain, hindering ability to match with parent recv request

Signed-off-by: Eric Raut <eraut@amazon.com>
(cherry picked from commit a1c9db98b6b94cbecd8e95d2647815676f8ed111)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
