### PR TITLE
include: remove config.h from headers

### DIFF
--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-#include "config.h"
-
 #include <assert.h>
 #include <pthread.h>
 #include <stdbool.h>

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -9,8 +9,6 @@
 extern "C" {
 #endif
 
-#include "config.h"
-
 #include <rdma/fabric.h>
 
 #include "nccl_ofi.h"

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -6,7 +6,6 @@
 #ifndef NCCL_OFI_TRACEPOINT_H_
 #define NCCL_OFI_TRACEPOINT_H_
 
-#include "config.h"
 #include "tracing_impl/nvtx.h"
 #include "tracing_impl/lttng.h"
 

--- a/include/tuner/nccl_ofi_tuner.h
+++ b/include/tuner/nccl_ofi_tuner.h
@@ -5,8 +5,6 @@
 #ifndef NCCL_OFI_TUNER_H_
 #define NCCL_OFI_TUNER_H_
 
-#include "config.h"
-
 #include <linux/limits.h>
 #include <nccl/tuner.h>
 

--- a/include/tuner/nccl_ofi_tuner_common.h
+++ b/include/tuner/nccl_ofi_tuner_common.h
@@ -5,8 +5,6 @@
 #ifndef NCCL_OFI_TUNER_COMMON_H_
 #define NCCL_OFI_TUNER_COMMON_H_
 
-#include "config.h"
-
 #include <linux/limits.h>
 #include <nccl/tuner.h>
 


### PR DESCRIPTION
Header files shouldn't include `config.h`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
