### PR TITLE
Refactor endpoint types to use C++ inheritance

### DIFF
--- a/include/nccl_ofi_ep_addr_list.h
+++ b/include/nccl_ofi_ep_addr_list.h
@@ -14,8 +14,7 @@
 
 
 /* Endpoint structure used by plugin code */
-struct nccl_net_ofi_ep;
-typedef struct nccl_net_ofi_ep nccl_net_ofi_ep_t;
+class nccl_net_ofi_ep_t;
 
 
 class nccl_ofi_ep_addr_list_t {

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -734,7 +734,7 @@ public:
 
 	inline nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device()
 	{
-		return (nccl_net_ofi_rdma_device_t *)this->rdma_endpoint_get_domain()->base.device;
+		return (nccl_net_ofi_rdma_device_t *) rdma_endpoint_get_domain()->base.device;
 	}
 
 	/**
@@ -742,9 +742,9 @@ public:
 	 */
 	inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_rail(uint16_t rail_id)
 	{
-		assert(this->rails);
-		assert(rail_id < this->num_rails);
-		return &this->rails[rail_id];
+		assert(rails);
+		assert(rail_id < num_rails);
+		return &rails[rail_id];
 	}
 
 	/**
@@ -752,9 +752,9 @@ public:
 	 */
 	inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_control_rail(uint16_t rail_id)
 	{
-		assert(this->control_rails);
-		assert(rail_id < this->num_control_rails);
-		return &this->control_rails[rail_id];
+		assert(control_rails);
+		assert(rail_id < num_control_rails);
+		return &control_rails[rail_id];
 	}
 
 	/**

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -885,7 +885,7 @@ public:
 	bool use_long_rkeys;
 
 	/* Pending requests queue */
-	std::deque<nccl_net_ofi_rdma_req_t *> *pending_reqs_queue = nullptr;
+	std::deque<nccl_net_ofi_rdma_req_t *> pending_reqs_queue;
 	/* Lock for `pending_reqs_queue` */
 	pthread_mutex_t pending_reqs_lock;
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -692,7 +692,7 @@ public:
 
 	inline nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain()
 	{
-		return (nccl_net_ofi_rdma_domain_t *)this->domain;
+		return (nccl_net_ofi_rdma_domain_t *) domain;
 	}
 
 	/* Number of rails */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -742,7 +742,7 @@ public:
 	 */
 	inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_rail(uint16_t rail_id)
 	{
-		assert(rails);
+		assert(!rails.empty());
 		assert(rail_id < num_rails);
 		return &rails[rail_id];
 	}
@@ -752,7 +752,7 @@ public:
 	 */
 	inline nccl_net_ofi_ep_rail_t *rdma_endpoint_get_control_rail(uint16_t rail_id)
 	{
-		assert(control_rails);
+		assert(!control_rails.empty());
 		assert(rail_id < num_control_rails);
 		return &control_rails[rail_id];
 	}
@@ -877,10 +877,10 @@ public:
 	uint16_t num_control_rails;
 
 	/* Array of `num_rails` endpoint rails */
-	nccl_net_ofi_ep_rail_t *rails = nullptr;
+	std::vector<nccl_net_ofi_ep_rail_t> rails;
 
 	/* Array of `num_control_rails` endpoint rails */
-	nccl_net_ofi_ep_rail_t *control_rails = nullptr;
+	std::vector<nccl_net_ofi_ep_rail_t> control_rails;
 
 	bool use_long_rkeys;
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -158,7 +158,7 @@ public:
 
 	inline nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device()
 	{
-		return (nccl_net_ofi_sendrecv_device_t *)this->sendrecv_endpoint_get_domain()->base.device;
+		return (nccl_net_ofi_sendrecv_device_t *) sendrecv_endpoint_get_domain()->base.device;
 	}
 
 	/**
@@ -168,7 +168,7 @@ public:
 	 */
 	inline struct fid_domain* sendrecv_endpoint_get_ofi_domain()
 	{
-		return this->sendrecv_endpoint_get_domain()->domain;
+		return sendrecv_endpoint_get_domain()->domain;
 	}
 
 	/* Current available tag ID */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -130,7 +130,7 @@ public:
 
 	inline nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain()
 	{
-		return (nccl_net_ofi_sendrecv_domain_t *)this->domain;
+		return (nccl_net_ofi_sendrecv_domain_t *) domain;
 	}
 
 	/* Current available tag ID */

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -253,7 +253,7 @@ ncclResult_t nccl_net_ofi_listen_v5(int dev_id, void *handle, void **lComm)
 {
 	int ret = 0;
 	nccl_net_ofi_device_t *device = NULL;
-	nccl_net_ofi_ep_t *base_ep = NULL;
+	nccl_net_ofi_ep_t *ep = NULL;
 	nccl_net_ofi_listen_comm_t **listen_comm =
 		(nccl_net_ofi_listen_comm_t **)lComm;
 
@@ -275,18 +275,16 @@ ncclResult_t nccl_net_ofi_listen_v5(int dev_id, void *handle, void **lComm)
 	}
 
 	/* Retrieve and validate endpoint */
-	device->get_ep(device, &base_ep);
-	if (OFI_UNLIKELY(base_ep == NULL)) {
+	device->get_ep(device, &ep);
+	if (OFI_UNLIKELY(ep == NULL)) {
 		NCCL_OFI_WARN("Error accessing endpoint. Endpoint has not been initialized.");
 		return check_return(ncclInternalError);
 	}
 
-	ret = base_ep->listen(base_ep,
-						  (nccl_net_ofi_conn_handle_t *)handle,
-						  listen_comm);
+	ret = ep->listen(static_cast<nccl_net_ofi_conn_handle_t *>(handle), listen_comm);
 
 	if (ret != 0) {
-		base_ep->release_ep(base_ep, false, false);
+		ep->release_ep(false, false);
 	}
 	return nccl_net_ofi_retval_translate(ret);
 }
@@ -361,7 +359,7 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 	}
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_ep_t *base_ep = NULL;
+	nccl_net_ofi_ep_t *ep = NULL;
 	bool created_ep = false;
 	if (ofi_handle->state.comm == nullptr) {
 		nccl_net_ofi_device_t *device = plugin->get_device(plugin, dev_id);
@@ -370,14 +368,14 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 			return check_return(ncclInternalError);
 		}
 
-		int ret = device->get_ep(device, &base_ep);
+		int ret = device->get_ep(device, &ep);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return nccl_net_ofi_retval_translate(ret);
 		}
 		created_ep = true;
 	} else {
-		base_ep = ofi_handle->state.comm->ep;
-		if (OFI_UNLIKELY(base_ep == NULL)) {
+		ep = ofi_handle->state.comm->ep;
+		if (OFI_UNLIKELY(ep == NULL)) {
 			NCCL_OFI_WARN("Error accessing endpoint. Endpoint has not been initialized.");
 			return check_return(ncclInternalError);
 		}
@@ -386,15 +384,16 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 	/* Connect */
 	nccl_net_ofi_send_comm_t **send_comm =
 		(nccl_net_ofi_send_comm_t **)sComm;
-	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm, trafficClass);
+	int ret = ep->connect(static_cast<nccl_net_ofi_conn_handle_t *>(handle), send_comm,
+			      trafficClass);
 
 	if (created_ep) {
 		/**
 		 * Release the ep if we acquired one before calling
-		 * base_ep->connect(). The protocol should have acquired its own
+		 * ep->connect(). The protocol should have acquired its own
 		 * endpoint when creating the communictor.
 		 */
-		base_ep->release_ep(base_ep, false, false);
+		ep->release_ep(false, false);
 	}
 
 	return nccl_net_ofi_retval_translate(ret);
@@ -467,7 +466,7 @@ ncclResult_t nccl_net_ofi_accept_v5(void *lComm, void **rComm)
 			ret = -EINVAL;
 			goto error;
 		}
-		ep->release_ep(ep, false, false);
+		ep->release_ep(false, false);
 	}
 
 error:

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -1139,16 +1139,16 @@ int nccl_net_ofi_domain_fini(nccl_net_ofi_domain_t *domain)
 int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
 {
 	int ret = 0;
-	nccl_net_ofi_domain_t *domain_ptr = this->domain;
+	nccl_net_ofi_domain_t *domain_ptr = domain;
 
 	if (!skip_lock) {
 		nccl_net_ofi_mutex_lock(&domain_ptr->domain_lock);
 	}
 
-	this->decrement_ref_cnt();
+	decrement_ref_cnt();
 
 	/* Store ref_cnt in local variable in case the endpoint gets deleted */
-	int local_ref_cnt = this->ref_cnt;
+	int local_ref_cnt = ref_cnt;
 	
 	if (local_ref_cnt == 0 || force_cleanup) {
 		/* If this was the endpoint we stored in domain for connection
@@ -1161,7 +1161,7 @@ int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
 			NCCL_OFI_INFO(NCCL_NET, "Endpoint %p still have ref count %d when released",
 				      this, local_ref_cnt);
 		}
-		ret = this->cleanup_resources();
+		ret = cleanup_resources();
 		delete this;
 	}
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -909,7 +909,7 @@ int nccl_net_ofi_rdma_ep_t::check_post_rx_buffers_rail(nccl_net_ofi_ep_rail_t *r
 	/* Not taking lock here since we are only reading a value.
 	   If needed, post_rx_buffs_on_rail will take the lock. */
 	if (rail->num_rx_buff_posted < rail->min_rx_buff_posted) {
-		return this->post_rx_buffs_on_rail(rail);
+		return post_rx_buffs_on_rail(rail);
 	}
 
 	return 0;
@@ -924,9 +924,9 @@ int nccl_net_ofi_rdma_ep_t::repost_rx_buff(nccl_net_ofi_rdma_req_t *rx_buff_req)
 	ret = send_progress(rx_buff_req);
 	if (ret == -FI_EAGAIN) {
 		/* Add to pending reqs queue */
-		nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-		this->pending_reqs_queue->push_back(rx_buff_req);
-		nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+		pending_reqs_queue->push_back(rx_buff_req);
+		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		NCCL_OFI_TRACE_PENDING_INSERT(rx_buff_req);
 
 		return 0;
@@ -937,7 +937,7 @@ int nccl_net_ofi_rdma_ep_t::repost_rx_buff(nccl_net_ofi_rdma_req_t *rx_buff_req)
 	rdma_req_rx_buff_data_t *rx_buff_data = get_rx_buff_data(rx_buff_req);
 
 	/* Next, check the posted count and post more buffers if needed. */
-	return this->check_post_rx_buffers_rail(rx_buff_data->rail);
+	return check_post_rx_buffers_rail(rx_buff_data->rail);
 }
 
 
@@ -950,7 +950,7 @@ int nccl_net_ofi_rdma_ep_t::decrease_rx_buff_cnt(nccl_net_ofi_ep_rail_t *rail)
 
 	nccl_net_ofi_mutex_unlock(&rail->rx_buff_mutex);
 
-	return this->check_post_rx_buffers_rail(rail);
+	return check_post_rx_buffers_rail(rail);
 }
 
 
@@ -1793,12 +1793,12 @@ int nccl_net_ofi_rdma_ep_t::process_pending_reqs()
 
 	while (true) {
 		nccl_net_ofi_rdma_req_t *req = NULL;
-		nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-		if (!this->pending_reqs_queue->empty()) {
-			req = this->pending_reqs_queue->front();
-			this->pending_reqs_queue->pop_front();
+		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+		if (!pending_reqs_queue->empty()) {
+			req = pending_reqs_queue->front();
+			pending_reqs_queue->pop_front();
 		}
-		nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		if (req == NULL) { break; }
 
 		switch (req->type) {
@@ -1828,9 +1828,9 @@ int nccl_net_ofi_rdma_ep_t::process_pending_reqs()
 			break;
 		} else if (rc == -FI_EAGAIN) {
 			/* Put the request in the front of the queue and try again later */
-			nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-			this->pending_reqs_queue->push_front(req);
-			nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+			nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+			pending_reqs_queue->push_front(req);
+			nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 			rc = 0;
 			break;
 		}
@@ -1934,7 +1934,7 @@ int nccl_net_ofi_rdma_ep_t::ofi_process_cq()
 {
 	int ret;
 
-	nccl_net_ofi_rdma_domain_t *domain_ptr = this->rdma_endpoint_get_domain();
+	nccl_net_ofi_rdma_domain_t *domain_ptr = rdma_endpoint_get_domain();
 	nccl_net_ofi_rdma_device_t *device = rdma_domain_get_device(domain_ptr);
 
 	for (uint16_t rail_id = 0; rail_id != domain_ptr->num_rails; ++rail_id) {
@@ -1947,7 +1947,7 @@ int nccl_net_ofi_rdma_ep_t::ofi_process_cq()
 	}
 
 	/* Process any pending requests */
-	ret = this->process_pending_reqs();
+	ret = process_pending_reqs();
 	if (OFI_UNLIKELY(ret != 0 && ret != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Failed call to process_pending_reqs: %d", ret);
 	}
@@ -2314,9 +2314,9 @@ int nccl_net_ofi_rdma_ep_t::handle_rx_eagain(nccl_net_ofi_ep_rail_t *rail,
 					     size_t num_buffs_failed)
 {
 	/* Add to pending reqs queue */
-	nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-	this->pending_reqs_queue->push_back(req);
-	nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+	nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+	pending_reqs_queue->push_back(req);
+	nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 	NCCL_OFI_TRACE_PENDING_INSERT(req);
 
 	nccl_net_ofi_mutex_lock(&rail->rx_buff_mutex);
@@ -2362,7 +2362,7 @@ int nccl_net_ofi_rdma_ep_t::post_rx_buffs_on_rail(nccl_net_ofi_ep_rail_t *rail)
 			/* Update posted count */
 			/* We failed to post num_buffs_failed buffers that we promised above */
 			size_t num_buffs_failed = buffers_needed - i - 1;
-			ret = this->handle_rx_eagain(rail, req, num_buffs_failed);
+			ret = handle_rx_eagain(rail, req, num_buffs_failed);
 			if (ret != 0) return ret;
 
 			break;
@@ -2381,18 +2381,18 @@ int nccl_net_ofi_rdma_ep_t::post_rx_buffs()
 	int ret = 0;
 	nccl_net_ofi_ep_rail_t *rail;
 
-	for (uint16_t rail_id = 0; rail_id < this->num_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_rail(rail_id);
-		ret = this->post_rx_buffs_on_rail(rail);
+	for (uint16_t rail_id = 0; rail_id < num_rails; ++rail_id) {
+		rail = rdma_endpoint_get_rail(rail_id);
+		ret = post_rx_buffs_on_rail(rail);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed call to post_rx_buffs_on_rail");
 			goto exit;
 		}
 	}
 
-	for (uint16_t rail_id = 0; rail_id < this->num_control_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_control_rail(rail_id);
-		ret = this->post_rx_buffs_on_rail(rail);
+	for (uint16_t rail_id = 0; rail_id < num_control_rails; ++rail_id) {
+		rail = rdma_endpoint_get_control_rail(rail_id);
+		ret = post_rx_buffs_on_rail(rail);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed call to post_rx_buffs_on_rail(control_rail)");
 			goto exit;
@@ -3301,17 +3301,17 @@ static inline int insert_rdma_recv_req_into_msgbuff(nccl_net_ofi_rdma_recv_comm_
 int nccl_net_ofi_rdma_ep_t::process_cq_if_pending()
 {
 	/* Process the CQ if there are any pending requests */
-	nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-	bool is_deque_empty = this->pending_reqs_queue->empty();
-	nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+	nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+	bool is_deque_empty = pending_reqs_queue->empty();
+	nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 	if (!is_deque_empty) {
-		int ret = this->ofi_process_cq();
+		int ret = ofi_process_cq();
 		if (ret != 0) {
 			return ret;
 		}
-		nccl_net_ofi_mutex_lock(&this->pending_reqs_lock);
-		is_deque_empty = this->pending_reqs_queue->empty();
-		nccl_net_ofi_mutex_unlock(&this->pending_reqs_lock);
+		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
+		is_deque_empty = pending_reqs_queue->empty();
+		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		if (!is_deque_empty) {
 			/* Network is still busy. */
 			return -EAGAIN;
@@ -4057,12 +4057,12 @@ static int comm_close_handler(void)
 
 void nccl_net_ofi_rdma_ep_t::rdma_endpoint_abort()
 {
-	nccl_net_ofi_domain_t *base_domain = &this->rdma_endpoint_get_domain()->base;
+	nccl_net_ofi_domain_t *base_domain = &rdma_endpoint_get_domain()->base;
 	int dev_id = base_domain->device->dev_id;
 
 	pthread_wrapper domain_lock(&base_domain->domain_lock);
 
-	this->release_rdma_ep_resources(dev_id);
+	release_rdma_ep_resources(dev_id);
 
 	base_domain->domain_active = false;
 }
@@ -4733,13 +4733,13 @@ void nccl_net_ofi_rdma_ep_t::prepare_conn_resp(nccl_net_ofi_rdma_recv_comm_t *r_
 	conn_resp->comm_id = r_comm->local_comm_id;
 
 	/* Set number of rails to be sent back to remote for verification */
-	conn_resp->num_rails = this->num_rails;
-	conn_resp->num_control_rails = this->num_control_rails;
+	conn_resp->num_rails = num_rails;
+	conn_resp->num_control_rails = num_control_rails;
 
 	/* Set libfabric endpoint names for each rail */
-	for (uint16_t rail_id = 0; rail_id != this->num_rails; ++rail_id) {
+	for (uint16_t rail_id = 0; rail_id != num_rails; ++rail_id) {
 		rdma_ep_name = &conn_resp->ep_names[rail_id];
-		ep_rail = this->rdma_endpoint_get_rail(rail_id);
+		ep_rail = rdma_endpoint_get_rail(rail_id);
 
 		assert(sizeof(rdma_ep_name->ep_name) == sizeof(ep_rail->local_ep_name));
 		memcpy(rdma_ep_name->ep_name, ep_rail->local_ep_name,
@@ -4748,9 +4748,9 @@ void nccl_net_ofi_rdma_ep_t::prepare_conn_resp(nccl_net_ofi_rdma_recv_comm_t *r_
 	}
 
 	/* Set libfabric endpoint names for each control rail */
-	for (uint16_t rail_id = 0; rail_id != this->num_control_rails; ++rail_id) {
+	for (uint16_t rail_id = 0; rail_id != num_control_rails; ++rail_id) {
 		rdma_ep_name = &conn_resp->control_ep_names[rail_id];
-		ep_rail = this->rdma_endpoint_get_control_rail(rail_id);
+		ep_rail = rdma_endpoint_get_control_rail(rail_id);
 
 		assert(sizeof(rdma_ep_name->ep_name) == sizeof(ep_rail->local_ep_name));
 		memcpy(rdma_ep_name->ep_name, ep_rail->local_ep_name,
@@ -5052,7 +5052,7 @@ int nccl_net_ofi_rdma_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 
 	CHECK_DOMAIN_ACTIVE(domain_ptr, "listen");
 
-	ret = this->post_rx_buffs();
+	ret = post_rx_buffs();
 	if (ret != 0) {
 		NCCL_OFI_WARN("Error posting rx buffers: %d", ret);
 		return ret;
@@ -5952,25 +5952,25 @@ void nccl_net_ofi_rdma_ep_t::prepare_send_connect_message(uint32_t local_comm_id
 	conn_msg->comm_id = local_comm_id;
 
 	/* Set number of rails to be sent back to remote for verification */
-	conn_msg->num_rails = this->num_rails;
-	conn_msg->num_control_rails = this->num_control_rails;
+	conn_msg->num_rails = num_rails;
+	conn_msg->num_control_rails = num_control_rails;
 
 	/* Set libfabric endpoint names for each control rail */
-	for (uint16_t rail_id = 0; rail_id != this->num_control_rails; ++rail_id) {
+	for (uint16_t rail_id = 0; rail_id != num_control_rails; ++rail_id) {
 		memcpy(conn_msg->control_ep_names[rail_id].ep_name,
-		       this->control_rails[rail_id].local_ep_name,
-		       this->control_rails[rail_id].local_ep_name_len);
+		       control_rails[rail_id].local_ep_name,
+		       control_rails[rail_id].local_ep_name_len);
 		conn_msg->control_ep_names[rail_id].ep_name_len =
-			this->control_rails[rail_id].local_ep_name_len;
+			control_rails[rail_id].local_ep_name_len;
 	}
 
 	/* Set libfabric endpoint names for each rail */
-	for (uint16_t rail_id = 0; rail_id != this->num_rails; ++rail_id) {
+	for (uint16_t rail_id = 0; rail_id != num_rails; ++rail_id) {
 		memcpy(conn_msg->ep_names[rail_id].ep_name,
-		       this->rails[rail_id].local_ep_name,
-		       this->rails[rail_id].local_ep_name_len);
+		       rails[rail_id].local_ep_name,
+		       rails[rail_id].local_ep_name_len);
 		conn_msg->ep_names[rail_id].ep_name_len =
-			this->rails[rail_id].local_ep_name_len;
+			rails[rail_id].local_ep_name_len;
 	}
 }
 
@@ -6017,7 +6017,7 @@ int nccl_net_ofi_rdma_ep_t::init_rx_buffers()
 {
 	int ret = 0;
 	nccl_net_ofi_ep_rail_t *rail;
-	nccl_net_ofi_rdma_domain_t *domain_ptr = this->rdma_endpoint_get_domain();
+	nccl_net_ofi_rdma_domain_t *domain_ptr = rdma_endpoint_get_domain();
 
 	/* This is a little bit of a heuristic, but we need as many requests as
 	   we have posted control messages, so that's as reasonable a starting
@@ -6025,38 +6025,38 @@ int nccl_net_ofi_rdma_ep_t::init_rx_buffers()
 	ret = nccl_ofi_freelist_init(sizeof(nccl_net_ofi_rdma_req_t),
 				     ofi_nccl_rdma_min_posted_control_buffers(), 16, 0,
 				     rdma_fl_req_entry_init, rdma_fl_req_entry_fini,
-				     &this->rx_buff_reqs_fl);
+				     &rx_buff_reqs_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init rx_buff_reqs_fl");
 		return ret;
 	}
 
-	ret = nccl_ofi_freelist_init_mr(this->ctrl_rx_buff_size,
+	ret = nccl_ofi_freelist_init_mr(ctrl_rx_buff_size,
 					ofi_nccl_rdma_min_posted_control_buffers(), 16, 0,
 					NULL, NULL,
 					freelist_regmr_host_fn, freelist_deregmr_host_fn,
-					domain_ptr, 1, &this->ctrl_rx_buff_fl);
+					domain_ptr, 1, &ctrl_rx_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to init ctrl_rx_buff_fl");
-		if (nccl_ofi_freelist_fini(this->rx_buff_reqs_fl))
+		if (nccl_ofi_freelist_fini(rx_buff_reqs_fl))
 			NCCL_OFI_WARN("Also failed to freelist_fini rx_buff_reqs_fl");
 		return ret;
 	}
 
-	if (this->eager_rx_buff_size > 0) {
-		ret = nccl_ofi_freelist_init_mr(this->eager_rx_buff_size,
+	if (eager_rx_buff_size > 0) {
+		ret = nccl_ofi_freelist_init_mr(eager_rx_buff_size,
 						ofi_nccl_rdma_min_posted_eager_buffers(), 16, 0,
 						NULL, NULL,
 						freelist_regmr_host_fn, freelist_deregmr_host_fn,
-						domain_ptr, EAGER_RX_BUFFER_ALIGNMENT, &this->eager_rx_buff_fl);
+						domain_ptr, EAGER_RX_BUFFER_ALIGNMENT, &eager_rx_buff_fl);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to init eager_rx_buff_size");
-			nccl_ofi_freelist_fini(this->ctrl_rx_buff_fl);
-			nccl_ofi_freelist_fini(this->rx_buff_reqs_fl);
+			nccl_ofi_freelist_fini(ctrl_rx_buff_fl);
+			nccl_ofi_freelist_fini(rx_buff_reqs_fl);
 			return ret;
 		}
 	} else {
-		this->eager_rx_buff_fl = NULL;
+		eager_rx_buff_fl = NULL;
 	}
 
 	/*
@@ -6065,27 +6065,27 @@ int nccl_net_ofi_rdma_ep_t::init_rx_buffers()
 	 * The parameters account for all the rails, so scale down bounds to
 	 * what a single rail would need.
 	 */
-	for (uint16_t rail_id = 0; rail_id < this->num_control_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_control_rail(rail_id);
+	for (uint16_t rail_id = 0; rail_id < num_control_rails; ++rail_id) {
+		rail = rdma_endpoint_get_control_rail(rail_id);
 		rail->min_rx_buff_posted = NCCL_OFI_DIV_CEIL(
-			ofi_nccl_rdma_min_posted_control_buffers(), this->num_control_rails
+			ofi_nccl_rdma_min_posted_control_buffers(), num_control_rails
 		);
 		rail->max_rx_buff_posted = NCCL_OFI_DIV_CEIL(
-			ofi_nccl_rdma_max_posted_control_buffers(), this->num_control_rails
+			ofi_nccl_rdma_max_posted_control_buffers(), num_control_rails
 		);
 		rail->num_rx_buff_posted = 0;
 		nccl_net_ofi_mutex_init(&rail->rx_buff_mutex, NULL);
 		rail->rx_buff_req_alloc = ctrl_rx_buff_req_alloc;
 	}
 
-	for (uint16_t rail_id = 0; rail_id < this->num_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_rail(rail_id);
-		if (this->eager_rx_buff_size >= 0) {
+	for (uint16_t rail_id = 0; rail_id < num_rails; ++rail_id) {
+		rail = rdma_endpoint_get_rail(rail_id);
+		if (eager_rx_buff_size >= 0) {
 			rail->min_rx_buff_posted = NCCL_OFI_DIV_CEIL(
-				ofi_nccl_rdma_min_posted_eager_buffers(), this->num_rails
+				ofi_nccl_rdma_min_posted_eager_buffers(), num_rails
 				);
 			rail->max_rx_buff_posted = NCCL_OFI_DIV_CEIL(
-				ofi_nccl_rdma_max_posted_eager_buffers(), this->num_rails
+				ofi_nccl_rdma_max_posted_eager_buffers(), num_rails
 				);
 		} else {
 			rail->min_rx_buff_posted = 0;
@@ -6105,33 +6105,33 @@ int nccl_net_ofi_rdma_ep_t::fini_rx_buffers()
 	int ret = 0;
 	nccl_net_ofi_ep_rail_t *rail;
 
-	ret = nccl_ofi_freelist_fini(this->ctrl_rx_buff_fl);
+	ret = nccl_ofi_freelist_fini(ctrl_rx_buff_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to fini ctrl_rx_buff_fl");
 		return ret;
 	}
 
-	if (this->eager_rx_buff_fl != NULL) {
-		ret = nccl_ofi_freelist_fini(this->eager_rx_buff_fl);
+	if (eager_rx_buff_fl != NULL) {
+		ret = nccl_ofi_freelist_fini(eager_rx_buff_fl);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Failed to fini eager_rx_buff_fl");
 			return ret;
 		}
 	}
 
-	ret = nccl_ofi_freelist_fini(this->rx_buff_reqs_fl);
+	ret = nccl_ofi_freelist_fini(rx_buff_reqs_fl);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to fini rx_buff_reqs_fl");
 		return ret;
 	}
 
-	for (uint16_t rail_id = 0; rail_id < this->num_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_rail(rail_id);
+	for (uint16_t rail_id = 0; rail_id < num_rails; ++rail_id) {
+		rail = rdma_endpoint_get_rail(rail_id);
 		nccl_net_ofi_mutex_destroy(&rail->rx_buff_mutex);
 	}
 
-	for (uint16_t rail_id = 0; rail_id < this->num_control_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_control_rail(rail_id);
+	for (uint16_t rail_id = 0; rail_id < num_control_rails; ++rail_id) {
+		rail = rdma_endpoint_get_control_rail(rail_id);
 		nccl_net_ofi_mutex_destroy(&rail->rx_buff_mutex);
 	}
 
@@ -6269,7 +6269,7 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm_t **s_c
 	*s_comm = NULL;
 
 	/* Retrieve and validate device */
-	nccl_net_ofi_rdma_device_t *device = this->rdma_endpoint_get_device();
+	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device();
 	if (OFI_UNLIKELY(device == NULL)) {
 		NCCL_OFI_WARN("Error accessing device");
 		return -EINVAL;
@@ -6313,7 +6313,7 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm_t **s_c
 	   get_ep(). Increase the refcnt so the endpoint is not freed when the
 	   API releases it.
 	   Caller assumed to own domain lock. */
-	this->increment_ref_cnt();
+	increment_ref_cnt();
 
 	/* Allocate send communicator ID */
 	comm_id = device->comm_idpool->allocate_id();
@@ -6369,7 +6369,7 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm_t **s_c
 			device->comm_idpool->free_id(ret_s_comm->local_comm_id);
 		}
 		nccl_net_ofi_mutex_destroy(&ret_s_comm->ctrl_recv_lock);
-		this->decrement_ref_cnt();
+		decrement_ref_cnt();
 		free_rdma_send_comm(ret_s_comm);
 	}
 
@@ -6403,7 +6403,7 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 		return -EINVAL;
 	}
 
-	ret = this->post_rx_buffs();
+	ret = post_rx_buffs();
 	if (ret != 0) {
 		NCCL_OFI_WARN("Error posting rx buffers: %d", ret);
 		return ret;
@@ -6413,7 +6413,7 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 	 * Create the communicator if it has not yet been created.
 	 */
 	if (s_comm == nullptr) {
-		ret = this->create_send_comm(&s_comm);
+		ret = create_send_comm(&s_comm);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
 		}
@@ -6423,14 +6423,14 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 		comm_state->comm = &s_comm->base.base;
 
 		nccl_ofi_rdma_connection_info_t conn_msg;
-		this->prepare_send_connect_message(s_comm->local_comm_id, &conn_msg);
+		prepare_send_connect_message(s_comm->local_comm_id, &conn_msg);
 
 		/* Create connector */
 		s_comm->connector = domain_ptr->cm->connect(*handle, &conn_msg, sizeof(conn_msg));
 	}
 
 	/* Progress our engine to get completions */
-	ret = this->ofi_process_cq();
+	ret = ofi_process_cq();
 	if (OFI_UNLIKELY(ret != 0)) {
 		goto error;
 	}
@@ -6490,13 +6490,13 @@ void nccl_net_ofi_rdma_ep_t::release_rdma_ep_resources(int dev_id)
 {
 	nccl_net_ofi_ep_rail_t *rail;
 
-	for (uint16_t rail_id = 0; rail_id != this->num_control_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_control_rail(rail_id);
+	for (uint16_t rail_id = 0; rail_id != num_control_rails; ++rail_id) {
+		rail = rdma_endpoint_get_control_rail(rail_id);
 		nccl_net_ofi_rdma_ep_t::ep_rail_release(rail, dev_id);
 	}
 
-	for (uint16_t rail_id = 0; rail_id != this->num_rails; ++rail_id) {
-		rail = this->rdma_endpoint_get_rail(rail_id);
+	for (uint16_t rail_id = 0; rail_id != num_rails; ++rail_id) {
+		rail = rdma_endpoint_get_rail(rail_id);
 		nccl_net_ofi_rdma_ep_t::ep_rail_release(rail, dev_id);
 	}
 }
@@ -6592,7 +6592,7 @@ int nccl_net_ofi_rdma_ep_t::init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *
 	for (uint16_t rail_id = 0; rail_id != device->num_rails; ++rail_id) {
 		rail_dev = rdma_device_get_rail(device, rail_id);
 		domain_rail = rdma_domain_get_rail(domain_arg, rail_id);
-		rail = this->rdma_endpoint_get_rail(rail_id);
+		rail = rdma_endpoint_get_rail(rail_id);
 
 		ret = nccl_net_ofi_rdma_ep_t::ep_rail_init(dev_id, rail_id, rail_dev, 
 							   domain_rail, rail, FI_TC_UNSPEC);
@@ -6603,11 +6603,11 @@ int nccl_net_ofi_rdma_ep_t::init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *
 	}
 
 	/* Initialize libfabric resources of endpoint control rails */
-	for (uint16_t rail_id = 0; rail_id != this->num_control_rails; ++rail_id) {
+	for (uint16_t rail_id = 0; rail_id != num_control_rails; ++rail_id) {
 		rail_dev = rdma_device_get_rail(device, rail_id);
 		domain_rail = rdma_domain_get_rail(domain_arg, rail_id);
-		rail = this->rdma_endpoint_get_rail(rail_id);
-		control_rail = this->rdma_endpoint_get_control_rail(rail_id);
+		rail = rdma_endpoint_get_rail(rail_id);
+		control_rail = rdma_endpoint_get_control_rail(rail_id);
 
 		ret = nccl_net_ofi_rdma_ep_t::ep_rail_init(dev_id, rail_id, rail_dev,
 							   domain_rail, control_rail, tc);
@@ -6619,7 +6619,7 @@ int nccl_net_ofi_rdma_ep_t::init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *
 
  exit:
 	if (ret != 0) {
-		this->release_rdma_ep_resources(dev_id);
+		release_rdma_ep_resources(dev_id);
 	}
 
 	return ret;
@@ -6632,13 +6632,13 @@ int nccl_net_ofi_rdma_ep_t::cleanup_resources() {
 
 	called_cleanup_resources = true;
 
-	nccl_net_ofi_rdma_device_t *device = this->rdma_endpoint_get_device();
+	nccl_net_ofi_rdma_device_t *device = rdma_endpoint_get_device();
 
 	/* Ideally we would "un-post" the rx buffers, but this
 	   should be accomplished by closing the endpoint. */
-	this->release_rdma_ep_resources(device->base.dev_id);
+	release_rdma_ep_resources(device->base.dev_id);
 
-	err_code = this->fini_rx_buffers();
+	err_code = fini_rx_buffers();
 	if (err_code != 0) {
 		NCCL_OFI_WARN("rdma endpoint cleanup: tearing down freelists failed, rc %d", err_code);
 		ret = -EINVAL;
@@ -6858,12 +6858,12 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 
 	is_endpoint_per_communicator_ep = false;
 
-	ret = this->init_rail_ofi_resources(device, domain_arg);
+	ret = init_rail_ofi_resources(device, domain_arg);
 	if (ret != 0) {
 		throw std::runtime_error("rdma endpoint constructor: initializing rails failed");
 	}
 
-	ret = this->init_rx_buffers();
+	ret = init_rx_buffers();
 	if (ret != 0) {
 		NCCL_OFI_WARN("Preparation of rx buffers failed");
 		throw std::runtime_error("rdma endpoint constructor: initializing rx_buffers failed");

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6655,9 +6655,6 @@ int nccl_net_ofi_rdma_ep_t::cleanup_resources() {
 		ret = -EINVAL;
 	}
 
-	free(control_rails);
-	free(rails);
-
 	assert(ret == 0);
 
 	return ret;
@@ -6825,19 +6822,10 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 
 	use_long_rkeys = device->use_long_rkeys;
 
-	rails = (nccl_net_ofi_ep_rail_t *)calloc(num_rails,
-						 sizeof(nccl_net_ofi_ep_rail_t));
-	if (!rails) {
-		NCCL_OFI_WARN("Unable to allocate rdma rails");
-		throw std::runtime_error("rdma endpoint constructor: data rail allocation failed");
-	}
+	/* Zero-initialize the rails and control_rails vector elements */
+	rails = std::vector<nccl_net_ofi_ep_rail_t>(num_rails, nccl_net_ofi_ep_rail_t{});
 
-	control_rails = (nccl_net_ofi_ep_rail_t *)calloc(num_control_rails,
-							 sizeof(nccl_net_ofi_ep_rail_t));
-	if (!control_rails) {
-		NCCL_OFI_WARN("Unable to allocate rdma control rails");
-		throw std::runtime_error("rdma endpoint constructor: control rail allocation failed");
-	}
+	control_rails = std::vector<nccl_net_ofi_ep_rail_t>(num_control_rails, nccl_net_ofi_ep_rail_t{});
 
 	pending_reqs_queue = new std::deque<nccl_net_ofi_rdma_req_t *>;
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -925,7 +925,7 @@ int nccl_net_ofi_rdma_ep_t::repost_rx_buff(nccl_net_ofi_rdma_req_t *rx_buff_req)
 	if (ret == -FI_EAGAIN) {
 		/* Add to pending reqs queue */
 		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-		pending_reqs_queue->push_back(rx_buff_req);
+		pending_reqs_queue.push_back(rx_buff_req);
 		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		NCCL_OFI_TRACE_PENDING_INSERT(rx_buff_req);
 
@@ -1008,7 +1008,7 @@ static inline int handle_ctrl_recv(nccl_net_ofi_rdma_send_comm_t *s_comm,
 		if (ret == -FI_EAGAIN) {
 			/* Add to pending reqs queue */
 			nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-			ep->pending_reqs_queue->push_back(req);
+			ep->pending_reqs_queue.push_back(req);
 			nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 			ret = 0;
 			NCCL_OFI_TRACE_PENDING_INSERT(req);
@@ -1776,7 +1776,7 @@ static int receive_progress(nccl_net_ofi_rdma_req_t *req, bool add_to_pending)
 		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep;
 		/* Place in pending requests queue for next try */
 		nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-		ep->pending_reqs_queue->push_back(req);
+		ep->pending_reqs_queue.push_back(req);
 		nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 		rc = 0;
 
@@ -1794,9 +1794,9 @@ int nccl_net_ofi_rdma_ep_t::process_pending_reqs()
 	while (true) {
 		nccl_net_ofi_rdma_req_t *req = NULL;
 		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-		if (!pending_reqs_queue->empty()) {
-			req = pending_reqs_queue->front();
-			pending_reqs_queue->pop_front();
+		if (!pending_reqs_queue.empty()) {
+			req = pending_reqs_queue.front();
+			pending_reqs_queue.pop_front();
 		}
 		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		if (req == NULL) { break; }
@@ -1829,7 +1829,7 @@ int nccl_net_ofi_rdma_ep_t::process_pending_reqs()
 		} else if (rc == -FI_EAGAIN) {
 			/* Put the request in the front of the queue and try again later */
 			nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-			pending_reqs_queue->push_front(req);
+			pending_reqs_queue.push_front(req);
 			nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 			rc = 0;
 			break;
@@ -2315,7 +2315,7 @@ int nccl_net_ofi_rdma_ep_t::handle_rx_eagain(nccl_net_ofi_ep_rail_t *rail,
 {
 	/* Add to pending reqs queue */
 	nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-	pending_reqs_queue->push_back(req);
+	pending_reqs_queue.push_back(req);
 	nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 	NCCL_OFI_TRACE_PENDING_INSERT(req);
 
@@ -3302,7 +3302,7 @@ int nccl_net_ofi_rdma_ep_t::process_cq_if_pending()
 {
 	/* Process the CQ if there are any pending requests */
 	nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-	bool is_deque_empty = pending_reqs_queue->empty();
+	bool is_deque_empty = pending_reqs_queue.empty();
 	nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 	if (!is_deque_empty) {
 		int ret = ofi_process_cq();
@@ -3310,7 +3310,7 @@ int nccl_net_ofi_rdma_ep_t::process_cq_if_pending()
 			return ret;
 		}
 		nccl_net_ofi_mutex_lock(&pending_reqs_lock);
-		is_deque_empty = pending_reqs_queue->empty();
+		is_deque_empty = pending_reqs_queue.empty();
 		nccl_net_ofi_mutex_unlock(&pending_reqs_lock);
 		if (!is_deque_empty) {
 			/* Network is still busy. */
@@ -4232,7 +4232,7 @@ static int flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
 	} else {
 		/* Add to pending reqs queue */
 		nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-		ep->pending_reqs_queue->push_back(req);
+		ep->pending_reqs_queue.push_back(req);
 		nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 		ret = 0;
 		NCCL_OFI_TRACE_PENDING_INSERT(req);
@@ -5654,7 +5654,7 @@ static inline int check_post_rx_buff_req(nccl_net_ofi_rdma_req_t *rx_buff_req)
 		if (ret == -FI_EAGAIN) {
 			/* Place in pending requests queue for next try */
 			nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-			ep->pending_reqs_queue->push_back(rx_buff_req);
+			ep->pending_reqs_queue.push_back(rx_buff_req);
 			nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 			NCCL_OFI_TRACE_PENDING_INSERT(rx_buff_req);
 
@@ -5872,7 +5872,7 @@ retry:
 		if (ret == -FI_EAGAIN) {
 			/* Add to pending reqs queue */
 			nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-			ep->pending_reqs_queue->push_back(req);
+			ep->pending_reqs_queue.push_back(req);
 			nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 			ret = 0;
 			NCCL_OFI_TRACE_PENDING_INSERT(req);
@@ -6208,7 +6208,7 @@ static int rma_write_impl(nccl_net_ofi_send_comm_t *send_comm, void* src, size_t
 	if (ret == -FI_EAGAIN) {
 		/* Add to pending reqs queue */
 		nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
-		ep->pending_reqs_queue->push_back(req);
+		ep->pending_reqs_queue.push_back(req);
 		nccl_net_ofi_mutex_unlock(&ep->pending_reqs_lock);
 		ret = 0;
 		NCCL_OFI_TRACE_PENDING_INSERT(req);
@@ -6644,11 +6644,6 @@ int nccl_net_ofi_rdma_ep_t::cleanup_resources() {
 		ret = -EINVAL;
 	}
 
-	if (pending_reqs_queue) {
-		delete pending_reqs_queue;
-		pending_reqs_queue = nullptr;
-	}
-
 	err_code = nccl_net_ofi_mutex_destroy(&pending_reqs_lock);
 	if (err_code != 0) {
 		NCCL_OFI_WARN("rdma endpoint destructor: destroying pending_reqs_lock mutex failed, rc %d", err_code);
@@ -6826,8 +6821,6 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 	rails = std::vector<nccl_net_ofi_ep_rail_t>(num_rails, nccl_net_ofi_ep_rail_t{});
 
 	control_rails = std::vector<nccl_net_ofi_ep_rail_t>(num_control_rails, nccl_net_ofi_ep_rail_t{});
-
-	pending_reqs_queue = new std::deque<nccl_net_ofi_rdma_req_t *>;
 
 	ret = nccl_net_ofi_mutex_init(&pending_reqs_lock, NULL);
 	if (ret != 0) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2119,7 +2119,7 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 	nccl_net_ofi_sendrecv_device_t *device = nullptr;
 
 	/* Validate device */
-	device = this->sendrecv_endpoint_get_device();
+	device = sendrecv_endpoint_get_device();
 	if (OFI_UNLIKELY(device == nullptr)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		ret = -EINVAL;
@@ -2183,7 +2183,7 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 	tag = 0;
 	max_tag = device->max_tag;
 
-	struct fid_domain *ofi_domain = this->sendrecv_endpoint_get_ofi_domain();
+	struct fid_domain *ofi_domain = sendrecv_endpoint_get_ofi_domain();
 	ret = nccl_ofi_ofiutils_init_connection(device->info,
 						ofi_domain,
 						&ofi_ep,


### PR DESCRIPTION
Draft PR for a first iteration of using proper C++ inheritance in the OFI NCCL plugin.

Replaces the C-style inheritance of having a base endpoint instance as the first member of the transport endpoint types with the C++ approach of making nccl_net_ofi_ep_t a parent class with virtual functions that the transport endpoint types override. This also refactors the allocation and free functions for the base and transport endpoint types to be constructors and destructors.

Some changes this draft PR does not yet include:
1. Moving endpoint constructor and destructor helper functions to be private member functions. For example,  `nccl_net_ofi_rdma_ep_t`'s constructor calls helper functions `init_rail_ofi_resources` and `init_rx_buffers`, which are currently free functions in `nccl_ofi_rdma.cpp` and should be private member functions of `nccl_net_ofi_rdma_ep_t`
2. Sort out constructor and destructor for endpoint rails: `nccl_net_ofi_ep_rail_t` is currently initialized and torn-down using free functions `ep_rail_init` and `ep_rail_release`, which could be turned into the rail's constructor and destructor respectively

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
