### PR TITLE
rdma: rename bounce to rx_buff

### DIFF
--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -64,11 +64,11 @@ typedef enum {
 } nccl_ofi_msgbuff_result_t;
 
 /* Type of element stored in msg buffer. This is used to distinguish between
-   reqs and bounce buffers (when we don't have req) stored in the message buffer */
+   reqs and rx buffers (when we don't have req) stored in the message buffer */
 typedef enum {
 	/* Request */
 	NCCL_OFI_MSGBUFF_REQ,
-	/* Bounce buffer */
+	/* Rx buffer */
 	NCCL_OFI_MSGBUFF_BUFF
 } nccl_ofi_msgbuff_elemtype_t;
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -288,15 +288,17 @@ OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 1);
 OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (128 * 1024));
 
 /*
- * Minimum bounce buffers posted per endpoint. The plugin will attempt to post
- * more bounce buffers if we dip below this threshold, allocating new bounce
+ * Minimum rx buffers (ctrl/eager) posted per endpoint. The plugin will attempt
+ * to post more rx buffers if we dip below this threshold, allocating new rx
  * buffers if needed.
+ *
+ * Note: the parameter is called "bounce buffer" for backward compatibility.
  */
 OFI_NCCL_PARAM_INT(rdma_min_posted_bounce_buffers, "RDMA_MIN_POSTED_BOUNCE_BUFFERS", 64);
 
 /*
- * Maximum bounce buffers posted per endpoint. The plugin will not attempt to
- * post more bounce buffers if we reach this threshold, returning available
+ * Maximum rx buffers posted per endpoint. The plugin will not attempt to
+ * post more rx buffers if we reach this threshold, returning available
  * buffers to the free list if needed
  */
 OFI_NCCL_PARAM_INT(rdma_max_posted_bounce_buffers, "RDMA_MAX_POSTED_BOUNCE_BUFFERS", 128);


### PR DESCRIPTION
*Description of changes:*

Bounce buffers are used to receive both eager messages and ctrl messages -- in the latter case, the name "bounce buffer" doesn't make sense. Thus, rename to the more generic "rx_buff".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
