### PR TITLE
packaging: add a hack for efa-config/libfabric

### DIFF
--- a/contrib/debian-template/rules
+++ b/contrib/debian-template/rules
@@ -23,5 +23,9 @@ override_dh_auto_configure:
 		--disable-tests \
 		--disable-werror
 
+#%:
+#	dh $@
+# this is a hack to work around efa-installer diamond dependency with
+# efa-config/libfabric-aws and should be removed.
 %:
-	dh $@
+	LD_LIBRARY_PATH=/opt/amazon/efa/lib:${LD_LIBRARY_PATH} dh $@


### PR DESCRIPTION
efa-config is necessary to populate ldconfig cache for libfabric, rather than libfabric specifying this itself. This means its insufficient for aws-ofi-nccl to simply depend on libfabric, because pulling in libfabric as a build dependency doesn't pull in efa-config, which is necessary to actually resolve the library. Add a gross hack that runs the entire build with LD_LIBRARY_PATH set. It's an understatement to say that this is not ideal.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
