### PR TITLE
config: Expose same GUID from a same 0xefa3 device

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -284,6 +284,12 @@ struct nccl_net_ofi_device {
 	 */
 	char *name;
 
+	/*
+	 * Globally unique device identifier that combines
+	 * host identity with device-specific information.
+	 */
+	uint64_t guid;
+
 	/* do we need to use an mr rkey pool?  This is a
 	 * provider-specific behavior determined when providers are
 	 * selected.

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -40,4 +40,11 @@ void nccl_ofi_ofiutils_free_info_list(struct fi_info *info_list);
 
 int nccl_ofi_mr_keys_need_own_key(struct fi_info* provider, bool *provide_own_mr_key);
 
+
+/*
+* @brief Get first non-loopback interface IP address
+* @return IP address as uint32_t (network byte order), 0 on error
+*/
+uint32_t nccl_ofi_get_first_interface_ip(void);
+
 #endif

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -55,4 +55,10 @@ void platform_sort_rails(struct fi_info **info_list, size_t num_rails, size_t nu
  */
 bool platform_default_domain_per_thread(void) __attribute__((weak));
 
+/*
+ * Platform-specific hook to generate a unique device identifier.
+ */
+uint64_t platform_get_unique_node_id(struct fi_info *info, int device_index) __attribute__((weak));
+
+
 #endif // End NCCL_OFI_PLATFORM_H_

--- a/src/nccl_ofi_system.cpp
+++ b/src/nccl_ofi_system.cpp
@@ -1,6 +1,5 @@
 /*
  * Copyright (c) 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
- * Copyright (c) 2015-2018, NVIDIA CORPORATION. All rights reserved.
  */
 
 #include "config.h"


### PR DESCRIPTION
*Description of changes:*
NCCL requires the same GUID for the same EFA device from the api nccl_net_ofi_info_properties.

The EFA Firmware now provides the unique id per-card pci_bus on bits 16-23 of the GUID stored in /sys/class/infiniband/<device_name>/node_guid. Using these bits with a combination of hash of the instance ID to beat that into 56-bits we get a node unique ID for the EFA Device.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
