### PR TITLE
[V1.14.x] Cherry-pick CI changes

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -163,7 +163,6 @@ pipeline {
                     def stages = [:]
 
                     def timeout = "--timeout 40"
-                    def nccl_version = "--test-nccl-version v2.26.2-1"
                     def cluster_type = "--cluster-type manual_cluster"
                     def test_target = "--test-target aws-ofi-nccl"
                     def test_type = "--test-type pr"
@@ -176,7 +175,7 @@ pipeline {
                     def persistent_manual_cluster_addl_args = " --keep-cluster --skip-fixture-setup --skip-health-checks --use-existing-installer --skip-portafiducia-install --enable-placement-group false --lean-cluster-setup"
                     def container_addl_args = " --test-in-containers-on-ec2"
 
-                    def base_args = "${efa_installer} ${nccl_version} ${timeout} ${cluster_type} ${test_target} ${test_type} ${build_type} ${pr_num} ${nccl_test_iter} ${persistent_manual_cluster_addl_args}"
+                    def base_args = "${efa_installer} ${timeout} ${cluster_type} ${test_target} ${test_type} ${build_type} ${pr_num} ${nccl_test_iter} ${persistent_manual_cluster_addl_args}"
 
                     def num_instances = 4
                     def p3dn_lock_label = "p3dn-1-4node"

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -186,12 +186,15 @@ pipeline {
                     def trn1_lock_label = "trn1-1-4node"
                     def trn1n_lock_label = "trn1n-1-4node"
 
+                    def nvidia_test_list = "--test-list test_nccl_test test_ofi_nccl_functional"
+                    def neuron_test_list = "--test-list test_nccom_test"
+
                     def p3_p4_p5_base_os = "alinux2"
-                    def p3_p4_addl_args = "${base_args} ${container_addl_args} --test-list test_nccl_test test_ofi_nccl_functional"
-                    def p5_addl_args = "${base_args} ${container_addl_args} --test-list test_nccl_test"
-                    def g4dn_addl_args = "${base_args} --test-list test_nccl_test test_ofi_nccl_functional"
+                    def p3_p4_addl_args = "${base_args} ${container_addl_args} ${nvidia_test_list}"
+                    def p5_addl_args = "${base_args} ${container_addl_args}  ${nvidia_test_list}"
+                    def g4dn_addl_args = "${base_args} ${nvidia_test_list}"
                     def g4dn_tcp_addl_args = "${g4dn_addl_args} ${test_tcp_provider}"
-                    def neuron_addl_args = "${base_args} --test-list test_nccom_test"
+                    def neuron_addl_args = "${base_args} ${neuron_test_list}"
 
                     // p3dn tests
                     stages["4_p3dn_al2"] = get_test_stage_with_lock_container("4_p3dn_al2", env.BUILD_TAG, p3_p4_p5_base_os, "alinux2", "p3dn.24xlarge", p3dn_lock_label, num_instances, p3_p4_addl_args)

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -123,14 +123,14 @@ jobs:
       - name: Call `make`
         run: make V=1
 
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
       - name: Call `make install`
         run: make install V=1
 
       - name: Call `make distcheck`
         run: make distcheck V=1
-
-      - name: Call `make check`
-        run: make check V=1
 
   distcheck:
     runs-on: ubuntu-22.04
@@ -250,14 +250,14 @@ jobs:
       - name: Call `make`
         run: make V=1
 
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
       - name: Call `make install`
         run: sudo make install V=1
 
       - name: Call `make distcheck`
         run: make distcheck V=1
-
-      - name: Call `make check`
-        run: make check V=1
 
       - name: Upload config.log
         if: failure()


### PR DESCRIPTION

Cherry-pick following CI changes into V1.14.x branch
```
9761e70 .ci/aws: Remove NCCL version definition from Jenkins file
48ee8dd .ci/aws: Enable OFI NCCL functional tests on p5 instance type
e9402e8 ci: Make "make check" more verbose
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
