### PR TITLE
Remove support for not creating local MRs

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,9 +103,6 @@ extern int nic_dup_conns;
    read in the polling loop without protection of a lock. */
 extern size_t cq_read_count;
 
-/* Indicates if memory registration of local buffers is required */
-extern bool local_mr;
-
 /* Indicates if endpoint memory registration is required */
 extern bool endpoint_mr;
 
@@ -745,7 +742,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
  * @return      0 (Success)
  *
  * Set required behavior flags (and print debugging information) for
- * local_mr, virt_addr_mr, and endpoint_mr.
+ * virt_addr_mr, and endpoint_mr.
  */
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -50,8 +50,6 @@ int nic_dup_conns = 0;
    read in the polling loop without protection of a lock. */
 size_t cq_read_count = 1;
 
-/* Indicates if memory registration of local buffers is required */
-bool local_mr = false;
 /* Indicates if endpoint memory registration is required */
 bool endpoint_mr = false;
 
@@ -611,17 +609,6 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 			NCCL_OFI_WARN("EFA provider requires at least libfabric version 1.22.0.");
 			return -ENOTSUP;
 		}
-	}
-
-	/* Check if provider requires local memory registration */
-	if (selected_provider->domain_attr->mr_mode & FI_MR_LOCAL) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
-			       selected_provider->fabric_attr->prov_name);
-		local_mr = true;
-	} else {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
-			       selected_provider->fabric_attr->prov_name);
-		local_mr = false;
 	}
 
 	/* Check if provider uses remote virtual addressing */


### PR DESCRIPTION
Commits 27548d4 and a1ac0f5 fixed providers that required memory registrations when FI_MR_LOCAL was set, but also broke providers that clear FI_MR_LOCAL (such as HPE's provider), because I did not account for the mr_local handling in the send/recv transport.

We don't have a great way to test that case from AWS, the vast majority of transfers will either be HMEM (which creates an MR anyway) or control messages (which have a freelist which creates an MR), and the Libfabric specification allows passing an MR descriptor to a local operation even if the provider clears the FI_MR_LOCAL bit.  Therefore, the best path forward seems to be removing the code to skip registration if FI_MR_LOCAL is cleared, and always creating an MR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
