### PR TITLE
core: Don't create an endpoint per thread

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -349,10 +349,12 @@ struct nccl_net_ofi_domain {
 	int (*create_endpoint)(nccl_net_ofi_domain_t *domain,
 			       nccl_net_ofi_ep_t **ep);
 
-	/* hash table of active endpoints.  We reuse endpoints based
-	 * on the thread that calls get_ep().
-	 */
-	nccl_net_ofi_ep_t *endpoint_table;
+	/* endpoint used for (at a minimum) receiving connection
+	   messages.  Send/Recv protocol uses this for all
+	   communication.  The rdma protocol uses this for all tx
+	   requests and all connection-establishment requests, but may
+	   have additional endpoints for the rx side of rdma writes. */
+	nccl_net_ofi_ep_t *endpoint;
 
 	/* thread id of the thread that called get_domain().  Used as
 	   the hash key for the domain hash */

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -878,7 +878,7 @@ static int nccl_net_ofi_domain_get_ep(nccl_net_ofi_domain_t *domain,
 
 		domain->endpoint = ep;
 
-		NCCL_OFI_TRACE(NCCL_NET, "Eendpoint %p for domain %p is created",
+		NCCL_OFI_TRACE(NCCL_NET, "Endpoint %p for domain %p is created",
 			       ep, domain);
 	}
 


### PR DESCRIPTION
Remove the functionality to create an endpoint per thread.  Originally, this was used to create a full domain/endpoint/cq set of objects per thread that created a communicator, but that got messy as the rdma transport created multiple endpoints per thread based on the comm in use.  So we ended up in a place where we were creating a domain per thread (sometimes) and an endpoint per thread (always), which was messy but worked.

Now that there's an explicit domain object and we create a domain per thread, all the endpoint per thread stuff was really duplicative, so just remove it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
