### PR TITLE
Refactor nccl_ofi_idpool to C++

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -348,7 +348,7 @@ struct nccl_net_ofi_domain {
 	nccl_ofi_mr_cache_t *mr_cache;
 
 	/* Memory registration key pool */
-	nccl_ofi_idpool_t mr_rkey_pool;
+	nccl_ofi_idpool_t *mr_rkey_pool;
 
 	pthread_mutex_t domain_lock;
 

--- a/include/nccl_ofi_idpool.h
+++ b/include/nccl_ofi_idpool.h
@@ -5,90 +5,75 @@
 #ifndef NCCL_OFI_IDPOOL_H_
 #define NCCL_OFI_IDPOOL_H_
 
-#include <pthread.h>
-#include <stdint.h>
+#include <mutex>
+#include <vector>
+
 
 /*
  * Pool of IDs, used to keep track of communicator IDs and MR keys.
  */
-typedef struct nccl_ofi_idpool {
+class nccl_ofi_idpool_t {
+public:
+	/*
+	 * @brief	Initialize pool of IDs
+	 *
+	 * Allocates and initializes a nccl_ofi_idpool_t object, marking all
+	 * IDs as available.
+	 */
+	nccl_ofi_idpool_t(size_t size);
+
+
+	/* Disable implicit copy constructor and asignment operator */
+	nccl_ofi_idpool_t(const nccl_ofi_idpool_t&) = delete;
+	nccl_ofi_idpool_t& operator=(const nccl_ofi_idpool_t&) = delete;
+
+
+	/*
+	 * @brief	Allocate an ID
+	 *
+	 * Extract an available ID from the ID pool, mark the ID as
+	 * unavailable in the pool, and return extracted ID. Throws exception if
+	 * called on an empty idpool, returns FI_KEY_NOTAVAIL if no ID was available.
+	 *
+	 * This operation is locked by the ID pool's internal lock.
+	 *
+	 * @return	the extracted ID (zero-based) on success,
+	 *		FI_KEY_NOTAVAIL if no ID was available
+	 */
+	size_t allocate_id();
+
+
+	/*
+	 * @brief	Free an ID from the pool
+	 *
+	 * Return input ID into the pool.
+	 *
+	 * This operation is locked by the ID pool's internal lock. Throws exception
+	 * on error.
+	 *
+	 * @param	id
+	 *		The ID to release (zero-based)
+	 */
+	void free_id(size_t id);
+
+
+	/* Return number of IDs in the id pool */
+	size_t get_size();
+
+
+/* Make member variables protected to allow for unit test child classes to 
+   directly access them */	
+protected:
 	/* Size of the id pool (number of IDs) */
 	size_t size;
 
 	/* ID pool bit array. A bit set in the array indicates
-	   that the ID corresponding to its index is available.*/
-	uint64_t *ids;
-
+	   that the ID corresponding to its index is available.
+	   Stored as long vector elements */
+	std::vector<uint64_t> idpool;
+	
 	/* Lock for concurrency */
-	pthread_mutex_t lock;
-} nccl_ofi_idpool_t;
-
-/*
- * @brief	Initialize pool of IDs
- *
- * Allocates and initializes a nccl_ofi_idpool_t object, marking all
- * IDs as available.
- *
- * @param	idpool_p
- *		Return value with the ID pool pointer allocated
- * @param	size
- *		Size of the id pool (number of IDs)
- * @return	0 on success
- *		non-zero on error
- */
-int nccl_ofi_idpool_init(nccl_ofi_idpool_t *idpool, size_t size);
-
-/*
- * @brief	Allocate an ID
- *
- * Extract an available ID from the ID pool, mark the ID as
- * unavailable in the pool, and return extracted ID. No-op in case
- * no ID was available.
- *
- * This operation is locked by the ID pool's internal lock.
- *
- * @param	idpool
- *		The ID pool
- * @return	the extracted ID (zero-based) on success,
- *		negative value on error
- */
-int nccl_ofi_idpool_allocate_id(nccl_ofi_idpool_t *idpool);
-
-/*
- * @brief	Free an ID from the pool
- *
- * Return input ID into the pool.
- *
- * This operation is locked by the ID pool's internal lock.
- *
- * @param	idpool
- *		The ID pool
- * @param	id
- *		The ID to release (zero-based)
- * @return	0 on success
- *		non-zero on error
- */
-int nccl_ofi_idpool_free_id(nccl_ofi_idpool_t *idpool, size_t id);
-
-/*
- * @brief	Release pool of IDs and free resources
- *
- * Releases a nccl_ofi_idpool_t object and frees allocated memory.
- *
- * @param	idpool_p
- *		Pointer to the ID pool, it will be set to NULL on success
- * @return	0 on success
- *		non-zero on error
- */
-int nccl_ofi_idpool_fini(nccl_ofi_idpool_t *idpool);
-
-
-/*
- * @brief        Check if an idpool has been initialized with a size
- *               other than 0.
- */
-static inline bool nccl_ofi_idpool_active(nccl_ofi_idpool_t *idpool) {
-	return (idpool->size != 0);
-}
+	std::mutex lock;
+};
 
 #endif // End NCCL_OFI_IDPOOL_H_

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -1046,15 +1046,10 @@ int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_
 				size_t_bits);
 			return -EINVAL;
 		}
-		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 1 << shift);
+		domain->mr_rkey_pool = new nccl_ofi_idpool_t(1 << shift);
 	} else {
 		/* Mark key pool as not in use */
-		ret = nccl_ofi_idpool_init(&domain->mr_rkey_pool, 0);
-	}
-	if (ret != 0) {
-		NCCL_OFI_WARN("Creating MR id pool failed: %s",
-			      strerror(-ret));
-		return -ret;
+		domain->mr_rkey_pool = new nccl_ofi_idpool_t(0);
 	}
 
 exit:
@@ -1068,8 +1063,10 @@ int nccl_net_ofi_domain_fini(nccl_net_ofi_domain_t *domain)
 		nccl_ofi_mr_cache_finalize(domain->mr_cache);
 	}
 
-	nccl_ofi_idpool_fini(&domain->mr_rkey_pool);
-
+	if (domain->mr_rkey_pool != NULL) {
+		delete domain->mr_rkey_pool;
+		domain->mr_rkey_pool = NULL;
+	}
 	return 0;
 }
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2882,6 +2882,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 		auto key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
+			ret = key;
 			goto error;
 		}
 		ret_handle->mr_key = static_cast<uint64_t>(key);
@@ -4521,6 +4522,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
 	if (OFI_UNLIKELY(comm_id < 0)) {
 		r_comm->local_comm_id = COMM_ID_INVALID;
+		ret = comm_id;
 		goto error;
 	}
 	r_comm->local_comm_id = (uint32_t)comm_id;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2800,7 +2800,7 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		return 0;
 	}
 
-	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = domain->base.mr_rkey_pool;
 	nccl_ofi_mr_cache_t *mr_cache = domain->base.mr_cache;
 
 	if (mr_cache) {
@@ -2820,12 +2820,8 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		}
 	}
 
-	if (nccl_ofi_idpool_active(key_pool)) {
-		ret = nccl_ofi_idpool_free_id(key_pool, mr_handle->mr_key);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Error freeing MR key %ld, leaking key",
-				      mr_handle->mr_key);
-		}
+	if (key_pool->get_size() != 0) {
+		key_pool->free_id(mr_handle->mr_key);
 	}
 
 	for (int rail_id = 0; rail_id < domain->num_rails; ++rail_id) {
@@ -2860,7 +2856,7 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 	struct fi_mr_attr mr_attr = {};
 	uint64_t regattr_flags = 0;
 	int num_rails = domain->num_rails;
-	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = domain->base.mr_rkey_pool;
 
 	*mhandle = NULL;
 
@@ -2878,11 +2874,11 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 		goto error;
 	}
 
-	if (nccl_ofi_idpool_active(key_pool)) {
-		auto key = nccl_ofi_idpool_allocate_id(key_pool);
-		if (OFI_UNLIKELY(key < 0)) {
+    if (key_pool->get_size() != 0) {
+		auto key = key_pool->allocate_id();
+		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			NCCL_OFI_WARN("MR key allocation failed");
-			ret = key;
+			ret = -ENOMEM;
 			goto error;
 		}
 		ret_handle->mr_key = static_cast<uint64_t>(key);
@@ -3791,10 +3787,7 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm_t *r_comm)
 	rdma_device_set_comm(device, r_comm->local_comm_id, NULL);
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
-	}
+	device->comm_idpool->free_id(r_comm->local_comm_id);
 
 	ret = nccl_net_ofi_mutex_destroy(&r_comm->ctrl_counter_lock);
 	if (ret != 0) {
@@ -3966,11 +3959,7 @@ static int send_comm_destroy(nccl_net_ofi_rdma_send_comm_t *s_comm)
 	rdma_device_set_comm(device, s_comm->local_comm_id, NULL);
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(device->comm_idpool, s_comm->local_comm_id);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, s_comm->local_comm_id);
-		return ret;
-	}
+	device->comm_idpool->free_id(s_comm->local_comm_id);
 
 	/* Destroy domain */
 #if HAVE_NVTX_TRACING && NCCL_OFI_NVTX_TRACE_PER_COMM
@@ -4473,7 +4462,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 {
 	int ret = 0;
 
-	int comm_id = 0;
+	size_t comm_id = 0;
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = NULL;
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
 	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain);
@@ -4519,10 +4508,10 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 	r_comm->n_ctrl_delivered = 0;
 
 	/* Allocate recv communicator ID */
-	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
-	if (OFI_UNLIKELY(comm_id < 0)) {
+	comm_id = device->comm_idpool->allocate_id();
+	if (OFI_UNLIKELY(comm_id == FI_KEY_NOTAVAIL)) {
 		r_comm->local_comm_id = COMM_ID_INVALID;
-		ret = comm_id;
+		ret = -ENOMEM;
 		goto error;
 	}
 	r_comm->local_comm_id = (uint32_t)comm_id;
@@ -4701,10 +4690,7 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 		if (r_comm->msgbuff)
 			nccl_ofi_msgbuff_destroy(r_comm->msgbuff);
 		if (COMM_ID_INVALID != r_comm->local_comm_id) {
-			ret = nccl_ofi_idpool_free_id(device->comm_idpool, r_comm->local_comm_id);
-			if (ret != 0) {
-				NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, r_comm->local_comm_id);
-			}
+			device->comm_idpool->free_id(r_comm->local_comm_id);
 		}
 		nccl_net_ofi_mutex_destroy(&r_comm->ctrl_counter_lock);
 		free_rdma_recv_comm(r_comm);
@@ -5099,11 +5085,7 @@ static int listen_close(nccl_net_ofi_listen_comm_t *listen_comm)
 	}
 
 	/* Release communicator ID */
-	ret = nccl_ofi_idpool_free_id(rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)base_ep)->comm_idpool,
-				      l_comm->comm_id);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, l_comm->comm_id);
-	}
+	rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)base_ep)->comm_idpool->free_id(l_comm->comm_id);
 
 	free(l_comm);
 	ret = base_ep->release_ep(base_ep, false, false);
@@ -5117,7 +5099,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_listen_comm_t *l_comm = NULL;
-	int comm_id = 0;
+	size_t comm_id = 0;
 	nccl_net_ofi_rdma_ep_t *ep =
 		(nccl_net_ofi_rdma_ep_t *)base_ep;
 	nccl_net_ofi_ep_rail_t *first_control_rail = rdma_endpoint_get_control_rail(ep, 0);
@@ -5162,10 +5144,10 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 	l_comm->base.close = listen_close;
 
 	/* Allocate listen communicator ID */
-	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
-	if (OFI_UNLIKELY(comm_id < 0)) {
+	comm_id = device->comm_idpool->allocate_id();
+	if (OFI_UNLIKELY(comm_id == FI_KEY_NOTAVAIL)) {
 		l_comm->comm_id = COMM_ID_INVALID;
-		ret = comm_id;
+		ret = -ENOMEM;
 		goto error;
 	}
 	l_comm->comm_id = (uint32_t)comm_id;
@@ -5185,9 +5167,7 @@ static int listen(nccl_net_ofi_ep_t *base_ep,
 
 error:
 	if (l_comm && COMM_ID_INVALID != l_comm->comm_id) {
-		if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, l_comm->comm_id)) {
-			NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, l_comm->comm_id);
-		}
+		device->comm_idpool->free_id(l_comm->comm_id);
 	}
 	free(l_comm);
  exit:
@@ -6441,7 +6421,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 				   nccl_net_ofi_rdma_send_comm_t **s_comm)
 {
 	int ret = 0;
-	int comm_id = 0;
+	size_t comm_id = 0;
 	fi_addr_t remote_addr;
 	nccl_net_ofi_rdma_send_comm_t *ret_s_comm = NULL;
 	int num_rails = ep->num_rails;
@@ -6500,10 +6480,10 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
 	ret_s_comm->remote_comm_id = handle->comm_id;
 
 	/* Allocate send communicator ID */
-	comm_id = nccl_ofi_idpool_allocate_id(device->comm_idpool);
-	if (OFI_UNLIKELY(comm_id < 0)) {
+	comm_id = device->comm_idpool->allocate_id();
+	if (OFI_UNLIKELY(comm_id == FI_KEY_NOTAVAIL)) {
 		ret_s_comm->local_comm_id = COMM_ID_INVALID;
-		ret = comm_id;
+		ret = -ENOMEM;
 		goto error;
 	}
 	ret_s_comm->local_comm_id = (uint32_t)comm_id;
@@ -6579,9 +6559,7 @@ static inline int create_send_comm(nccl_net_ofi_conn_handle_t *handle,
  error:
 	if (ret_s_comm) {
 		if (COMM_ID_INVALID != ret_s_comm->local_comm_id) {
-			if (0 != nccl_ofi_idpool_free_id(device->comm_idpool, ret_s_comm->local_comm_id)) {
-				NCCL_OFI_WARN("Error freeing communicator ID %" PRIu32, ret_s_comm->local_comm_id);
-			}
+			device->comm_idpool->free_id(ret_s_comm->local_comm_id);
 		}
 		nccl_net_ofi_mutex_destroy(&ret_s_comm->ctrl_recv_lock);
 		free_rdma_send_comm(ret_s_comm);
@@ -7608,12 +7586,7 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
 	}
 
 	if (device->comm_idpool) {
-		ret = nccl_ofi_idpool_fini(device->comm_idpool);
-		if (ret) {
-			NCCL_OFI_WARN("Failed to free idpool");
-			if (first_error == 0) first_error = ret;
-		}
-		free(device->comm_idpool);
+		delete device->comm_idpool;
 		device->comm_idpool = NULL;
 	}
 
@@ -7766,19 +7739,7 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	}
 
 	/* Initialize device ID pool */
-	device->comm_idpool = (nccl_ofi_idpool_t *)malloc(sizeof(nccl_ofi_idpool_t));
-	if (OFI_UNLIKELY(device->comm_idpool == NULL)) {
-		NCCL_OFI_WARN("Unable to allocate rdma endpoint ID pool");
-		ret = -ENOMEM;
-		goto error;
-	}
-
-	ret = nccl_ofi_idpool_init(device->comm_idpool, device->num_comm_ids);
-	if (OFI_UNLIKELY(ret != 0)) {
-		free(device->comm_idpool);
-		device->comm_idpool = NULL;
-		goto error;
-	}
+	device->comm_idpool = new nccl_ofi_idpool_t(device->num_comm_ids);
 
 	/* NVTX domain */
 #if HAVE_NVTX_TRACING && NCCL_OFI_NVTX_TRACE_PER_DEV

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -623,6 +623,7 @@ static int sendrecv_mr_buffers_register(struct fid_domain *domain,
 		int key = nccl_ofi_idpool_allocate_id(key_pool);
 		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
+			ret = key;
 			goto exit;
 		}
 		ret_handle->mr_key = static_cast<uint64_t>(key);

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -619,11 +619,11 @@ static int sendrecv_mr_buffers_register(struct fid_domain *domain,
 		goto exit;
 	}
 
-	if (nccl_ofi_idpool_active(key_pool)) {
-		int key = nccl_ofi_idpool_allocate_id(key_pool);
-		if (OFI_UNLIKELY(key < 0)) {
+	if (key_pool->get_size() != 0) {
+		size_t key = key_pool->allocate_id();
+		if (OFI_UNLIKELY(key == FI_KEY_NOTAVAIL)) {
 			NCCL_OFI_WARN("MR key allocation failed");
-			ret = key;
+			ret = -ENOMEM;
 			goto exit;
 		}
 		ret_handle->mr_key = static_cast<uint64_t>(key);
@@ -781,12 +781,8 @@ static int sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_han
 		}
 	}
 
-	if (nccl_ofi_idpool_active(key_pool) && OFI_LIKELY(mr_handle->mr_key != MR_KEY_INIT_VALUE)) {
-		ret = nccl_ofi_idpool_free_id(key_pool, mr_handle->mr_key);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Error freeing MR key %" PRIu64 ", leaking key",
-				mr_handle->mr_key);
-		}
+	if (key_pool->get_size() != 0 && OFI_LIKELY(mr_handle->mr_key != MR_KEY_INIT_VALUE)) {
+		key_pool->free_id(mr_handle->mr_key);
 	}
 
 	if (mr_handle->mr != nullptr) {
@@ -849,7 +845,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 		/* Cache miss */
 	}
 
-	key_pool = &domain->base.mr_rkey_pool;
+	key_pool = domain->base.mr_rkey_pool;
 	struct fid_domain *ofi_domain;
 	ofi_domain = sendrecv_endpoint_get_ofi_domain(ep);
 	ret = sendrecv_mr_base_register(ofi_domain, ep->ofi_ep, key_pool,
@@ -915,7 +911,7 @@ static int sendrecv_recv_comm_dereg_mr(nccl_net_ofi_recv_comm_t *recv_comm,
 	assert(domain != NULL);
 
 	auto *mr_handle = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(mhandle);
-	return sendrecv_comm_mr_base_dereg(mr_handle, &domain->base.mr_rkey_pool, domain->base.mr_cache);
+	return sendrecv_comm_mr_base_dereg(mr_handle, domain->base.mr_rkey_pool, domain->base.mr_cache);
 }
 
 /**
@@ -941,7 +937,7 @@ static int sendrecv_freelist_regmr_host_fn(void *opaque, void *data, size_t size
 		return -ENOMEM;
 	}
 
-	freelist_handle->key_pool = &(sendrecv_endpoint_get_domain(ep))->base.mr_rkey_pool;
+	freelist_handle->key_pool = (sendrecv_endpoint_get_domain(ep))->base.mr_rkey_pool;
 
 	int ret = sendrecv_mr_buffers_internal_register(domain->domain,
 							ep->ofi_ep,
@@ -1388,7 +1384,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 	struct fid_domain *ofi_domain;
 	nccl_net_ofi_sendrecv_recv_comm_t *r_comm = NULL;
 	size_t req_size = sizeof(nccl_net_ofi_sendrecv_req_t);
-	nccl_ofi_idpool_t *key_pool = &domain->base.mr_rkey_pool;
+	nccl_ofi_idpool_t *key_pool = domain->base.mr_rkey_pool;
 	int dev_id = device->base.dev_id;
 
 	/* Insert remote EP address to AV */
@@ -1777,7 +1773,7 @@ static int sendrecv_send_comm_dereg_mr(nccl_net_ofi_send_comm_t *send_comm,
 	assert(domain != NULL);
 
 	auto *mr_handle = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(mhandle);
-	return sendrecv_comm_mr_base_dereg(mr_handle, &domain->base.mr_rkey_pool,
+	return sendrecv_comm_mr_base_dereg(mr_handle, domain->base.mr_rkey_pool,
 				  domain->base.mr_cache);
 }
 

--- a/tests/unit/idpool.cpp
+++ b/tests/unit/idpool.cpp
@@ -4,11 +4,28 @@
 
 #include "config.h"
 
+#include <stdexcept>
 #include <stdio.h>
 
 #include "test-common.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_math.h"
+
+/* Define unit test child class nccl_ofi_idpool_t that can directly access
+   the idpool protected variable */
+class nccl_ofi_idpool_t_unit_test : public nccl_ofi_idpool_t {
+public:
+	nccl_ofi_idpool_t_unit_test(size_t size_arg) : nccl_ofi_idpool_t(size_arg) {}
+
+	/* Return the idpool element value of a valid vector index */
+	uint64_t get_element(size_t index)
+	{
+		std::lock_guard<std::mutex> l(lock);
+		/* Use built-in bounds-checking of the std::vector::at member function */
+		return idpool.at(index);
+	}
+};
+
 
 int main(int argc, char *argv[]) {
 
@@ -23,84 +40,97 @@ int main(int argc, char *argv[]) {
 		/* Scale pool size to number of 64-bit uints (rounded up) */
 		size_t num_long_elements = NCCL_OFI_ROUND_UP(size, sizeof(uint64_t) * 8) / (sizeof(uint64_t) * 8);
 
-		nccl_ofi_idpool_t *idpool = (nccl_ofi_idpool_t *)malloc(sizeof(nccl_ofi_idpool_t));
-		assert(NULL != idpool);
-
-		/* Test nccl_ofi_idpool_init */
-		ret = nccl_ofi_idpool_init(idpool, size);
-		assert(0 == ret);
-		assert(idpool->size == size);
+		/* Test nccl_ofi_idpool_t constructor */
+		auto *idpool = new nccl_ofi_idpool_t_unit_test(size);
+		assert(idpool->get_size() == size);
 
 		/* Test that all bits are set */
 		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
-				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
+				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->get_element(i));
 			} else {
-				assert(0xffffffffffffffff == idpool->ids[i]);
+				assert(0xffffffffffffffff == idpool->get_element(i));
 			}
 		}
 
 		/* Test nccl_ofi_allocate_id */
-		int id = 0;
+		size_t id = 0;
 		(void) id; // Avoid unused-variable warning
 		for (uint64_t i = 0; i < size; i++) {
-			id = nccl_ofi_idpool_allocate_id(idpool);
+			id = idpool->allocate_id();
 			assert((uint64_t)id == i);
 		}
-		id = nccl_ofi_idpool_allocate_id(idpool);
-		assert(-ENOMEM == id);
+		if (size != 0) {
+			/* test error handling when there are no free IDs */
+			id = idpool->allocate_id();
+			assert(id == FI_KEY_NOTAVAIL);
+		} else {
+			try {
+				/* Test error handling when trying to allocate from an empty idpool. */ 
+				id = idpool->allocate_id();
+				exit(1);
+			}
+			catch (const std::exception&) {
+				/* Successfully threw expected exception */ 
+			}
+		}
 
 		/* Test freeing and reallocating IDs */
-		if (size) {
-			int holes[] = {(int)(size/3), (int)(size/2)}; // Must be in increasing order
+		if (size != 0) {
+			size_t holes[] = {(size/3), (size/2)}; // Must be in increasing order
 
-			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(size_t); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
-					ret = nccl_ofi_idpool_free_id(idpool, holes[i]);
-					assert(0 == ret);
+					idpool->free_id(holes[i]);
 				}
 			}
 
-			for (size_t i = 0; i < sizeof(holes) / sizeof(int); i++) {
+			for (size_t i = 0; i < sizeof(holes) / sizeof(size_t); i++) {
 				if (0 == i || holes[i] != holes[i-1]) {
-					id = nccl_ofi_idpool_allocate_id(idpool);
+					id = idpool->allocate_id();
 					assert(id == holes[i]);
 				}
 			}
 		}
 
 		/* Test nccl_ofi_free_id */
-		ret = nccl_ofi_idpool_free_id(idpool, (int)size);
-		assert(-EINVAL == ret);
-
-		for (size_t i = 0; i < size; i++) {
-			ret = nccl_ofi_idpool_free_id(idpool, i);
-			assert(0 == ret);
+		try {
+			/* If size == 0, test error handling when trying to free from an 
+			   empty idpool. If size > 0, test out-of-bounds error handling */
+			idpool->free_id(size);
+			exit(1);
+		}
+		catch (const std::exception&) {
+			/* Successfully threw expected exception */ 
 		}
 
-		if (size) {
-			ret = nccl_ofi_idpool_free_id(idpool, 0);
-			assert(-ENOTSUP == ret);
+		for (size_t i = 0; i < size; i++) {
+			idpool->free_id(i);
+		}
+
+		if (size != 0) {
+			try {
+				/* Test error handling when trying to free an ID is that already 
+				   marked as available */
+				idpool->free_id(0);
+				exit(1);
+			}
+			catch (const std::exception&) {
+				/* Successfully threw expected exception */ 
+			}
 		}
 
 		/* Test that all bits are set */
 		for (size_t i = 0; i < num_long_elements; i++) {
 			if (i == num_long_elements - 1 && size % (sizeof(uint64_t) * 8)) {
-				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->ids[i]);
+				assert((1ULL << (size % (sizeof(uint64_t) * 8))) - 1 == idpool->get_element(i));
 			} else {
-				assert(0xffffffffffffffff == idpool->ids[i]);
+				assert(0xffffffffffffffff == idpool->get_element(i));
 			}
 		}
 
-		/* Test nccl_ofi_idpool_fini */
-		ret = nccl_ofi_idpool_fini(idpool);
-		assert(0 == ret);
-		/* nccl_ofi_idpool_fini is a no-op if the pool is
-		   0-sized or uninitialized */
-		ret = nccl_ofi_idpool_fini(idpool);
-		assert(0 == ret);
-
-		free(idpool);
+		/* Test deconstructor */
+		delete idpool;
 		idpool = NULL;
 	}
 


### PR DESCRIPTION
Refactors the nccl_ofi_idpool implementation to C++, creating a nccl_ofi_idpool_t class with std::vector and std::mutex member variables and thread-safe wrappers to interact with the std:vector. Updates all usage of the previous nccl_ofi_idpool C implementation to use the new class.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.