### PR TITLE
rdma: Add ability to force rails count value

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -389,6 +389,13 @@ OFI_NCCL_PARAM_INT(tuner_net_comp_overhead, "TUNER_NET_COMP_OVERHEAD", 3);
  */
 OFI_NCCL_PARAM_INT(use_low_lat_tc, "USE_LOW_LATENCY_TC", 1);
 
+/*
+ * Number of rails that the rdma transport should build.  If the
+ * number of rails is more than the number of NICs, then the number of
+ * rails must be a multiple of the number of NICs.
+ */
+OFI_NCCL_PARAM_INT(force_num_rails, "FORCE_NUM_RAILS", 0);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif


### PR DESCRIPTION
Add an environment variable OFI_NCCL_FORCE_NUM_RAILS, which will force the number of rails to be the given value (0 means follow the default). If the value is less than the number of NICs found, only the first value NICs will be used.  If the value is more than the number of NICS found, then this will create multiple rails per NIC, with the requirement that the number of rails be a multiple of the number of NICs.

The goal of this patch is to allow P5/P5e and P5en interoparate without lots of rail count detection code.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
