### PR TITLE
python: Reformat python scripts using ruff

### DIFF
--- a/contrib/python/ofi_nccl/tuner/cli/main.py
+++ b/contrib/python/ofi_nccl/tuner/cli/main.py
@@ -2,27 +2,31 @@ import typer
 import pathlib
 import pandas as pd
 import numpy as np
-import os
-from enum import Enum
 from .wrapper import NCCLProto, NCCLAlgo, Tuner, TunerPlatform
 
 app = typer.Typer(name="show-tuner-decisions")
 
+
 @app.command()
-def show_all(library: pathlib.Path,
-             min_ranks_per_node: int = 1,
-             max_ranks_per_node: int = 64,
-             inc_ranks_per_node: int = 1,
-             min_nnodes: int = 2,
-             max_nnodes: int = np.log2(2048),
-             inc_nnodes: int = 2,
-             ):
+def show_all(
+    library: pathlib.Path,
+    min_ranks_per_node: int = 1,
+    max_ranks_per_node: int = 64,
+    inc_ranks_per_node: int = 1,
+    min_nnodes: int = 2,
+    max_nnodes: int = np.log2(2048),
+    inc_nnodes: int = 2,
+):
     df = (
         pd.concat(
             [
-                Tuner(library, nranks=(rpn * nodecnt), nnodes=nodecnt, platform=platform).analyze_all()
-                for nodecnt in range(min_nnodes, max_nnodes+1, inc_nnodes)
-                for rpn in range(min_ranks_per_node, max_ranks_per_node+1, inc_ranks_per_node)
+                Tuner(
+                    library, nranks=(rpn * nodecnt), nnodes=nodecnt, platform=platform
+                ).analyze_all()
+                for nodecnt in range(min_nnodes, max_nnodes + 1, inc_nnodes)
+                for rpn in range(
+                    min_ranks_per_node, max_ranks_per_node + 1, inc_ranks_per_node
+                )
                 for platform in TunerPlatform
             ]
         )
@@ -35,7 +39,7 @@ def show_all(library: pathlib.Path,
     df["platform"] = df["platform"].apply(lambda x: str(TunerPlatform(x).name))
 
     pd.set_option("display.max_rows", None)
-    pd.set_option('display.multi_sparse', False)
+    pd.set_option("display.multi_sparse", False)
     for collective in df["collective"].unique():
         sf = df[df["collective"] == collective]
         print(sf)

--- a/contrib/python/ofi_nccl/tuner/cli/wrapper.py
+++ b/contrib/python/ofi_nccl/tuner/cli/wrapper.py
@@ -46,6 +46,7 @@ class NCCLProto(int, Enum):
     LL128 = 1
     SIMPLE = 2
 
+
 class TunerPlatform(str, Enum):
     P5en = "p5en.48xlarge"
     P5 = "p5.48xlarge"
@@ -66,7 +67,12 @@ class Tuner:
         self.logger.log(py_level, message)
 
     def __init__(
-            self, tuner_dso: pathlib.Path, nranks: int, nnodes: int, platform: TunerPlatform, log_level=logging.DEBUG
+        self,
+        tuner_dso: pathlib.Path,
+        nranks: int,
+        nnodes: int,
+        platform: TunerPlatform,
+        log_level=logging.DEBUG,
     ):
         self.nranks = nranks
         self.nnodes = nnodes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR includes the changes to only reformat the python scripts using [`ruff`](https://github.com/astral-sh/ruff) as declared in https://github.com/aws/aws-ofi-nccl/blob/master/contrib/python/pyproject.toml#L23 without changing any functionalities

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
