### PR TITLE
ci: Make "make check" more verbose

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -123,14 +123,14 @@ jobs:
       - name: Call `make`
         run: make V=1
 
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
       - name: Call `make install`
         run: make install V=1
 
       - name: Call `make distcheck`
         run: make distcheck V=1
-
-      - name: Call `make check`
-        run: make check V=1
 
   distcheck:
     runs-on: ubuntu-22.04
@@ -250,14 +250,14 @@ jobs:
       - name: Call `make`
         run: make V=1
 
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
       - name: Call `make install`
         run: sudo make install V=1
 
       - name: Call `make distcheck`
         run: make distcheck V=1
-
-      - name: Call `make check`
-        run: make check V=1
 
       - name: Upload config.log
         if: failure()


### PR DESCRIPTION
Print the test suite log when "make check" has a failure, so that there's more debugging output on what caused the faiulre.  Also run "make check" before "make distcheck", since distcheck is a superset of the check tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
