### PR TITLE
fix(ofiutils): set error code before failing

### DIFF
--- a/src/nccl_ofi_ofiutils.c
+++ b/src/nccl_ofi_ofiutils.c
@@ -408,6 +408,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 		support_gdr = GDR_SUPPORTED;
 #else
 		NCCL_OFI_WARN("Using Libfabric 1.18 API with GPUDirect RDMA support, and FI_OPT_CUDA_API_PERMITTED is not declared.");
+		ret = -EOPNOTSUPP;
 		goto error;
 #endif
 	}


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-ofi-nccl/issues/753

*Description of changes:*

Return an error code to prevent the code proceeding after failure

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
