### PR TITLE
Add histogram interface

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2023-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2023-2025 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
@@ -38,4 +38,6 @@ noinst_HEADERS = \
 	internal/tuner/nccl_defaults.h \
 	nccl_ofi_platform.h \
 	nccl_ofi_ep_addr_list.h \
-	platform-aws.h
+	platform-aws.h \
+	stats/histogram.h \
+	stats/histogram_binner.h

--- a/include/stats/histogram.h
+++ b/include/stats/histogram.h
@@ -1,0 +1,122 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM
+#define NCCL_OFI_STATS_HISTOGRAM
+
+#include <cassert>
+#include <chrono>
+#include <cstddef>
+#include <string>
+#include <sstream>
+#include <vector>
+
+#include "nccl_ofi_log.h"
+#include "histogram_binner.h"
+
+
+//
+// Base histogram class.  Histograms are a lightweight mechanism for tracking
+// events occurances in code and are used for instrumenting the plugin code.
+//
+// T is the type of the data that will be inserted into the histogram.  Any POD
+//  will work, and little effort has been put into making the interface safe for
+//  non-Pods.
+//
+template <typename T, typename Binner>
+class histogram {
+public:
+	histogram(const std::string& description_arg, Binner binner_arg)
+		: description(description_arg), binner(binner_arg),
+		bins(binner.get_num_bins()), num_samples(0), first_insert(true)
+	{
+	}
+
+	void insert(const T& input_val)
+	{
+		if (OFI_UNLIKELY(first_insert)) {
+			max_val = min_val = input_val;
+			first_insert = false;
+		}
+
+		if (input_val > max_val) {
+			max_val = input_val;
+		} else if (input_val < min_val) {
+			min_val = input_val;
+		}
+
+		bins[binner.get_bin(input_val)]++;
+		num_samples++;
+	}
+
+	void print_stats(void) {
+		auto range_labels = binner.get_bin_ranges();
+
+		NCCL_OFI_INFO(NCCL_NET, "histogram %s", description.c_str());
+		NCCL_OFI_INFO(NCCL_NET, "  min: %ld, max: %ld, num_samples: %lu",
+					(long int)min_val, (long int)max_val, num_samples);
+		for (size_t i = 0 ; i < bins.size() ; ++i) {
+			std::stringstream ss;
+			ss << "    " << range_labels[i] << " - ";
+			if (i + 1 != bins.size()) {
+				ss << range_labels[i + 1] - 1;
+			} else {
+				ss << "    ";
+			}
+			ss  << "    " << bins[i];
+			NCCL_OFI_INFO(NCCL_NET, "%s", ss.str().c_str());
+		}
+	}
+
+protected:
+	std::string description;
+	Binner binner;
+	std::vector<std::size_t> bins;
+	T max_val;
+	T min_val;
+	std::size_t num_samples;
+	bool first_insert;
+};
+
+
+//
+// Histogram class for tracking intervals.  A timer_histogram class can only
+// track one interval at a time, and will auto-insert the result when
+// stop_timer() is called.  Times are recorded in microseconds.
+//
+// T is the type of the data that will be inserted into the histogram.  Any POD
+//  will work, and little effort has been put into making the interface safe for
+//  non-Pods.
+template <typename Binner, typename clock = std::chrono::steady_clock, typename T  = std::size_t>
+class timer_histogram : public histogram<T, Binner> {
+public:
+	using rep = T;
+	using histogram<T, Binner>::insert;
+
+	timer_histogram(const std::string &description_arg, Binner binner_arg)
+		: histogram<T, Binner>(description_arg, binner_arg)
+	{
+	}
+
+	void start_timer(void)
+	{
+		start_time = clock::now();
+		asm volatile ("" : : : "memory");
+	}
+
+	rep stop_timer(void)
+	{
+		asm volatile ("" : : : "memory");
+		auto now = clock::now();
+		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(now - start_time);
+		insert(duration.count());
+		return duration.count();
+	}
+
+
+protected:
+	typename clock::time_point start_time;
+};
+
+#endif

--- a/include/stats/histogram_binner.h
+++ b/include/stats/histogram_binner.h
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_BINNER
+#define NCCL_OFI_STATS_HISTOGRAM_BINNER
+
+#include <cassert>
+#include <vector>
+
+
+//
+// A linear binner creates `num_bins_arg` bins, each of size `bin_size_arg`
+// where the first bin's range is `min_val_arg` to `min_val_arg + bin_size_arg -
+// 1`.
+//
+template <typename T>
+class histogram_linear_binner {
+public:
+	histogram_linear_binner(const T& min_val_arg, const T& bin_size_arg,
+				std::size_t num_bins_arg)
+		: min_val(min_val_arg),bin_size(bin_size_arg), num_bins(num_bins_arg)
+	{
+	}
+
+
+	std::size_t get_bin(const T& input_val)
+	{
+		assert(input_val >= min_val);
+		std::size_t bin =  (input_val - min_val) / bin_size;
+		if (bin >= num_bins) {
+			bin = num_bins - 1;
+		}
+		return bin;
+	}
+
+
+	std::size_t get_num_bins(void) const
+	{
+		return num_bins;
+	}
+
+
+	const std::vector<T> & get_bin_ranges(void)
+	{
+		if (range_labels.size() == 0) {
+			for (std::size_t i = 0 ; i < num_bins ; ++i) {
+				T val = min_val + (i * bin_size);
+				range_labels.insert(range_labels.end(), val);
+			}
+		}
+
+		return range_labels;
+	}
+
+protected:
+	const T min_val;
+	const T bin_size;
+
+	const std::size_t num_bins;
+
+	std::vector<T> range_labels;
+};
+
+
+//
+// Flexible binner where the user provides the list of starting points of the
+// bin.  Slowest binner, since a linear search is currently used to find the
+// right bin.  This could be made log(n), but even that will be considerably
+// slower than the direct computation used in the linear binner.
+//
+template <typename T>
+class histogram_custom_binner {
+public:
+	histogram_custom_binner(const std::vector<T> &ranges_arg)
+		: ranges(ranges_arg)
+	{
+	}
+
+
+	std::size_t get_bin(const T& input_val)
+	{
+		std::size_t ret = 0;
+
+		assert(input_val >= ranges[0]);
+		for (auto i  = ranges.begin() + 1 ; i != ranges.end() ; ++i) {
+			if (*i > input_val) {
+				break;
+			}
+			ret++;
+		}
+
+		return ret;
+	}
+
+
+	std::size_t get_num_bins(void) const
+	{
+		return ranges.size();
+	}
+
+
+	const std::vector<std::size_t> & get_bin_ranges(void)
+	{
+		return ranges;
+	}
+
+protected:
+	std::vector<T> ranges;
+};
+
+#endif

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -6,3 +6,5 @@ mr
 msgbuff
 region_based_tuner
 scheduler
+histogram
+histogram_binner

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2023, Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2018-2025, Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
@@ -19,7 +19,9 @@ noinst_PROGRAMS = \
 	scheduler \
 	idpool \
 	ep_addr_list \
-	mr
+	mr \
+	histogram_binner \
+	histogram
 
 if WANT_PLATFORM_AWS
 noinst_PROGRAMS += aws_platform_mapper
@@ -43,6 +45,8 @@ scheduler_SOURCES = scheduler.cpp
 ep_addr_list_SOURCES = ep_addr_list.cpp
 mr_SOURCES = mr.cpp
 aws_platform_mapper_SOURCES = aws_platform_mapper.cpp
+histogram_binner_SOURCES = histogram_binner.cpp
+histogram_SOURCES = histogram.cpp
 
 TESTS = $(noinst_PROGRAMS)
 endif

--- a/tests/unit/histogram.cpp
+++ b/tests/unit/histogram.cpp
@@ -1,0 +1,144 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#include "config.h"
+
+#include <iostream>
+
+#include "test-common.h"
+#include "stats/histogram.h"
+
+
+#define CHECK_AND_EXIT(x)				      \
+	if (!(x)) {					      \
+		std::cerr << "Failure: " << #x << std::endl; \
+		exit(1);				      \
+	}
+
+// wrapper around histogram to get access to the results to verify
+template <typename T, class Binner>
+class test_histogram : public histogram<T, Binner> {
+public:
+	test_histogram(const std::string& description_arg, Binner binner_arg) :
+		histogram<T, Binner>(description_arg, binner_arg)
+	{
+	}
+
+	const std::vector<std::size_t> & get_results(void)
+	{
+		return this->bins;
+	}
+};
+
+
+static void check_histogram(void)
+{
+	using Binner = histogram_linear_binner<int>;
+
+	test_histogram<int, Binner> histogram("testing!",
+						   Binner(0, 2, 5));;
+
+	histogram.insert(0);
+	histogram.insert(1);
+	histogram.insert(2);
+	histogram.insert(3);
+	histogram.insert(4);
+	histogram.insert(5);
+	histogram.insert(6);
+	histogram.insert(7);
+	histogram.insert(8);
+	histogram.insert(9);
+	histogram.insert(10);
+	histogram.insert(0);
+
+	auto results = histogram.get_results();
+	CHECK_AND_EXIT(results.size() == 5);
+	CHECK_AND_EXIT(results[0] == 3);
+	CHECK_AND_EXIT(results[1] == 2);
+	CHECK_AND_EXIT(results[2] == 2);
+	CHECK_AND_EXIT(results[3] == 2);
+	CHECK_AND_EXIT(results[4] == 3);
+
+	histogram.print_stats();
+}
+
+
+class test_clock {
+public:
+	using rep = std::size_t;
+	using period = std::nano;
+	using duration = std::chrono::duration<rep, period>;
+	using time_point = std::chrono::time_point<test_clock>;
+	static constexpr bool is_steady = true;
+
+	static time_point now() noexcept
+	{
+		return time_point(duration(std::chrono::nanoseconds(clock)));
+	}
+
+	static void advance_time(rep inc_val)
+	{
+		clock += inc_val;
+	}
+
+private:
+	static rep clock;
+};
+test_clock::rep test_clock::clock = 0;
+
+
+static void check_timer_histogram(void)
+{
+	using test_histogram = timer_histogram<histogram_linear_binner<std::size_t>,
+						test_clock>;
+	using Binner = histogram_linear_binner<test_histogram::rep>;
+
+	test_histogram::rep time;
+
+	test_histogram timer_histogram("timers!", Binner(0, 10, 5));
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(1);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 0);
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(1000);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 1);
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(5000);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 5);
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(10000);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 10);
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(15000);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 15);
+
+	timer_histogram.start_timer();
+	test_clock::advance_time(100000);
+	time = timer_histogram.stop_timer();
+	CHECK_AND_EXIT(time == 100);
+
+	timer_histogram.print_stats();
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	ofi_log_function = logger;
+
+	check_histogram();
+	check_timer_histogram();
+
+        return 0;
+}

--- a/tests/unit/histogram_binner.cpp
+++ b/tests/unit/histogram_binner.cpp
@@ -1,0 +1,68 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#include "config.h"
+
+#include <iostream>
+
+#include "stats/histogram_binner.h"
+
+
+#define CHECK_AND_EXIT(x)				      \
+	if (!(x)) {					      \
+		std::cerr << "Failure: " << #x << std::endl; \
+		exit(1);				      \
+	}
+
+
+static void check_linear(void)
+{
+	histogram_linear_binner<std::size_t> linear(0, 10, 10);
+	CHECK_AND_EXIT(linear.get_num_bins() == 10);
+	CHECK_AND_EXIT(linear.get_bin(0) == 0);
+	CHECK_AND_EXIT(linear.get_bin(1) == 0);
+	CHECK_AND_EXIT(linear.get_bin(10) == 1);
+	CHECK_AND_EXIT(linear.get_bin(99) == 9);
+	CHECK_AND_EXIT(linear.get_bin(100) == 9);
+	CHECK_AND_EXIT(linear.get_bin(1000) == 9);
+
+	auto linear_labels = linear.get_bin_ranges();
+	CHECK_AND_EXIT(linear_labels.size() == linear.get_num_bins());
+	CHECK_AND_EXIT(linear_labels[0] == 0);
+	CHECK_AND_EXIT(linear_labels[1] == 10);
+	CHECK_AND_EXIT(linear_labels[9] == 90);
+}
+
+
+static void check_custom(void)
+{
+	std::vector<int> input_sizes(5);
+	input_sizes[0] = -100;
+	input_sizes[1] = 0;
+	input_sizes[2] = 50;
+	input_sizes[3] = 1000;
+	input_sizes[4] = 10000;
+	histogram_custom_binner<int> custom(input_sizes);
+	CHECK_AND_EXIT(custom.get_num_bins() == 5);
+	CHECK_AND_EXIT(custom.get_bin(-10) == 0);
+	CHECK_AND_EXIT(custom.get_bin(-1) == 0);
+	CHECK_AND_EXIT(custom.get_bin(0) == 1);
+	CHECK_AND_EXIT(custom.get_bin(10) == 1);
+	CHECK_AND_EXIT(custom.get_bin(49) == 1);
+	CHECK_AND_EXIT(custom.get_bin(50) == 2);
+	CHECK_AND_EXIT(custom.get_bin(51) == 2);
+	CHECK_AND_EXIT(custom.get_bin(999) == 2);
+	CHECK_AND_EXIT(custom.get_bin(1000) == 3);
+	CHECK_AND_EXIT(custom.get_bin(1000000) == 4);
+}
+
+
+int
+main(int argc, char *argv[])
+{
+	check_linear();
+	check_custom();
+
+	return 0;
+}


### PR DESCRIPTION
Add basic in-memory histogram classes to track events and time intervals.  This was useful to me in looking at some of the cq completion behaviors, so thought we should make it available for other analysis work as well.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
