### PR TITLE
fix : Default to nccl internal tuner on two nodes

### DIFF
--- a/src/tuner/nccl_ofi_regions.c
+++ b/src/tuner/nccl_ofi_regions.c
@@ -936,6 +936,13 @@ ncclResult_t region_get_coll_info_internal_v2(nccl_ofi_tuner_context_t *ctx,
 		goto exit;
 	}
 
+	/* Skip when two nodes or lesser because the regions are not well defined and fallback
+	 * to NCCL's internal tunings */
+	if (region_ctx->dims.num_nodes <= 2) {
+		ret = ncclSuccess;
+		goto exit;
+	}
+
 	p.x = (double)nBytes;
 	p.y = (double)region_ctx->dims.num_ranks;
 
@@ -996,6 +1003,13 @@ ncclResult_t region_get_coll_info_internal_v3(nccl_ofi_tuner_context_t *ctx,
 		goto exit;
 	}
 
+	/* Skip when two nodes or lesser because the regions are not well defined and fallback
+	 * to NCCL's internal tunings */
+	if (region_ctx->dims.num_nodes <= 2) {
+		ret = ncclSuccess;
+		goto exit;
+	}
+	
 	p.x = (double)nBytes;
 	p.y = (double)region_ctx->dims.num_ranks;
 


### PR DESCRIPTION
*Description of changes:*

Since the regions are not well defined and have many outliers at two nodes, 
we should default to the internal tuner on two nodes.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
