### PR TITLE
rdma: Set eager max size to 0

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -319,7 +319,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
  */
-OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE", 0);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
As a first step in disabling eager, set max size to 0.  Assuming performance tests show no regression, we'll figure out what work we need to also properly handle 0 byte sends.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
