### PR TITLE
Fix 0 byte sends/receives with user buffer registration

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -678,9 +678,6 @@ struct nccl_net_ofi_ep_rail {
 	/* Completion Queue handle */
 	struct fid_cq *cq;
 
-	/* Access domain handles */
-	struct fid_domain *domain;
-
 	/*
 	 * Rx buffer management
 	 */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -123,17 +123,10 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  * allocate a RDMA memory registration handle with `num_rails`+`num_control_rails` rails.
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
-
 	int num_rails;
-
-	int num_control_rails;
 
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;
-
-	/* Array of size `num_control_rails' */
-	struct fid_mr **control_mr;
-
 } nccl_net_ofi_rdma_mr_handle_t;
 
 /* Contents of ctrl message sent from receiver to sender to advertise

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -592,9 +592,6 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	/* Comm ID provided by remote endpoint */
 	uint32_t remote_comm_id;
 
-	/* The flush buffer */
-	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
-
 	uint16_t next_msg_seq_num;
 
 	nccl_ofi_msgbuff_t *msgbuff;
@@ -849,6 +846,9 @@ typedef struct nccl_net_ofi_rdma_domain {
 
 	int num_rails;
 	nccl_net_ofi_rdma_domain_rail_t *domain_rails;
+
+	/* The flush buffer */
+	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
 
 	/* List of endpoints and set of addresses they have connections to */
 	nccl_ofi_ep_addr_list_t *ep_addr_list;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -125,6 +125,9 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
 typedef struct nccl_net_ofi_rdma_mr_handle {
 	int num_rails;
 
+	/* value of mr key id, if keys must be requested */
+	int mr_key;
+
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;
 } nccl_net_ofi_rdma_mr_handle_t;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -368,7 +368,8 @@ static inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_control_rail(nccl_net_of
  */
 static inline struct fid_domain *rdma_endpoint_get_ofi_domain(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
 {
-	return rdma_endpoint_get_rail(ep, rail_id)->domain;
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	return rdma_domain_get_rail(domain, rail_id)->domain;
 }
 
 /*
@@ -7007,7 +7008,6 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 	int ret = 0;
 	struct fi_info *rail_info = dev_rail->info;
 
-	ep_rail->domain = domain_rail->domain;
 	if (ep_rail->cq == NULL) {
 		/* cq will be NULL most of the time, but there's a
 		   hack in init_rail_ofi_resources to have the control
@@ -7038,7 +7038,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 	}
 
 	ret = nccl_ofi_ofiutils_init_connection(rail_info,
-						ep_rail->domain,
+						domain_rail->domain,
 						&ep_rail->ofi_ep,
 						&ep_rail->av,
 						&ep_rail->cq);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2897,8 +2897,7 @@ error:
  *		non-zero on error
 */
 static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
-		    nccl_ofi_idpool_t *key_pool,
-		    nccl_ofi_mr_cache_t *mr_cache)
+		    nccl_net_ofi_rdma_domain_t *domain)
 {
 	int ret = 0;
 
@@ -2912,6 +2911,8 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		return -EINVAL;
 	}
 
+	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
+	nccl_ofi_mr_cache_t *mr_cache = domain->base.mr_cache;
 
 	if (mr_cache) {
 		/*
@@ -2996,7 +2997,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 					      dev_id, type, &mr_attr, regattr_flags,
 					      &ret_handle->mr[rail_id]);
 		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr(ret_handle, key_pool, NULL) != 0) {
+			if (dereg_mr(ret_handle, domain)) {
 				NCCL_OFI_WARN("Error de-registering MR");
 			}
 			ret_handle = NULL;
@@ -3025,10 +3026,9 @@ exit:
  * @return	Memory registration handle
 */
 static int reg_mr(nccl_net_ofi_rdma_domain_t *domain,
-		     nccl_ofi_mr_ckey_ref ckey,
-		     int type,
-		     nccl_ofi_mr_cache_t *mr_cache,
-		     nccl_net_ofi_rdma_mr_handle_t **mhandle)
+		  nccl_ofi_mr_ckey_ref ckey,
+		  int type,
+		  nccl_net_ofi_rdma_mr_handle_t **mhandle)
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
@@ -3036,7 +3036,8 @@ static int reg_mr(nccl_net_ofi_rdma_domain_t *domain,
 
 	assert(domain);
 
-	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
+	nccl_ofi_mr_cache_t *mr_cache = domain->base.mr_cache;
+
 	if (mr_cache) {
 		/*
 		 * MR cache is locked between lookup and insert, to be sure we
@@ -3063,7 +3064,7 @@ static int reg_mr(nccl_net_ofi_rdma_domain_t *domain,
 						     ckey,
 						     ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr(ret_handle, key_pool, NULL) != 0) {
+			if (dereg_mr(ret_handle, domain) != 0) {
 				NCCL_OFI_WARN("Error de-registering MR");
 			}
 
@@ -3143,7 +3144,7 @@ static int reg_internal_mr(nccl_net_ofi_rdma_domain_t *domain, void *data,
 	assert(NCCL_OFI_IS_ALIGNED(size, system_page_size));
 
 	const nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(data, size);
-	return reg_mr(domain, &ckey, type, NULL, mhandle);
+	return reg_mr(domain, &ckey, type, mhandle);
 }
 
 static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
@@ -3157,7 +3158,6 @@ static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 	return reg_mr(domain,
 		      ckey,
 		      type,
-		      domain->base.mr_cache,
 		      (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
@@ -3172,13 +3172,12 @@ static int reg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	return reg_mr(domain,
 		      ckey,
 		      type,
-		      domain->base.mr_cache,
 		      (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
 typedef struct {
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle;
-	nccl_ofi_idpool_t *key_pool;
+	nccl_net_ofi_rdma_domain_t *domain;
 } freelist_regmr_fn_handle_t;
 
 /**
@@ -3196,12 +3195,6 @@ static int freelist_regmr_host_fn(void *domain_void_ptr, void *data, size_t size
 	nccl_net_ofi_rdma_domain_t *domain = (nccl_net_ofi_rdma_domain_t *)domain_void_ptr;
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle;
-	int ret = reg_internal_mr(domain, data, size, NCCL_PTR_HOST, &mr_handle);
-
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed call to reg_mr: %d", ret);
-		return -EIO;
-	}
 
 	freelist_regmr_fn_handle_t *freelist_handle =
 		(freelist_regmr_fn_handle_t *)malloc(sizeof(freelist_regmr_fn_handle_t));
@@ -3210,8 +3203,15 @@ static int freelist_regmr_host_fn(void *domain_void_ptr, void *data, size_t size
 		return -ENOMEM;
 	}
 
+        int ret = reg_internal_mr(domain, data, size, NCCL_PTR_HOST, &mr_handle);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed call to reg_mr: %d", ret);
+		free(freelist_handle);
+		return -EIO;
+	}
+
 	freelist_handle->mr_handle = mr_handle;
-	freelist_handle->key_pool = &(domain)->base.mr_rkey_pool;
+	freelist_handle->domain = domain;
 	*handle = (void *)freelist_handle;
 	return 0;
 }
@@ -3225,7 +3225,7 @@ static int freelist_deregmr_host_fn(void *handle)
 {
 	freelist_regmr_fn_handle_t *freelist_handle = (freelist_regmr_fn_handle_t *)handle;
 	assert(freelist_handle);
-	int ret = dereg_mr(freelist_handle->mr_handle, freelist_handle->key_pool, NULL);
+	int ret = dereg_mr(freelist_handle->mr_handle, freelist_handle->domain);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Failed call to dereg_mr");
 		return -EIO;
@@ -3245,7 +3245,7 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	assert(domain != NULL);
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	return dereg_mr(mr_handle, domain);
 }
 
 /*
@@ -3727,7 +3727,7 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = r_comm->flush_buff.mr_handle;
 
 	if (mr_handle) {
-		ret = dereg_mr(mr_handle, &domain->base.mr_rkey_pool, NULL);
+		ret = dereg_mr(mr_handle, domain);
 	}
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
@@ -5276,7 +5276,7 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle =
 		(nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	return dereg_mr(mr_handle, domain);
 }
 
 static int alloc_rdma_write_req(nccl_net_ofi_rdma_send_comm_t *s_comm,

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3641,13 +3641,16 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_domain_t *domai
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
 		goto exit;
 	}
-	ret = nccl_net_ofi_dealloc_mr_buffer(domain->flush_buff.host_buffer,
-					    system_page_size);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)", ret);
-		goto exit;
+
+	if (domain->flush_buff.host_buffer != MAP_FAILED) {
+		ret = nccl_net_ofi_dealloc_mr_buffer(domain->flush_buff.host_buffer,
+						     system_page_size);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)", ret);
+			goto exit;
+		}
+		domain->flush_buff.host_buffer = MAP_FAILED;
 	}
-	domain->flush_buff.host_buffer = MAP_FAILED;
 
  exit:
 	return ret;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3618,11 +3618,6 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	return ret;
 }
 
-static inline bool is_flush_buff_enabled(void)
-{
-	return !ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush;
-}
-
 /*
  * @brief	Deregister flush buffer if flush buffer was registered. Deallocate flush buffer.
  *
@@ -3634,11 +3629,10 @@ static inline bool is_flush_buff_enabled(void)
  * @return	0, on success
  * 		error, on others
  */
-static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm,
-							nccl_net_ofi_rdma_domain_t *domain)
+static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_domain_t *domain)
 {
 	int ret = 0;
-	nccl_net_ofi_rdma_mr_handle_t *mr_handle = r_comm->flush_buff.mr_handle;
+	nccl_net_ofi_rdma_mr_handle_t *mr_handle = domain->flush_buff.mr_handle;
 
 	if (mr_handle) {
 		ret = dereg_mr(mr_handle, domain);
@@ -3647,13 +3641,13 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
 		goto exit;
 	}
-	ret = nccl_net_ofi_dealloc_mr_buffer(r_comm->flush_buff.host_buffer,
+	ret = nccl_net_ofi_dealloc_mr_buffer(domain->flush_buff.host_buffer,
 					    system_page_size);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)", ret);
 		goto exit;
 	}
-	r_comm->flush_buff.host_buffer = MAP_FAILED;
+	domain->flush_buff.host_buffer = MAP_FAILED;
 
  exit:
 	return ret;
@@ -3672,14 +3666,12 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_
  * @return	0, on success
  * 		error, on others
  */
-static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int dev_id)
+static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_domain_t *domain, int dev_id)
 {
 	int ret = 0;
 	int rc;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = NULL;
-	nccl_net_ofi_rdma_flush_buffer_t *flush_buff = &r_comm->flush_buff;
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
-	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	nccl_net_ofi_rdma_flush_buffer_t *flush_buff = &domain->flush_buff;
 
 	NCCL_OFI_TRACE(NCCL_NET, "Registering buffer for flush operations");
 
@@ -3692,7 +3684,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 	}
 
 	/* make sure flush destination address does not overflow beyond host buffer */
-	assert(((cpu_cache_line_size * ep->num_rails) + flush_buff->size) <= system_page_size);
+	assert(((cpu_cache_line_size * domain->num_rails) + flush_buff->size) <= system_page_size);
 
 	/* Check if provider requires registration of local buffers */
 	if (local_mr == true) {
@@ -3735,7 +3727,6 @@ static inline void free_rdma_recv_comm(nccl_net_ofi_rdma_recv_comm_t *r_comm) {
 static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 {
 	nccl_net_ofi_rdma_device_t *device = NULL;
-	nccl_net_ofi_rdma_domain_t *domain = NULL;
 	int ret = 0;
 
 	/* Retrieve and validate endpoint */
@@ -3746,23 +3737,12 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 		return ret;
 	}
 
-	domain = rdma_endpoint_get_domain(ep);
-	assert(domain != NULL);
-
 	device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
 
 	if (r_comm->send_close_req != NULL) {
 		ret = r_comm->send_close_req->free(r_comm->send_close_req, false);
 		if (ret != 0) {
-			return ret;
-		}
-	}
-
-	if (is_flush_buff_enabled()) {
-		ret = dealloc_and_dereg_flush_buff(r_comm, domain);
-		if (ret != 0) {
-			NCCL_OFI_WARN("Failed to deregister ctrl buffer pool");
 			return ret;
 		}
 	}
@@ -4198,9 +4178,6 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	}
 #endif
 
-	assert(r_comm->flush_buff.host_buffer);
-	assert(r_comm->flush_buff.mr_handle);
-
 	/*
 	 * Find the non-zero request for which we will issue flush.
 	 * A single operation can flush all request at once.
@@ -4625,17 +4602,6 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		NCCL_OFI_WARN("Could not allocate NCCL OFI requests free list for dev %d",
 				  dev_id);
 		goto error;
-	}
-
-	/*
-	 * Setup flush resources if using GPUDirect RDMA unless user disables
-	 * flush operations
-	 */
-	if (is_flush_buff_enabled()) {
-		ret = alloc_and_reg_flush_buff(r_comm, dev_id);
-		if (OFI_UNLIKELY(ret != 0)) {
-			goto error;
-		}
 	}
 
 	/* Allocate connect message, will be returned after the
@@ -5669,7 +5635,8 @@ static int post_flush_req(nccl_net_ofi_rdma_req_t *req)
 {
  	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
-	nccl_net_ofi_rdma_flush_buffer_t *f_buff = &r_comm->flush_buff;
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	nccl_net_ofi_rdma_flush_buffer_t *f_buff = &domain->flush_buff;
 	rdma_req_flush_data_t *flush_data = get_flush_data(req);
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail;
 	ssize_t rc = 0;
@@ -7263,6 +7230,12 @@ nccl_net_ofi_rdma_domain_free(nccl_net_ofi_domain_t *base_domain)
 	int ret;
 	nccl_net_ofi_rdma_domain_t *domain = (nccl_net_ofi_rdma_domain_t *)base_domain;
 
+	ret = dealloc_and_dereg_flush_buff(domain);
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed to deregister ctrl buffer pool");
+		return ret;
+	}
+
 	for (int i = 0 ; i < domain->num_rails ; ++i) {
 		if (domain->domain_rails[i].cq != NULL) {
 			fi_close(&domain->domain_rails[i].cq->fid);
@@ -7367,6 +7340,13 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 		}
 	}
 
+	/*
+	 * Setup flush resources.
+	 */
+	ret = alloc_and_reg_flush_buff(domain, device->base.dev_id);
+	if (OFI_UNLIKELY(ret != 0)) {
+		goto error;
+	}
 
 error:
 	if (ret != 0) {


### PR DESCRIPTION
The primary goal of this patch series is to fix another bug introduced with https://github.com/aws/aws-ofi-nccl/pull/614 that https://github.com/aws/aws-ofi-nccl/pull/794 didn't fix, specifically an issue with how NCCL 2.24 and earlier behaved with 0 byte send/recv from user registered buffers.  In those configurations, NCCL would pass an mhandle that was valid but not one that covered the base pointer of the buffer.  This patch fixes that by using the flush buffer for the source / dest of 0 byte send / recv, so that we always have a valid MR for the buffer.

That was simplest by moving the flush buffer into the domain, so that we didn't have to add a ton of flush buffers, one for each new communicator.  However, that simplified the code just enough that static analysis suddenly found lots of existing leaks, potential leaks, and use after frees, which required some significant code cleanup in the reg_mr and dereg_mr code paths.  So this patch series grew significantly longer than originally anticipated.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
