### PR TITLE
build: Remove libnccl-net before creating symlink

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -73,7 +73,7 @@ else
 
 if ENABLE_NCCL_NET_SYMLINK
 install-exec-hook:
-	cd $(DESTDIR)$(libdir) && $(LN_S) libnccl-net-ofi.so libnccl-net.so
+	cd $(DESTDIR)$(libdir) && rm -f libnccl-net.so && $(LN_S) libnccl-net-ofi.so libnccl-net.so
 
 uninstall-local:
 	@files=libnccl-net.so ; dir='$(DESTDIR)$(libdir)' ; $(am__uninstall_files_from_dir)


### PR DESCRIPTION
f71aea22 changed the default library name from libnccl-net.so to libnccl-net-ofi.so, and then created a symlink from libnccl-net-ofi.so to libnccl-net.so.  The commit missed the upgrade path, where the install directory already contained a libnccl-net.so file, causing the symlink creation to fail.

This commit removes the libnccl-net.so file/symlink before creating the symlink, fixing the upgrade path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
