### PR TITLE
Switch from fine grained locking throughout the code base to device and domain level locking

### DIFF
--- a/include/nccl_ofi_deque.h
+++ b/include/nccl_ofi_deque.h
@@ -47,8 +47,6 @@ struct nccl_ofi_deque_t {
 	 * locations.
 	 */
 	nccl_ofi_deque_elem_t head;
-	/* Lock for deque operations */
-	pthread_mutex_t lock;
 };
 typedef struct nccl_ofi_deque_t nccl_ofi_deque_t;
 
@@ -79,16 +77,12 @@ static inline int nccl_ofi_deque_insert_back(nccl_ofi_deque_t *deque, nccl_ofi_d
 	assert(deque);
 	assert(deque_elem);
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
 	deque_elem->next = &deque->head;
 	deque_elem->prev = deque->head.prev;
 
 	assert(deque->head.prev);
 	deque->head.prev->next = deque_elem;
 	deque->head.prev = deque_elem;
-
-	nccl_net_ofi_mutex_unlock(&deque->lock);
 
 	return 0;
 }
@@ -104,8 +98,6 @@ static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	assert(deque);
 	assert(deque_elem);
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
 	deque_elem->next = deque->head.next;
 	deque_elem->prev = &deque->head;
 
@@ -113,13 +105,11 @@ static inline int nccl_ofi_deque_insert_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	deque->head.next->prev = deque_elem;
 	deque->head.next = deque_elem;
 
-	nccl_net_ofi_mutex_unlock(&deque->lock);
-
 	return 0;
 }
 
 /*
- * Check if the deque is empty. This call does not take the mutex.
+ * Check if the deque is empty.
  *
  * @return true if empty, false if not
  */
@@ -138,27 +128,20 @@ static inline int nccl_ofi_deque_remove_front(nccl_ofi_deque_t *deque, nccl_ofi_
 	assert(deque);
 	assert(deque_elem);
 
-	/* Shortcut to avoid taking mutex for empty deque */
 	if (nccl_ofi_deque_isempty(deque)) {
 		*deque_elem = NULL;
 		return 0;
 	}
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
-	/* Check for empty deque. We need to do this again because the check above
-	   was before we acquired the lock. */
-	if (nccl_ofi_deque_isempty(deque)) {
-		*deque_elem = NULL;
-		goto unlock;
-	}
-
 	*deque_elem = deque->head.next;
+	/* gcc 7.3.1 (AL2) is terrified *deque_elem is NULL here.
+	 * None of us can figure out why, but add this check to make
+	 * the compiler happy. */
+	if (OFI_UNLIKELY(*deque_elem == NULL)) {
+		return 0;
+	}
 	deque->head.next = (*deque_elem)->next;
 	(*deque_elem)->next->prev = &deque->head;
-
-unlock:
-	nccl_net_ofi_mutex_unlock(&deque->lock);
 
 	return 0;
 }
@@ -171,8 +154,6 @@ static inline void nccl_ofi_deque_remove(nccl_ofi_deque_t *deque, nccl_ofi_deque
 	assert(deque);
 	assert(deque_elem);
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
 	assert(deque_elem->prev && deque_elem->next);
 
 	deque_elem->prev->next = deque_elem->next;
@@ -183,8 +164,6 @@ static inline void nccl_ofi_deque_remove(nccl_ofi_deque_t *deque, nccl_ofi_deque
 	/* Reset deque_elem pointers to avoid dangling pointers */
 	deque_elem->prev = NULL;
 	deque_elem->next = NULL;
-
-	nccl_net_ofi_mutex_unlock(&deque->lock);
 }
 
 /**
@@ -196,15 +175,12 @@ static inline nccl_ofi_deque_elem_t *nccl_ofi_deque_get_front(nccl_ofi_deque_t *
 
 	nccl_ofi_deque_elem_t *ret_elem = NULL;
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
 	if (nccl_ofi_deque_isempty(deque)) {
 		ret_elem = NULL;
 	} else {
 		ret_elem = deque->head.next;
 	}
 
-	nccl_net_ofi_mutex_unlock(&deque->lock);
 	return ret_elem;
 }
 
@@ -218,14 +194,10 @@ static inline nccl_ofi_deque_elem_t *nccl_ofi_deque_get_next(nccl_ofi_deque_t *d
 
 	nccl_ofi_deque_elem_t *ret_elem = NULL;
 
-	nccl_net_ofi_mutex_lock(&deque->lock);
-
 	ret_elem = deque_elem->next;
 	if (ret_elem == (&deque->head)) {
 		ret_elem = NULL;
 	}
-
-	nccl_net_ofi_mutex_unlock(&deque->lock);
 
 	return ret_elem;
 }

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -23,9 +23,6 @@ typedef struct nccl_ofi_idpool {
 	/* ID pool bit array. A bit set in the array indicates
 	   that the ID corresponding to its index is available.*/
 	uint64_t *ids;
-
-	/* Lock for concurrency */
-	pthread_mutex_t lock;
 } nccl_ofi_idpool_t;
 
 /*

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -182,7 +182,6 @@ typedef struct nccl_ofi_mr_cache {
 	size_t used;
 	uint32_t hit_count;
 	uint32_t miss_count;
-	pthread_mutex_t lock;
 } nccl_ofi_mr_cache_t;
 
 /**

--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -99,8 +99,6 @@ typedef struct {
 	uint16_t msg_last_incomplete;
 	// Points to the message after the inserted message with highest sequence number.
 	uint16_t msg_next;
-	// Mutex for this msg buffer -- locks all non-init operations
-	pthread_mutex_t lock;
 } nccl_ofi_msgbuff_t;
 
 /**

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -123,6 +123,7 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  * allocate a RDMA memory registration handle with `num_rails`+`num_control_rails` rails.
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
+	struct nccl_net_ofi_rdma_device *device;
 
 	int num_rails;
 
@@ -394,12 +395,6 @@ typedef struct nccl_net_ofi_rdma_req {
 	/* Size of completed request */
 	size_t size;
 
-	/*
-	 * Protect updating critical fields such as size and ncompls when
-	 * network xfer happened over multiple rails
-	 */
-	pthread_mutex_t req_lock;
-
 	/* State of request */
 	nccl_net_ofi_rdma_req_state_t state;
 
@@ -533,7 +528,6 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 
 	nccl_ofi_deque_elem_t cleanup_list_elem;
 
-	pthread_mutex_t ctrl_recv_lock;
 	bool received_close_message;
 	/* Counters for total sent and received control messages */
 	uint64_t n_ctrl_received;
@@ -613,7 +607,6 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	nccl_ofi_deque_elem_t cleanup_list_elem;
 
 	/* Counters for total sent and received control messages */
-	pthread_mutex_t ctrl_counter_lock;
 	uint64_t n_ctrl_sent;
 	uint64_t n_ctrl_delivered;
 
@@ -838,6 +831,8 @@ typedef struct nccl_net_ofi_rdma_domain {
 
 	/* List of endpoints and set of addresses they have connections to */
 	nccl_ofi_ep_addr_list_t *ep_addr_list;
+
+	pthread_mutex_t rdma_domain_lock;
 } nccl_net_ofi_rdma_domain_t;
 
 

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -94,8 +94,7 @@ typedef struct nccl_net_ofi_threshold_scheduler {
 	nccl_net_ofi_scheduler_t base;
 	/* Round robin counter */
 	unsigned int rr_counter;
-	/* Lock for round robin counter */
-	pthread_mutex_t rr_lock;
+
 	/* Minimum size of the message in bytes before message is
 	 * multiplexed */
 	size_t min_stripe_size;

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -58,6 +58,7 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
                   FI_OPT_MAX_MSG_SIZE,
                   FI_OPT_SHARED_MEMORY_PERMITTED,
                   FI_MR_DMABUF,
+		  FI_PROGRESS_CONTROL_UNIFIED,
 		  FI_OPT_INJECT_RMA_SIZE],
                   [], [], [AC_INCLUDES_DEFAULT
 [#include <rdma/fi_endpoint.h>

--- a/src/nccl_ofi_deque.c
+++ b/src/nccl_ofi_deque.c
@@ -23,13 +23,6 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 	deque->head.prev = &deque->head;
 	deque->head.next = &deque->head;
 
-	int ret = pthread_mutex_init(&deque->lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to initialize deque mutex.");
-		free(deque);
-		return -ret;
-	}
-
 	assert(deque_p);
 	*deque_p = deque;
 
@@ -39,14 +32,6 @@ int nccl_ofi_deque_init(nccl_ofi_deque_t **deque_p)
 int nccl_ofi_deque_finalize(nccl_ofi_deque_t *deque)
 {
 	assert(deque);
-
-	/* Since user allocates all memory used for deque elements, we don't need to
-	   deallocate any entries here. :D */
-	int ret = pthread_mutex_destroy(&deque->lock);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to destroy deque mutex.");
-		return -ret;
-	}
 
 	free(deque);
 	return 0;

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -92,17 +92,9 @@ static int freelist_init_internal(size_t entry_size,
 	freelist->deregmr_fn = deregmr_fn;
 	freelist->regmr_opaque = regmr_opaque;
 
-	ret = pthread_mutex_init(&freelist->lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
-		free(freelist);
-		return -ret;
-	}
-
 	ret = nccl_ofi_freelist_add(freelist, initial_entry_count);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Allocating initial freelist entries failed: %d", ret);
-		pthread_mutex_destroy(&freelist->lock);
 		free(freelist);
 		return ret;
 
@@ -194,8 +186,6 @@ int nccl_ofi_freelist_fini(nccl_ofi_freelist_t *freelist)
 
 	freelist->entry_size = 0;
 	freelist->entries = NULL;
-
-	pthread_mutex_destroy(&freelist->lock);
 
 	free(freelist);
 

--- a/src/nccl_ofi_mr.c
+++ b/src/nccl_ofi_mr.c
@@ -37,9 +37,6 @@ nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
 		goto error;
 	}
 
-	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
-		goto error;
-	}
 	/*
 	 * System page size isn't reflective of the GDR mappings. We're not trying to map a
 	 * whole page, but just to find an interval that makes an array-based cache manageable.
@@ -70,8 +67,6 @@ void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache)
 		      "MR cache %d hits %d misses",
 		      cache->hit_count,
 		      cache->miss_count);
-
-	nccl_net_ofi_mutex_destroy(&cache->lock);
 
 	free(cache->slots);
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -7744,14 +7744,22 @@ static void get_hints(struct fi_info *hints)
 	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM | FI_MR_VIRT_ADDR |
 		FI_MR_ALLOCATED | FI_MR_PROV_KEY;
 	hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
-	hints->domain_attr->threading = FI_THREAD_SAFE;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
-	/* Set progress mode to unspec to use the provider's default
-	 * mode.  We hard poll for completion, but if a provider is
-	 * faster with async progress, then we don't really care and
-	 * should let it do that. */
+	/* If libfabric is new enough to support
+	 * FI_PROGRESS_CONTROL_UNIFIED, specify MANUAL /
+	 * CONTROL_UNIFIED progress, to remove the domain lock from
+	 * the completion queue polling.  Otherwise, set
+	 * PROGRESS_UNSPEC to allow the provider to pick what it
+	 * thinks will go fastsest.
+	 */
+#if HAVE_DECL_FI_PROGRESS_CONTROL_UNIFIED
+	hints->domain_attr->control_progress = FI_PROGRESS_CONTROL_UNIFIED;
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+#else
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;;
+#endif
 }
 
 

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2849,9 +2849,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret = nccl_ofi_mr_cache_del_entry(mr_cache, mr_handle);
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -3001,7 +2999,6 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 		 * MR cache is locked between lookup and insert, to be sure we
 		 * insert a missing entry
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = (nccl_net_ofi_rdma_mr_handle_t *)
 			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey);
 
@@ -3032,10 +3029,6 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 	}
 
 exit:
-	if (mr_cache) {
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
-	}
-
 	*mhandle = ret_handle;
 	return ret;
 }

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -99,7 +99,6 @@ static size_t eager_max_size = 0;
 /* List of comms undergoing deferred cleanup */
 static nccl_ofi_deque_t *s_comm_cleanup_list = NULL;
 static nccl_ofi_deque_t *r_comm_cleanup_list = NULL;
-static pthread_mutex_t comm_cleanup_list_lock = PTHREAD_MUTEX_INITIALIZER;
 /* Number of open (not finalizing) send and recv comms */
 static int num_open_comms = 0;
 
@@ -750,7 +749,6 @@ static inline int inc_req_completion(nccl_net_ofi_rdma_req_t *req,
 {
 	int ret = 0;
 	int ncompls;
-	nccl_net_ofi_mutex_lock(&req->req_lock);
 
 	req->size += size;
 	ncompls = ++(req->ncompls);
@@ -764,8 +762,6 @@ static inline int inc_req_completion(nccl_net_ofi_rdma_req_t *req,
 		/* Trace this completion */
 		NCCL_OFI_TRACE_COMPLETIONS(req->dev_id, req, req);
 	}
-
-	nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 	return -ret;
 }
@@ -795,13 +791,9 @@ static inline int set_eager_copy_completed(nccl_net_ofi_rdma_req_t *req)
 	nccl_net_ofi_rdma_req_t *recv_req = eager_copy_data->recv_req;
 	rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 
-	nccl_net_ofi_mutex_lock(&req->req_lock);
-
 	/* Set send ctrl request completed */
 	req->ncompls = 1;
 	req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
-
-	nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 	/* Get size of received data */
 	rdma_req_rx_buff_data_t *rx_buff_data = get_rx_buff_data(eager_copy_data->eager_rx_buff_req);
@@ -826,10 +818,6 @@ static inline int set_eager_copy_completed(nccl_net_ofi_rdma_req_t *req)
  * Set send ctrl request to completed. Furthermore, increment
  * completions of parent request (receive request).
  *
- * Modifications of the send control request are guarded by the send
- * control request's lock.  Modifications of the receive request are
- * guarded by the receive request's lock.
- *
  * @param	req
  *		Send ctrl request
  * @return	0, on success
@@ -846,17 +834,11 @@ static inline int set_send_ctrl_completed(nccl_net_ofi_rdma_req_t *req)
 	nccl_net_ofi_rdma_recv_comm_t *r_comm =
 		(nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 
-	nccl_net_ofi_mutex_lock(&req->req_lock);
-
 	/* Set send ctrl request completed */
 	req->ncompls = 1;
 	req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
 
-	nccl_net_ofi_mutex_unlock(&req->req_lock);
-
-	nccl_net_ofi_mutex_lock(&r_comm->ctrl_counter_lock);
 	r_comm->n_ctrl_delivered += 1;
-	nccl_net_ofi_mutex_unlock(&r_comm->ctrl_counter_lock);
 
 	/* Add completion to parent request */
 	return inc_req_completion(recv_req, 0, recv_data->total_num_compls);
@@ -868,10 +850,6 @@ static inline int set_send_ctrl_completed(nccl_net_ofi_rdma_req_t *req)
  * Increment segment completions of receive segment request. In case
  * all segments arrived, increment completions of parent request
  * (receive request).
- *
- * Modifications of the receive segment request are guarded by the
- * receive segment request's lock.  Modifications of the receive
- * request are guarded by the receive request's lock.
  *
  * @param	req
  *		Receive request
@@ -888,8 +866,6 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req_t *req,
 	assert(req->type == NCCL_OFI_RDMA_RECV_SEGMS);
 	int ret = 0;
 	bool segms_received;
-	
-	nccl_net_ofi_mutex_lock(&req->req_lock);
 
 	/* Sum up segment sizes */
 	req->size += size;
@@ -909,16 +885,8 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req_t *req,
 		/* Total number of completions have arrived */
 		req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
 
-		/* Release lock of receive segment request before
-		 * receive request is set to completed to avoid
-		 * unlocking receive segment request after it has been
-		 * freed in `test()` */
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
-		
 		/* Add completion to parent request */
 		ret = inc_req_completion(recv_req, req->size, recv_data->total_num_compls);
-	} else {
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 	}
 
 	return ret;
@@ -949,14 +917,12 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm_t *s_
 	send_data->remote_len = ctrl_msg->buff_len;
 
 	/* If recv buffer is smaller than send buffer, we reduce the size of the send req */
-	nccl_net_ofi_mutex_lock(&req->req_lock);
 	if (send_data->remote_len < send_data->buff_len) {
 		NCCL_OFI_TRACE(NCCL_NET, "Remote recv buffer (%zu) smaller than send buffer (%zu)",
 			       send_data->remote_len, send_data->buff_len);
 		req->size = send_data->remote_len;
 		send_data->buff_len = send_data->remote_len;
 	}
-	nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 	send_data->schedule = scheduler->get_schedule(scheduler, send_data->buff_len, device->num_rails);
 	if (OFI_UNLIKELY(send_data->schedule == NULL)) {
@@ -1025,12 +991,8 @@ static inline int repost_rx_buff(nccl_net_ofi_rdma_ep_t *ep,
 static inline int decrease_rx_buff_cnt(nccl_net_ofi_rdma_ep_t *ep,
 					   nccl_net_ofi_ep_rail_t *rail)
 {
-	nccl_net_ofi_mutex_lock(&rail->rx_buff_mutex);
-
 	assert(rail->num_rx_buff_posted > 0);
 	rail->num_rx_buff_posted--;
-
-	nccl_net_ofi_mutex_unlock(&rail->rx_buff_mutex);
 
 	return check_post_rx_buffers_rail(ep, rail);
 }
@@ -1102,7 +1064,6 @@ static inline int handle_ctrl_recv(nccl_net_ofi_rdma_send_comm_t *s_comm,
 		/* If recv buffer is smaller than send buffer, we reduce the size of the send req, even if we have
 		   have already eagerly sent the whole send buffer. The receive side will discard the extra data. */
 		send_data->remote_len = ctrl_msg->buff_len;
-		nccl_net_ofi_mutex_lock(&req->req_lock);
 		if (send_data->remote_len < send_data->buff_len) {
 			NCCL_OFI_TRACE(NCCL_NET,
 				       "Remote recv buffer (%zu) smaller than send buffer (%zu) in eager send",
@@ -1110,7 +1071,6 @@ static inline int handle_ctrl_recv(nccl_net_ofi_rdma_send_comm_t *s_comm,
 			req->size = send_data->remote_len;
 			send_data->buff_len = send_data->remote_len;
 		}
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 		/* In the eager case, increment completion count for send req */
 		ret = inc_req_completion(req, 0, send_data->total_num_compls);
@@ -1257,13 +1217,9 @@ static int handle_close_msg_recv(nccl_net_ofi_rdma_req_t *rx_buff_req)
 	nccl_net_ofi_rdma_send_comm_t *s_comm = rdma_device_get_send_comm(device, close_msg->send_comm_id);
 	assert(s_comm);
 
-	nccl_net_ofi_mutex_lock(&s_comm->ctrl_recv_lock);
-
 	assert(s_comm->received_close_message == false);
 	s_comm->received_close_message = true;
 	s_comm->n_ctrl_expected = close_msg->ctrl_counter;
-
-	nccl_net_ofi_mutex_unlock(&s_comm->ctrl_recv_lock);
 
 	return repost_rx_buff(ep, rx_buff_req);
 }
@@ -1383,9 +1339,7 @@ static inline int handle_rx_buff_recv(nccl_net_ofi_rdma_device_t *device, int ra
 			goto exit;
 		}
 
-		nccl_net_ofi_mutex_lock(&s_comm->ctrl_recv_lock);
 		s_comm->n_ctrl_received += 1;
-		nccl_net_ofi_mutex_unlock(&s_comm->ctrl_recv_lock);
 
 		break;
 	case NCCL_OFI_RDMA_MSG_CLOSE:
@@ -2064,8 +2018,6 @@ static inline int free_base_req(uint64_t *num_inflight_reqs,
 		goto exit;
 	}
 
-	nccl_net_ofi_mutex_destroy(&req->req_lock);
-
 	/* Update free list */
 	if (OFI_UNLIKELY(nccl_ofi_reqs_fl == NULL)) {
 		ret = -EINVAL;
@@ -2394,12 +2346,8 @@ static inline int handle_rx_eagain(nccl_net_ofi_rdma_ep_t *ep,
 	}
 	NCCL_OFI_TRACE_PENDING_INSERT(req);
 
-	nccl_net_ofi_mutex_lock(&rail->rx_buff_mutex);
-
 	assert(rail->num_rx_buff_posted >= num_buffs_failed);
 	rail->num_rx_buff_posted -= num_buffs_failed;
-
-	nccl_net_ofi_mutex_unlock(&rail->rx_buff_mutex);
 
 	return ret;
 }
@@ -2409,13 +2357,9 @@ static inline int post_rx_buffs_on_rail(nccl_net_ofi_rdma_ep_t *ep,
 {
 	int ret = 0;
 
-	nccl_net_ofi_mutex_lock(&rail->rx_buff_mutex);
-
 	size_t buffers_needed = rail->max_rx_buff_posted -
 				rail->num_rx_buff_posted;
 	rail->num_rx_buff_posted = rail->max_rx_buff_posted;
-
-	nccl_net_ofi_mutex_unlock(&rail->rx_buff_mutex);
 
 	/* Post all the rx buffers we need */
 	for (size_t i = 0; i < buffers_needed; ++i) {
@@ -2654,8 +2598,6 @@ static int finish_connect(nccl_net_ofi_rdma_send_comm_t *s_comm)
 	return ret;
 }
 
-#define __compiler_barrier() do { asm volatile ("" : : : "memory"); } while(0)
-
 static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 {
 	int ret = 0;
@@ -2675,6 +2617,8 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_comm->ep;
 	assert(ep != NULL);
 
+	nccl_net_ofi_mutex_lock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
+
 	/* Process more completions unless the current request is
 	 * completed */
 	if (req->state != NCCL_OFI_RDMA_REQ_COMPLETED
@@ -2688,11 +2632,8 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	if (OFI_LIKELY(req->state == NCCL_OFI_RDMA_REQ_COMPLETED)) {
 
 		size_t req_size;
-		nccl_net_ofi_mutex_lock(&req->req_lock);
 
 		req_size = req->size;
-
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 		if (size)
 			*size = req_size;
@@ -2735,6 +2676,8 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	}
 
  exit:
+	nccl_net_ofi_mutex_unlock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
+
 	return ret;
 }
 
@@ -2766,7 +2709,6 @@ static void prepare_send_conn_resp_req(nccl_net_ofi_rdma_listen_comm_t *l_comm)
  */
 static int prepare_recv_conn_req(nccl_net_ofi_rdma_listen_comm_t *l_comm)
 {
-	int ret;
 	nccl_net_ofi_rdma_req_t *req = &l_comm->req;
 
 	req->type = NCCL_OFI_RDMA_RECV_CONN;
@@ -2775,12 +2717,6 @@ static int prepare_recv_conn_req(nccl_net_ofi_rdma_listen_comm_t *l_comm)
 	req->state = NCCL_OFI_RDMA_REQ_PENDING;
 	req->comm = &l_comm->base.base;
 	req->dev_id = l_comm->base.base.dev_id;
-	/* Initialize mutex for request access */
-	ret = nccl_net_ofi_mutex_init(&req->req_lock, NULL);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to initialize mutex");
-		return -ret;
-	}
 
 	return 0;
 }
@@ -2975,6 +2911,8 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 		ret = -ENOMEM;
 		goto exit;
 	}
+
+	ret_handle->device = device;
 
 	/* Create memory registration request */
 	ret = set_mr_req_attr(key_pool, dev_id, ckey, &regattr_flags, type, &mr_attr);
@@ -3171,30 +3109,40 @@ static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 			    nccl_ofi_mr_ckey_ref ckey,
 			    int type, void **mhandle)
 {
+	int ret;
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)send_comm->base.ep;
 	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 	assert(domain != NULL);
 
-	return reg_mr_ep(ep,
-			 ckey,
-			 type,
-			 domain->base.mr_cache,
-			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
+	ret = reg_mr_ep(ep,
+			ckey,
+			type,
+			domain->base.mr_cache,
+			(nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	return ret;
 }
 
 static int reg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 			    nccl_ofi_mr_ckey_ref ckey,
 			    int type, void **mhandle)
 {
+	int ret;
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)recv_comm->base.ep;
 	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 	assert(domain != NULL);
 
-	return reg_mr_ep(ep,
-			 ckey,
-			 type,
-			 domain->base.mr_cache,
-			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
+	ret = reg_mr_ep(ep,
+			ckey,
+			type,
+			domain->base.mr_cache,
+			(nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	return ret;
 }
 
 typedef struct {
@@ -3258,6 +3206,8 @@ static int freelist_deregmr_host_fn(void *handle)
 static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 						nccl_net_ofi_mr_handle_t *mhandle)
 {
+	int ret;
+
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)recv_comm->base.ep;
 	assert(ep != NULL);
@@ -3266,7 +3216,12 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	assert(domain != NULL);
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
+	ret = dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	return ret;
 }
 
 /*
@@ -3290,16 +3245,7 @@ static inline nccl_net_ofi_rdma_req_t *allocate_req(nccl_ofi_freelist_t *fl)
 	req->base.test = test;
 	req->ncompls = 0;
 
-	/* Initialize mutex for request access */
-	if (nccl_net_ofi_mutex_init(&req->req_lock, NULL)) {
-		NCCL_OFI_WARN("Unable to initialize mutex");
-		goto cleanup;
-	}
-
 	return req;
-cleanup:
-	nccl_ofi_freelist_entry_free(fl, elem);
-	return NULL;
 }
 
 /**
@@ -3579,15 +3525,13 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 
 	if (r_comm->comm_active == false) {
 		NCCL_OFI_WARN("Called irecv on inactive communicator");
-		ret = -EINVAL;
-		goto error;
+		return -EINVAL;
 	}
 
 	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
-		ret = -ENOSPC;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
 			      NCCL_OFI_MAX_REQUESTS);
-		goto error;
+		return -ENOSPC;
 	}
 
 	dev_id = r_comm->base.base.dev_id;
@@ -3597,6 +3541,14 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 
 	device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
+
+	/* The Nvidia and Neuron threading guarantee is that at most
+	 * one thread will access communicator resources at a time.
+	 * This means that it is safe to manipulate the request
+	 * objects (which are per-communicator resources) outside of
+	 * the lock.
+	 */
+	nccl_net_ofi_mutex_lock(&rdma_endpoint_get_device(ep)->base.device_lock);
 
 	ret = process_cq_if_pending(ep);
 	if (ret == -EAGAIN) {
@@ -3682,9 +3634,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	NCCL_OFI_TRACE_RECV(dev_id, r_comm->local_comm_id, sizes[0], req, base_req);
 
 	/* Send ctrl msg */
-	nccl_net_ofi_mutex_lock(&r_comm->ctrl_counter_lock);
 	r_comm->n_ctrl_sent += 1;
-	nccl_net_ofi_mutex_unlock(&r_comm->ctrl_counter_lock);
 	ret = receive_progress(recv_data->send_ctrl_req, true);
 	if (OFI_UNLIKELY(ret != 0)) {
 		/* TODO: Remove req from message buffer */
@@ -3722,6 +3672,8 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		req->free(req, false);
 	*base_req = NULL;
  exit:
+	nccl_net_ofi_mutex_unlock(&rdma_endpoint_get_device(ep)->base.device_lock);
+
 	return ret;
 }
 
@@ -3907,7 +3859,6 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
 	}
 
-	ret = nccl_net_ofi_mutex_destroy(&r_comm->ctrl_counter_lock);
 	if (ret != 0) {
 		return ret;
 	}
@@ -3991,10 +3942,8 @@ static int recv_comm_process_all_finalizing(void)
 
 		if (r_comm->send_close_req == NULL) {
 			/* Waiting for all ctrls to complete */
-			nccl_net_ofi_mutex_lock(&r_comm->ctrl_counter_lock);
 			bool all_ctrl_msgs_delivered =
 				(r_comm->n_ctrl_delivered == r_comm->n_ctrl_sent);
-			nccl_net_ofi_mutex_unlock(&r_comm->ctrl_counter_lock);
 
 			if (all_ctrl_msgs_delivered) {
 				/* Send close message */
@@ -4012,10 +3961,7 @@ static int recv_comm_process_all_finalizing(void)
 		} else /* (r_comm->send_close_req != NULL) */ {
 
 			/* Waiting for close message delivery */
-			nccl_net_ofi_mutex_lock(&r_comm->send_close_req->req_lock);
 			nccl_net_ofi_rdma_req_state_t state = r_comm->send_close_req->state;
-			nccl_net_ofi_mutex_unlock(&r_comm->send_close_req->req_lock);
-
 			if (state == NCCL_OFI_RDMA_REQ_ERROR) {
 				NCCL_OFI_WARN("Send close message complete with error");
 				ret = -EIO;
@@ -4087,7 +4033,6 @@ static int send_comm_destroy(nccl_net_ofi_rdma_send_comm_t *s_comm)
 	}
 #endif
 
-	ret = nccl_net_ofi_mutex_destroy(&s_comm->ctrl_recv_lock);
 	if (ret != 0) {
 		return ret;
 	}
@@ -4125,13 +4070,8 @@ static int send_comm_process_all_finalizing(void)
 			goto exit;
 		}
 
-		nccl_net_ofi_mutex_lock(&s_comm->ctrl_recv_lock);
-
 		bool ready_to_destroy = (s_comm->received_close_message) &&
 			(s_comm->n_ctrl_received == s_comm->n_ctrl_expected);
-
-		nccl_net_ofi_mutex_unlock(&s_comm->ctrl_recv_lock);
-
 		if (ready_to_destroy) {
 			nccl_ofi_deque_remove(s_comm_cleanup_list, elem);
 
@@ -4206,8 +4146,6 @@ static int recv_close_deferred(nccl_net_ofi_recv_comm_t *recv_comm)
 
 	r_comm->comm_active = false;
 
-	nccl_net_ofi_mutex_lock(&comm_cleanup_list_lock);
-
 	/* Defer cleanup until we deliver all outstanding control messages
 	   and deliver the close message */
 	nccl_ofi_deque_insert_back(r_comm_cleanup_list,
@@ -4216,8 +4154,6 @@ static int recv_close_deferred(nccl_net_ofi_recv_comm_t *recv_comm)
 	assert(num_open_comms > 0);
 	num_open_comms--;
 	ret = comm_close_handler();
-
-	nccl_net_ofi_mutex_unlock(&comm_cleanup_list_lock);
 
  exit:
 	return ret;
@@ -4271,14 +4207,21 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	nccl_net_ofi_rdma_mr_handle_t **mr_handles = (nccl_net_ofi_rdma_mr_handle_t **)mhandles;
 
 	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
-		ret = -ENOSPC;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
 			      NCCL_OFI_MAX_REQUESTS);
-		goto error;
+		return -ENOSPC;
 	}
 
 	ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
 	assert(ep != NULL);
+
+	/* The Nvidia and Neuron threading guarantee is that at most
+	 * one thread will access communicator resources at a time.
+	 * This means that it is safe to manipulate the request
+	 * objects (which are per-communicator resources) outside of
+	 * the lock.
+	 */
+	nccl_net_ofi_mutex_lock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
 
 	/* Process any pending requests */
 	network_busy = false;
@@ -4362,6 +4305,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	if (req)
 		req->free(req, false);
  exit:
+	nccl_net_ofi_mutex_unlock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
 	*base_req = NULL;
 	return ret;
 }
@@ -4579,12 +4523,6 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		goto error;
 	}
 
-	ret = nccl_net_ofi_mutex_init(&r_comm->ctrl_counter_lock, NULL);
-	if (ret != 0) {
-		free_rdma_recv_comm(r_comm);
-		return NULL;
-	}
-
 	r_comm->base.base.type = NCCL_NET_OFI_RECV_COMM;
 	r_comm->base.base.dev_id = dev_id;
 	r_comm->base.regMr = reg_mr_recv_comm;
@@ -4788,7 +4726,6 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 				NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
 			}
 		}
-		nccl_net_ofi_mutex_destroy(&r_comm->ctrl_counter_lock);
 		free_rdma_recv_comm(r_comm);
 	}
 
@@ -4928,7 +4865,7 @@ static int close_listen_recv_comm(nccl_net_ofi_rdma_listen_comm_t *l_comm)
 static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 			   nccl_net_ofi_recv_comm_t **recv_comm)
 {
-	int ret = 0;
+	int close_ret, ret = 0;
 	nccl_net_ofi_rdma_req_state_t req_state;
 
 	nccl_net_ofi_rdma_listen_comm_t *l_comm =
@@ -4958,6 +4895,8 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	assert(domain != NULL);
 	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
 	assert(device != NULL);
+
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
 
 	int dev_id = device->base.dev_id;
 
@@ -5003,13 +4942,12 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		/* Check if the connect message is received */
-		nccl_net_ofi_mutex_lock(&req->req_lock);
 		req_state = req->state;
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 		/* Wait until connect message is sent */
 		if (req_state != NCCL_OFI_RDMA_REQ_COMPLETED) {
-			return 0;
+			ret = 0;
+			goto clean_exit;
 		}
 
 		/* Number of remote rails and number of local rails match */
@@ -5052,9 +4990,7 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		nccl_net_ofi_mutex_lock(&(domain->base.domain_lock));
 		ep->base.ref_cnt++;
-		nccl_net_ofi_mutex_unlock(&(domain->base.domain_lock));
 
 		/* Reset request state for connect response message */
 		prepare_send_conn_resp_req(l_comm);
@@ -5079,7 +5015,8 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		/* COMM_SEND_CONN: Send connect response message to remote */
 		ret = post_send_conn_resp(r_comm, conn_msg, device, ep, req);
 		if (ret == -FI_EAGAIN) {
-			return 0;
+			ret = 0;
+			goto clean_exit;
 		}
 		else if (ret != 0) {
 			goto exit;
@@ -5100,13 +5037,12 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		}
 
 		/* Check if the connect response message is sent */
-		nccl_net_ofi_mutex_lock(&req->req_lock);
 		req_state = req->state;
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 		/* Wait until connect response message is sent */
 		if (req_state != NCCL_OFI_RDMA_REQ_COMPLETED) {
-			return 0;
+			ret = 0;
+			goto clean_exit;
 		}
 
 		*recv_comm = &r_comm->base;
@@ -5125,19 +5061,23 @@ static int accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		NCCL_OFI_WARN("Invalid state of receive communicator object: %d",
 			      l_comm->stage);
 		ret = -EINVAL;
+		goto exit;
 	}
 
-	nccl_net_ofi_mutex_lock(&comm_cleanup_list_lock);
 	++num_open_comms;
-	nccl_net_ofi_mutex_unlock(&comm_cleanup_list_lock);
 
- exit:;
+ exit:
 	/* Close receive communicator in case listen operation failed */
-	int close_ret = close_listen_recv_comm(l_comm);
+	close_ret = close_listen_recv_comm(l_comm);
 	if (close_ret) {
 		NCCL_OFI_WARN("Failed to close listen communicator");
 	}
-	return ret ? ret : close_ret;
+	if (ret == 0) ret = close_ret;
+
+clean_exit:
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	return ret;
 }
 
 static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
@@ -5150,24 +5090,25 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_ep_t *base_ep = l_comm->base.base.ep;
 	assert(base_ep != NULL);
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_ep;
+
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
 
 	if (l_comm->req.state == NCCL_OFI_RDMA_REQ_PENDING) {
 		NCCL_OFI_WARN("Unable to free request of listen communicator. Request is still pending. Leaking memory.");
-		return -EINVAL;
+		ret = -EINVAL;
+		goto exit;
 	}
 
 	if (l_comm->r_comm) {
 		ret = recv_comm_destroy(l_comm->r_comm);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Unable to close receive communicator stored in listen communicator. Leaking memory.");
-			return ret;
+			goto exit;
 		}
-	}
-
-	ret = nccl_net_ofi_mutex_destroy(&l_comm->req.req_lock);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to destroy req_lock");
-		return -ret;
 	}
 
 	/* Release communicator ID */
@@ -5177,7 +5118,12 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, l_comm->comm_id);
 	}
 
+exit:
 	free(l_comm);
+
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	/* release_ep takes the base.device_lock */
 	ret = base_ep->release_ep(base_ep, false, false);
 
 	return ret;
@@ -5194,9 +5140,13 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 		(nccl_net_ofi_rdma_ep_t *)base_ep;
 	nccl_net_ofi_ep_rail_t *first_control_rail = rdma_endpoint_get_control_rail(ep, 0);
 
-	/* Retrieve and validate device */
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
+
 	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
+
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
 
 	int dev_id = device->base.dev_id;
 
@@ -5263,12 +5213,16 @@ error:
 	}
 	free(l_comm);
  exit:
+
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
 	return ret;
 }
 
 static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 				       nccl_net_ofi_mr_handle_t *mhandle)
 {
+	int ret;
+
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)send_comm->base.ep;
 	assert(ep != NULL);
@@ -5278,7 +5232,12 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle =
 		(nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
+	ret = dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
+
+	return ret;
 }
 
 static int alloc_rdma_write_req(nccl_net_ofi_rdma_send_comm_t *s_comm,
@@ -5802,18 +5761,13 @@ static inline int check_post_rx_buff_req(nccl_net_ofi_rdma_req_t *rx_buff_req)
 	int ret = 0;
 	rdma_req_rx_buff_data_t *rx_buff_data = get_rx_buff_data(rx_buff_req);
 	nccl_net_ofi_rdma_ep_t *ep = rx_buff_data->ep;
-
 	nccl_net_ofi_ep_rail_t *rail = rx_buff_data->rail;
-
-	nccl_net_ofi_mutex_lock(&rail->rx_buff_mutex);
 
 	bool need_post = false;
 	if (rail->num_rx_buff_posted < rail->max_rx_buff_posted) {
 		++(rail->num_rx_buff_posted);
 		need_post = true;
 	}
-
-	nccl_net_ofi_mutex_unlock(&rail->rx_buff_mutex);
 
 	if (need_post) {
 		/* Attempt to re-post rx buffer */
@@ -5866,22 +5820,28 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 
 	if (s_comm->comm_active == false) {
 		NCCL_OFI_WARN("Called isend on inactive communicator");
-		ret = -EINVAL;
-		goto error;
+		return -EINVAL;
 	}
 
 	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
 	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == NCCL_OFI_MAX_SEND_REQUESTS)) {
-		ret = -EINVAL;
 		NCCL_OFI_WARN("Can not support more than %d inflight requests",
 			      NCCL_OFI_MAX_SEND_REQUESTS);
-		goto error;
+		return -EINVAL;
 	}
 
 	dev_id = s_comm->base.base.dev_id;
 
 	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->base.base.ep;
 	assert(ep != NULL);
+
+	/* The Nvidia and Neuron threading guarantee is that at most
+	 * one thread will access communicator resources at a time.
+	 * This means that it is safe to manipulate the request
+	 * objects (which are per-communicator resources) outside of
+	 * the lock.
+	 */
+	nccl_net_ofi_mutex_lock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
 
 	ret = process_cq_if_pending(ep);
 	if (ret == -EAGAIN) {
@@ -6039,6 +5999,7 @@ retry:
 		req->free(req, false);
 	*base_req = NULL;
  exit:
+	nccl_net_ofi_mutex_unlock(&rdma_endpoint_get_domain(ep)->rdma_domain_lock);
 	return ret;
 }
 
@@ -6070,8 +6031,6 @@ static int send_close_deferred(nccl_net_ofi_send_comm_t *send_comm)
 
 	s_comm->comm_active = false;
 
-	nccl_net_ofi_mutex_lock(&comm_cleanup_list_lock);
-
 	/* Deferred cleanup */
 	nccl_ofi_deque_insert_back(s_comm_cleanup_list,
 				   &s_comm->cleanup_list_elem);
@@ -6079,7 +6038,6 @@ static int send_close_deferred(nccl_net_ofi_send_comm_t *send_comm)
 	assert(num_open_comms > 0);
 	num_open_comms--;
 	ret = comm_close_handler();
-	nccl_net_ofi_mutex_unlock(&comm_cleanup_list_lock);
 
  exit:
 	return ret;
@@ -6235,7 +6193,6 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 			ofi_nccl_rdma_max_posted_bounce_buffers(), ep->num_control_rails
 		);
 		rail->num_rx_buff_posted = 0;
-		nccl_net_ofi_mutex_init(&rail->rx_buff_mutex, NULL);
 		rail->rx_buff_req_alloc = ctrl_rx_buff_req_alloc;
 	}
 
@@ -6248,7 +6205,6 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 			ofi_nccl_rdma_max_posted_bounce_buffers(), ep->num_rails
 		);
 		rail->num_rx_buff_posted = 0;
-		nccl_net_ofi_mutex_init(&rail->rx_buff_mutex, NULL);
 		rail->rx_buff_req_alloc = eager_rx_buff_req_alloc;
 	}
 
@@ -6267,7 +6223,6 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 static inline int fini_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 {
 	int ret = 0;
-	nccl_net_ofi_ep_rail_t *rail;
 
 	ret = nccl_ofi_freelist_fini(ep->ctrl_rx_buff_fl);
 	if (ret != 0) {
@@ -6285,16 +6240,6 @@ static inline int fini_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to fini rx_buff_reqs_fl");
 		return ret;
-	}
-
-	for (int rail_id = 0; rail_id < ep->num_rails; ++rail_id) {
-		rail = rdma_endpoint_get_rail(ep, rail_id);
-		nccl_net_ofi_mutex_destroy(&rail->rx_buff_mutex);
-	}
-
-	for (int rail_id = 0; rail_id < ep->num_control_rails; ++rail_id) {
-		rail = rdma_endpoint_get_control_rail(ep, rail_id);
-		nccl_net_ofi_mutex_destroy(&rail->rx_buff_mutex);
 	}
 
 	return ret;
@@ -6472,12 +6417,6 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 		return -ENOMEM;
 	}
 
-	ret = nccl_net_ofi_mutex_init(&ret_s_comm->ctrl_recv_lock, NULL);
-	if (ret != 0) {
-		free_rdma_send_comm(ret_s_comm);
-		return ret;
-	}
-
 	ret_s_comm->base.base.type = NCCL_NET_OFI_SEND_COMM;
 	ret_s_comm->base.base.ep = &ep->base;
 	ret_s_comm->base.base.dev_id = dev_id;
@@ -6581,7 +6520,6 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 				NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, ret_s_comm->local_comm_id);
 			}
 		}
-		nccl_net_ofi_mutex_destroy(&ret_s_comm->ctrl_recv_lock);
 		free_rdma_send_comm(ret_s_comm);
 	}
 
@@ -6715,22 +6653,27 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 	nccl_net_ofi_rdma_send_comm_t *s_comm =
 		(nccl_net_ofi_rdma_send_comm_t *)comm_state->comm;
 
-	/* Retrieve and validate devices */
+	nccl_net_ofi_rdma_domain_t *domain = (nccl_net_ofi_rdma_domain_t *)base_ep->domain;
+	assert(domain != NULL);
+
 	nccl_net_ofi_rdma_device_t *device = (nccl_net_ofi_rdma_device_t *)base_ep->domain->device;
 	assert(device != NULL);
 
+	nccl_net_ofi_mutex_lock(&domain->rdma_domain_lock);
+	
 	/* Connection establishment is not done yet */
 	nccl_ofi_comm_stage_t stage = comm_state->stage;
 	if (stage == COMM_CONNECTED) {
 		NCCL_OFI_WARN("Handle %p object already has an active send communicator (%p).",
 			      handle, s_comm);
-		return -EINVAL;
+		ret = -EINVAL;
+		goto exit;
 	}
 
 	ret = post_rx_buffs(ep);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Error posting rx buffers: %d", ret);
-		return ret;
+		goto exit;
 	}
 
 	/*
@@ -6752,10 +6695,11 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		/* Build send communicator with one comm rail */
 		ret = create_send_comm(handle, ep, &s_comm);
 		if (OFI_UNLIKELY(ret != 0)) {
-			return ret;
+			goto exit;
 		}
 		if (OFI_UNLIKELY(s_comm == NULL)) {
-			return -ENOMEM;
+			ret = -ENOMEM;
+			goto exit;;
 		}
 		comm_state->comm = &s_comm->base.base;
 
@@ -6763,7 +6707,8 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		req = prepare_send_conn_req(s_comm);
 		if (OFI_UNLIKELY(req == NULL)) {
 			send_comm_destroy(s_comm);
-			return -ENOMEM;
+			ret = -ENOMEM;
+			goto exit;
 		}
 		comm_state->req = &req->base;
 
@@ -6771,7 +6716,8 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		s_comm->conn_resp_req = prepare_recv_conn_resp_req(s_comm);
 		if (OFI_UNLIKELY(s_comm->conn_resp_req == NULL)) {
 			send_comm_destroy(s_comm);
-			return -EINVAL;
+			ret = -EINVAL;
+			goto exit;
 		}
 
 		comm_state->stage = COMM_SEND_CONN;
@@ -6781,12 +6727,13 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		/* COMM_SEND_CONN: Post a connect message to send peer connections */
 		ret = post_send_conn(s_comm, device, ep, req);
 		if (ret == -FI_EAGAIN) {
-			return 0;
+			ret = 0;
+			goto exit;
 		}
 		else if (ret != 0) {
 			req->free(req, false);
 			send_comm_destroy(s_comm);
-			return ret;
+			goto exit;
 		}
 
 		comm_state->stage = COMM_CONN_REQ_PENDING;
@@ -6802,17 +6749,16 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 			/* Send communicator cannot be closed since
 			 * send request of send connect message is
 			 * still pending */
-			return ret;
+			goto exit;
 		}
 
 		/* Check if the connect message is sent */
-		nccl_net_ofi_mutex_lock(&req->req_lock);
 		conn_msg_state = req->state;
-		nccl_net_ofi_mutex_unlock(&req->req_lock);
 
 		/* Wait until connect message is sent */
 		if (conn_msg_state != NCCL_OFI_RDMA_REQ_COMPLETED) {
-			return 0;
+			ret = 0;
+			goto exit;
 		}
 
 		/* Release connect message request */
@@ -6836,21 +6782,20 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 		 * connection establishment will be finalized. */
 		ret = ofi_process_cq(ep);
 		if (OFI_UNLIKELY(ret != 0)) {
-			return ret;
+			goto exit;
 		}
 
-		nccl_net_ofi_mutex_lock(&s_comm->conn_resp_req->req_lock);
 		conn_resp_req_state = s_comm->conn_resp_req->state;
-		nccl_net_ofi_mutex_unlock(&s_comm->conn_resp_req->req_lock);
 
 		/* Wait until conn resp message is received */
 		if (conn_resp_req_state != NCCL_OFI_RDMA_REQ_COMPLETED) {
-			return 0;
+			ret = 0;
+			goto exit;
 		}
 
 		ret = finish_connect(s_comm);
 		if (OFI_UNLIKELY(ret != 0)) {
-			return ret;
+			goto exit;
 		}
 
 		comm_state->stage = COMM_CONNECTED;
@@ -6860,15 +6805,14 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 	case COMM_CONNECTED:
 	default:
 		NCCL_OFI_WARN("Invalid state of send communicator object: %d", stage);
-		return -EINVAL;
+		ret = -EINVAL;
 	};
 
-	nccl_net_ofi_mutex_lock(&comm_cleanup_list_lock);
 	++num_open_comms;
-	nccl_net_ofi_mutex_unlock(&comm_cleanup_list_lock);
 
 	*send_comm = &s_comm->base;
-
+exit:
+	nccl_net_ofi_mutex_unlock(&domain->rdma_domain_lock);
 	return ret;
 }
 
@@ -7317,6 +7261,8 @@ nccl_net_ofi_rdma_domain_free(nccl_net_ofi_domain_t *base_domain)
 		domain->ep_addr_list = NULL;
 	}
 
+	nccl_net_ofi_mutex_destroy(&domain->rdma_domain_lock);
+
 	ret = nccl_net_ofi_domain_fini(&domain->base);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to delete domain");
@@ -7370,6 +7316,12 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 		domain->ep_addr_list = NULL;
 	}
 
+	ret = nccl_net_ofi_mutex_init(&domain->rdma_domain_lock, NULL);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Unable to initialize rdma domain mutex");
+		return NULL;
+	}
+
 	domain->domain_rails = (nccl_net_ofi_rdma_domain_rail_t *)calloc(domain->num_rails,
 									 sizeof(nccl_net_ofi_rdma_domain_rail_t));
 	if (domain->domain_rails == NULL) {
@@ -7406,7 +7358,6 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 			domain_rail->cq = NULL;
 		}
 	}
-
 
 error:
 	if (ret != 0) {

--- a/src/nccl_ofi_scheduler.c
+++ b/src/nccl_ofi_scheduler.c
@@ -84,14 +84,11 @@ static inline int set_schedule_by_threshold(nccl_net_ofi_threshold_scheduler_t *
 	assert(num_stripes <= num_rails);
 
 	int curr_rail_id, next_rail_id;
-	nccl_net_ofi_mutex_lock(&scheduler->rr_lock);
 
 	/* Retieve and increment multiplex-round-robin counter; wrap around if required */
 	curr_rail_id = scheduler->rr_counter;
 	next_rail_id = (curr_rail_id + num_stripes) % num_rails;
 	scheduler->rr_counter = next_rail_id;
-
-	nccl_net_ofi_mutex_unlock(&scheduler->rr_lock);
 
 	/* Number of bytes left to assign */
 	size_t left = size;
@@ -219,12 +216,6 @@ static int threshold_scheduler_fini(nccl_net_ofi_scheduler_t *scheduler_p)
 	assert(scheduler_p);
 	assert(scheduler_p->schedule_fl);
 
-	ret = nccl_net_ofi_mutex_destroy(&scheduler->rr_lock);
-	if (ret) {
-		NCCL_OFI_WARN("Could not destroy threshold scheduler pthread mutex");
-		return -ret;
-	}
-
 	ret = scheduler_fini(scheduler_p);
 	if (ret) {
 		NCCL_OFI_WARN("Could not destroy threshold scheduler");
@@ -284,14 +275,6 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size,
 	scheduler->base.fini = threshold_scheduler_fini;
 	scheduler->rr_counter = 0;
 	scheduler->min_stripe_size = min_stripe_size;
-
-	ret = nccl_net_ofi_mutex_init(&scheduler->rr_lock, NULL);
-	if (ret) {
-		NCCL_OFI_WARN("Could not initialize mutex for round robin counter");
-		scheduler_fini(&scheduler->base);
-		free(scheduler);
-		return -ret;
-	}
 
 	*scheduler_p = &scheduler->base;
 

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -766,9 +766,7 @@ static int sendrecv_comm_mr_base_dereg(nccl_net_ofi_comm_t *base_comm,
 		 * cache itself, this call would either just decrement the
 		 * refcnt, or delete the entry for this handle.
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret = nccl_ofi_mr_cache_del_entry(mr_cache, (void *)mr_handle);
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -843,7 +841,6 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 		 * MR cache is locked between lookup and insert, to be sure we
 		 * insert a missing entry
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey);
 		if (ret_handle) {
 			/* Cache hit */
@@ -878,10 +875,6 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 	}
 
 unlock:
-	if (mr_cache) {
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
-	}
-
 	nccl_net_ofi_mutex_unlock(&domain->base.domain_lock);
 
 	*mhandle = ret_handle;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2579,11 +2579,22 @@ static void sendrecv_get_hints(struct fi_info *hints, int req_gdr)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->threading = FI_THREAD_SAFE;
+	hints->domain_attr->threading = FI_THREAD_DOMAIN;
 
-	/* Set progress mode to unspec to use the provider's default mode. */
+	/* If libfabric is new enough to support
+	 * FI_PROGRESS_CONTROL_UNIFIED, specify MANUAL /
+	 * CONTROL_UNIFIED progress, to remove the domain lock from
+	 * the completion queue polling.  Otherwise, set
+	 * PROGRESS_UNSPEC to allow the provider to pick what it
+	 * thinks will go fastsest.
+	 */
+#if HAVE_DECL_FI_PROGRESS_CONTROL_UNIFIED
+	hints->domain_attr->control_progress = FI_PROGRESS_CONTROL_UNIFIED;
+	hints->domain_attr->data_progress = FI_PROGRESS_MANUAL;
+#else
 	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;;
+#endif
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;


### PR DESCRIPTION
Switch from finegrained locking in all the various data structures to device and domain level locks.  This means that we have slightly higher contention on the locks if we're in a multi-accelerator per process region and not using domain-per-thread (which we do on trainium).  In return, the locking code is way easier to understand and we (literally) remove thousands of locks (possible we have way too many request structures).  This probably isn't the right end state, but is a major step forward and a good point to checkpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
