### PR TITLE
.ci/aws: Make cluster and testing timeout consistent

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -162,7 +162,7 @@ pipeline {
                 script {
                     def stages = [:]
 
-                    def timeout = "--timeout 40"
+                    def timeout = "--timeout 240"
                     def nccl_version = "--test-nccl-version v2.22.3-1"
                     def cluster_type = "--cluster-type manual_cluster"
                     def test_target = "--test-target aws-ofi-nccl"


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR includes:

- Increased cluster timeout from `40` to `240` minutes, which is the same configured for testing timeout


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
