### PR TITLE
Remove -fno-exceptions

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -43,9 +43,9 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CXX
 AC_LANG([C++])
 
-dnl use C++17, disable exceptions, and disable runtime type information
+dnl use C++17, disable runtime type information
 AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
-CXXFLAGS="${CXXFLAGS} -fno-rtti -fno-exceptions"
+CXXFLAGS="${CXXFLAGS} -fno-rtti"
 
 dnl AM_PROG_AR must be called before LT_INIT
 AM_PROG_AR

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -848,10 +848,6 @@ int nccl_net_ofi_device_init(nccl_net_ofi_device_t *device, nccl_net_ofi_plugin_
 
 	device->create_domain = NULL;
 	device->domain_table = new std::unordered_map<long, nccl_net_ofi_domain_t *>;
-	if (device->domain_table == NULL) {
-		NCCL_OFI_WARN("Could not allocate domain table");
-		return -ENOMEM;
-	}
 
 exit:
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7357,11 +7357,6 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 
 	if (ofi_nccl_endpoint_per_communicator() != 0) {
 		domain->ep_addr_list = new nccl_ofi_ep_addr_list_t;
-		if (domain->ep_addr_list == NULL) {
-			NCCL_OFI_WARN("Failed to init ep addr list");
-			ret = -ENOMEM;
-			goto error;
-		}
 	} else {
 		domain->ep_addr_list = NULL;
 	}


### PR DESCRIPTION
Removes the `-fno-exceptions` C++ compiler flags. NCCL currently does not build with the flag, so removing it here should not have a performance impact and will make it easier to handle errors from constructors/deconstructors and STL libraries.

Also removes checking for NULL after allocating with `new`. Since `(std::nothrow)` was not being used to specify non-throwing allocators, errors in the constructor would just throw an exception rather than return NULL, making the NULL checks unnecessary. With `-fno-exceptions` removed, the exception will now be propagated up the stack.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
