### PR TITLE
fix: packaging/deb: explicitly disable optionals

### DIFF
--- a/contrib/debian-template/rules
+++ b/contrib/debian-template/rules
@@ -21,6 +21,8 @@ override_dh_auto_configure:
 		--with-cuda=/usr/local/cuda \
 		--enable-cudart-dynamic \
 		--disable-tests \
+		--without-lttng \
+		--without-valgrind \
 		--disable-werror
 
 #%:


### PR DESCRIPTION
there is a chain of unfortunate hacks on top of unfortunate hacks that result in the potential for broken packages to be generated.

1. the EFA installer pipeline does not use pbuilder/cowbuilder/etc to build each package in a chroot with only its stated dependencies. Instead, a single AMI is booted once and all packages are built in the same AMI lifetime. LTTNG apparently existed in this environment, for whatever reason.

2. Rather than explicit configuration ala cmake, we use autotools where it's idiomatic to enable features if software is available in the system path, and otherwise disables it. We did not explicitly state these options before when building packages.

3. due to libfabric-aws not shipping a symvers/symbols file, and also due to the fact that builds atop EFA installer need to support linking cuda without necessarily stating a dependency on cuda, we disable shlibdeps.

4. This means that we might find ourselves in a position of linking valgrind/lttng due to its availability in the build environment and autodetection by ./configure, and then the package is constructed without any stated dependency on either of them, producing a binary which fails at runtime due to lacking the required libs.

Yikes. Explicitly disable both of them so this can't happen.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
