### PR TITLE
fix(rdma): fix traffic class parameter in endpoint creation

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -6993,7 +6993,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 		rail_info->tx_attr->tclass = tclass;
 	}
 
-	ret = nccl_ofi_ofiutils_init_connection(dev_rail->info,
+	ret = nccl_ofi_ofiutils_init_connection(rail_info,
 						ep_rail->domain,
 						&ep_rail->ofi_ep,
 						&ep_rail->av,


### PR DESCRIPTION
The plugin sets the `FI_TC_LOW_LATENCY` traffic class parameter for control endpoints. We were passing the wrong argument to `nccl_ofi_ofiutils_init_connection`, resulting in the traffic class setting being ignored.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
