### PR TITLE
fix: unload: Cleanup active domains and endpoints

### DIFF
--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -226,7 +226,7 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 						  listen_comm);
 
 	if (ret != 0) {
-		base_ep->release_ep(base_ep);
+		base_ep->release_ep(base_ep, false, false);
 	}
 	return nccl_net_ofi_retval_translate(ret);
 }
@@ -318,7 +318,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
 	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm);
 
 	if (ret != 0) {
-		base_ep->release_ep(base_ep);
+		base_ep->release_ep(base_ep, false, false);
 	}
 
 	return nccl_net_ofi_retval_translate(ret);
@@ -520,7 +520,7 @@ ncclResult_t nccl_net_ofi_accept(void *lComm, void **rComm)
 			ret = -EINVAL;
 			goto error;
 		}
-		ep->release_ep(ep);
+		ep->release_ep(ep, false, false);
 	}
 
 error:


### PR DESCRIPTION
When aborting with no connection established, there were QPs leaked if any domain and endpoint left open.

This patch adds domain and endpoint cleanup logic at the beginning of rdma and sendrecv device release (which will be called by `nccl_net_ofi_plugin_fini()` for each device) to prevent the QP leak.

Note the logic can be triggered without #772.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
