### PR TITLE
rdma: Do not fail recv when returning a NULL request

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3611,10 +3611,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	}
 
 	ret = insert_rdma_recv_req_into_msgbuff(r_comm, eager, &req);
-	if (ret != 0) {
-		goto free_req;
-	} else if (req == NULL) {
-		ret = -ENOMEM;
+	if (ret != 0 || req == NULL) {
 		goto free_req;
 	}
 


### PR DESCRIPTION
In insert_rdma_recv_req_into_msgbuff(), when a request can not be added to the msg buff because it was already in  progress, we intend to return a NULL request so NCCL can retry the operation. Instead, we were returning this error (which translates to ncclSystemError) causing the application to fail. The send side logic handles this correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
