### PR TITLE
release: v1.14.x fix the NCCL version in RELEASENOTES

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -22,7 +22,7 @@ or greater. AWS customers are generally recommended to track
 for performance improvements and bug fixes.
 
 The 1.14.x release series supports
-[NCCL 2.25.3-1](https://github.com/NVIDIA/nccl/releases/tag/v2.25.3-1)
+[NCCL 2.26.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.26.2-1)
 while maintaining backward compatibility with older NCCL versions
 ([NCCL v2.17.1](https://github.com/NVIDIA/nccl/releases/tag/v2.17.1-1) and later).
 

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.14.1a1], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.14.0], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])

--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.14.0], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.14.1a1], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.c])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Correct the NCCL version to [NCCL 2.26.2-1](https://github.com/NVIDIA/nccl/releases/tag/v2.26.2-1) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
