### PR TITLE
unit/platform-mapper: ENABLE_TRACE segfault fix

### DIFF
--- a/tests/unit/aws_platform_mapper.c
+++ b/tests/unit/aws_platform_mapper.c
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include "test-common.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -95,6 +96,7 @@ static struct ec2_platform_data test_map_1[] = {
 
 int main(int argc, char *argv[]) {
 	int ret = 0;
+	ofi_log_function = logger;
 
 	/* verify we get the answer we want on real platforms */
 	ret += check_known_platforms();


### PR DESCRIPTION
this test did not bind the global logger to a pointer, which caused a deref when run under ENABLE_TRACE builds.