### PR TITLE
Control message scheduling improvements

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -283,6 +283,12 @@ OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 1);
 OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (128 * 1024));
 
 /*
+ * The round robin scheduler has two round robin counts, for small (likely
+ * control) and medium (likely data) messages.  This parameter moves that value.
+ */
+OFI_NCCL_PARAM_UINT(sched_max_small_msg_size, "SCHED_MAX_SMALL_RR_SIZE", 64);
+
+/*
  * Deprecated value to control both eager and control bounce counts.
  */
 OFI_NCCL_PARAM_INT(deprecated_rdma_min_posted_bounce_buffers, "RDMA_MIN_POSTED_BOUNCE_BUFFERS", -1);

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -283,20 +283,42 @@ OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 1);
 OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (128 * 1024));
 
 /*
- * Minimum rx buffers (ctrl/eager) posted per endpoint. The plugin will attempt
- * to post more rx buffers if we dip below this threshold, allocating new rx
- * buffers if needed.
- *
- * Note: the parameter is called "bounce buffer" for backward compatibility.
+ * Deprecated value to control both eager and control bounce counts.
  */
-OFI_NCCL_PARAM_INT(rdma_min_posted_bounce_buffers, "RDMA_MIN_POSTED_BOUNCE_BUFFERS", 64);
+OFI_NCCL_PARAM_INT(deprecated_rdma_min_posted_bounce_buffers, "RDMA_MIN_POSTED_BOUNCE_BUFFERS", -1);
+
+/*
+ * Deprecated value to control both eager and control bounce counts.
+ */
+OFI_NCCL_PARAM_INT(deprecated_rdma_max_posted_bounce_buffers, "RDMA_MAX_POSTED_BOUNCE_BUFFERS", -1);
+
+/*
+ * Minimum eager rx buffers posted per endpoint. The plugin will attempt to post
+ * more rx buffers if we dip below this threshold, allocating new rx buffers if
+ * needed.
+ */
+OFI_NCCL_PARAM_INT(rdma_min_posted_eager_buffers, "RDMA_MIN_POSTED_EAGER_BUFFERS", 64);
 
 /*
  * Maximum rx buffers posted per endpoint. The plugin will not attempt to
  * post more rx buffers if we reach this threshold, returning available
  * buffers to the free list if needed
  */
-OFI_NCCL_PARAM_INT(rdma_max_posted_bounce_buffers, "RDMA_MAX_POSTED_BOUNCE_BUFFERS", 128);
+OFI_NCCL_PARAM_INT(rdma_max_posted_eager_buffers, "RDMA_MAX_POSTED_EAGER_BUFFERS", 128);
+
+/*
+ * Minimum control rx buffers posted per endpoint. The plugin will attempt to post
+ * more rx buffers if we dip below this threshold, allocating new rx buffers if
+ * needed.
+ */
+OFI_NCCL_PARAM_INT(rdma_min_posted_control_buffers, "RDMA_MIN_POSTED_CONTROL_BUFFERS", 1920);
+
+/*
+ * Maximum rx buffers posted per endpoint. The plugin will not attempt to
+ * post more rx buffers if we reach this threshold, returning available
+ * buffers to the free list if needed
+ */
+OFI_NCCL_PARAM_INT(rdma_max_posted_control_buffers, "RDMA_MAX_POSTED_CONTROL_BUFFERS", 2048);
 
 /*
  * Whether to spread the control message across multiple rails in round robin fashion or

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -330,7 +330,7 @@ OFI_NCCL_PARAM_INT(rdma_max_posted_control_buffers, "RDMA_MAX_POSTED_CONTROL_BUF
  * Whether to spread the control message across multiple rails in round robin fashion or
  * send it consistenly on one rail.
  */
-OFI_NCCL_PARAM_INT(rdma_rr_ctrl_msg, "RR_CTRL_MSG", 0);
+OFI_NCCL_PARAM_INT(rdma_rr_ctrl_msg, "RR_CTRL_MSG", 1);
 
 /*
  * Internode network latency reported to NCCL. Defaults to 0, unless the configured

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -89,9 +89,12 @@ typedef struct nccl_net_ofi_scheduler {
 typedef struct nccl_net_ofi_threshold_scheduler {
 	nccl_net_ofi_scheduler_t base;
 	/* Round robin counter */
+	unsigned int rr_small_counter;
 	unsigned int rr_counter;
 	/* Lock for round robin counter */
 	pthread_mutex_t rr_lock;
+	/* threshold for small messages */
+	size_t max_small_msg_size;
 	/* Minimum size of the message in bytes before message is
 	 * multiplexed */
 	size_t min_stripe_size;

--- a/include/nccl_ofi_scheduler.h
+++ b/include/nccl_ofi_scheduler.h
@@ -108,13 +108,11 @@ void nccl_net_ofi_release_schedule(nccl_net_ofi_scheduler_t *scheduler,
  *
  * @param	num_rails
  *		Number of rails
- * @param min_stripe_size
- * 		Minimum size of a message in bytes before message is multiplexed
  * @return	Scheduler, on success
  *		NULL, on error
  * @return	0, on success
  *		non-zero, on error
  */
-int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size, nccl_net_ofi_scheduler_t **scheduler);
+int nccl_net_ofi_threshold_scheduler_init(int num_rails, nccl_net_ofi_scheduler_t **scheduler);
 
 #endif // End NCCL_OFI_SCHEDULER_H_

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7634,7 +7634,7 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
  * Create an rdma device object
  */
 static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
-	nccl_net_ofi_plugin_t *plugin, int dev_id, struct fi_info *info_list, nccl_ofi_topo_t *topo, size_t min_strip_size)
+	nccl_net_ofi_plugin_t *plugin, int dev_id, struct fi_info *info_list, nccl_ofi_topo_t *topo)
 {
 	int ret = 0;
 	int length = 0, target_length;
@@ -7723,7 +7723,7 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	}
 
 	/* Create scheduler */
-	ret = nccl_net_ofi_threshold_scheduler_init(length, min_strip_size, &device->scheduler);
+	ret = nccl_net_ofi_threshold_scheduler_init(length, &device->scheduler);
 	if (ret != 0) {
 		goto error;
 	}
@@ -7901,8 +7901,7 @@ static inline int nccl_net_ofi_rdma_plugin_complete_init(nccl_net_ofi_plugin_t *
 		nccl_net_ofi_rdma_device_t *device = nccl_net_ofi_rdma_device_create(&rdma_plugin->base,
 		                                                                     (int)dev_id,
 		                                                                     info_list,
-		                                                                     rdma_plugin->topo,
-		                                                                     ofi_nccl_min_stripe_size());
+		                                                                     rdma_plugin->topo);
 		if (device == NULL) {
 			NCCL_OFI_WARN("Device creation failed");
 			return -ENOMEM;

--- a/src/nccl_ofi_scheduler.cpp
+++ b/src/nccl_ofi_scheduler.cpp
@@ -11,6 +11,7 @@
 
 #include "nccl_ofi_scheduler.h"
 #include "nccl_ofi_math.h"
+#include "nccl_ofi_param.h"
 #include "nccl_ofi_pthread.h"
 
 /*
@@ -263,7 +264,7 @@ static inline int scheduler_init(int num_rails, nccl_net_ofi_scheduler_t *schedu
 	return ret;
 }
 
-int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size, nccl_net_ofi_scheduler_t **scheduler_p)
+int nccl_net_ofi_threshold_scheduler_init(int num_rails, nccl_net_ofi_scheduler_t **scheduler_p)
 {
 	int ret = 0;
 	nccl_net_ofi_threshold_scheduler_t *scheduler = NULL;
@@ -285,7 +286,7 @@ int nccl_net_ofi_threshold_scheduler_init(int num_rails, size_t min_stripe_size,
 	scheduler->base.get_schedule = get_threshold_schedule;
 	scheduler->base.fini = threshold_scheduler_fini;
 	scheduler->rr_counter = 0;
-	scheduler->min_stripe_size = min_stripe_size;
+	scheduler->min_stripe_size = ofi_nccl_min_stripe_size();
 
 	ret = nccl_net_ofi_mutex_init(&scheduler->rr_lock, NULL);
 	if (ret) {

--- a/tests/unit/scheduler.cpp
+++ b/tests/unit/scheduler.cpp
@@ -131,6 +131,8 @@ static inline int test_threshold_scheduler()
 	size_t min_stripe_size = 4096;
 	setenv("OFI_NCCL_MIN_STRIPE_SIZE", "4096", 1);
 
+	setenv("OFI_NCCL_SCHED_MAX_SMALL_RR_SIZE", "64", 1);
+
 	nccl_net_ofi_scheduler_t *scheduler;
 	if (nccl_net_ofi_threshold_scheduler_init(num_rails, &scheduler)) {
 		NCCL_OFI_WARN("Failed to initialize threshold scheduler");
@@ -159,7 +161,7 @@ static inline int test_threshold_scheduler()
 	                         min_stripe_size};
 	size_t msg_size_per_stripe_1[6][1] =
 		{{msg_sizes_1[0]}, {msg_sizes_1[1]}, {msg_sizes_1[2]}, {msg_sizes_1[3]}, {msg_sizes_1[4]}, {msg_sizes_1[5]}};
-	int rail_ids_1[6][1] = {{0}, {1}, {2}, {3}, {0}, {1}}; /* In round-robin for each iteration a new rail-id is used */
+	int rail_ids_1[6][1] = {{0}, {0}, {1}, {2}, {3}, {0}}; /* In round-robin for each iteration a new rail-id is used */
 	size_t offsets_1[6][1] = {{0}, {0}, {0}, {0}, {0}, {0}}; /* Offset remaines 0 in round robin */
 	for (int iter = 0; iter < 6; iter++) {
 		ret = test_multiplexer(scheduler,
@@ -193,7 +195,7 @@ static inline int test_threshold_scheduler()
 
 	/* For each message ensure that two rails are used. Also ensure that the rail-id pairs
 	 * are round-robin between each schedule */
-	int rail_ids_2[6][2] = {{2, 3}, {0, 1}, {2, 3}, {0, 1}, {2, 3}, {0, 1}};
+	int rail_ids_2[6][2] = {{1, 2}, {3, 0}, {1, 2}, {3, 0}, {1, 2}, {3, 0}};
 	size_t offsets_2[6][2] = {{0, stripe_size[0]},
 				  {0, stripe_size[1]},
 				  {0, stripe_size[2]},
@@ -235,7 +237,7 @@ static inline int test_threshold_scheduler()
 	}
 	/* For each message ensure that three rails are used. Also ensure that the rail-id triplets
 	 * are round-robin between each schedule */
-	int rail_ids_3[6][2] = {{2, 3}, {0, 1}, {2, 3}, {0, 1}, {2, 3}, {0, 1}};
+	int rail_ids_3[6][2] = {{1, 2}, {3, 0}, {1, 2}, {3, 0}, {1, 2}, {3, 0}};
 	size_t offsets_3[6][2] = {{0, (stripe_size[0] * 2) / 2},
 				  {0, (stripe_size[1] * 2) / 2},
 				  {0, (stripe_size[2] * 2) / 2},
@@ -276,7 +278,7 @@ static inline int test_threshold_scheduler()
 		remaining_stripe_size[iter] = msg_sizes_4[iter] - (3 * stripe_size[iter]);
 	}
 	/* For each message ensure that all four rails are used. */
-	int rail_ids_4[6][4] = {{2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}, {2, 3, 0, 1}};
+	int rail_ids_4[6][4] = {{1, 2, 3, 0}, {1, 2, 3, 0}, {1, 2, 3, 0}, {1, 2, 3, 0}, {1, 2, 3, 0}, {1, 2, 3, 0}};
 	size_t offsets_4[6][4] = {{0, stripe_size[0], stripe_size[0] * 2, stripe_size[0] * 3},
 				  {0, stripe_size[1], stripe_size[1] * 2, stripe_size[1] * 3},
 				  {0, stripe_size[2], stripe_size[2] * 2, stripe_size[2] * 3},

--- a/tests/unit/scheduler.cpp
+++ b/tests/unit/scheduler.cpp
@@ -123,14 +123,16 @@ static inline int test_multiplexer(nccl_net_ofi_scheduler_t *scheduler,
 
 static inline int test_threshold_scheduler()
 {
-	size_t min_stripe_size = 4096;
 	size_t align = 128;
 	int num_rails = 4;
 	int num_stripes = 0;
 	int ret = 0;
 
+	size_t min_stripe_size = 4096;
+	setenv("OFI_NCCL_MIN_STRIPE_SIZE", "4096", 1);
+
 	nccl_net_ofi_scheduler_t *scheduler;
-	if (nccl_net_ofi_threshold_scheduler_init(num_rails, min_stripe_size, &scheduler)) {
+	if (nccl_net_ofi_threshold_scheduler_init(num_rails, &scheduler)) {
 		NCCL_OFI_WARN("Failed to initialize threshold scheduler");
 		return ret;
 	}


### PR DESCRIPTION
Three changes all around control message handling:

* Split the eager and control message posted rx limit settings, and greatly increase the number of posted control rx buffers.
* Split the round-robin behavior for short and long messages, to avoid a degenerate case where control messages used one NIC and large messages used another, leading to bandwidth limitations)
* Enable using all rails for control messages by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
