### PR TITLE
.ci/aws: Skip default SCM checkout

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -134,6 +134,7 @@ pipeline {
     options {
         buildDiscarder(logRotator(daysToKeepStr: "365"))
         timeout(time: 8, unit: 'HOURS')
+        skipDefaultCheckout()
     }
     environment {
         // AWS region where the cluster is created


### PR DESCRIPTION
*Issue #, if available:*

Jenkins has a default step to checkout the code base from SCM, which took around 30s. But we defined next step to be workspace cleanup.

*Description of changes:*

This change is to skip the default step and only checkout the code base as we defined in the pipeline step

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
