### PR TITLE
fix(rdma): fix decrement of `num_inflight_writes` counter

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2108,7 +2108,7 @@ static inline int free_send_req(nccl_net_ofi_rdma_req_t *req,
 
 	send_data = get_send_data(req);
 
-	if (!send_data->eager) {
+	if (!send_data->eager && dec_inflight_reqs) {
 		/* free is going to be called inside of test(), which will
 		   happen in a time when NCCL guarantees no other thread will
 		   be accessing the communicator.  So no mutex protections are


### PR DESCRIPTION
The `num_inflight_writes` counter tracks the number of inflight RDMA
write operations. It is used in deciding whether to send a message
eagerly.

Currently, we decrement the counter when freeing the corresponding send
request. There is one case where we free a send request, resulting in
decrementing `num_inflight_writes`, before we reach the point where we
increment this counter. In this case, we pass `dec_inflight_reqs =
false` to `free`.
So, only decrement the writes counter if this flag is true.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
