### PR TITLE
Remove FI_MR_LOCAL advertisement

### DIFF
--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -7809,7 +7809,7 @@ static void get_hints(struct fi_info *hints)
 
 	hints->ep_attr->type = FI_EP_RDM;
 
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_HMEM | FI_MR_VIRT_ADDR |
+	hints->domain_attr->mr_mode = FI_MR_HMEM | FI_MR_VIRT_ADDR |
 		FI_MR_ALLOCATED | FI_MR_PROV_KEY;
 	hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
 	hints->domain_attr->threading = FI_THREAD_SAFE;

--- a/src/nccl_ofi_sendrecv.c
+++ b/src/nccl_ofi_sendrecv.c
@@ -2438,7 +2438,7 @@ error:
 static void sendrecv_get_hints(struct fi_info *hints, int req_gdr)
 {
 	hints->caps = FI_LOCAL_COMM | FI_REMOTE_COMM | FI_TAGGED | FI_MSG;
-	hints->domain_attr->mr_mode = FI_MR_LOCAL | FI_MR_ENDPOINT;
+	hints->domain_attr->mr_mode = FI_MR_ENDPOINT;
 	hints->domain_attr->mr_key_size = (size_t) ofi_nccl_mr_key_size();
 
 	if (req_gdr) {


### PR DESCRIPTION
 The RDMA and SENDRECV transports do not actually support FI_MR_LOCAL as connection messages are sent with a NULL descriptor field.  Fixing that is slightly more involved, so start with a quick patch to remove advertisement of FI_MR_LOCAL support.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
