### PR TITLE
config: Enable DMABUF by default (Except on EFA gen 1-3)

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -273,9 +273,9 @@ OFI_NCCL_PARAM_INT(disable_gdr_required_check, "DISABLE_GDR_REQUIRED_CHECK", 0);
  * the plugin has no freedom to renegotiate DMABUF support with NCCL, and so it
  * is fatal. Under those conditions, users should ensure that they have set this
  * environment variable to '1' to force NCCL to avoid providing dmabuf file
- * desciptors. This is the default, pending perf investigations.
+ * desciptors.
  */
-OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 1);
+OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
 
 /*
  * Messages sized larger than this threshold will be striped across multiple rails

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -58,8 +58,11 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [
         AC_MSG_CHECKING([if CUDA 11.3+ is available for GDR Write Flush support])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+        #ifndef __cplusplus
+        #include <assert.h>
+        #endif
         #include <cuda.h>
-        _Static_assert(CUDA_VERSION >= 11030, "cudart>=11030 required for cuFlushGPUDirectRDMAWrites");
+        static_assert(CUDA_VERSION >= 11030, "cudart>=11030 required for cuFlushGPUDirectRDMAWrites");
         ])],[ check_cuda_gdr_flush_define=1 chk_result=yes ],
             [ check_cuda_gdr_flush_define=0 chk_result=no ])
         AC_MSG_RESULT(${chk_result})
@@ -70,8 +73,11 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [
         AC_MSG_CHECKING([if CUDA 11.7+ is available for DMA-BUF support])
         AC_COMPILE_IFELSE([AC_LANG_PROGRAM([
+        #ifndef __cplusplus
+        #include <assert.h>
+        #endif
         #include <cuda.h>
-        _Static_assert(CUDA_VERSION >= 11070, "cudart>=11070 required for DMABUF");
+        static_assert(CUDA_VERSION >= 11070, "cudart>=11070 required for DMABUF");
         ])],[ check_cuda_dmabuf_define=1 chk_result=yes ],
             [ check_cuda_dmabuf_define=0 chk_result=no ])
         AC_MSG_RESULT(${chk_result})


### PR DESCRIPTION
*Description of changes:*

This commit enables DMA-BUF by default, except for EFA generations 1-3.  See comment in ofi_nccl_net.c for information on why we do not enable DMA-BUF on older EFA generations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
