### PR TITLE
Revert "rdma: Support FI_CONTEXT and FI_CONTEXT2"

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -361,8 +361,6 @@ typedef struct {
 typedef struct nccl_net_ofi_rdma_req {
 	nccl_net_ofi_req_t base;
 
-	struct fi_context2 ctx[MAX_NUM_RAILS];
-
 	/* Associated Comm object */
 	nccl_net_ofi_comm_t *comm;
 


### PR DESCRIPTION
*Description of changes:*

Reverting the commit - https://github.com/aws/aws-ofi-nccl/commit/731ebfa9177771ea69ddcae8561efa43aef7345c
on the release branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
