### PR TITLE
v1.14.x: Cherry pick commits from master

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -172,7 +172,7 @@ pipeline {
                     def nccl_test_iter = "--test-aws-ofi-nccl-nccltest-iterations 5"
                     def efa_installer = "--use-prebuilt-ami-with-efa-installer true"
 
-                    def persistent_manual_cluster_addl_args = " --keep-cluster --skip-fixture-setup --skip-health-checks --use-existing-installer --cleanup-pf-directory --enable-placement-group false"
+                    def persistent_manual_cluster_addl_args = " --keep-cluster --skip-fixture-setup --skip-health-checks --use-existing-installer --cleanup-pf-directory --enable-placement-group false --lean-cluster-setup"
                     def container_addl_args = " --test-in-containers-on-ec2"
 
                     def base_args = "${efa_installer} ${nccl_version} ${timeout} ${cluster_type} ${test_target} ${test_type} ${build_type} ${pr_num} ${nccl_test_iter} ${persistent_manual_cluster_addl_args}"

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -109,6 +109,9 @@ extern bool endpoint_mr;
 /* Indicates if remote virtual addressing is used */
 extern bool virt_addr_mr;
 
+/* Indicates if provider's data progress model is FI_PROGRESS_AUTO */
+extern bool data_progress_auto;
+
 /* Selected communication protocol.
  *
  * Until the protocol environment variable is checked in init(), this
@@ -742,7 +745,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
  * @return      0 (Success)
  *
  * Set required behavior flags (and print debugging information) for
- * virt_addr_mr, and endpoint_mr.
+ * virt_addr_mr, endpoint_mr and data_progress_auto.
  */
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -103,9 +103,6 @@ extern int nic_dup_conns;
    read in the polling loop without protection of a lock. */
 extern size_t cq_read_count;
 
-/* Indicates if memory registration of local buffers is required */
-extern bool local_mr;
-
 /* Indicates if endpoint memory registration is required */
 extern bool endpoint_mr;
 
@@ -745,7 +742,7 @@ int nccl_net_ofi_dealloc_mr_buffer(void *ptr, size_t size);
  * @return      0 (Success)
  *
  * Set required behavior flags (and print debugging information) for
- * local_mr, virt_addr_mr, and endpoint_mr.
+ * virt_addr_mr, and endpoint_mr.
  */
 int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_provider,
 					     unsigned int num_providers);

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -319,7 +319,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", -1);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -396,6 +396,14 @@ OFI_NCCL_PARAM_INT(use_low_lat_tc, "USE_LOW_LATENCY_TC", 1);
  */
 OFI_NCCL_PARAM_INT(force_num_rails, "FORCE_NUM_RAILS", 0);
 
+/*
+ * 1 to enable early completion, 0 to disable it.
+ * Default at -1 to follow the data progress model, given that 
+ * early completion feature is contigent on FI_PROGRESS_AUTO data progress model
+ * i.e. enabled when FI_PROGRESS_AUTO, otherwise disabled
+ */
+OFI_NCCL_PARAM_INT(early_completion, "EARLY_COMPLETION", -1);
+
 #ifdef __cplusplus
 } // End extern "C"
 #endif

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -104,6 +104,7 @@ enum nccl_ofi_rdma_msg_type {
 	NCCL_OFI_RDMA_MSG_CTRL,
 	NCCL_OFI_RDMA_MSG_EAGER,
 	NCCL_OFI_RDMA_MSG_CLOSE,
+	NCCL_OFI_RDMA_MSG_CTRL_NO_COMPLETION,
 	NCCL_OFI_RDMA_MSG_INVALID = 15,
 	NCCL_OFI_RDMA_MSG_MAX = NCCL_OFI_RDMA_MSG_INVALID,
 };
@@ -260,6 +261,12 @@ typedef struct {
 	/* Total number of completions. Expect one completion for receiving the
 	 * control message and one completion for each send segment. */
 	int total_num_compls;
+	/* 
+	 * Flag to indicate target side early completion, so that sender side
+	 * uses the corresponding RMA write operation.
+	 * True to use fi_write instead of fi_writedata in send() 
+	 */
+	bool no_target_completion;
 #if HAVE_NVTX_TRACING
 	nvtxRangeId_t trace_id;
 	nvtxRangeId_t seg_trace_id[MAX_NUM_RAILS];

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -123,17 +123,10 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
  * allocate a RDMA memory registration handle with `num_rails`+`num_control_rails` rails.
  */
 typedef struct nccl_net_ofi_rdma_mr_handle {
-
 	int num_rails;
-
-	int num_control_rails;
 
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;
-
-	/* Array of size `num_control_rails' */
-	struct fid_mr **control_mr;
-
 } nccl_net_ofi_rdma_mr_handle_t;
 
 /* Contents of ctrl message sent from receiver to sender to advertise

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -590,9 +590,6 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	/* Comm ID provided by remote endpoint */
 	uint32_t remote_comm_id;
 
-	/* The flush buffer */
-	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
-
 	uint16_t next_msg_seq_num;
 
 	nccl_ofi_msgbuff_t *msgbuff;
@@ -847,6 +844,9 @@ typedef struct nccl_net_ofi_rdma_domain {
 
 	int num_rails;
 	nccl_net_ofi_rdma_domain_rail_t *domain_rails;
+
+	/* The flush buffer */
+	nccl_net_ofi_rdma_flush_buffer_t flush_buff;
 
 	/* List of endpoints and set of addresses they have connections to */
 	nccl_ofi_ep_addr_list_t *ep_addr_list;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -676,9 +676,6 @@ struct nccl_net_ofi_ep_rail {
 	/* Completion Queue handle */
 	struct fid_cq *cq;
 
-	/* Access domain handles */
-	struct fid_domain *domain;
-
 	/*
 	 * Rx buffer management
 	 */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -125,6 +125,9 @@ typedef uint16_t nccl_ofi_rdma_msg_type_t;
 typedef struct nccl_net_ofi_rdma_mr_handle {
 	int num_rails;
 
+	/* value of mr key id, if keys must be requested */
+	int mr_key;
+
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;
 } nccl_net_ofi_rdma_mr_handle_t;

--- a/src/nccl_ofi_api.c
+++ b/src/nccl_ofi_api.c
@@ -789,14 +789,6 @@ ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** data,
 		return check_return(ncclInvalidArgument);
 	}
 
-	/* 
-	 * Reset to NULL for now until optional receive completion logic is
-	 * implemented
-	 */
-	if (*request == (void *)NCCL_NET_OPTIONAL_RECV_COMPLETION) {
-		*request = NULL;
-	}
-
 	ncclResult_t validation_result = msg_length_verify_max_size(sizes, n);
 	if (validation_result != ncclSuccess) {
 		return check_return(validation_result);

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -56,6 +56,9 @@ bool endpoint_mr = false;
 /* Indicates if remote virtual addressing is used */
 bool virt_addr_mr = false;
 
+/* Indicates if provider's data progress model is FI_PROGRESS_AUTO */
+bool data_progress_auto = false;
+
 /* Selected communication protocol. */
 const char *nccl_ofi_selected_protocol = NULL;
 
@@ -631,6 +634,22 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require endpoint memory registration",
 			       selected_provider->fabric_attr->prov_name);
 		endpoint_mr = false;
+	}
+
+	/* Check provider's data progress model */
+	if (selected_provider->domain_attr->data_progress == FI_PROGRESS_AUTO) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s uses FI_PROGRESS_AUTO data progress model",
+					selected_provider->fabric_attr->prov_name);
+		data_progress_auto = true;
+	} else if (selected_provider->domain_attr->data_progress == FI_PROGRESS_MANUAL) {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s uses FI_PROGRESS_MANUAL data progress model",
+					selected_provider->fabric_attr->prov_name);
+		data_progress_auto = false;
+	} else {
+		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s uses data progress model: %d",
+					selected_provider->fabric_attr->prov_name,
+					selected_provider->domain_attr->data_progress);
+		data_progress_auto = false;
 	}
 
 	return 0;

--- a/src/nccl_ofi_net.c
+++ b/src/nccl_ofi_net.c
@@ -50,8 +50,6 @@ int nic_dup_conns = 0;
    read in the polling loop without protection of a lock. */
 size_t cq_read_count = 1;
 
-/* Indicates if memory registration of local buffers is required */
-bool local_mr = false;
 /* Indicates if endpoint memory registration is required */
 bool endpoint_mr = false;
 
@@ -611,17 +609,6 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 			NCCL_OFI_WARN("EFA provider requires at least libfabric version 1.22.0.");
 			return -ENOTSUP;
 		}
-	}
-
-	/* Check if provider requires local memory registration */
-	if (selected_provider->domain_attr->mr_mode & FI_MR_LOCAL) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s requires registration of local memory buffers",
-			       selected_provider->fabric_attr->prov_name);
-		local_mr = true;
-	} else {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not require registration of local memory buffers",
-			       selected_provider->fabric_attr->prov_name);
-		local_mr = false;
 	}
 
 	/* Check if provider uses remote virtual addressing */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3619,13 +3619,16 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_domain_t *domai
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
 		goto exit;
 	}
-	ret = nccl_net_ofi_dealloc_mr_buffer(domain->flush_buff.host_buffer,
-					    system_page_size);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)", ret);
-		goto exit;
+
+	if (domain->flush_buff.host_buffer != MAP_FAILED) {
+		ret = nccl_net_ofi_dealloc_mr_buffer(domain->flush_buff.host_buffer,
+						     system_page_size);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)", ret);
+			goto exit;
+		}
+		domain->flush_buff.host_buffer = MAP_FAILED;
 	}
-	domain->flush_buff.host_buffer = MAP_FAILED;
 
  exit:
 	return ret;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -368,7 +368,8 @@ static inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_control_rail(nccl_net_of
  */
 static inline struct fid_domain *rdma_endpoint_get_ofi_domain(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
 {
-	return rdma_endpoint_get_rail(ep, rail_id)->domain;
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+	return rdma_domain_get_rail(domain, rail_id)->domain;
 }
 
 /*
@@ -6984,7 +6985,6 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 	int ret = 0;
 	struct fi_info *rail_info = dev_rail->info;
 
-	ep_rail->domain = domain_rail->domain;
 	if (ep_rail->cq == NULL) {
 		/* cq will be NULL most of the time, but there's a
 		   hack in init_rail_ofi_resources to have the control
@@ -7015,7 +7015,7 @@ static int ep_rail_init(nccl_net_ofi_rdma_ep_t *ep,
 	}
 
 	ret = nccl_ofi_ofiutils_init_connection(rail_info,
-						ep_rail->domain,
+						domain_rail->domain,
 						&ep_rail->ofi_ep,
 						&ep_rail->av,
 						&ep_rail->cq);

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3691,25 +3691,19 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_domain_t *domain, int dev_
 	/* make sure flush destination address does not overflow beyond host buffer */
 	assert(((cpu_cache_line_size * domain->num_rails) + flush_buff->size) <= system_page_size);
 
-	/* Check if provider requires registration of local buffers */
-	if (local_mr == true) {
-		/* Register flush dummy buffer for provider access */
-		ret = reg_internal_mr(domain, flush_buff->host_buffer, system_page_size,
-			  NCCL_PTR_HOST, &mr_handle);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
-				      dev_id);
-			rc = nccl_net_ofi_dealloc_mr_buffer(flush_buff->host_buffer,
-							    system_page_size);
-			if (rc != 0) {
-				NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)",
-					      rc);
-			}
-			flush_buff->host_buffer = MAP_FAILED;
+	/* Register flush dummy buffer for provider access */
+	ret = reg_internal_mr(domain, flush_buff->host_buffer, system_page_size,
+			      NCCL_PTR_HOST, &mr_handle);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
+			      dev_id);
+		rc = nccl_net_ofi_dealloc_mr_buffer(flush_buff->host_buffer,
+						    system_page_size);
+		if (rc != 0) {
+			NCCL_OFI_WARN("Unable to deallocate flush buffer (%d)",
+				      rc);
 		}
-	} else {
-		NCCL_OFI_TRACE(NCCL_NET,
-			       "Skip registering host buffer. local_mr: %d", local_mr);
+		flush_buff->host_buffer = MAP_FAILED;
 	}
 
 	flush_buff->mr_handle = mr_handle;

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -372,14 +372,6 @@ static inline struct fid_domain *rdma_endpoint_get_ofi_domain(nccl_net_ofi_rdma_
 }
 
 /*
- * @brief return the domain for the control endpoint and rail.
- */
-static inline struct fid_domain *rdma_endpoint_get_ofi_control_domain(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
-{
-	return rdma_endpoint_get_control_rail(ep, rail_id)->domain;
-}
-
-/*
  * @brief	Write topology to NCCL topology file
  *
  * This function writes a NCCL topology file to a memfd file, and
@@ -2819,19 +2811,6 @@ static int dereg_rails(nccl_net_ofi_rdma_mr_handle_t *handle)
 	int ret = 0;
 	int rc = 0;
 	int num_rails = handle->num_rails;
-	int num_control_rails = handle->num_control_rails;
-
-	/* Cleanup memory registration for control rails */
-	for (int rail_id = 0; rail_id != num_control_rails; ++rail_id) {
-		/* No memory registration available for this rail */
-		if (!handle->control_mr[rail_id]) continue;
-		rc = fi_close(&handle->control_mr[rail_id]->fid);
-		if (OFI_UNLIKELY(rc != 0)) {
-			NCCL_OFI_WARN("Unable to de-register memory on control MR. RC: %d, Error: %s",
-				      rc, fi_strerror(-rc));
-			ret = rc;
-		}
-	}
 
 	/* Cleanup memory registration for data rails */
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
@@ -2850,9 +2829,6 @@ static int dereg_rails(nccl_net_ofi_rdma_mr_handle_t *handle)
 
 static inline void free_rdma_mr_handle(nccl_net_ofi_rdma_mr_handle_t *handle) {
 	if (handle) {
-		if (handle->control_mr) {
-			free(handle->control_mr);
-		}
 		if (handle->mr) {
 			free(handle->mr);
 		}
@@ -2870,7 +2846,7 @@ static inline void free_rdma_mr_handle(nccl_net_ofi_rdma_mr_handle_t *handle) {
  * @return	handle, on success
  *		NULL, on error
  */
-static inline nccl_net_ofi_rdma_mr_handle_t *calloc_rdma_mr_handle(int num_rails, int num_control_rails)
+static inline nccl_net_ofi_rdma_mr_handle_t *calloc_rdma_mr_handle(int num_rails)
 {
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = (nccl_net_ofi_rdma_mr_handle_t *)calloc(1, sizeof(nccl_net_ofi_rdma_mr_handle_t));
 
@@ -2882,12 +2858,6 @@ static inline nccl_net_ofi_rdma_mr_handle_t *calloc_rdma_mr_handle(int num_rails
 	ret_handle->mr = (struct fid_mr **)calloc(num_rails, sizeof(struct fid_mr *));
 	if (OFI_UNLIKELY(!ret_handle->mr)) {
 		NCCL_OFI_WARN("Unable to allocate memory registration handles array");
-		goto error;
-	}
-
-	ret_handle->control_mr = (struct fid_mr **)calloc(num_control_rails, sizeof(struct fid_mr *));
-	if (OFI_UNLIKELY(!ret_handle->control_mr)) {
-		NCCL_OFI_WARN("Unable to allocate memory registration control handles array");
 		goto error;
 	}
 
@@ -2986,12 +2956,11 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 
 	int dev_id = device->base.dev_id;
 	int num_rails = ep->num_rails;
-	int num_control_rails = ep->num_control_rails;
 
 	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 
 	/* Allocate rdma memory registration handle */
-	ret_handle = calloc_rdma_mr_handle(num_rails, num_control_rails);
+	ret_handle = calloc_rdma_mr_handle(num_rails);
 	if (OFI_UNLIKELY(!ret_handle)) {
 		NCCL_OFI_WARN("Unable to allocate memory registration handle");
 		ret = -ENOMEM;
@@ -3017,24 +2986,6 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 		ret = register_rail_mr_buffer(ofi_domain, rail->ofi_ep,
 					      dev_id, type, &mr_attr, regattr_flags,
 					      &ret_handle->mr[rail_id]);
-		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr_ep(ret_handle, key_pool, NULL) != 0) {
-				NCCL_OFI_WARN("Error de-registering MR");
-			}
-			ret_handle = NULL;
-			goto exit;
-		}
-	}
-
-	/* Register memory on each control rail */
-	ret_handle->num_control_rails = num_control_rails;
-	for (int rail_id = 0; rail_id != num_control_rails; ++rail_id) {
-		nccl_net_ofi_ep_rail_t *rail = rdma_endpoint_get_control_rail(ep, rail_id);
-		ofi_domain = rdma_endpoint_get_ofi_control_domain(ep, rail_id);
-
-		ret = register_rail_mr_buffer(ofi_domain, rail->ofi_ep,
-					      dev_id, type, &mr_attr, regattr_flags,
-					      &ret_handle->control_mr[rail_id]);
 		if (OFI_UNLIKELY(ret != 0)) {
 			if (dereg_mr_ep(ret_handle, key_pool, NULL) != 0) {
 				NCCL_OFI_WARN("Error de-registering MR");
@@ -5674,8 +5625,8 @@ static ssize_t send_ctrl_post(nccl_net_ofi_rdma_recv_comm_t *r_comm,
 
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = rdma_recv_comm_get_control_rail(r_comm, rail_id);
 
-	assert(rail_id < mr_handle->num_control_rails);
-	void *desc = fi_mr_desc(mr_handle->control_mr[rail_id]);
+	assert(rail_id < mr_handle->num_rails);
+	void *desc = fi_mr_desc(mr_handle->mr[rail_id]);
 
 	ssize_t rc = fi_send(comm_rail->local_ep, ctrl_fl_elem->ptr,
 			size,

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -3440,11 +3440,13 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)recv_comm;
 	rdma_req_recv_data_t *recv_data = NULL;
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_domain_t *domain = NULL;
 	nccl_net_ofi_rdma_device_t *device = NULL;
 	int dev_id = 0;
 	nccl_net_ofi_rdma_mr_handle_t **mr_handles = (nccl_net_ofi_rdma_mr_handle_t **)mhandles;
 	uint16_t msg_seq_num = 0;
 	bool eager = false;
+	int i;
 
 	assert(r_comm != NULL);
 
@@ -3465,6 +3467,9 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 
 	ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
 	assert(ep != NULL);
+
+	domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	device = rdma_endpoint_get_device(ep);
 	assert(device != NULL);
@@ -3512,6 +3517,25 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 		NCCL_OFI_WARN("Message %hu has invalid status.", msg_seq_num);
 		ret = -EINVAL;
 		goto error;
+	}
+
+	/* NCCL versions prior to 2.24 require special handling for 0 byte
+	 * messages when using user buffer registration.  NCCL passes the base
+	 * pointer from the user buffer, but passes the registration from the
+	 * channel buffer, to avoid an MR cache lookup.  This is fine with
+	 * InfiniBand, where the spec says the SGE is not used for a 0 byte
+	 * message, but is a problem for EFA, which validates the pointer / MR
+	 * even for a 0 byte transfer.
+	 *
+	 * To handle this case, we use the flush buffer (note we still move 0
+	 * bytes of data, we just need a valid SGE) instead of the provided base
+	 * pointer and MR
+	 */
+	for (i = 0 ; i < n ; i++) {
+		if (sizes[i] == 0) {
+			buffers[i] = domain->flush_buff.host_buffer;
+			mr_handles[i] = domain->flush_buff.mr_handle;
+		}
 	}
 
 	ret = allocate_rdma_recv_req(r_comm, device, dev_id, msg_seq_num,
@@ -5717,6 +5741,7 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 	nccl_net_ofi_rdma_send_comm_t *s_comm = (nccl_net_ofi_rdma_send_comm_t *)send_comm;
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
+	nccl_net_ofi_rdma_domain_t *domain = NULL;
 	nccl_net_ofi_rdma_req_t *req = NULL;
 	uint16_t msg_seq_num = s_comm->next_msg_seq_num;
 	bool polled_cq = false;
@@ -5744,6 +5769,9 @@ static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int t
 
 	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->base.base.ep;
 	assert(ep != NULL);
+
+	domain = rdma_endpoint_get_domain(ep);
+	assert(domain != NULL);
 
 	ret = process_cq_if_pending(ep);
 	if (ret == -EAGAIN) {
@@ -5819,6 +5847,23 @@ retry:
 		}
 		polled_cq = true;
 		goto retry;
+	}
+
+	/* NCCL versions prior to 2.24 require special handling for 0 byte
+	 * messages when using user buffer registration.  NCCL passes the base
+	 * pointer from the user buffer, but passes the registration from the
+	 * channel buffer, to avoid an MR cache lookup.  This is fine with
+	 * InfiniBand, where the spec says the SGE is not used for a 0 byte
+	 * message, but is a problem for EFA, which validates the pointer / MR
+	 * even for a 0 byte transfer.
+	 *
+	 * To handle this case, we use the flush buffer (note we still move 0
+	 * bytes of data, we just need a valid SGE) instead of the provided base
+	 * pointer and MR
+	 */
+	if (size == 0) {
+		data = domain->flush_buff.host_buffer;
+		mr_handle = domain->flush_buff.mr_handle;
 	}
 
 	/* Determine if this should be sent eagerly. */

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -466,8 +466,6 @@ exit:
  *
  * @param	key_pool
  *		Device key pool
- * @param	dev_id
- *		Device ID
  * @param	data
  *		Memory region to be registered
  * @param	size
@@ -480,7 +478,7 @@ exit:
  * @return	0 on success
  *		non-zero on error
  */ 
-static int set_mr_req_attr(nccl_ofi_idpool_t *key_pool, int dev_id,
+static int set_mr_req_attr(uint64_t mr_key,
 			   nccl_ofi_mr_ckey_ref ckey, uint64_t *flags,
 			   int type, struct fi_mr_attr *mr_attr)
 {
@@ -530,37 +528,12 @@ static int set_mr_req_attr(nccl_ofi_idpool_t *key_pool, int dev_id,
 		goto exit;
 	}
 
-	if (nccl_ofi_idpool_active(key_pool)) {
-		int key = nccl_ofi_idpool_allocate_id(key_pool);
-		if (OFI_UNLIKELY(key < 0)) {
-			NCCL_OFI_WARN("MR key allocation failed");
-			goto exit;
-		}
-		mr_attr->requested_key = (uint64_t)key;
-	}
+	mr_attr->requested_key = mr_key;
 
  exit:
 	return ret;
 }
 
-static int register_rail_mr_buffer(struct fid_domain *domain,
-				   int dev_id,
-				   int type, struct fi_mr_attr *mr_attr,
-				   uint64_t flags, struct fid_mr **mr_handle)
-{
-	int ret = 0;
-
-	ret = fi_mr_regattr(domain, mr_attr, flags, mr_handle);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Unable to register memory (type = %d) for device %d. RC: %d, Error: %s",
-			      type, dev_id, ret, fi_strerror(-ret));
-		ret = -EINVAL;
-		goto exit;
-	}
-
- exit:
-	return ret;
-}
 
 /*
  * @brief	Calculate length of libfabric NIC info list
@@ -2791,75 +2764,6 @@ static int prepare_recv_conn_req(nccl_net_ofi_rdma_listen_comm_t *l_comm)
 	return 0;
 }
 
-/*
- * @brief	Deregister libfabric memory registration of rails
- *
- * Deregister registered memory of all rails associated with
- * `handle'. Rails without registered memory (NULL pointers in
- * handle's libfabric memory registration array) are skipped.
- */
-static int dereg_rails(nccl_net_ofi_rdma_mr_handle_t *handle)
-{
-	int ret = 0;
-	int rc = 0;
-	int num_rails = handle->num_rails;
-
-	/* Cleanup memory registration for data rails */
-	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
-		/* No memory registration available for this rail */
-		if (!handle->mr[rail_id]) continue;
-		rc = fi_close(&handle->mr[rail_id]->fid);
-		if (OFI_UNLIKELY(rc != 0)) {
-			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
-				      rc, fi_strerror(-rc));
-			ret = rc;
-		}
-	}
-
-	return ret;
-}
-
-static inline void free_rdma_mr_handle(nccl_net_ofi_rdma_mr_handle_t *handle) {
-	if (handle) {
-		if (handle->mr) {
-			free(handle->mr);
-		}
-		free(handle);
-	}
-}
-
-/*
- * @brief	Allocate a rdma memory registration handle with `num_rails' rails using `calloc()'
- *
- * @param	num_rails
- *		The number of rails of the allocated receive communicator
- * @param	num_control_rails
- *		The number of control rails of the allocated receive communicator
- * @return	handle, on success
- *		NULL, on error
- */
-static inline nccl_net_ofi_rdma_mr_handle_t *calloc_rdma_mr_handle(int num_rails)
-{
-	nccl_net_ofi_rdma_mr_handle_t *ret_handle = (nccl_net_ofi_rdma_mr_handle_t *)calloc(1, sizeof(nccl_net_ofi_rdma_mr_handle_t));
-
-	if (OFI_UNLIKELY(!ret_handle)) {
-		NCCL_OFI_WARN("Unable to allocate memory registration handle");
-		goto error;
-	}
-
-	ret_handle->mr = (struct fid_mr **)calloc(num_rails, sizeof(struct fid_mr *));
-	if (OFI_UNLIKELY(!ret_handle->mr)) {
-		NCCL_OFI_WARN("Unable to allocate memory registration handles array");
-		goto error;
-	}
-
-	return ret_handle;
-
-error:
-
-	free_rdma_mr_handle(ret_handle);
-	return NULL;
-}
 
 /*
  * @brief	Deregister memory region
@@ -2880,13 +2784,7 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 	int ret = 0;
 
 	if (OFI_UNLIKELY(mr_handle == NULL)) {
-		NCCL_OFI_WARN("Null MR handle provided. This is an error.");
-		return -EINVAL;
-	}
-
-	if (OFI_UNLIKELY(mr_handle->num_rails < 0)) {
-		NCCL_OFI_WARN("Unexpected number of rails in rdma memory registration handle");
-		return -EINVAL;
+		return 0;
 	}
 
 	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
@@ -2909,24 +2807,35 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		}
 	}
 
-	if (nccl_ofi_idpool_active(key_pool)) {
-		uint64_t key = fi_mr_key(mr_handle->mr[0]);
-		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
-			ret = -ENOENT;
-			NCCL_OFI_WARN("Error retrieving MR key, leaking key");
-		} else {
-			ret = nccl_ofi_idpool_free_id(key_pool, key);
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_WARN("Error freeing MR key %" PRIu64 ", leaking key", key);
-			}
+	if (nccl_ofi_idpool_active(key_pool) && mr_handle->mr_key >= 0) {
+		ret = nccl_ofi_idpool_free_id(key_pool, mr_handle->mr_key);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Error freeing MR key %d, leaking key",
+				      mr_handle->mr_key);
 		}
 	}
 
-	ret = dereg_rails(mr_handle);
+	for (int rail_id = 0; rail_id < domain->num_rails; ++rail_id) {
+		/* No memory registration available for this rail */
+		if (mr_handle->mr[rail_id] == NULL) {
+			continue;
+		}
 
-	free_rdma_mr_handle(mr_handle);
+		ret = fi_close(&mr_handle->mr[rail_id]->fid);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Unable to de-register memory. RC: %d, Error: %s",
+				      ret, fi_strerror(-ret));
+		}
+	}
+
+	if (mr_handle->mr != NULL) {
+		free(mr_handle->mr);
+	}
+	free(mr_handle);
+
 	return ret;
 }
+
 
 static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 				   nccl_ofi_mr_ckey_ref ckey,
@@ -2935,35 +2844,42 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
-	*mhandle = NULL;
 	struct fi_mr_attr mr_attr = {};
 	uint64_t regattr_flags = 0;
-
-	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
-	assert(device != NULL);
-
-	int dev_id = device->base.dev_id;
 	int num_rails = domain->num_rails;
-
 	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 
+	*mhandle = NULL;
+
 	/* Allocate rdma memory registration handle */
-	ret_handle = calloc_rdma_mr_handle(num_rails);
+	ret_handle =  (nccl_net_ofi_rdma_mr_handle_t *)calloc(1, sizeof(nccl_net_ofi_rdma_mr_handle_t));
 	if (OFI_UNLIKELY(!ret_handle)) {
 		NCCL_OFI_WARN("Unable to allocate memory registration handle");
+		return -ENOMEM;
+	}
+
+	ret_handle->mr = (struct fid_mr **)calloc(num_rails, sizeof(struct fid_mr *));
+	if (OFI_UNLIKELY(!ret_handle->mr)) {
+		NCCL_OFI_WARN("Unable to allocate memory registration handles array");
 		ret = -ENOMEM;
-		goto exit;
+		goto error;
+	}
+
+        if (nccl_ofi_idpool_active(key_pool)) {
+		ret_handle->mr_key =nccl_ofi_idpool_allocate_id(key_pool);
+		if (OFI_UNLIKELY(ret_handle->mr_key < 0)) {
+			NCCL_OFI_WARN("MR key allocation failed");
+			ret = ret_handle->mr_key;
+			goto error;
+		}
 	}
 
 	/* Create memory registration request */
-	ret = set_mr_req_attr(key_pool, dev_id, ckey, &regattr_flags, type, &mr_attr);
+	ret = set_mr_req_attr((uint64_t)ret_handle->mr_key, ckey, &regattr_flags, type, &mr_attr);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not set registration request attributes, dev: %d",
-			dev_id);
-		free_rdma_mr_handle(ret_handle);
-		ret_handle = NULL;
-		goto exit;
+			      rdma_domain_get_device(domain)->base.dev_id);
+		goto error;
 	}
 
 	/* Register memory on each rail */
@@ -2971,20 +2887,18 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
 		nccl_net_ofi_rdma_domain_rail_t *domain_rail = rdma_domain_get_rail(domain, rail_id);
 
-		ret = register_rail_mr_buffer(domain_rail->domain,
-					      dev_id, type, &mr_attr, regattr_flags,
-					      &ret_handle->mr[rail_id]);
+		ret = fi_mr_regattr(domain_rail->domain, &mr_attr,
+				    regattr_flags, &ret_handle->mr[rail_id]);
 		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr(ret_handle, domain)) {
-				NCCL_OFI_WARN("Error de-registering MR");
-			}
-			ret_handle = NULL;
-			goto exit;
+			goto error;
 		}
 	}
 
-exit:
 	*mhandle = ret_handle;
+	return 0;
+
+error:
+	(void) dereg_mr(ret_handle, domain);
 	return ret;
 }
 /*

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -364,15 +364,6 @@ static inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_control_rail(nccl_net_of
 }
 
 /*
- * @brief return the domain for the endpoint and rail.
- */
-static inline struct fid_domain *rdma_endpoint_get_ofi_domain(nccl_net_ofi_rdma_ep_t *ep, int rail_id)
-{
-	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
-	return rdma_domain_get_rail(domain, rail_id)->domain;
-}
-
-/*
  * @brief	Write topology to NCCL topology file
  *
  * This function writes a NCCL topology file to a memfd file, and
@@ -553,9 +544,9 @@ static int set_mr_req_attr(nccl_ofi_idpool_t *key_pool, int dev_id,
 }
 
 static int register_rail_mr_buffer(struct fid_domain *domain,
-					    struct fid_ep *ep, int dev_id,
-					    int type, struct fi_mr_attr *mr_attr,
-					    uint64_t flags, struct fid_mr **mr_handle)
+				   int dev_id,
+				   int type, struct fi_mr_attr *mr_attr,
+				   uint64_t flags, struct fid_mr **mr_handle)
 {
 	int ret = 0;
 
@@ -2883,9 +2874,9 @@ error:
  * @return	0 on success
  *		non-zero on error
 */
-static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
-		       nccl_ofi_idpool_t *key_pool,
-		       nccl_ofi_mr_cache_t *mr_cache)
+static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
+		    nccl_ofi_idpool_t *key_pool,
+		    nccl_ofi_mr_cache_t *mr_cache)
 {
 	int ret = 0;
 
@@ -2936,7 +2927,7 @@ static int dereg_mr_ep(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 	return ret;
 }
 
-static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
+static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 				   nccl_ofi_mr_ckey_ref ckey,
 				   int type,
 				   nccl_net_ofi_rdma_mr_handle_t **mhandle)
@@ -2944,19 +2935,15 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	*mhandle = NULL;
-	struct fid_domain *ofi_domain;
 	struct fi_mr_attr mr_attr = {};
 	uint64_t regattr_flags = 0;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device(ep);
+	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
 	assert(device != NULL);
 
-	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
-	assert(domain != NULL);
-
 	int dev_id = device->base.dev_id;
-	int num_rails = ep->num_rails;
+	int num_rails = domain->num_rails;
 
 	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 
@@ -2981,14 +2968,13 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_ep_t *ep,
 	/* Register memory on each rail */
 	ret_handle->num_rails = num_rails;
 	for (int rail_id = 0; rail_id != num_rails; ++rail_id) {
-		nccl_net_ofi_ep_rail_t *rail = rdma_endpoint_get_rail(ep, rail_id);
-		ofi_domain = rdma_endpoint_get_ofi_domain(ep, rail_id);
+		nccl_net_ofi_rdma_domain_rail_t *domain_rail = rdma_domain_get_rail(domain, rail_id);
 
-		ret = register_rail_mr_buffer(ofi_domain, rail->ofi_ep,
+		ret = register_rail_mr_buffer(domain_rail->domain,
 					      dev_id, type, &mr_attr, regattr_flags,
 					      &ret_handle->mr[rail_id]);
 		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr_ep(ret_handle, key_pool, NULL) != 0) {
+			if (dereg_mr(ret_handle, key_pool, NULL) != 0) {
 				NCCL_OFI_WARN("Error de-registering MR");
 			}
 			ret_handle = NULL;
@@ -3001,10 +2987,10 @@ exit:
 	return ret;
 }
 /*
- * @brief	Register memory region on RDMA endpoint
+ * @brief	Register memory region on RDMA domain
  *
- * @param	ep
- *		RDMA endpoint on which memory region is registered
+ * @param	domain
+ *		RDMA domain on which memory region is registered
  * @param	data
  *		Pointer to MR
  * @param	size
@@ -3016,7 +3002,7 @@ exit:
  *
  * @return	Memory registration handle
 */
-static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
+static int reg_mr(nccl_net_ofi_rdma_domain_t *domain,
 		     nccl_ofi_mr_ckey_ref ckey,
 		     int type,
 		     nccl_ofi_mr_cache_t *mr_cache,
@@ -3026,10 +3012,7 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	*mhandle = NULL;
 
-	assert(ep);
-
-	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
-	assert(domain != NULL);
+	assert(domain);
 
 	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
 	if (mr_cache) {
@@ -3048,7 +3031,7 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 		/* Cache miss */
 	}
 
-	ret = reg_mr_on_device(ep, ckey, type, &ret_handle);
+	ret = reg_mr_on_device(domain, ckey, type, &ret_handle);
 	if (OFI_UNLIKELY(ret != 0)) {
 		goto exit;
 	}
@@ -3058,7 +3041,7 @@ static int reg_mr_ep(nccl_net_ofi_rdma_ep_t *ep,
 						     ckey,
 						     ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
-			if (dereg_mr_ep(ret_handle, key_pool, NULL) != 0) {
+			if (dereg_mr(ret_handle, key_pool, NULL) != 0) {
 				NCCL_OFI_WARN("Error de-registering MR");
 			}
 
@@ -3129,16 +3112,16 @@ exit:
  *
  * @return	Memory registration handle
 */
-static int reg_internal_mr_ep(nccl_net_ofi_rdma_ep_t *ep, void *data,
-				       size_t size, int type,
-				       nccl_net_ofi_rdma_mr_handle_t **mhandle)
+static int reg_internal_mr(nccl_net_ofi_rdma_domain_t *domain, void *data,
+			   size_t size, int type,
+			   nccl_net_ofi_rdma_mr_handle_t **mhandle)
 {
 	assert(system_page_size > 0);
 	assert(NCCL_OFI_IS_PTR_ALIGNED(data, system_page_size));
 	assert(NCCL_OFI_IS_ALIGNED(size, system_page_size));
 
 	const nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(data, size);
-	return reg_mr_ep(ep, &ckey, type, NULL, mhandle);
+	return reg_mr(domain, &ckey, type, NULL, mhandle);
 }
 
 static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
@@ -3146,14 +3129,14 @@ static int reg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 			    int type, void **mhandle)
 {
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)send_comm->base.ep;
-	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
+        nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 	assert(domain != NULL);
 
-	return reg_mr_ep(ep,
-			 ckey,
-			 type,
-			 domain->base.mr_cache,
-			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	return reg_mr(domain,
+		      ckey,
+		      type,
+		      domain->base.mr_cache,
+		      (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
 static int reg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
@@ -3164,11 +3147,11 @@ static int reg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 	assert(domain != NULL);
 
-	return reg_mr_ep(ep,
-			 ckey,
-			 type,
-			 domain->base.mr_cache,
-			 (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
+	return reg_mr(domain,
+		      ckey,
+		      type,
+		      domain->base.mr_cache,
+		      (nccl_net_ofi_rdma_mr_handle_t **)mhandle);
 }
 
 typedef struct {
@@ -3186,15 +3169,15 @@ typedef struct {
  * @param	size
  *		Size of memory region. Must be a multiple of page size.
  */
-static int freelist_regmr_host_fn(void *ep_void_ptr, void *data, size_t size, void **handle)
+static int freelist_regmr_host_fn(void *domain_void_ptr, void *data, size_t size, void **handle)
 {
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)ep_void_ptr;
+	nccl_net_ofi_rdma_domain_t *domain = (nccl_net_ofi_rdma_domain_t *)domain_void_ptr;
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle;
-	int ret = reg_internal_mr_ep(ep, data, size, NCCL_PTR_HOST, &mr_handle);
+	int ret = reg_internal_mr(domain, data, size, NCCL_PTR_HOST, &mr_handle);
 
 	if (ret != 0) {
-		NCCL_OFI_WARN("Failed call to reg_mr_ep: %d", ret);
+		NCCL_OFI_WARN("Failed call to reg_mr: %d", ret);
 		return -EIO;
 	}
 
@@ -3206,7 +3189,7 @@ static int freelist_regmr_host_fn(void *ep_void_ptr, void *data, size_t size, vo
 	}
 
 	freelist_handle->mr_handle = mr_handle;
-	freelist_handle->key_pool = &(rdma_endpoint_get_domain(ep))->base.mr_rkey_pool;
+	freelist_handle->key_pool = &(domain)->base.mr_rkey_pool;
 	*handle = (void *)freelist_handle;
 	return 0;
 }
@@ -3220,9 +3203,9 @@ static int freelist_deregmr_host_fn(void *handle)
 {
 	freelist_regmr_fn_handle_t *freelist_handle = (freelist_regmr_fn_handle_t *)handle;
 	assert(freelist_handle);
-	int ret = dereg_mr_ep(freelist_handle->mr_handle, freelist_handle->key_pool, NULL);
+	int ret = dereg_mr(freelist_handle->mr_handle, freelist_handle->key_pool, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Failed call to dereg_mr_ep");
+		NCCL_OFI_WARN("Failed call to dereg_mr");
 		return -EIO;
 	}
 	free(freelist_handle);
@@ -3240,7 +3223,7 @@ static int dereg_mr_recv_comm(nccl_net_ofi_recv_comm_t *recv_comm,
 	assert(domain != NULL);
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	return dereg_mr(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 /*
@@ -3722,7 +3705,7 @@ static inline int dealloc_and_dereg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = r_comm->flush_buff.mr_handle;
 
 	if (mr_handle) {
-		ret = dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, NULL);
+		ret = dereg_mr(mr_handle, &domain->base.mr_rkey_pool, NULL);
 	}
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to deregister flush buffer");
@@ -3760,6 +3743,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle = NULL;
 	nccl_net_ofi_rdma_flush_buffer_t *flush_buff = &r_comm->flush_buff;
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 
 	NCCL_OFI_TRACE(NCCL_NET, "Registering buffer for flush operations");
 
@@ -3777,7 +3761,7 @@ static int alloc_and_reg_flush_buff(nccl_net_ofi_rdma_recv_comm_t *r_comm, int d
 	/* Check if provider requires registration of local buffers */
 	if (local_mr == true) {
 		/* Register flush dummy buffer for provider access */
-		ret = reg_internal_mr_ep(ep, flush_buff->host_buffer, system_page_size,
+		ret = reg_internal_mr(domain, flush_buff->host_buffer, system_page_size,
 			  NCCL_PTR_HOST, &mr_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Could not register dummy buffer for flush, dev: %d",
@@ -4738,7 +4722,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		NCCL_OFI_MAX(sizeof(nccl_net_ofi_rdma_ctrl_msg_t),
 			     sizeof(nccl_net_ofi_rdma_close_msg_t)),
 		8, 8, NCCL_OFI_MAX_REQUESTS, freelist_regmr_host_fn,
-		freelist_deregmr_host_fn, ep, 1,
+		freelist_deregmr_host_fn, domain, 1,
 		&r_comm->ctrl_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Call to freelist_init_mr failed: %d", ret);
@@ -5270,7 +5254,7 @@ static int dereg_mr_send_comm(nccl_net_ofi_send_comm_t *send_comm,
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle =
 		(nccl_net_ofi_rdma_mr_handle_t *)mhandle;
-	return dereg_mr_ep(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	return dereg_mr(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 static int alloc_rdma_write_req(nccl_net_ofi_rdma_send_comm_t *s_comm,
@@ -6183,6 +6167,7 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 {
 	int ret = 0;
 	nccl_net_ofi_ep_rail_t *rail;
+	nccl_net_ofi_rdma_domain_t *domain = rdma_endpoint_get_domain(ep);
 
 	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t),
 				     ofi_nccl_rdma_min_posted_bounce_buffers(), 16, 0,
@@ -6195,7 +6180,7 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 	ret = nccl_ofi_freelist_init_mr(ep->ctrl_rx_buff_size,
 					ofi_nccl_rdma_min_posted_bounce_buffers(), 16, 0,
 					freelist_regmr_host_fn, freelist_deregmr_host_fn,
-					ep, 1, &ep->ctrl_rx_buff_fl);
+					domain, 1, &ep->ctrl_rx_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init ctrl_rx_buff_fl");
 		if (nccl_ofi_freelist_fini(ep->rx_buff_reqs_fl))
@@ -6207,7 +6192,7 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
 		ret = nccl_ofi_freelist_init_mr(ep->eager_rx_buff_size,
 						ofi_nccl_rdma_min_posted_bounce_buffers(), 16, 0,
 						freelist_regmr_host_fn, freelist_deregmr_host_fn,
-						ep, EAGER_RX_BUFFER_ALIGNMENT, &ep->eager_rx_buff_fl);
+						domain, EAGER_RX_BUFFER_ALIGNMENT, &ep->eager_rx_buff_fl);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to init eager_rx_buff_size");
 			nccl_ofi_freelist_fini(ep->ctrl_rx_buff_fl);
@@ -6221,7 +6206,7 @@ static inline int init_rx_buffers(nccl_net_ofi_rdma_ep_t *ep)
         ret = nccl_ofi_freelist_init_mr(sizeof(nccl_ofi_rdma_connection_info_t),
 					4, 4, 0,
 					freelist_regmr_host_fn, freelist_deregmr_host_fn,
-					ep, sizeof(void *), &ep->conn_msg_fl);
+					domain, sizeof(void *), &ep->conn_msg_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init conn_msg freelist");
 		if (ep->eager_rx_buff_fl != NULL) {


### PR DESCRIPTION
*Description of changes:*

Cherry-picked below commits into 1.14.x branch

```
9d90c0e  rdma: Support early completion of recv() requests
4117397 ofi: add data progress model detection
a20854e Remove support for not creating local MRs
167e6dc rdma: Overwrite buffers for 0 byte messages
161cb12 rdma: Fix flush buffer cleanup
4195fa8 rdma: Move flush buffer to domain object
21ac264 rdma: Simplify MR paths
f898cb9 rdma: Simplify MR argument passing
d22b961 rdma: Make MRs be domain oriented (instead of EP)
8ee095e rdma: Remove ofi domain pointer from endpoint
4bfb9e0 rdma: Remove control rail MRs from MR
1c3b82f .ci/aws: Configure PortaFiducia to run in lean setup
ba5850a rdma: Disable eager by default
```

skipped following from master
```
71a1e68 neuron: add inf2e.32xlarge
26ed86b rdma: Fix request lookup on error
```

only conflict that needed manual resolution was in `rdma: Support early completion of recv() requests`, when calling `fi_writedata`, there was a context2 change in master that needed to remove.


Testing:
nccl-test pass against both efa-rdm and efa-direct branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
