### PR TITLE
Remove -fanalyzer (which is broken with G++)

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -34,6 +34,12 @@ dnl AM_PROG_AR
 AX_CHECK_ENABLE_DEBUG([no])
 
 # Checks for programs
+
+dnl Enable _GNU_SOURCE and other system extensions. The plugin uses several
+dnl nonstandard system functions, and the plugin only supports Linux OSes, so
+dnl the risk of silently enabling system extensions is minimal.
+AC_USE_SYSTEM_EXTENSIONS
+
 AC_PROG_CXX
 AC_LANG([C++])
 
@@ -41,10 +47,6 @@ dnl use C++17, disable exceptions, and disable runtime type information
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
 CXXFLAGS="${CXXFLAGS} -fno-rtti -fno-exceptions"
 
-dnl Enable _GNU_SOURCE and other system extensions. The plugin uses several
-dnl nonstandard system functions, and the plugin only supports Linux OSes, so
-dnl the risk of silently enabling system extensions is minimal.
-AC_USE_SYSTEM_EXTENSIONS
 dnl AM_PROG_AR must be called before LT_INIT
 AM_PROG_AR
 AC_PROG_RANLIB

--- a/configure.ac
+++ b/configure.ac
@@ -175,11 +175,10 @@ AS_IF([test "${enable_trace}" = "yes" ],
        AC_MSG_RESULT(no)])
 AC_DEFINE_UNQUOTED([OFI_NCCL_TRACE], [${trace}], [Defined to 1 unit test output should include TRACE level])
 
-picky_cflags=""
 picky_cxxflags=""
 AC_DEFUN([ADD_PICKY_FLAGS],[
     AC_LANG_PUSH([C++])
-    AX_CHECK_COMPILE_FLAG([$1], [picky_cxxflags="${picky_cxxflags} $1"], [], [-Werror -x c++])
+    AX_CHECK_COMPILE_FLAG([$1], [picky_cxxflags="${picky_cxxflags} $1"], [], [-Werror])
     AC_LANG_POP()
     ])
 
@@ -220,23 +219,19 @@ dnl todo: clang-sa flags
 AC_ARG_ENABLE([picky-compiler],
    [AS_HELP_STRING([--disable-picky-compiler], [Disable adding picky compiler flags.])])
 AS_IF([test "${enable_picky_compiler}" != "no"],
-      [AC_MSG_NOTICE([Adding ${picky_cflags} to CFLAGS.])
-       CFLAGS="${CFLAGS} ${picky_cflags}"
+      [AC_MSG_NOTICE([Adding ${picky_cxxflags} to CXXFLAGS.])
        CXXFLAGS="${CXXFLAGS} ${picky_cxxflags}"
-       AS_UNSET([picky_cxxflags])
-       AS_UNSET([picky_cflags])])
+       AS_UNSET([picky_cxxflags])])
 
 werror_flags="-Werror"
 AC_ARG_ENABLE([werror],
    [AS_HELP_STRING([--enable-werror], [(Developer) Enable setting -Werror.  Off by default, unless building from Git tree.])])
 AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
-      [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CFLAGS.])
-       CXXFLAGS="${werror_flags} ${CXXFLAGS} "
-       CFLAGS="${werror_flags} ${CFLAGS} "],
+      [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CXXFLAGS.])
+       CXXFLAGS="${werror_flags} ${CXXFLAGS} "],
       [test "${enable_werror}" = "yes"],
-      [AC_MSG_NOTICE([Adding ${werror_flags} to CFLAGS.])
-       CXXFLAGS="${werror_flags} ${CXXFLAGS} "
-       CFLAGS="${werror_flags} ${CFLAGS} "])
+      [AC_MSG_NOTICE([Adding ${werror_flags} to CXXFLAGS.])
+       CXXFLAGS="${werror_flags} ${CXXFLAGS} "])
 
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
 

--- a/configure.ac
+++ b/configure.ac
@@ -182,46 +182,66 @@ AC_DEFUN([ADD_PICKY_FLAGS],[
     AC_LANG_POP()
     ])
 
-dnl standard and normal
-ADD_PICKY_FLAGS([-Wall -Wextra])
-dnl C specific warning that warngs when using C features which prevent parsing
-dnl as C++. Best-effort, and doesn't cover everything.
-ADD_PICKY_FLAGS([-Wc++-compat])
-dnl gcc manual says this is enabled with c++-compat, but seemingly bugged.
-ADD_PICKY_FLAGS([-Wjump-misses-init])
-
-dnl some top-level API functions have unused parameters, but we have to keep
-dnl them. TODO: explicitly annotate those functions, rather than setting this
-dnl globally.
-ADD_PICKY_FLAGS([-Wno-unused-parameter])
-
-dnl warn when a variable shadows another variable.
-ADD_PICKY_FLAGS([-Wshadow])
-dnl warn on security issues around functions that format output (ie printf)
-ADD_PICKY_FLAGS([-Wformat=2])
-dnl warn for potential performance problem casts
-ADD_PICKY_FLAGS([-Wcast-align])
-dnl warn if a null dereference is detected
-ADD_PICKY_FLAGS([-Wnull-dereference])
-
-dnl warn when a case statement is missing a break or a line that contains a
-dnl comment before the next case.
-ADD_PICKY_FLAGS([-Wimplicit-fallthrough=2])
-
-dnl functions should either have internal linkage (static) or there should be a
-dnl header declarating the function.
-ADD_PICKY_FLAGS([-Wmissing-declarations])
-
-dnl enable GCC's static analyzer
-ADD_PICKY_FLAGS([-fanalyzer])
-dnl todo: clang-sa flags
-
 AC_ARG_ENABLE([picky-compiler],
    [AS_HELP_STRING([--disable-picky-compiler], [Disable adding picky compiler flags.])])
-AS_IF([test "${enable_picky_compiler}" != "no"],
-      [AC_MSG_NOTICE([Adding ${picky_cxxflags} to CXXFLAGS.])
-       CXXFLAGS="${CXXFLAGS} ${picky_cxxflags}"
-       AS_UNSET([picky_cxxflags])])
+AS_IF([test "${enable_picky_compiler}" != "no"], [
+    dnl standard and normal
+    ADD_PICKY_FLAGS([-Wall -Wextra])
+
+    dnl some top-level API functions have unused parameters, but we have to keep
+    dnl them. TODO: explicitly annotate those functions, rather than setting this
+    dnl globally.
+    ADD_PICKY_FLAGS([-Wno-unused-parameter])
+
+    dnl warn when a variable shadows another variable.
+    ADD_PICKY_FLAGS([-Wshadow])
+    dnl warn on security issues around functions that format output (ie printf)
+    ADD_PICKY_FLAGS([-Wformat=2])
+    dnl warn for potential performance problem casts
+    ADD_PICKY_FLAGS([-Wcast-align])
+    dnl warn if a null dereference is detected
+    ADD_PICKY_FLAGS([-Wnull-dereference])
+
+    dnl warn when a case statement is missing a break or a line that contains a
+    dnl comment before the next case.
+    ADD_PICKY_FLAGS([-Wimplicit-fallthrough=2])
+
+    dnl functions should either have internal linkage (static) or there should be a
+    dnl header declarating the function.
+    ADD_PICKY_FLAGS([-Wmissing-declarations])
+
+    dnl try to enable GCC's static analyzer.  We've tripped over a number of
+    dnl problems with GNU's static analyzer and C++ code, especially regarding
+    dnl NULL return and leak reports from simple inheritance (as one example:
+    dnl https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94355).  We really loved
+    dnl the analyzer for C code and would like it back, but even the simple
+    dnl example below trips multiple issues which really prevent the tool from
+    dnl being useful (as of GCC 14.2.0).  So we disable it in hopes that one day
+    dnl we can re-enable it.
+    dnl
+    dnl    class A {
+    dnl    public:
+    dnl        A(int num) : vec(num) { }
+    dnl        A() { }
+    dnl        std::vector<int> vec;
+    dnl    };
+    dnl
+    dnl    class B : public A {
+    dnl    public:
+    dnl        B(int num) : A(num) { }
+    dnl    };
+    dnl
+    dnl    auto b = new B(10);
+    dnl    delete b;
+    dnl
+    dnl ADD_PICKY_FLAGS([-fanalyzer])
+
+    dnl todo: clang-sa flags
+
+    AC_MSG_NOTICE([Adding ${picky_cxxflags} to CXXFLAGS.])
+    CXXFLAGS="${CXXFLAGS} ${picky_cxxflags}"
+])
+AS_UNSET([picky_cxxflags])
 
 werror_flags="-Werror"
 AC_ARG_ENABLE([werror],

--- a/m4/check_pkg_hwloc.m4
+++ b/m4/check_pkg_hwloc.m4
@@ -13,7 +13,7 @@ AC_DEFUN([CHECK_PKG_HWLOC], [
   check_pkg_LIBS_save="${LIBS}"
 
   AC_ARG_WITH([hwloc],
-     [AC_HELP_STRING([--with-hwloc=PATH], [Path to non-standard hwloc installation])])
+     [AS_HELP_STRING([--with-hwloc=PATH], [Path to non-standard hwloc installation])])
 
   AS_IF([test -n "${with_hwloc}"], [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-hwloc=${with_hwloc}"])
 


### PR DESCRIPTION
A patch series that most importantly removes -fanalyzer from our picky flags, because it will wrongly complain about memory leaks and NULL de-references on even the simplest of inherited object test codes.  We'll miss it, but not as much as we'd miss having working inheritance.

Found some C cruft and some autoconf warnings while touching this code (and trying, in vain, to find a set of analyzer warnings that were useful and not broken).  So those are fixed, too.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
