### PR TITLE
rdma: Skip eager protocol when writes outstanding

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -498,6 +498,8 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	nccl_net_ofi_send_comm_t base;
 
 	uint64_t num_inflight_reqs;
+	uint64_t num_inflight_writes;
+
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
 	/* Comm ID provided by the local endpoint */


### PR DESCRIPTION
The LL128 protocol causes an interesting pattern where there's a long string of large-ish messages and then a "leftover", most notable on power of 2 message sizes like are used in benchmarks. If that leftover bit is eager sized, you end up with an eager message queued behind a bunch of writes, which doesn't gain you anything in latency hiding the receive request, but then costs you the fixup on the remote side.

This patch implements an overly simplistic version of runting, which skips eager if there is already a write outstanding on the communicator.  This is wrong for a couple reasons.  First, we should probably use a BDP or similar to determine how much data should be in flight before we skip the eager protocol. Second, we should really decrement the counter on cqe processing time, but that is a locking mess.  And finally, it should really be a domain counter instead of a communicator counter, but again, see the locking mess comment.  The NCCL communication patterns are generally simple enough that none of these really seem to matter, so we go with simplicity for now.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
