### PR TITLE
fix(m4): Disable lttng when --with-lttng not specified during configuration

### DIFF
--- a/m4/check_pkg_lttng.m4
+++ b/m4/check_pkg_lttng.m4
@@ -15,10 +15,10 @@ AC_DEFUN([CHECK_PKG_LTTNG], [
   AC_ARG_WITH([lttng],
      [AS_HELP_STRING([--with-lttng=DIR], [Enable tracing capability with LTTNG @<:@default=no@:>@])])
 
-  AS_IF([test -z "${with_lttng}" -o "${with_lttng}" = "yes"],
-        [],
-        [test "${with_lttng}" = "no"],
+  AS_IF([test -z "${with_lttng}" -o "${with_lttng}" = "no"],
         [check_pkg_found=no],
+        [test "${with_lttng}" = "yes"],
+        [],
         [AS_IF([test -d ${with_lttng}/lib64], [check_pkg_libdir="lib64"], [check_pkg_libdir="lib"])
          CPPFLAGS="-isystem ${with_lttng}/include ${CPPFLAGS}"
          LDFLAGS="-L${with_lttng}/${check_pkg_libdir} ${LDFLAGS}"])


### PR DESCRIPTION
### Disable LTTng by default unless explicitly enabled during configuration

- This change modifies the build system to disable LTTng tracing support by default unless explicitly enabled.
- Disabling lttng works around recent functional ring test kernel issue on Ubuntu 22.04.

Unit tested configure with:
- `--with-lttng=no` or without `--with-lttng` : HAVE_LIBLTTNG_UST is defined as 0.
- `--with-lttng=yes`: HAVE_LIBLTTNG_UST is defined as 1.  The libnccl-net.so links to the detected lttng ust library.
- `--with-lttng=<path>`: HAVE_LIBLTTNG_UST` is defined as 1. The libnccl-net.so links to the specified lttng ust library.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
