### PR TITLE
.ci/aws: Add tcp provider test on g4dn

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -171,6 +171,7 @@ pipeline {
                     def pr_num = "--test-aws-ofi-nccl-pr $env.CHANGE_ID"
                     def nccl_test_iter = "--test-aws-ofi-nccl-nccltest-iterations 5"
                     def efa_installer = "--use-prebuilt-ami-with-efa-installer true"
+                    def test_tcp_provider = "--test-libfabric-provider tcp"
 
                     def persistent_manual_cluster_addl_args = " --keep-cluster --skip-fixture-setup --skip-health-checks --use-existing-installer --cleanup-pf-directory --enable-placement-group false --lean-cluster-setup"
                     def container_addl_args = " --test-in-containers-on-ec2"
@@ -189,6 +190,7 @@ pipeline {
                     def p3_p4_addl_args = "${base_args} ${container_addl_args} --test-list test_nccl_test test_ofi_nccl_functional"
                     def p5_addl_args = "${base_args} ${container_addl_args} --test-list test_nccl_test"
                     def g4dn_addl_args = "${base_args} --test-list test_nccl_test test_ofi_nccl_functional"
+                    def g4dn_tcp_addl_args = "${g4dn_addl_args} ${test_tcp_provider}"
                     def neuron_addl_args = "${base_args} --test-list test_nccom_test"
 
                     // p3dn tests
@@ -208,6 +210,7 @@ pipeline {
 
                     // g4dn tests
                     stages["4_g4dn_ubuntu2204"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
+                    stages["4_g4dn_ubuntu2204_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204_tcp", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
 
                     // trn1 tests
                     stages["4_trn1_ubuntu2004"] = get_test_stage_with_lock_persistent("4_trn1_ubuntu2004", env.BUILD_TAG, "ubuntu2004", "trn1.32xlarge", trn1_lock_label, num_instances, neuron_addl_args)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Following the [config schema in PortaFiducia](https://code.amazon.com/packages/PortaFiducia/blobs/4ec5d2da102e8e459270f1b1cb3a332c9f8273d9/--/tests/configs/config_schema.yaml?__session=eyJwa2ciOiJQb3J0YUZpZHVjaWEiLCJ0YWJzIjpbeyJmaWxlIjoidGVzdHMvY29uZmlncy9jb25maWdfc2NoZW1hLnlhbWwjTDI0Ni1MMjUyIn0seyJmaWxlIjoidGVzdHMvdGVzdF9vcmNoZXN0cmF0b3IucHkifSx7ImZpbGUiOiJodHRwczovL2NvZGUuYW1hem9uLmNvbS9zZWFyY2g%2FdGVybT10ZXN0X2xpYmZhYnJpY19wcm92aWRlcitycCUzQVBvcnRhRmlkdWNpYSJ9LHsiZmlsZSI6InRlc3RzL2NvbmZpZ3MvbGliZmFicmljX3ByX3Rlc3QueWFtbCNMMTUifV19#L246-L252), adding tcp provider test coverage on g4dn

Current g4dn PR CI takes 17 minutes to run, comparing to the longest pull is 45 minutes, so adding tcp provider test won't  increase PR CI time.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
