### PR TITLE
dist: Change default library to libnccl-net-ofi.so

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -236,6 +236,12 @@ AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
        CXXFLAGS="${werror_flags} ${CXXFLAGS} "
        CFLAGS="${werror_flags} ${CFLAGS} "])
 
+AC_ARG_ENABLE([nccl-net-symlink],
+      [AS_HELP_STRING([--disable-nccl-net-symlink],
+           [Do not create symlink libnccl-net.so to point at libnccl-net-ofi.so.  Useful in cases where
+	   you are trying to install multiple plugins in the same container.])])
+AM_CONDITIONAL([ENABLE_NCCL_NET_SYMLINK], [test "${enable_nccl_net_symlink}" != "no"])
+
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
 
 AC_CONFIG_FILES([Makefile

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -65,10 +65,19 @@ else
   libinternal_net_cudart_plugin_la_LDFLAGS = -whole-archive -static -avoid-version $(CUDA_LDFLAGS)
   libinternal_net_cudart_plugin_la_LIBADD = $(CUDA_LIBS)
   libinternal_net_plugin_la_LIBADD = libinternal_net_cudart_plugin.la
-  lib_LTLIBRARIES = libnccl-net.la
-  libnccl_net_la_SOURCES =
-  libnccl_net_la_LIBADD = libinternal_net_plugin.la
-  libnccl_net_la_LDFLAGS = -module -avoid-version
+  lib_LTLIBRARIES = libnccl-net-ofi.la
+  libnccl_net_ofi_la_SOURCES =
+  libnccl_net_ofi_la_LIBADD = libinternal_net_plugin.la
+  libnccl_net_ofi_la_LDFLAGS = -module -avoid-version
+
+
+if ENABLE_NCCL_NET_SYMLINK
+install-exec-hook:
+	cd $(DESTDIR)$(libdir) && $(LN_S) libnccl-net-ofi.so libnccl-net.so
+
+uninstall-local:
+	@files=libnccl-net.so ; dir='$(DESTDIR)$(libdir)' ; $(am__uninstall_files_from_dir)
+endif
 endif
 
 


### PR DESCRIPTION
The NGC containers have added some logic to try and support multiple plugins by renaming the OFI plugin to libnccl-net-aws.so.  Ignoring the naming for a second, it's clearly useful for us to conform to Sylvain's original expectation that everyone named plugins as libnccl-net-<network>.so and providing a symlink to the generic name where appropriate.  This patch causes us to generate the plugin as libnccl-net-ofi.so and create a symlink from libnccl-net-ofi.so to libnccl-net.so for backwards compatibility.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
