### PR TITLE
aws: Improve platform lookup handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ tests/unit/ep_addr_list
 tests/unit/mr
 tests/unit/region_based_tuner
 tests/unit/show_tuner_decisions
+tests/unit/aws_platform_mapper
 
 # http://www.gnu.org/software/automake
 .deps/

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ tests/unit/show_tuner_costs
 tests/unit/ep_addr_list
 tests/unit/mr
 tests/unit/region_based_tuner
+tests/unit/show_tuner_decisions
 
 # http://www.gnu.org/software/automake
 .deps/

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,4 +38,5 @@ noinst_HEADERS = \
 	tracing_impl/nvtx.h \
 	internal/tuner/nccl_defaults.h \
 	nccl_ofi_platform.h \
-	nccl_ofi_ep_addr_list.h
+	nccl_ofi_ep_addr_list.h \
+	platform-aws.h

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -19,6 +19,7 @@ extern "C" {
 
 struct ec2_platform_data {
 	const char* name;
+	const char* regex;
 	const char* topology;
 	int default_dup_conns;
 	float latency;

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * Access helper functions from platform-aws specifically for unit
+ * tests.  You do not want to include this file outside of
+ * platform-aws.c or a unit test, or you'll break linking on non-AWS
+ * platforms.
+ */
+
+#ifndef PLATFORM_AWS_H_
+#define PLATFORM_AWS_H_
+
+#include <stdbool.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+struct ec2_platform_data {
+	const char* name;
+	const char* topology;
+	int default_dup_conns;
+	float latency;
+	bool gdr_required;
+	bool net_flush_required;
+	const char *default_protocol;
+	int domain_per_thread;
+};
+
+
+/*
+ * @brief        Get the platform data map
+ *
+ * This function exists solely to test
+ * platform_aws_get_platform_entry() against the production data map.
+ */
+struct ec2_platform_data *platform_aws_get_platform_map(size_t *len);
+
+
+/*
+ * @brief	Returns platform data for current platform type, if found
+ *
+ * @input	Platform type
+ *
+ * @return	NULL, if no topology found
+ * 		platform data, if match found
+ */
+struct ec2_platform_data *platform_aws_get_platform_entry(const char *platform_type,
+							  struct ec2_platform_data *platform_data_list,
+							  size_t platform_data_len);
+
+
+#ifdef __cplusplus
+} // End extern "C"
+#endif
+
+#endif // End NCCL_OFI_H_

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -71,7 +71,12 @@ static struct ec2_platform_data platform_data_map[] = {
 	},
 	{
 		.name = "p-series",
-		.regex = "^p5.*",
+		/*
+		 * we only want to match P5 and later, as earlier
+		 * platforms all either need to be ignored or special
+		 * cased.
+		 */
+		.regex = "^p([5-9]|[0-9]{2,}).*",
 		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 75.0,
@@ -145,7 +150,7 @@ struct ec2_platform_data *platform_aws_get_platform_entry(const char *platform_t
 				break;
 			}
 		} else {
-			ret = regcomp(&regex, platform_data_list[idx].regex, 0);
+			ret = regcomp(&regex, platform_data_list[idx].regex, REG_EXTENDED);
 			if (ret != 0) {
 				NCCL_OFI_WARN("Could not compile platform_type regex for %s",
 					      platform_data_list[idx].regex);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -20,6 +20,10 @@ noinst_PROGRAMS = \
 	ep_addr_list \
 	mr
 
+if WANT_PLATFORM_AWS
+noinst_PROGRAMS += aws_platform_mapper
+endif
+
 if !ENABLE_NEURON
 if WANT_PLATFORM_AWS
   AM_LDFLAGS = $(CUDA_LDFLAGS)
@@ -38,6 +42,7 @@ msgbuff_SOURCES = msgbuff.c
 scheduler_SOURCES = scheduler.c
 ep_addr_list_SOURCES = ep_addr_list.c
 mr_SOURCES = mr.c
+aws_platform_mapper_SOURCES = aws_platform_mapper.c
 
 TESTS = $(noinst_PROGRAMS)
 endif

--- a/tests/unit/aws_platform_mapper.c
+++ b/tests/unit/aws_platform_mapper.c
@@ -61,6 +61,9 @@ static int check_known_platforms(void)
 	ret += check_value(platform_data_list, len, "g5.48xlarge", "g5.48xlarge");
 	ret += check_value(platform_data_list, len, "g6.16xlarge", NULL);
 
+	// obviously future platforms
+	ret += check_value(platform_data_list, len, "p100.2048xlarge", "p-series");
+
 	return ret;
 }
 

--- a/tests/unit/aws_platform_mapper.c
+++ b/tests/unit/aws_platform_mapper.c
@@ -43,22 +43,22 @@ static int check_known_platforms(void)
 
 	platform_data_list = platform_aws_get_platform_map(&len);
 
-	ret += check_value(platform_data_list, len, "trn1.32xlarge", "^trn1.*");
-	ret += check_value(platform_data_list, len, "trn1n.32xlarge", "^trn1.*");
-	ret += check_value(platform_data_list, len, "trn1.2xlarge", "^trn1.*");
-	ret += check_value(platform_data_list, len, "trn2.48xlarge", "^trn2.*");
-	ret += check_value(platform_data_list, len, "trn2u.48xlarge", "^trn2.*");
+	ret += check_value(platform_data_list, len, "trn1.32xlarge", "trn1");
+	ret += check_value(platform_data_list, len, "trn1n.32xlarge", "trn1");
+	ret += check_value(platform_data_list, len, "trn1.2xlarge", "trn1");
+	ret += check_value(platform_data_list, len, "trn2.48xlarge", "trn2");
+	ret += check_value(platform_data_list, len, "trn2u.48xlarge", "trn2");
 	ret += check_value(platform_data_list, len, "inf2.48xlarge", NULL);
 	ret += check_value(platform_data_list, len, "p3.2xlarge", NULL);
 	ret += check_value(platform_data_list, len, "p3.8xlarge", NULL);
 	ret += check_value(platform_data_list, len, "p3.16xlarge", NULL);
-	ret += check_value(platform_data_list, len, "p3dn.24xlarge", "^p3dn.24xlarge$");
-	ret += check_value(platform_data_list, len, "p4d.24xlarge", "^p4d.24xlarge$");
-	ret += check_value(platform_data_list, len, "p4de.24xlarge", "^p4de.24xlarge$");
-	ret += check_value(platform_data_list, len, "p5.48xlarge", "^p5.*");
-	ret += check_value(platform_data_list, len, "p5e.48xlarge", "^p5.*");
-	ret += check_value(platform_data_list, len, "p5en.48xlarge", "^p5.*");
-	ret += check_value(platform_data_list, len, "g5.48xlarge", "^g5.48xlarge$");
+	ret += check_value(platform_data_list, len, "p3dn.24xlarge", "p3dn.24xlarge");
+	ret += check_value(platform_data_list, len, "p4d.24xlarge", "p4d.24xlarge");
+	ret += check_value(platform_data_list, len, "p4de.24xlarge", "p4de.24xlarge");
+	ret += check_value(platform_data_list, len, "p5.48xlarge", "p-series");
+	ret += check_value(platform_data_list, len, "p5e.48xlarge", "p-series");
+	ret += check_value(platform_data_list, len, "p5en.48xlarge", "p-series");
+	ret += check_value(platform_data_list, len, "g5.48xlarge", "g5.48xlarge");
 	ret += check_value(platform_data_list, len, "g6.16xlarge", NULL);
 
 	return ret;
@@ -67,7 +67,8 @@ static int check_known_platforms(void)
 
 static struct ec2_platform_data test_map_1[] = {
 	{
-		.name = "^platform-x$",
+		.name = "first",
+		.regex = "^platform-x$",
 		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 0.0,
@@ -77,7 +78,8 @@ static struct ec2_platform_data test_map_1[] = {
 		.domain_per_thread = 0,
 	},
 	{
-		.name = "^platform.*",
+		.name = "second",
+		.regex = "^platform.*",
 		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 0.0,
@@ -95,8 +97,8 @@ int main(int argc, char *argv[]) {
 	ret += check_known_platforms();
 
 	/* make sure we maintain ordering */
-	ret += check_value(test_map_1, 2, "platform-x", "^platform-x$");
-	ret += check_value(test_map_1, 2, "platform-xy", "^platform.*");
+	ret += check_value(test_map_1, 2, "platform-x", "first");
+	ret += check_value(test_map_1, 2, "platform-xy", "second");
 
 	return ret;
 }

--- a/tests/unit/aws_platform_mapper.c
+++ b/tests/unit/aws_platform_mapper.c
@@ -1,0 +1,102 @@
+/*
+ * Copyright (c) 2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "platform-aws.h"
+
+
+/* check that we get the expected response for all our known platforms */
+static int check_value(struct ec2_platform_data *platform_data_list, size_t len,
+		       const char *platform_type, const char *expected_value)
+{
+	struct ec2_platform_data *entry = platform_aws_get_platform_entry(platform_type,
+									  platform_data_list,
+									  len);
+
+	if (NULL == entry && expected_value != NULL) {
+		printf("Got NULL reply, expected %s\n", expected_value);
+		return 1;
+	} else if (NULL != entry && expected_value == NULL) {
+		printf("Got reply %s, expected NULL\n", entry->name);
+		return 1;
+	} else if (NULL == entry && expected_value == NULL) {
+		return 0;
+	} else if (0 != strcmp(entry->name, expected_value)) {
+		printf("Got reply %s, expected %s\n", entry->name, expected_value);
+		return 1;
+	}
+
+	return 0;
+}
+
+
+static int check_known_platforms(void)
+{
+	struct ec2_platform_data *platform_data_list;
+	size_t len;
+	int ret = 0;
+
+	platform_data_list = platform_aws_get_platform_map(&len);
+
+	ret += check_value(platform_data_list, len, "trn1.32xlarge", "^trn1.*");
+	ret += check_value(platform_data_list, len, "trn1n.32xlarge", "^trn1.*");
+	ret += check_value(platform_data_list, len, "trn1.2xlarge", "^trn1.*");
+	ret += check_value(platform_data_list, len, "trn2.48xlarge", "^trn2.*");
+	ret += check_value(platform_data_list, len, "trn2u.48xlarge", "^trn2.*");
+	ret += check_value(platform_data_list, len, "inf2.48xlarge", NULL);
+	ret += check_value(platform_data_list, len, "p3.2xlarge", NULL);
+	ret += check_value(platform_data_list, len, "p3.8xlarge", NULL);
+	ret += check_value(platform_data_list, len, "p3.16xlarge", NULL);
+	ret += check_value(platform_data_list, len, "p3dn.24xlarge", "^p3dn.24xlarge$");
+	ret += check_value(platform_data_list, len, "p4d.24xlarge", "^p4d.24xlarge$");
+	ret += check_value(platform_data_list, len, "p4de.24xlarge", "^p4de.24xlarge$");
+	ret += check_value(platform_data_list, len, "p5.48xlarge", "^p5.*");
+	ret += check_value(platform_data_list, len, "p5e.48xlarge", "^p5.*");
+	ret += check_value(platform_data_list, len, "p5en.48xlarge", "^p5.*");
+	ret += check_value(platform_data_list, len, "g5.48xlarge", "^g5.48xlarge$");
+	ret += check_value(platform_data_list, len, "g6.16xlarge", NULL);
+
+	return ret;
+}
+
+
+static struct ec2_platform_data test_map_1[] = {
+	{
+		.name = "^platform-x$",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 0.0,
+		.gdr_required = false,
+		.net_flush_required = false,
+		.default_protocol = NULL,
+		.domain_per_thread = 0,
+	},
+	{
+		.name = "^platform.*",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 0.0,
+		.gdr_required = false,
+		.net_flush_required = false,
+		.default_protocol = NULL,
+		.domain_per_thread = 0,
+	},
+};
+
+int main(int argc, char *argv[]) {
+	int ret = 0;
+
+	/* verify we get the answer we want on real platforms */
+	ret += check_known_platforms();
+
+	/* make sure we maintain ordering */
+	ret += check_value(test_map_1, 2, "platform-x", "^platform-x$");
+	ret += check_value(test_map_1, 2, "platform-xy", "^platform.*");
+
+	return ret;
+}


### PR DESCRIPTION
This was originally just a patch to add unit tests for the regex handling, but also tagged on a commit to change the p5 match to match all p5 or later platforms, because it's a reasonable example.  Ended up splitting the name into a name and regex, otherwise every time you changed the regex (like the p5 extension), you had to update the unit test, and that was just annoying. Especially during the inevitable messing up regex cycle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
