### PR TITLE
freelist: Handle 0 byte entry_size

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -319,7 +319,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
  */
-OFI_NCCL_PARAM_UINT(eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -750,8 +750,19 @@ struct nccl_net_ofi_rdma_ep {
 	nccl_ofi_freelist_t *conn_msg_fl;
 	/* Size of ctrl rx buffers */
 	size_t ctrl_rx_buff_size;
-	/* Size of eager rx buffers */
-	size_t eager_rx_buff_size;
+	/* Size of eager rx buffers.  Will be -1 if eager is entirely
+	 * disabled. */
+	ssize_t eager_rx_buff_size;
+	/* max size of eager messages.  This is only separate from
+	 * eager_rx_buff_size because the EFA provider incorrectly throws an
+	 * EINVAL when posting 0 byte rx buffers.  To work around that,
+	 * eager_rx_buff_size will either be -1 or positive (but not zero) and
+	 * eager_send_size is the comparison that should be used for deciding
+	 * whether a message is eligible for eager.  eager_send_size will never
+	 * be larger than eager_rx_buff_size.  Will be -1 if eager is entirely
+	 * disabled.
+	 */
+	ssize_t eager_send_size;
 
 	/* true if the current endpoint is a endpoint_per_communicator
 	   receive communicator */

--- a/src/nccl_ofi_freelist.c
+++ b/src/nccl_ofi_freelist.c
@@ -68,6 +68,15 @@ static int freelist_init_internal(size_t entry_size,
 
 	freelist->memcheck_redzone_size = NCCL_OFI_ROUND_UP(MEMCHECK_REDZONE_SIZE, entry_alignment);
 
+        /* The rest of the freelist code doesn't deal well with a 0 byte entry
+         * so increase to 8 bytes in that case rather than adding a bunch of
+	 * special cases for size == 0 in the rest of the code.  This happens
+         * before the bump-up for entry alignment and redzone checking, which
+         * may further increase the size.
+	 */
+        if (entry_size == 0) {
+		entry_size = 8;
+	}
 	freelist->entry_size = NCCL_OFI_ROUND_UP(entry_size,
 		NCCL_OFI_MAX(entry_alignment, NCCL_OFI_MAX(8, MEMCHECK_GRANULARITY)));
 	freelist->entry_size += freelist->memcheck_redzone_size;

--- a/src/platform-aws.c
+++ b/src/platform-aws.c
@@ -332,9 +332,13 @@ static int configure_ep_max_msg_size(struct fid_ep *ep)
 	int ret = 0;
 
 #if HAVE_DECL_FI_OPT_MAX_MSG_SIZE
-	size_t eager_max_size = (size_t)ofi_nccl_eager_max_size();
-	size_t optval = NCCL_OFI_MAX(NCCL_OFI_MAX(sizeof(nccl_net_ofi_rdma_ctrl_msg_t), eager_max_size),
+	ssize_t eager_max_size = (ssize_t)ofi_nccl_eager_max_size();
+	size_t optval = NCCL_OFI_MAX(sizeof(nccl_net_ofi_rdma_ctrl_msg_t),
 				     sizeof(nccl_ofi_rdma_connection_info_t));
+
+	if (eager_max_size > 0) {
+		optval = NCCL_OFI_MAX(optval, (size_t)eager_max_size);
+	}
 
 	ret = fi_setopt(&ep->fid, FI_OPT_ENDPOINT, FI_OPT_MAX_MSG_SIZE, &optval, sizeof(optval));
 


### PR DESCRIPTION
*Description of changes:*

Parts of the freelist assume entry_size is larger than 0 bytes, but the interface does not check for size and does not specify restrictions either way.  Improve the situation by overriding a 0 byte entry size to be 8 bytes (plus any additional size increases caused by the alignment and redzone requirements).  This seems better than a bunch of 0 byte checks through the rest of the code.

(cherry picked from commit 74fc0ae4ac08c6dba79ff2907231a7a500e2efda)

*Issue #, if available:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
