### PR TITLE
Add and update tracepoints for improved analysis 

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -34,7 +34,8 @@
 	NCCL_OFI_TRACE_SEND_NVTX(dev, size, comm, msg_seq_num, request, nccl_req); \
 } while(0)
 
-#define NCCL_OFI_TRACE_SEND_END(request) do { \
+#define NCCL_OFI_TRACE_SEND_END(dev, comm, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, SendEnd, dev, comm, request); \
 	NCCL_OFI_TRACE_SEND_END_NVTX(request); \
 } while(0)
 
@@ -78,7 +79,8 @@
 	NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_END(request) do { \
+#define NCCL_OFI_TRACE_RECV_END(dev, comm, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, RecvEnd, dev, comm, request); \
 	NCCL_OFI_TRACE_RECV_END_NVTX(request); \
 } while(0)
 

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -82,8 +82,8 @@
 	NCCL_OFI_TRACE_RECV_END_NVTX(request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, size, request, msg_seq_num) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, size, request, msg_seq_num); \
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, comm, size, request, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, comm, size, request, msg_seq_num); \
 	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request, msg_seq_num); \
 } while(0)
 

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -15,8 +15,8 @@
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, msg_seq_num, request, nccl_req); \
 } while (0)
 
-#define NCCL_OFI_TRACE_RECV_SENDRECV(dev, tag, size, request, nccl_req) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
+#define NCCL_OFI_TRACE_RECV_SENDRECV(dev, comm, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm, size, request, nccl_req); \
 } while(0)
 
 #define NCCL_OFI_TRACE_FLUSH_SENDRECV(request, nccl_req) do { \
@@ -73,9 +73,9 @@
 	NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV(dev, tag, size, request, nccl_req) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, tag, size, request, nccl_req); \
-	NCCL_OFI_TRACE_RECV_NVTX(dev, tag, size, request, nccl_req); \
+#define NCCL_OFI_TRACE_RECV(dev, comm, size, request, nccl_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm, size, request, nccl_req); \
+	NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req); \
 } while(0)
 
 #define NCCL_OFI_TRACE_RECV_END(request) do { \

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -68,7 +68,20 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    SendEnd,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
 
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
@@ -235,6 +248,21 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(int, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    RecvEnd,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
     )
 )
 

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -245,6 +245,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_ARGS(
             int, dev,
             int, rail_id,
+            void *, comm,
             size_t, size,
             void *, request,
             uint16_t, msg_seq_num
@@ -252,6 +253,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(int, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -224,14 +224,14 @@ LTTNG_UST_TRACEPOINT_EVENT(
     Recv,
     LTTNG_UST_TP_ARGS(
             int, dev,
-            int, comm_id,
+            void *, comm,
             int, size,
             void *, request,
             void *, nccl_req
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer(int, comm_id, comm_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(int, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -150,7 +150,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_NVTX(dev, tag, size, request, nccl_req) do { \
+#define NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req) do { \
 	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
 			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -1442,7 +1442,7 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 		return ret;
 	}
 
-	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(req->dev_id, rail_id, cq_entry->len, req, req->msg_seq_num);
+	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(req->dev_id, rail_id, req->comm, cq_entry->len, req, req->msg_seq_num);
 
 	return 0;
 }

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -3589,7 +3589,7 @@ static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	/* At this point, we've successfully inserted a new request, so update the num inflight. */
 	(r_comm->num_inflight_reqs)++;
 
-	NCCL_OFI_TRACE_RECV(dev_id, r_comm->local_comm_id, sizes[0], req, base_req);
+	NCCL_OFI_TRACE_RECV(dev_id, r_comm, sizes[0], req, base_req);
 
 	/* Send ctrl msg */
 	nccl_net_ofi_mutex_lock(&r_comm->ctrl_counter_lock);

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2714,9 +2714,9 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 		}
 
 		if (req->type == NCCL_OFI_RDMA_SEND) {
-			NCCL_OFI_TRACE_SEND_END(req);
+			NCCL_OFI_TRACE_SEND_END(req->dev_id, base_comm, req);
 		} else if (req->type == NCCL_OFI_RDMA_RECV) {
-			NCCL_OFI_TRACE_RECV_END(req);
+			NCCL_OFI_TRACE_RECV_END(req->dev_id, base_comm, req);
 		}
 
 		assert(req->free);

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1047,7 +1047,7 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 			desc = fi_mr_desc(mr_handles[recv_n]);
 		}
 
-		NCCL_OFI_TRACE_RECV_SENDRECV(dev_id, r_comm->tag, sizes[recv_n], req, base_req);
+		NCCL_OFI_TRACE_RECV_SENDRECV(dev_id, r_comm, sizes[recv_n], req, base_req);
 
 		/*
 		 * TODO: Use NCCL provided tags when plugin supports grouped


### PR DESCRIPTION
Add and updated tracepoints for improved analysis 
- add RecvEnd, SendEnd to Lttng
- add comm field to Recv  segment completion trace
- change comm_id to comm for Recv tracepoint to align with other tracepoints

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.