### PR TITLE
fix : Converge the Ring-LL region at TUNER_MAX_RANKS

### DIFF
--- a/src/tuner/nccl_ofi_regions.c
+++ b/src/tuner/nccl_ofi_regions.c
@@ -356,8 +356,8 @@ static ncclResult_t region_init_internal_p5en(nccl_ofi_tuner_region_context_t *r
 			const nccl_ofi_tuner_region_t regions[] = {
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL,
-				 .num_vertices = 6,
-				 .vertices = {{0, 16}, {131072, 16}, {262144, 32}, {8388608, 256}, {33554432, 1024}, extended_ring_ll}},
+				 .num_vertices = 7,
+				 .vertices = {{0, 16}, {131072, 16}, {262144, 32}, {8388608, 256}, {33554432, 1024}, extended_ring_ll, {0, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL128,
 				 .num_vertices = 10,
@@ -399,8 +399,8 @@ static ncclResult_t region_init_internal_p5en(nccl_ofi_tuner_region_context_t *r
 			const nccl_ofi_tuner_region_t regions[] = {
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL,
-				 .num_vertices = 6,
-				 .vertices = {{0, 16}, {131072, 16}, {262144, 32}, {8388608, 256}, {33554432, 1024}, extended_ring_ll}},
+				 .num_vertices = 7,
+				 .vertices = {{0, 16}, {131072, 16}, {262144, 32}, {8388608, 256}, {33554432, 1024}, extended_ring_ll, {0, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL128,
 				 .num_vertices = 10,


### PR DESCRIPTION
*Description of changes:*
Currently the Ring-LL region for AG0x0 and RS0x0 starts with the point {0, 16} and extends till {TUNER_MAX_SIZE, TUNER_MAX_RANKS}. But the polygon was not completely closed without a point on the y-axis. Added a points {0, TUNER_MAX_RANKS}. This ensures the polygon is closed correctly.

*Testing*
Tested that the tuner is making the correct decisions by running unit tests show_tuner_decisions with AG0x0 and RS0x0 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
