### PR TITLE
init: Set NCCL_PROTO to simple when GDR is unsupported

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -791,4 +791,17 @@ int get_inject_rma_size_opt(struct fid_ep *ofi_ep,
  */
 long nccl_net_ofi_gettid(void);
 
+ /*
+ * @brief   Configures NCCL_PROTO environment variable to "simple".
+ *
+ * @details If NCCL_PROTO is not set, configures it to "simple" protocol.
+ *          If NCCL_PROTO is already set, skip the configuration.
+ *
+ * @input   log reason string
+ *
+ * @return  0 on success or when warning is issued
+ *          -errno in case of any failure
+ */
+int nccl_net_ofi_configure_nccl_proto_simple(const char *log_reason);
+
 #endif // End NCCL_OFI_H_


### PR DESCRIPTION
For providers that don't guarantee 8-byte atomicity (like TCP sockets), using LL/LL128 protocol can lead to data corruption in cases like message delivery reordering or non-8-byte-aligned MTU size, when cuda kernel is poling host memory for the completion bytes.
&nbsp;
This PR is to set NCCL_PROTO to "simple" and prevent data corruption from NCCL tuner selecting LL/LL128 protocol in:
- EFA provider without platform-specific configuration
- Non-EFA providers (e.g. TCP)
&nbsp;

The changes include:
- Moving `configure_nccl_proto` to `nccl_ofi_system.cpp`
- Calling `configure_nccl_proto` during plug-in initialization when GDR is unsupported
&nbsp;

Note:
- Warning for pre-existing NCCL_PROTO setting was removed as modern NCCL supports complex protocol formats (e.g., "allreduce:simple", "^LL"). We can consider adding protocol format validation to put an INFO.
- Currently place `configure_nccl_proto_simple` in `nccl_ofi_net.cpp`. We can find a better file location for this function later.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
