### PR TITLE
rmda:Fix mr_key to be uint64_t

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -122,7 +122,7 @@ typedef struct nccl_net_ofi_rdma_mr_handle {
 	int num_rails;
 
 	/* value of mr key id, if keys must be requested */
-	int mr_key;
+	uint64_t mr_key;
 
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;


### PR DESCRIPTION
*Description of changes:*

Fix mr_key type to be uint64_t, as per libfabric definition - https://github.com/ofiwg/libfabric/blob/11163b6da4ceca95b4135d9c316d9ee9de91e63b/include/rdma/fi_domain.h#L134

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
