### PR TITLE
Add all the features required to support efa-direct

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -505,9 +505,8 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	 * connection establishment */
 	nccl_net_ofi_rdma_req_t *conn_resp_req;
 
-	/* Message struct send connect message and receive connect
-	 * response message */
-	nccl_ofi_rdma_connection_info_t conn_msg;
+	/* free list item containing a nccl_ofi_rdma_connection_info_t */
+	nccl_ofi_freelist_elem_t *conn_msg;
 
 	uint16_t next_msg_seq_num;
 
@@ -624,6 +623,9 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 
 	bool comm_active;
 
+	/* free list item containing a nccl_ofi_rdma_connection_info_t */
+	nccl_ofi_freelist_elem_t *conn_msg;
+
 	/* Array of `num_rails` communicator rails */
 	nccl_net_ofi_rdma_recv_comm_rail_t *rails;
 	/* Array of `num_control_rails` communicator rails */
@@ -649,7 +651,11 @@ typedef struct nccl_net_ofi_rdma_listen_comm {
 	nccl_ofi_comm_stage_t stage;
 
 	/* Message struct send connect message and receive connect
-	 * response message */
+	 * response message
+	 *
+	 * TODO: This should really be a list of outstanding connect
+	 * messages to allow multiple connects per listen communicator.
+	 */
 	nccl_ofi_rdma_connection_info_t conn_msg;
 } nccl_net_ofi_rdma_listen_comm_t;
 
@@ -740,6 +746,8 @@ struct nccl_net_ofi_rdma_ep {
 	nccl_ofi_freelist_t *eager_rx_buff_fl;
 	/* Free list of rx buffer requests */
 	nccl_ofi_freelist_t *rx_buff_reqs_fl;
+	/* Free list for connection messages */
+	nccl_ofi_freelist_t *conn_msg_fl;
 	/* Size of ctrl rx buffers */
 	size_t ctrl_rx_buff_size;
 	/* Size of eager rx buffers */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -361,6 +361,8 @@ typedef struct {
 typedef struct nccl_net_ofi_rdma_req {
 	nccl_net_ofi_req_t base;
 
+	struct fi_context2 ctx[MAX_NUM_RAILS];
+
 	/* Associated Comm object */
 	nccl_net_ofi_comm_t *comm;
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -40,8 +40,9 @@ typedef struct nccl_net_ofi_sendrecv_listen_comm {
 	bool accepted;
 	/* Saves temporary state when creating receive communicator object */
 	save_comm_state_t state;
-	/* Saves peer address information */
-	nccl_ofi_connection_info_t *conn_info;
+
+	/* connecting peer information (nccl_ofi_connection_info_t) */
+	nccl_ofi_freelist_elem_t *conn_info;
 } nccl_net_ofi_sendrecv_listen_comm_t;
 
 typedef struct nccl_net_ofi_sendrecv_send_comm {
@@ -58,7 +59,8 @@ typedef struct nccl_net_ofi_sendrecv_send_comm {
 	fi_addr_t local_ep_addr;
 	struct fid_ep *local_ep;
 
-	nccl_ofi_connection_info_t *conn_info;
+	/* connecting peer information (nccl_ofi_connection_info_t) */
+	nccl_ofi_freelist_elem_t *conn_info;
 } nccl_net_ofi_sendrecv_send_comm_t;
 
 /* Metadata about dummy flush buffer */
@@ -119,6 +121,9 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 
 	/* Completion Queue handle */
 	struct fid_cq *cq;
+
+	/* free list for control messages */
+	nccl_ofi_freelist_t *conn_msg_fl;
 } nccl_net_ofi_sendrecv_ep_t;
 
 

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -601,8 +601,10 @@ exit:
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers)
 {
-	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected Provider is %s (found %d nics)",
-		      selected_provider->fabric_attr->prov_name, num_providers);
+	NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Selected provider is %s, fabric is %s (found %d nics)",
+		      selected_provider->fabric_attr->prov_name,
+		      selected_provider->fabric_attr->name,
+		      num_providers);
 
 	if (strncmp("efa", selected_provider->fabric_attr->prov_name, strlen("efa")) == 0) {
 		if (FI_VERSION_LT(fi_version(), FI_VERSION(1, 22))) {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -1618,11 +1618,20 @@ static inline int process_completions(struct fi_cq_data_entry *cq_entry, uint64_
 			/* Remote-initiated write is complete */
 			ret = handle_write_comp(&cq_entry[comp_idx], device, rail_id);
 		} else {
-			req = (nccl_net_ofi_rdma_req_t *)cq_entry[comp_idx].op_context;
-			if (OFI_UNLIKELY(req == NULL)) {
+			struct fi_context2 *ctx = (struct fi_context2 *)cq_entry[comp_idx].op_context;
+			if (OFI_UNLIKELY(ctx == NULL)) {
 				NCCL_OFI_WARN("Completion with unexpected NULL op_context");
 				return -EINVAL;
 			}
+                        /* To find the request, we need to find the
+			 * start of the context array.  Since the
+			 * sender will always use its rail_id for the
+			 * ctx array index, we can do the same.
+			 */
+			ctx -= rail_id;
+			req = container_of(ctx,
+					   nccl_net_ofi_rdma_req_t,
+					   ctx);
 
 			if (comp_flags & FI_SEND) {
 				/* Send completions */
@@ -1822,7 +1831,8 @@ static int post_rma_read(nccl_net_ofi_rdma_req_t *req)
 {
 	rdma_req_rma_op_data_t *rma_op_data = req_get_rma_op_data(req, NCCL_OFI_RDMA_READ);
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
-	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = rdma_recv_comm_get_rail(r_comm, 0);
+	int rail_id = 0;
+	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = rdma_recv_comm_get_rail(r_comm, rail_id);
 
 	ssize_t rc;
 	/* Post RMA read */
@@ -1830,7 +1840,7 @@ static int post_rma_read(nccl_net_ofi_rdma_req_t *req)
 		      rma_op_data->buff_len, rma_op_data->desc,
 		      comm_rail->remote_addr,
 		      rma_op_data->remote_buff,
-		      rma_op_data->remote_mr_key, req);
+		     rma_op_data->remote_mr_key, (void *)&req->ctx[rail_id]);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("fi_read failed; RC: %zd, Error: %s",
@@ -4918,7 +4928,7 @@ static int post_send_conn_resp(nccl_net_ofi_rdma_recv_comm_t *r_comm,
 
 	req->state = NCCL_OFI_RDMA_REQ_PENDING;
 	rc = fi_send(comm_rail->local_ep, (void *)r_comm->conn_msg->ptr, sizeof(nccl_ofi_rdma_connection_info_t), desc,
-		     comm_rail->remote_addr, req);
+		     comm_rail->remote_addr, (void *)&req->ctx[rail_id]);
 
 	if (rc == -FI_EAGAIN) {
 		req->state = NCCL_OFI_RDMA_REQ_CREATED;
@@ -5446,7 +5456,8 @@ static int insert_rdma_send_req_into_msgbuff(nccl_net_ofi_rdma_send_comm_t *s_co
 static int post_rma_write(nccl_net_ofi_rdma_req_t *req)
 {
 	nccl_net_ofi_rdma_send_comm_t *s_comm = (nccl_net_ofi_rdma_send_comm_t *)req->comm;
-	nccl_net_ofi_rdma_send_comm_rail_t *comm_rail = rdma_send_comm_get_rail(s_comm, 0);
+	size_t rail_id = 0;
+	nccl_net_ofi_rdma_send_comm_rail_t *comm_rail = rdma_send_comm_get_rail(s_comm, rail_id);
 	rdma_req_rma_op_data_t *rma_op_data = req_get_rma_op_data(req, NCCL_OFI_RDMA_WRITE);
 	ssize_t rc;
 
@@ -5470,7 +5481,7 @@ static int post_rma_write(nccl_net_ofi_rdma_req_t *req)
 	msg.addr = comm_rail->remote_addr;
 	msg.rma_iov = &rma_iov;
 	msg.rma_iov_count = 1;
-	msg.context = req;
+	msg.context = (void *)&req->ctx[rail_id];
 	msg.data = 0;
 
 	/* Post the message using fi_writemsg with FI_INJECT */
@@ -5500,7 +5511,7 @@ static int post_rdma_write(nccl_net_ofi_rdma_req_t *req,
 				xfer_info->msg_size, desc, send_data->wdata,
 				comm_rail->remote_addr,
 				send_data->remote_buff + xfer_info->offset,
-				send_data->remote_mr_key[rail_id], req);
+			  send_data->remote_mr_key[rail_id], (void *)&req->ctx[rail_id]);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("fi_writedata failed; RC: %zd, Error: %s",
@@ -5525,7 +5536,7 @@ static int post_rdma_eager_send(nccl_net_ofi_rdma_req_t *req,
 	ssize_t rc;
 	/* Post eager send */
 	rc = fi_senddata(comm_rail->local_ep, (void*)(((uintptr_t)send_data->buff) + xfer_info->offset), xfer_info->msg_size, desc,
-			 send_data->wdata, comm_rail->remote_addr, req);
+			 send_data->wdata, comm_rail->remote_addr, (void *)&req->ctx[rail_id]);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("fi_senddata failed; RC: %zd, Error: %s", rc, fi_strerror(-rc));
@@ -5568,7 +5579,7 @@ static int post_rx_buffer(nccl_net_ofi_rdma_req_t *req,
 	msg.desc = &desc;
 	msg.iov_count = 1;
 	msg.addr = FI_ADDR_UNSPEC;
-	msg.context = req;
+	msg.context = (void *)&req->ctx[ep_rail->rail_id];
 
 	req->state = NCCL_OFI_RDMA_REQ_CREATED;
 	ssize_t rc = fi_recvmsg(ep_rail->ofi_ep, &msg, flags);
@@ -5676,7 +5687,7 @@ static ssize_t send_ctrl_post(nccl_net_ofi_rdma_recv_comm_t *r_comm,
 	ssize_t rc = fi_send(comm_rail->local_ep, ctrl_fl_elem->ptr,
 			size,
 			desc,
-			comm_rail->remote_addr, req);
+			     comm_rail->remote_addr, (void *)&req->ctx[rail_id]);
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Error posting RDMA %s request. RC: %zd, Error: %s",
 			      nccl_net_ofi_req_str(req), rc, fi_strerror(-rc));
@@ -5778,7 +5789,7 @@ static int post_eager_copy(nccl_net_ofi_rdma_req_t *req)
 
 	ssize_t rc = fi_read(comm_rail->local_ep, recv_data->dst_buff,
 			     rx_buff_data->recv_len, desc, comm_rail->local_addr,
-			     (uint64_t)rx_buff, rx_key, req);
+			     (uint64_t)rx_buff, rx_key, (void *)&req->ctx[rx_rail_id]);
 
 	if ((rc != 0) && (rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Error posting RDMA ctrl request. RC: %zd, Error: %s",
@@ -5823,7 +5834,7 @@ static int post_flush_req(nccl_net_ofi_rdma_req_t *req)
 			     (void *)host_buff_addr,
 			     f_buff->size, desc, comm_rail->local_addr,
 			     (uint64_t)(virt_addr_mr ? flush_data->data : 0),
-			     cuda_key, req);
+			     cuda_key, (void *)&req->ctx[rail_id]);
 		if ((rc != 0) && (rc != -FI_EAGAIN)) {
 			NCCL_OFI_WARN("Error posting flush request. RC: %zd, Error: %s",
 				      rc, fi_strerror(-rc));
@@ -6732,7 +6743,7 @@ static int post_send_conn(nccl_net_ofi_rdma_send_comm_t *s_comm,
 	 * can be lifted.
 	 */
 	rc = fi_send(comm_rail->local_ep, (void *)s_comm->conn_msg->ptr, sizeof(nccl_ofi_rdma_connection_info_t), desc,
-		     comm_rail->remote_addr, req);
+		     comm_rail->remote_addr, (void *)&req->ctx[rail_id]);
 
 	if (rc == -FI_EAGAIN) {
 		/*
@@ -7858,7 +7869,7 @@ static void get_hints(struct fi_info *hints)
 	 * the NCCL level.  */
 	hints->caps |= FI_LOCAL_COMM | FI_REMOTE_COMM;
 
-	hints->mode = 0;
+	hints->mode = FI_CONTEXT | FI_CONTEXT2;
 
 	hints->ep_attr->type = FI_EP_RDM;
 


### PR DESCRIPTION
With this patch series, the rdma transport passes basic tests with the efa-direct fabric in the efa provider.  The primary issues were that both transports claimed support for FI_MR_LOCAL when they didn't actually support FI_MR_LOCAL and that the rdma transport did not support FI_CONTEXT2.  The sendrecv transport obviously doesn't work with efa-direct, however this patch series fixes the FI_MR_LOCAL issues in sendrecv, because fixing it in only one transport didn't make sense.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
