### PR TITLE
[V1.14.x] Add mr_handle structure to track mr_key

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -127,7 +127,7 @@ typedef struct nccl_net_ofi_rdma_mr_handle {
 	int num_rails;
 
 	/* value of mr key id, if keys must be requested */
-	int mr_key;
+	uint64_t mr_key;
 
 	/* Array of size `num_rails' */
 	struct fid_mr **mr;

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -15,6 +15,11 @@ extern "C" {
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_log.h"
 
+/* This is the initial value of mr_key. At key deregisteration time,
+ * it is used to validate if a key was generated and needed to be freed or not.
+ */
+#define MR_KEY_INIT_VALUE FI_KEY_NOTAVAIL
+
 typedef enum nccl_net_ofi_sendrecv_req_state {
 	NCCL_OFI_SENDRECV_REQ_CREATED = 0,
 	NCCL_OFI_SENDRECV_REQ_PENDING,
@@ -27,6 +32,11 @@ typedef enum nccl_net_ofi_sendrecv_req_direction {
 	NCCL_OFI_SENDRECV_SEND = 1,
 	NCCL_OFI_SENDRECV_RECV,
 } nccl_net_ofi_sendrecv_req_direction_t;
+
+typedef struct nccl_net_ofi_sendrecv_mr_handle {
+	uint64_t mr_key;
+	struct fid_mr *mr;
+} nccl_net_ofi_sendrecv_mr_handle_t;
 
 typedef struct nccl_net_ofi_sendrecv_listen_comm {
 	/* This base listen communicator must be the first member of
@@ -68,7 +78,7 @@ typedef struct nccl_net_ofi_sendrecv_flush_buffer {
 	void *host_buffer;
 	size_t size;
 	/* Memory registration handle of the local buffer */
-	struct fid_mr *mr_handle;
+	nccl_net_ofi_sendrecv_mr_handle_t *mr_handle;
 } nccl_net_ofi_sendrecv_flush_buffer_t;
 
 typedef struct nccl_net_ofi_sendrecv_recv_comm {

--- a/src/nccl_ofi_rdma.c
+++ b/src/nccl_ofi_rdma.c
@@ -2812,10 +2812,10 @@ static int dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handle,
 		}
 	}
 
-	if (nccl_ofi_idpool_active(key_pool) && mr_handle->mr_key >= 0) {
+	if (nccl_ofi_idpool_active(key_pool)) {
 		ret = nccl_ofi_idpool_free_id(key_pool, mr_handle->mr_key);
 		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Error freeing MR key %d, leaking key",
+			NCCL_OFI_WARN("Error freeing MR key %ld, leaking key",
 				      mr_handle->mr_key);
 		}
 	}
@@ -2870,17 +2870,18 @@ static inline int reg_mr_on_device(nccl_net_ofi_rdma_domain_t *domain,
 		goto error;
 	}
 
-        if (nccl_ofi_idpool_active(key_pool)) {
-		ret_handle->mr_key =nccl_ofi_idpool_allocate_id(key_pool);
-		if (OFI_UNLIKELY(ret_handle->mr_key < 0)) {
+	if (nccl_ofi_idpool_active(key_pool)) {
+		int key = nccl_ofi_idpool_allocate_id(key_pool);
+		if (OFI_UNLIKELY(key < 0)) {
 			NCCL_OFI_WARN("MR key allocation failed");
 			ret = ret_handle->mr_key;
 			goto error;
 		}
+		ret_handle->mr_key = (uint64_t)key;
 	}
 
 	/* Create memory registration request */
-	ret = set_mr_req_attr((uint64_t)ret_handle->mr_key, ckey, &regattr_flags, type, &mr_attr);
+	ret = set_mr_req_attr(ret_handle->mr_key, ckey, &regattr_flags, type, &mr_attr);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Could not set registration request attributes, dev: %d",
 			      rdma_domain_get_device(domain)->base.dev_id);


### PR DESCRIPTION
Reimplemented the following 2 master branch changes in C only style.

related PR - https://github.com/aws/aws-ofi-nccl/pull/833
```
2157b0a sendrecv: Add mr_handle structure to track mr_key

381b605 rmda:Fix mr_key to be uint64_t
```

nccl-test passing for both tcp and non-tcp provider with libfabric 2.1.x branch.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
