### PR TITLE
Revert "rdma: Disable eager by default"

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -319,7 +319,7 @@ OFI_NCCL_PARAM_INT(net_latency, "NET_LATENCY", -1);
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
  */
-OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", -1);
+OFI_NCCL_PARAM_INT(eager_max_size, "EAGER_MAX_SIZE", 8192);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION

*Description of changes:*
This reverts commit 13d728effb7ea12c2043b8b31def0d38a5092eb7.
We don't want to disable Eager in a public release branch yet before validating the performance changes. Reverting it in only v1.14.x branch. And will be included in v1.14.1 release

local nccl-test with libfabric `main` and `v1.22.x` both passed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
