### PR TITLE
.ci/aws: Jenkinsfile updates

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -132,7 +132,7 @@ pipeline {
         }
     }
     options {
-        buildDiscarder(logRotator(daysToKeepStr: "90"))
+        buildDiscarder(logRotator(daysToKeepStr: "365"))
         timeout(time: 8, unit: 'HOURS')
     }
     environment {

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -133,7 +133,7 @@ pipeline {
     }
     options {
         buildDiscarder(logRotator(daysToKeepStr: "90"))
-        timeout(time: 24, unit: 'HOURS')
+        timeout(time: 8, unit: 'HOURS')
     }
     environment {
         // AWS region where the cluster is created


### PR DESCRIPTION
This PR does the following:

* Decreases timeout from 24h to 8h, which will allow 8 jobs started at the same time to all pass (no impact now that jobs take 1 hour)
* Increase the amount of history retained from 90d to 360d

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
