### PR TITLE
Fix compatibility issues with tcp provider

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7996,6 +7996,9 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 			       "Using Libfabric 1.18 API, with GPUDirect RDMA support");
 		support_gdr = GDR_UNKNOWN;
+	} else if (ret == -FI_ENODATA) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "No eligible providers were found");
+		goto error;
 	} else {
 		NCCL_OFI_WARN("OFI fi_getinfo() call failed: %s", fi_strerror(ret));
 		goto error;

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2452,7 +2452,7 @@ nccl_net_ofi_sendrecv_device_release(nccl_net_ofi_device_t *base_device)
 }
 
 /**
- * Create an rdma device object
+ * Create a sendrecv device object
  */
 static nccl_net_ofi_sendrecv_device_t *
 nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
@@ -2718,6 +2718,29 @@ found:
 	if (provider_list == NULL) {
 		ret = -FI_ENODATA;
 		goto error;
+	}
+
+	/* The TCP provider in Libfabric versions prior to 2.2.0
+	 * erroneously requires a unique MR key even when FI_RMA
+	 * capabilities are not requested. Because we use local MRs
+	 * even if the provider does not require FI_MR_LOCAL and
+	 * because Libfabric clears the FI_MR_PROV_KEY mr_mode when
+	 * FI_RMA is not requested, we pass 0 as the mr key for all
+	 * registrations, tripping the TCP bug.
+	 * On versions of Libfabric before the bug is fixed, we
+	 * request FI_RMA capabilities from the tcp provider even
+	 * though we don't need it, so that we see the cleared
+	 * FI_MR_PROV_KEY, fi_mr_key() returns the passed key, and
+	 * everyone is happy (modulo a potential slight performance
+	 * hit for having the emulated RMA operations loaded).
+	 */
+	if (FI_VERSION_LT(fi_version(), FI_VERSION(2, 2)) &&
+			strcmp(provider_list->fabric_attr->prov_name, "tcp") == 0) {
+		struct fi_info *iter = provider_list;
+		while (iter != NULL) {
+			iter->caps |= FI_RMA;
+			iter = iter->next;
+		}
 	}
 
 	/* Allow for multiple virtual nics per nic to increase

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -30,6 +30,8 @@
 #include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_mr.h"
 
+/* Indicates if provider supports FI_RMA */
+bool support_fi_rma = false;
 
 static nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain(nccl_net_ofi_sendrecv_ep_t *ep)
 {
@@ -562,12 +564,16 @@ static int sendrecv_mr_buffers_register(struct fid_domain *domain,
 	nccl_ofi_mr_ckey_fill_mr_attrs(ckey, &mr_attr, &regattr_flags);
 	switch (type) {
 	case NCCL_PTR_HOST:
-		mr_attr.access |= FI_READ;
+		if (support_fi_rma) {
+			mr_attr.access |= FI_READ;
+		}
 		mr_attr.iface = FI_HMEM_SYSTEM;
 		break;
 #if HAVE_CUDA
 	case NCCL_PTR_CUDA:
-		mr_attr.access |= FI_REMOTE_READ;
+		if (support_fi_rma) {
+			mr_attr.access |= FI_REMOTE_READ;
+		}
 		mr_attr.iface = FI_HMEM_CUDA;
 
 		/* Get CUDA device ID */
@@ -2742,6 +2748,7 @@ found:
 			iter = iter->next;
 		}
 	}
+	support_fi_rma = ((provider_list->caps & FI_RMA) != 0);
 
 	/* Allow for multiple virtual nics per nic to increase
 	 * throughput for NICs that do not handle single QP situations


### PR DESCRIPTION
*Description of changes:*

**Commit 1**:
`rdma`: Lower provider not faound message to INFO

Not finding any provider in rdma initialization is not necessarily an error that users should be concerned by. When a transport isn't requested by the platform or user, both sendrecv and rdma transports are initialized. Given the restrictive requirements of the rdma transport, not finding a provider is a reasonable outcome. Log level set to INFO, instead of WARN will be sufficient. For other error codes, keeping them as WARN.

**Commit 2**:
`sendrecv`: Set FI_RMA for tcp provider

Regarding issue: https://github.com/ofiwg/libfabric/issues/10882 that `fi_mr_reg` call to the TCP provider will fail unless the `attr->requested_key` is unique for each call, while fix in Libfabric is in progress and will be included in Libfabric 2.2, plugin needs a workaround to unblock EFA installer release.  

This change to `sendrecv` sets FI_RMA capability for the TCP provider, and plugin will allocate and provide unique mr key so that it meets the fi_mr_reg call's current expectation.

**Commit 3**:
`sendrecv`: Only request READ access when RMA enabled

When remote access is not requested, mr access flags(FI_READ/FI_REMOTE_READ) should not be set either

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
