### PR TITLE
Rework API version management

### DIFF
--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -11,44 +11,53 @@
 
 struct nccl_ofi_properties;
 
-ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction);
-ncclResult_t nccl_net_ofi_devices(int *ndev);
+ncclResult_t nccl_net_ofi_init_v2(ncclDebugLogger_t logFunction);
+ncclResult_t nccl_net_ofi_devices_v2(int *ndev);
 ncclResult_t nccl_net_ofi_get_properties(int dev, struct nccl_ofi_properties *ofi_properties);
-ncclResult_t nccl_net_ofi_listen(int dev, void *handle, void **listenComm);
-ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm);
+ncclResult_t nccl_net_ofi_listen_v2(int dev, void *handle, void **listenComm);
+ncclResult_t nccl_net_ofi_listen_v5(int dev, void* handle, void **listenComm);
 // Nvidia introduced the ability to have part of the communication driven by a
 // cuda kernel, which requires a version-specific device pointer be passed
 // through the accept/connect APIs.  Rather than list all those connect calls
 // here, we just declare them in the nvidia interface file to keep this list sane.
-ncclResult_t nccl_net_ofi_connect(int dev, void* handle, void** sendComm);
-ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm);
-ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm);
-ncclResult_t nccl_net_ofi_accept_v4(void* listenComm, void** recvComm);
-ncclResult_t nccl_net_ofi_regMr_v7(void *comm, void *data, int size, int type,
+ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void **sendComm);
+ncclResult_t nccl_net_ofi_connect_v5(int dev, void* handle, void **sendComm);
+ncclResult_t nccl_net_ofi_accept_v2(void *listenComm, void **recvComm);
+ncclResult_t nccl_net_ofi_accept_v5(void* listenComm, void** recvComm);
+ncclResult_t nccl_net_ofi_regMr_v2(void *comm, void *data, int size, int type,
 				   void **mhandle);
-ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, size_t size, int type,
-				void **mhandle);
-ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
-ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle);
-ncclResult_t nccl_net_ofi_isend(void *sendComm, void* data, int size, int tag, void *mhandle, void** request);
-ncclResult_t nccl_net_ofi_isend_v4(void* sendComm, void* data, int size, void* mhandle, void** request);
-ncclResult_t nccl_net_ofi_isend_v9(void *sendComm, void* data, size_t size, int tag, void *mhandle, void** request);
-ncclResult_t nccl_net_ofi_irecv(void* recvComm, int n, void** buffers, int* sizes, int *tags, void** mhandles, void** request);
-ncclResult_t nccl_net_ofi_irecv_v4(void* recvComm, void* data, int size, void* mhandle, void** request);
-ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** buffers, size_t* sizes, int *tags, void** mhandles, void** request);
-ncclResult_t nccl_net_ofi_test(void *request, int *done, int *size);
-ncclResult_t nccl_net_ofi_iflush(void* recvComm, int n, void** buffers, int* sizes, void** mhandles, void** request);
-ncclResult_t nccl_net_ofi_flush_v3(void* recvComm, void* data, int size, void* mhandle);
-ncclResult_t nccl_net_ofi_iflush_v4(void* recvComm, void* data, int size, void* mhandle, void** request);
-ncclResult_t nccl_net_ofi_closeSend(void *sendComm);
-ncclResult_t nccl_net_ofi_closeRecv(void *recvComm);
-ncclResult_t nccl_net_ofi_closeListen(void *listenComm);
-ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key);
-ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhandle,
-				 uint64_t dest, uint64_t mr_key, void** req);
-ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
-					uint64_t dest, uint64_t mr_key, void** req);
-ncclResult_t nccl_net_ofi_iread(void* rComm, void* dest, size_t size, void* mhandle,
-				uint64_t src, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_regMr_v8(void *comm, void *data, size_t size, int type,
+				   void **mhandle);
+ncclResult_t nccl_net_ofi_regMrDmaBuf_v6(void* comm, void* data, size_t size, int type,
+					 uint64_t offset, int fd, void** mhandle);
+ncclResult_t nccl_net_ofi_deregMr_v2(void *comm, void *mhandle);
+ncclResult_t nccl_net_ofi_isend_v2(void* sendComm, void* data, int size, void* mhandle,
+				   void** request);
+ncclResult_t nccl_net_ofi_isend_v5(void *sendComm, void* data, int size, int tag, void *mhandle,
+				   void** request);
+ncclResult_t nccl_net_ofi_isend_v9(void *sendComm, void* data, size_t size, int tag, void *mhandle,
+				   void** request);
+ncclResult_t nccl_net_ofi_irecv_v2(void* recvComm, void* data, int size, void* mhandle,
+				   void** request);
+ncclResult_t nccl_net_ofi_irecv_v5(void* recvComm, int n, void** buffers, int* sizes, int *tags,
+				   void** mhandles, void** request);
+ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** buffers, size_t* sizes, int *tags,
+				   void** mhandles, void** request);
+ncclResult_t nccl_net_ofi_test_v2(void *request, int *done, int *size);
+ncclResult_t nccl_net_ofi_flush_v2(void* recvComm, void* data, int size, void* mhandle);
+ncclResult_t nccl_net_ofi_iflush_v4(void* recvComm, void* data, int size, void* mhandle,
+				    void** request);
+ncclResult_t nccl_net_ofi_iflush_v5(void* recvComm, int n, void** buffers, int* sizes,
+				    void** mhandles, void** request);
+ncclResult_t nccl_net_ofi_closeSend_v2(void *sendComm);
+ncclResult_t nccl_net_ofi_closeRecv_v2(void *recvComm);
+ncclResult_t nccl_net_ofi_closeListen_v2(void *listenComm);
+ncclResult_t nccl_net_ofi_get_mr_key_v5(void* mhandle, uint64_t* mr_key);
+ncclResult_t nccl_net_ofi_iwrite_v5(void* sComm, void* src, size_t size, void* mhandle,
+				    uint64_t dest, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_iwrite_inline_v5(void* sComm, void* src, size_t size,
+					   uint64_t dest, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_iread_v5(void* rComm, void* dest, size_t size, void* mhandle,
+				   uint64_t src, uint64_t mr_key, void** req);
 
 #endif // End NET_OFI_API_H_

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -16,6 +16,10 @@ ncclResult_t nccl_net_ofi_devices(int *ndev);
 ncclResult_t nccl_net_ofi_get_properties(int dev, struct nccl_ofi_properties *ofi_properties);
 ncclResult_t nccl_net_ofi_listen(int dev, void *handle, void **listenComm);
 ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm);
+// Nvidia introduced the ability to have part of the communication driven by a
+// cuda kernel, which requires a version-specific device pointer be passed
+// through the accept/connect APIs.  Rather than list all those connect calls
+// here, we just declare them in the nvidia interface file to keep this list sane.
 ncclResult_t nccl_net_ofi_connect(int dev, void* handle, void** sendComm);
 ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm);
 ncclResult_t nccl_net_ofi_accept(void *listenComm, void **recvComm);

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -138,7 +138,7 @@ static void nccl_net_ofi_fini(void)
 }
 
 
-ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
+ncclResult_t nccl_net_ofi_init_v2(ncclDebugLogger_t logFunction)
 {
 	int ret;
 
@@ -166,7 +166,7 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 }
 
 
-ncclResult_t nccl_net_ofi_devices(int *num_devices)
+ncclResult_t nccl_net_ofi_devices_v2(int *num_devices)
 {
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == NULL)) {
@@ -205,17 +205,17 @@ ncclResult_t nccl_net_ofi_get_properties(int dev_id, nccl_ofi_properties_t *ofi_
 }
 
 
-ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm)
+ncclResult_t nccl_net_ofi_listen_v2(int dev, void* handle, void** listenComm)
 {
         nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
 	ncclResult_t ret;
 
 	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
-		NCCL_OFI_WARN("RDMA protocol does not support listen_v4 interface");
+		NCCL_OFI_WARN("RDMA protocol does not support blocking listen interface");
 		return check_return(ncclInternalError);
 	}
 
-	ret = nccl_net_ofi_listen(dev, &nccl_net_ofi_handle, listenComm);
+	ret = nccl_net_ofi_listen_v5(dev, &nccl_net_ofi_handle, listenComm);
 	if (ret == ncclSuccess) {
 		memcpy(handle, &nccl_net_ofi_handle, NCCL_NET_HANDLE_MAXSIZE_V4);
 	}
@@ -224,7 +224,7 @@ ncclResult_t nccl_net_ofi_listen_v4(int dev, void* handle, void** listenComm)
 }
 
 
-ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
+ncclResult_t nccl_net_ofi_listen_v5(int dev_id, void *handle, void **lComm)
 {
 	int ret = 0;
 	nccl_net_ofi_device_t *device = NULL;
@@ -267,20 +267,20 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm)
 }
 
 
-ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm)
+ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void** sendComm)
 {
 	ncclResult_t ret = ncclSuccess;
         nccl_net_ofi_conn_handle_t nccl_net_ofi_handle = {};
 
 	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
-		NCCL_OFI_WARN("RDMA protocol does not support blocking connect_v4 interface");
+		NCCL_OFI_WARN("RDMA protocol does not support blocking connect interface");
 		return check_return(ncclInternalError);
 	}
 
         memcpy(&nccl_net_ofi_handle, handle, NCCL_NET_HANDLE_MAXSIZE_V4);
 
 	while (*sendComm == NULL) {
-		ret = nccl_net_ofi_connect(dev, &nccl_net_ofi_handle, sendComm);
+		ret = nccl_net_ofi_connect_v5(dev, &nccl_net_ofi_handle, sendComm);
 		if (ret != ncclSuccess)
 			return ret;
 	}
@@ -313,7 +313,7 @@ ncclResult_t nccl_net_ofi_connect_v4(int dev, void* handle, void** sendComm)
  * @return	0, on success
  * 		error, on others
  */
-ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
+ncclResult_t nccl_net_ofi_connect_v5(int dev_id, void *handle, void **sComm)
 {
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == NULL)) {
@@ -363,17 +363,17 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm)
 }
 
 
-ncclResult_t nccl_net_ofi_accept_v4(void* listenComm, void** recvComm)
+ncclResult_t nccl_net_ofi_accept_v2(void* listenComm, void** recvComm)
 {
 	ncclResult_t ret = ncclInvalidArgument;
 
 	if (0 == strcasecmp(nccl_ofi_selected_protocol, "RDMA")) {
-		NCCL_OFI_WARN("RDMA protocol does not support blocking accept_v4 interface.");
+		NCCL_OFI_WARN("RDMA protocol does not support blocking accept interface.");
 		return check_return(ncclInternalError);
 	}
 
 	while (*recvComm == NULL) {
-		ret = nccl_net_ofi_accept(listenComm, recvComm);
+		ret = nccl_net_ofi_accept_v5(listenComm, recvComm);
 		if (ret != ncclSuccess) {
 			goto error;
 		}
@@ -399,7 +399,7 @@ error:
  * @return	0, on success
  * 		error, on others
  */
-ncclResult_t nccl_net_ofi_accept(void *lComm, void **rComm)
+ncclResult_t nccl_net_ofi_accept_v5(void *lComm, void **rComm)
 {
 	if (OFI_UNLIKELY(plugin == NULL)) {
 		NCCL_OFI_WARN("Error accessing plugin. Plugin has not been initialized yet.");
@@ -437,28 +437,28 @@ error:
 }
 
 
-ncclResult_t nccl_net_ofi_regMr_v7(void *comm, void *data, int size, int type,
+ncclResult_t nccl_net_ofi_regMr_v2(void *comm, void *data, int size, int type,
 				   void **mhandle)
 {
-	return nccl_net_ofi_regMr(comm, data, (size_t)size, type, mhandle);
+	return nccl_net_ofi_regMr_v8(comm, data, (size_t)size, type, mhandle);
 }
 
 
-ncclResult_t nccl_net_ofi_regMr(void *comm, void *data, size_t size, int type,
-				void **mhandle)
+ncclResult_t nccl_net_ofi_regMr_v8(void *comm, void *data, size_t size, int type,
+				   void **mhandle)
 {
-	return nccl_net_ofi_regMrDmaBuf(comm,
-					data,
-					size,
-					type,
-					0,  /* default value, no offset. */
-					-1, /* default value, invalid file descriptor. */
-					mhandle);
+	return nccl_net_ofi_regMrDmaBuf_v6(comm,
+					   data,
+					   size,
+					   type,
+					   0,  /* default value, no offset. */
+					   -1, /* default value, invalid file descriptor. */
+					   mhandle);
 }
 
-ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
-				      int type, uint64_t offset,
-				      int fd, void** mhandle)
+ncclResult_t nccl_net_ofi_regMrDmaBuf_v6(void* comm, void* data, size_t size,
+					 int type, uint64_t offset,
+					 int fd, void** mhandle)
 {
 	int ret;
 	/* Retrieve and validate comm */
@@ -525,7 +525,8 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 	return nccl_net_ofi_retval_translate(ret);
 }
 
-ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
+
+ncclResult_t nccl_net_ofi_deregMr_v2(void *comm, void *mhandle)
 {
 	/* Retrieve and validate comm */
 	nccl_net_ofi_comm_t *base_comm =
@@ -567,15 +568,15 @@ ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 }
 
 
-ncclResult_t nccl_net_ofi_isend_v4(void* sendComm, void* data, int size,
-			  void* mhandle, void** request)
+ncclResult_t nccl_net_ofi_isend_v2(void* sendComm, void* data, int size,
+				   void* mhandle, void** request)
 {
-	return nccl_net_ofi_isend(sendComm, data, size, 0, mhandle, request);
+	return nccl_net_ofi_isend_v5(sendComm, data, size, 0, mhandle, request);
 }
 
 
-ncclResult_t nccl_net_ofi_isend(void *sComm, void* data, int size,
-				int tag, void *mhandle, void** req)
+ncclResult_t nccl_net_ofi_isend_v5(void *sComm, void* data, int size,
+				   int tag, void *mhandle, void** req)
 {
 	nccl_net_ofi_send_comm_t *send_comm =
 		(nccl_net_ofi_send_comm_t *)sComm;
@@ -605,28 +606,28 @@ ncclResult_t nccl_net_ofi_isend(void *sComm, void* data, int size,
 
 
 ncclResult_t nccl_net_ofi_isend_v9(void* sendComm, void* data, size_t size,
-				int tag, void* mhandle, void** request)
+				   int tag, void* mhandle, void** request)
 {
 	ncclResult_t validation_result = msg_length_verify_max_size(&size, 1);
 	if (validation_result != ncclSuccess) {
 		return check_return(validation_result);
 	}
 
-	return nccl_net_ofi_isend(sendComm, data, (int)size, tag, mhandle, request);
+	return nccl_net_ofi_isend_v5(sendComm, data, (int)size, tag, mhandle, request);
 }
 
 
-ncclResult_t nccl_net_ofi_irecv_v4(void* recvComm, void* data, int size,
-			  void* mhandle, void** request)
+ncclResult_t nccl_net_ofi_irecv_v2(void* recvComm, void* data, int size,
+				   void* mhandle, void** request)
 {
 	int tag = 0;
 
-	return nccl_net_ofi_irecv(recvComm, 1, &data, &size, &tag, &mhandle, request);
+	return nccl_net_ofi_irecv_v5(recvComm, 1, &data, &size, &tag, &mhandle, request);
 }
 
 
-ncclResult_t nccl_net_ofi_irecv(void* rComm, int n, void** buffers, int* sizes,
-				int *tags, void** mhandles, void** req)
+ncclResult_t nccl_net_ofi_irecv_v5(void* rComm, int n, void** buffers, int* sizes,
+				   int *tags, void** mhandles, void** req)
 {
 	nccl_net_ofi_recv_comm_t *recv_comm =
 		(nccl_net_ofi_recv_comm_t *)rComm;
@@ -666,7 +667,7 @@ ncclResult_t nccl_net_ofi_irecv(void* rComm, int n, void** buffers, int* sizes,
 
 
 ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** data,
-				size_t* sizes, int* tags, void** mhandles, void** request)
+				   size_t* sizes, int* tags, void** mhandles, void** request)
 {
 	if (OFI_UNLIKELY(recvComm == NULL || data == NULL ||
 					sizes == NULL || tags == NULL ||
@@ -690,11 +691,11 @@ ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** data,
 		sizesInt[i] = (int)sizes[i];
 	}
 
-	return nccl_net_ofi_irecv(recvComm, n, data, sizesInt, tags, mhandles, request);
+	return nccl_net_ofi_irecv_v5(recvComm, n, data, sizesInt, tags, mhandles, request);
 }
 
 
-ncclResult_t nccl_net_ofi_test(void* req, int* done, int* size)
+ncclResult_t nccl_net_ofi_test_v2(void* req, int* done, int* size)
 {
 	/* Validate request */
 	if (OFI_UNLIKELY(req == NULL)) {
@@ -707,7 +708,7 @@ ncclResult_t nccl_net_ofi_test(void* req, int* done, int* size)
 }
 
 
-ncclResult_t nccl_net_ofi_flush_v3(void* recvComm, void* data, int size, void* mhandle)
+ncclResult_t nccl_net_ofi_flush_v2(void* recvComm, void* data, int size, void* mhandle)
 {
 	void *req = NULL;
 	ncclResult_t ret = ncclSuccess;
@@ -719,7 +720,7 @@ ncclResult_t nccl_net_ofi_flush_v3(void* recvComm, void* data, int size, void* m
 	}
 
 	while (done == 0) {
-		ret = nccl_net_ofi_test(req, &done, &size);
+		ret = nccl_net_ofi_test_v2(req, &done, &size);
 		if (ret != ncclSuccess) {
 			return ret;
 		}
@@ -732,12 +733,12 @@ ncclResult_t nccl_net_ofi_flush_v3(void* recvComm, void* data, int size, void* m
 ncclResult_t nccl_net_ofi_iflush_v4(void* recvComm, void* data, int size,
 			   void* mhandle, void** request)
 {
-	return nccl_net_ofi_iflush(recvComm, 1, &data, &size, &mhandle, request);
+	return nccl_net_ofi_iflush_v5(recvComm, 1, &data, &size, &mhandle, request);
 }
 
 
-ncclResult_t nccl_net_ofi_iflush(void* rComm, int n, void** buffers, int* sizes,
-				 void** mhandles, void** req)
+ncclResult_t nccl_net_ofi_iflush_v5(void* rComm, int n, void** buffers, int* sizes,
+				    void** mhandles, void** req)
 {
 	nccl_net_ofi_recv_comm_t *recv_comm =
 		(nccl_net_ofi_recv_comm_t *)rComm;
@@ -779,7 +780,7 @@ ncclResult_t nccl_net_ofi_iflush(void* rComm, int n, void** buffers, int* sizes,
 /*
  * @brief	Destroy send communicator
  */
-ncclResult_t nccl_net_ofi_closeSend(void *sComm)
+ncclResult_t nccl_net_ofi_closeSend_v2(void *sComm)
 {
 	nccl_net_ofi_send_comm_t *send_comm = (nccl_net_ofi_send_comm_t *)sComm;
 
@@ -806,7 +807,7 @@ ncclResult_t nccl_net_ofi_closeSend(void *sComm)
 /*
  * @brief	Destroy receive communicator
  */
-ncclResult_t nccl_net_ofi_closeRecv(void *rComm)
+ncclResult_t nccl_net_ofi_closeRecv_v2(void *rComm)
 {
 	nccl_net_ofi_recv_comm_t *recv_comm = (nccl_net_ofi_recv_comm_t *)rComm;
 
@@ -830,7 +831,7 @@ ncclResult_t nccl_net_ofi_closeRecv(void *rComm)
 }
 
 
-ncclResult_t nccl_net_ofi_closeListen(void *lComm)
+ncclResult_t nccl_net_ofi_closeListen_v2(void *lComm)
 {
 	nccl_net_ofi_listen_comm_t *listen_comm =
 		(nccl_net_ofi_listen_comm_t *)lComm;
@@ -854,7 +855,7 @@ ncclResult_t nccl_net_ofi_closeListen(void *lComm)
 }
 
 
-ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key)
+ncclResult_t nccl_net_ofi_get_mr_key_v5(void* mhandle, uint64_t* mr_key)
 {
 	int ret = 0;
 	nccl_net_ofi_device_t *device = NULL;
@@ -885,8 +886,8 @@ ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key)
 }
 
 
-ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhandle,
-				 uint64_t dest, uint64_t mr_key, void** req)
+ncclResult_t nccl_net_ofi_iwrite_v5(void* sComm, void* src, size_t size, void* mhandle,
+				    uint64_t dest, uint64_t mr_key, void** req)
 {
 	nccl_net_ofi_send_comm_t *send_comm =
 		(nccl_net_ofi_send_comm_t *)sComm;
@@ -913,8 +914,8 @@ ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhan
 }
 
 
-ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
-				      uint64_t dest, uint64_t mr_key, void** req)
+ncclResult_t nccl_net_ofi_iwrite_inline_v5(void* sComm, void* src, size_t size,
+					   uint64_t dest, uint64_t mr_key, void** req)
 {
 	nccl_net_ofi_send_comm_t *send_comm =
 		(nccl_net_ofi_send_comm_t *)sComm;
@@ -941,8 +942,8 @@ ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
 }
 
 
-ncclResult_t nccl_net_ofi_iread(void* rComm, void* dest, size_t size, void* mhandle,
-				uint64_t src, uint64_t mr_key, void** req)
+ncclResult_t nccl_net_ofi_iread_v5(void* rComm, void* dest, size_t size, void* mhandle,
+				   uint64_t src, uint64_t mr_key, void** req)
 {
 	nccl_net_ofi_recv_comm_t *recv_comm =
 		(nccl_net_ofi_recv_comm_t *)rComm;

--- a/src/nccl_ofi_interface_neuron.cpp
+++ b/src/nccl_ofi_interface_neuron.cpp
@@ -19,7 +19,7 @@ static ncclResult_t init_v4(ncclDebugLogger_t logFunction)
 	 * API.
 	 */
 	setenv("OFI_NCCL_PROTOCOL", "SENDRECV", 0);
-	return nccl_net_ofi_init(logFunction);
+	return nccl_net_ofi_init_v2(logFunction);
 }
 
 static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v5_t* props)
@@ -72,42 +72,31 @@ static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v5_t* props)
 	return ret;
 }
 
-static ncclResult_t connect_v5(int dev, void* handle, void** sendComm)
-{
-	return nccl_net_ofi_connect(dev, handle, sendComm);
-}
-
-
-static ncclResult_t accept_v5(void* listenComm, void** recvComm)
-{
-	return nccl_net_ofi_accept(listenComm, recvComm);
-}
-
 
 extern "C" {
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v5_t ncclNetPlugin_v5 = {
 	.name = "AWS Libfabric",
-	.init = nccl_net_ofi_init,
-	.devices = nccl_net_ofi_devices,
+	.init = nccl_net_ofi_init_v2,
+	.devices = nccl_net_ofi_devices_v2,
 	.getProperties = getProperties_v5,
-	.listen = nccl_net_ofi_listen,
-	.connect = connect_v5,
-	.accept = accept_v5,
-	.regMr = nccl_net_ofi_regMr,
-	.regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend,
-	.irecv = nccl_net_ofi_irecv,
-	.iflush = nccl_net_ofi_iflush,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
-	.getMrKey = nccl_net_ofi_get_mr_key,
-	.iwrite = nccl_net_ofi_iwrite,
-	.iwriteInline = nccl_net_ofi_iwrite_inline,
-	.iread = nccl_net_ofi_iread,
+	.listen = nccl_net_ofi_listen_v5,
+	.connect = nccl_net_ofi_connect_v5,
+	.accept = nccl_net_ofi_accept_v5,
+	.regMr = nccl_net_ofi_regMr_v8,
+	.regMrDmaBuf = nccl_net_ofi_regMrDmaBuf_v6,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v5,
+	.irecv = nccl_net_ofi_irecv_v5,
+	.iflush = nccl_net_ofi_iflush_v5,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
+	.getMrKey = nccl_net_ofi_get_mr_key_v5,
+	.iwrite = nccl_net_ofi_iwrite_v5,
+	.iwriteInline = nccl_net_ofi_iwrite_inline_v5,
+	.iread = nccl_net_ofi_iread_v5,
 };
 
 static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
@@ -135,20 +124,20 @@ static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t *props)
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "AWS Libfabric",
 	.init = init_v4,
-	.devices = nccl_net_ofi_devices,
+	.devices = nccl_net_ofi_devices_v2,
 	.getProperties = getProperties_v4,
-	.listen = nccl_net_ofi_listen_v4,
-	.connect = nccl_net_ofi_connect_v4,
-	.accept = nccl_net_ofi_accept_v4,
-	.regMr = nccl_net_ofi_regMr,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend_v4,
-	.irecv = nccl_net_ofi_irecv_v4,
+	.listen = nccl_net_ofi_listen_v2,
+	.connect = nccl_net_ofi_connect_v2,
+	.accept = nccl_net_ofi_accept_v2,
+	.regMr = nccl_net_ofi_regMr_v8,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v2,
+	.irecv = nccl_net_ofi_irecv_v2,
 	.iflush = nccl_net_ofi_iflush_v4,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 } /* extern "C" */

--- a/src/nccl_ofi_interface_nvidia.cpp
+++ b/src/nccl_ofi_interface_nvidia.cpp
@@ -220,17 +220,50 @@ static ncclResult_t ptrSupport_v2(int dev_id, int *supportedTypes)
 }
 
 
-static ncclResult_t connect_v7(int dev, void* handle, void** sendComm,
-			       ncclNetDeviceHandle_v7_t** sendDevComm)
+// Nvidia introduced the ability to have part of the communication driven by a
+// cuda kernel, which requires a version-specific device pointer be passed
+// through the accept/connect APIs.  We don't support that interface, so we
+// never need to look at the third argument.  Rather than pollute the api
+// interface, just declare these wrappers in the nvidia interface.
+static ncclResult_t nccl_net_ofi_connect_v7(int dev, void* handle, void** sendComm,
+					    ncclNetDeviceHandle_v7_t** sendDevComm)
 {
 	return nccl_net_ofi_connect(dev, handle, sendComm);
 }
 
 
-static ncclResult_t accept_v7(void* listenComm, void** recvComm,
-			      ncclNetDeviceHandle_v7_t** recvDevComm)
+static ncclResult_t nccl_net_ofi_connect_v8(int dev, void* handle, void** sendComm,
+					    ncclNetDeviceHandle_v8_t** sendDevComm)
 {
-	return nccl_net_ofi_accept(listenComm, recvComm);
+	return nccl_net_ofi_connect(dev, handle, sendComm);
+}
+
+
+static ncclResult_t nccl_net_ofi_connect_v9(int dev, void* handle, void** sendComm,
+					    ncclNetDeviceHandle_v9_t** sendDevComm)
+{
+	return nccl_net_ofi_connect(dev, handle, sendComm);
+}
+
+
+static ncclResult_t nccl_net_ofi_accept_v7(void* listenComm, void** recvComm,
+					   ncclNetDeviceHandle_v7_t** recvDevComm)
+{
+	return nccl_net_ofi_accept(listenComm,  recvComm);
+}
+
+
+static ncclResult_t nccl_net_ofi_accept_v8(void* listenComm, void** recvComm,
+					   ncclNetDeviceHandle_v8_t** recvDevComm)
+{
+	return nccl_net_ofi_accept(listenComm,  recvComm);
+}
+
+
+static ncclResult_t nccl_net_ofi_accept_v9(void* listenComm, void** recvComm,
+					   ncclNetDeviceHandle_v9_t** recvDevComm)
+{
+	return nccl_net_ofi_accept(listenComm,  recvComm);
 }
 
 
@@ -339,8 +372,8 @@ NCCL_OFI_EXPORT_SYMBOL ncclNet_v7_t ncclNetPlugin_v7 = {
         .devices = nccl_net_ofi_devices,
         .getProperties = getProperties_v7,
         .listen = nccl_net_ofi_listen,
-        .connect = connect_v7,
-        .accept = accept_v7,
+        .connect = nccl_net_ofi_connect_v7,
+        .accept = nccl_net_ofi_accept_v7,
         .regMr = nccl_net_ofi_regMr_v7,
         .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
         .deregMr = nccl_net_ofi_deregMr,
@@ -361,8 +394,8 @@ NCCL_OFI_EXPORT_SYMBOL ncclNet_v8_t ncclNetPlugin_v8 = {
         .devices = nccl_net_ofi_devices,
         .getProperties = getProperties_v8,
         .listen = nccl_net_ofi_listen,
-        .connect = connect_v7,
-        .accept = accept_v7,
+        .connect = nccl_net_ofi_connect_v8,
+        .accept = nccl_net_ofi_accept_v8,
         .regMr = nccl_net_ofi_regMr,
         .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
         .deregMr = nccl_net_ofi_deregMr,
@@ -383,8 +416,8 @@ NCCL_OFI_EXPORT_SYMBOL ncclNet_v9_t ncclNetPlugin_v9 = {
         .devices = nccl_net_ofi_devices,
         .getProperties = getProperties_v9,
         .listen = nccl_net_ofi_listen,
-        .connect = connect_v7,
-        .accept = accept_v7,
+        .connect = nccl_net_ofi_connect_v9,
+        .accept = nccl_net_ofi_accept_v9,
         .regMr = nccl_net_ofi_regMr,
         .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
         .deregMr = nccl_net_ofi_deregMr,

--- a/src/nccl_ofi_interface_nvidia.cpp
+++ b/src/nccl_ofi_interface_nvidia.cpp
@@ -144,7 +144,7 @@ static ncclResult_t getProperties_v7(int dev_id, ncclNetProperties_v7_t *props)
 }
 
 
-static ncclResult_t getProperties_v6(int dev_id, ncclNetProperties_v6_t *props)
+static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v6_t *props)
 {
 	nccl_ofi_properties_t ofi_properties;
 	ncclResult_t ret = nccl_net_ofi_get_properties(dev_id, &ofi_properties);
@@ -172,10 +172,10 @@ static ncclResult_t getProperties_v6(int dev_id, ncclNetProperties_v6_t *props)
 }
 
 
-static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t* props)
+static ncclResult_t getProperties_v3(int dev_id, ncclNetProperties_v4_t* props)
 {
 	ncclNetProperties_v6_t props_v6;
-	ncclResult_t ret = getProperties_v6(dev_id, &props_v6);
+	ncclResult_t ret = getProperties_v5(dev_id, &props_v6);
 	if (ret != ncclSuccess) {
 		return ret;
 	}
@@ -195,7 +195,7 @@ static ncclResult_t getProperties_v4(int dev_id, ncclNetProperties_v4_t* props)
 static ncclResult_t pciPath_v2(int dev_id, char** path)
 {
 	ncclNetProperties_v6_t props_v6;
-	ncclResult_t ret = getProperties_v6(dev_id, &props_v6);
+	ncclResult_t ret = getProperties_v5(dev_id, &props_v6);
 	if (ret != ncclSuccess) {
 		return ret;
 	}
@@ -209,7 +209,7 @@ static ncclResult_t pciPath_v2(int dev_id, char** path)
 static ncclResult_t ptrSupport_v2(int dev_id, int *supportedTypes)
 {
 	ncclNetProperties_v6_t props_v6;
-	ncclResult_t ret = getProperties_v6(dev_id, &props_v6);
+	ncclResult_t ret = getProperties_v5(dev_id, &props_v6);
 	if (ret != ncclSuccess) {
 		return ret;
 	}
@@ -228,42 +228,42 @@ static ncclResult_t ptrSupport_v2(int dev_id, int *supportedTypes)
 static ncclResult_t nccl_net_ofi_connect_v7(int dev, void* handle, void** sendComm,
 					    ncclNetDeviceHandle_v7_t** sendDevComm)
 {
-	return nccl_net_ofi_connect(dev, handle, sendComm);
+       return nccl_net_ofi_connect_v5(dev, handle, sendComm);
 }
 
 
 static ncclResult_t nccl_net_ofi_connect_v8(int dev, void* handle, void** sendComm,
 					    ncclNetDeviceHandle_v8_t** sendDevComm)
 {
-	return nccl_net_ofi_connect(dev, handle, sendComm);
+	return nccl_net_ofi_connect_v5(dev, handle, sendComm);
 }
 
 
 static ncclResult_t nccl_net_ofi_connect_v9(int dev, void* handle, void** sendComm,
 					    ncclNetDeviceHandle_v9_t** sendDevComm)
 {
-	return nccl_net_ofi_connect(dev, handle, sendComm);
+	return nccl_net_ofi_connect_v5(dev, handle, sendComm);
 }
 
 
 static ncclResult_t nccl_net_ofi_accept_v7(void* listenComm, void** recvComm,
 					   ncclNetDeviceHandle_v7_t** recvDevComm)
 {
-	return nccl_net_ofi_accept(listenComm,  recvComm);
+	return nccl_net_ofi_accept_v5(listenComm,  recvComm);
 }
 
 
 static ncclResult_t nccl_net_ofi_accept_v8(void* listenComm, void** recvComm,
 					   ncclNetDeviceHandle_v8_t** recvDevComm)
 {
-	return nccl_net_ofi_accept(listenComm,  recvComm);
+	return nccl_net_ofi_accept_v5(listenComm,  recvComm);
 }
 
 
 static ncclResult_t nccl_net_ofi_accept_v9(void* listenComm, void** recvComm,
 					   ncclNetDeviceHandle_v9_t** recvDevComm)
 {
-	return nccl_net_ofi_accept(listenComm,  recvComm);
+	return nccl_net_ofi_accept_v5(listenComm,  recvComm);
 }
 
 
@@ -271,163 +271,163 @@ extern "C" {
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v2_t ncclNetPlugin_v2 = {
 	.name = "Libfabric",
-	.init = nccl_net_ofi_init,
-	.devices = nccl_net_ofi_devices,
+	.init = nccl_net_ofi_init_v2,
+	.devices = nccl_net_ofi_devices_v2,
 	.pciPath = pciPath_v2,
 	.ptrSupport = ptrSupport_v2,
-	.listen = nccl_net_ofi_listen_v4,
-	.connect = nccl_net_ofi_connect_v4,
-	.accept = nccl_net_ofi_accept_v4,
-	.regMr = nccl_net_ofi_regMr_v7,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend_v4,
-	.irecv = nccl_net_ofi_irecv_v4,
-	.flush = nccl_net_ofi_flush_v3,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
+	.listen = nccl_net_ofi_listen_v2,
+	.connect = nccl_net_ofi_connect_v2,
+	.accept = nccl_net_ofi_accept_v2,
+	.regMr = nccl_net_ofi_regMr_v2,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v2,
+	.irecv = nccl_net_ofi_irecv_v2,
+	.flush = nccl_net_ofi_flush_v2,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v3_t ncclNetPlugin_v3 = {
 	.name = "Libfabric",
-	.init = nccl_net_ofi_init,
-	.devices = nccl_net_ofi_devices,
-	.getProperties = getProperties_v4,
-	.listen = nccl_net_ofi_listen_v4,
-	.connect = nccl_net_ofi_connect_v4,
-	.accept = nccl_net_ofi_accept_v4,
-	.regMr = nccl_net_ofi_regMr_v7,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend_v4,
-	.irecv = nccl_net_ofi_irecv_v4,
-	.flush = nccl_net_ofi_flush_v3,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
+	.init = nccl_net_ofi_init_v2,
+	.devices = nccl_net_ofi_devices_v2,
+	.getProperties = getProperties_v3,
+	.listen = nccl_net_ofi_listen_v2,
+	.connect = nccl_net_ofi_connect_v2,
+	.accept = nccl_net_ofi_accept_v2,
+	.regMr = nccl_net_ofi_regMr_v2,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v2,
+	.irecv = nccl_net_ofi_irecv_v2,
+	.flush = nccl_net_ofi_flush_v2,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v4_t ncclNetPlugin_v4 = {
 	.name = "Libfabric",
-	.init = nccl_net_ofi_init,
-	.devices = nccl_net_ofi_devices,
-	.getProperties = getProperties_v4,
-	.listen = nccl_net_ofi_listen_v4,
-	.connect = nccl_net_ofi_connect_v4,
-	.accept = nccl_net_ofi_accept_v4,
-	.regMr = nccl_net_ofi_regMr_v7,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend_v4,
-	.irecv = nccl_net_ofi_irecv_v4,
+	.init = nccl_net_ofi_init_v2,
+	.devices = nccl_net_ofi_devices_v2,
+	.getProperties = getProperties_v3,
+	.listen = nccl_net_ofi_listen_v2,
+	.connect = nccl_net_ofi_connect_v2,
+	.accept = nccl_net_ofi_accept_v2,
+	.regMr = nccl_net_ofi_regMr_v2,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v2,
+	.irecv = nccl_net_ofi_irecv_v2,
 	.iflush = nccl_net_ofi_iflush_v4,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v5_t ncclNetPlugin_v5 = {
 	.name = "Libfabric",
-	.init = nccl_net_ofi_init,
-	.devices = nccl_net_ofi_devices,
-	.getProperties = getProperties_v6,
-	.listen = nccl_net_ofi_listen,
-	.connect = nccl_net_ofi_connect,
-	.accept = nccl_net_ofi_accept,
-	.regMr = nccl_net_ofi_regMr_v7,
-	.deregMr = nccl_net_ofi_deregMr,
-	.isend = nccl_net_ofi_isend,
-	.irecv = nccl_net_ofi_irecv,
-	.iflush = nccl_net_ofi_iflush,
-	.test = nccl_net_ofi_test,
-	.closeSend = nccl_net_ofi_closeSend,
-	.closeRecv = nccl_net_ofi_closeRecv,
-	.closeListen = nccl_net_ofi_closeListen,
+	.init = nccl_net_ofi_init_v2,
+	.devices = nccl_net_ofi_devices_v2,
+	.getProperties = getProperties_v5,
+	.listen = nccl_net_ofi_listen_v5,
+	.connect = nccl_net_ofi_connect_v5,
+	.accept = nccl_net_ofi_accept_v5,
+	.regMr = nccl_net_ofi_regMr_v2,
+	.deregMr = nccl_net_ofi_deregMr_v2,
+	.isend = nccl_net_ofi_isend_v5,
+	.irecv = nccl_net_ofi_irecv_v5,
+	.iflush = nccl_net_ofi_iflush_v5,
+	.test = nccl_net_ofi_test_v2,
+	.closeSend = nccl_net_ofi_closeSend_v2,
+	.closeRecv = nccl_net_ofi_closeRecv_v2,
+	.closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v6_t ncclNetPlugin_v6 = {
         .name = "Libfabric",
-        .init = nccl_net_ofi_init,
-        .devices = nccl_net_ofi_devices,
-        .getProperties = getProperties_v6,
-        .listen = nccl_net_ofi_listen,
-        .connect = nccl_net_ofi_connect,
-        .accept = nccl_net_ofi_accept,
-        .regMr = nccl_net_ofi_regMr_v7,
-        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-        .deregMr = nccl_net_ofi_deregMr,
-        .isend = nccl_net_ofi_isend,
-        .irecv = nccl_net_ofi_irecv,
-        .iflush = nccl_net_ofi_iflush,
-        .test = nccl_net_ofi_test,
-        .closeSend = nccl_net_ofi_closeSend,
-        .closeRecv = nccl_net_ofi_closeRecv,
-        .closeListen = nccl_net_ofi_closeListen,
+        .init = nccl_net_ofi_init_v2,
+        .devices = nccl_net_ofi_devices_v2,
+        .getProperties = getProperties_v5,
+        .listen = nccl_net_ofi_listen_v5,
+        .connect = nccl_net_ofi_connect_v5,
+        .accept = nccl_net_ofi_accept_v5,
+        .regMr = nccl_net_ofi_regMr_v2,
+        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf_v6,
+        .deregMr = nccl_net_ofi_deregMr_v2,
+        .isend = nccl_net_ofi_isend_v5,
+        .irecv = nccl_net_ofi_irecv_v5,
+        .iflush = nccl_net_ofi_iflush_v5,
+        .test = nccl_net_ofi_test_v2,
+        .closeSend = nccl_net_ofi_closeSend_v2,
+        .closeRecv = nccl_net_ofi_closeRecv_v2,
+        .closeListen = nccl_net_ofi_closeListen_v2,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v7_t ncclNetPlugin_v7 = {
         .name = "Libfabric",
-        .init = nccl_net_ofi_init,
-        .devices = nccl_net_ofi_devices,
+        .init = nccl_net_ofi_init_v2,
+        .devices = nccl_net_ofi_devices_v2,
         .getProperties = getProperties_v7,
-        .listen = nccl_net_ofi_listen,
+        .listen = nccl_net_ofi_listen_v5,
         .connect = nccl_net_ofi_connect_v7,
         .accept = nccl_net_ofi_accept_v7,
-        .regMr = nccl_net_ofi_regMr_v7,
-        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-        .deregMr = nccl_net_ofi_deregMr,
-        .isend = nccl_net_ofi_isend,
-        .irecv = nccl_net_ofi_irecv,
-        .iflush = nccl_net_ofi_iflush,
-        .test = nccl_net_ofi_test,
-        .closeSend = nccl_net_ofi_closeSend,
-        .closeRecv = nccl_net_ofi_closeRecv,
-        .closeListen = nccl_net_ofi_closeListen,
+        .regMr = nccl_net_ofi_regMr_v2,
+        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf_v6,
+        .deregMr = nccl_net_ofi_deregMr_v2,
+        .isend = nccl_net_ofi_isend_v5,
+        .irecv = nccl_net_ofi_irecv_v5,
+        .iflush = nccl_net_ofi_iflush_v5,
+        .test = nccl_net_ofi_test_v2,
+        .closeSend = nccl_net_ofi_closeSend_v2,
+        .closeRecv = nccl_net_ofi_closeRecv_v2,
+        .closeListen = nccl_net_ofi_closeListen_v2,
 	.getDeviceMr = NULL,
 	.irecvConsumed = NULL,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v8_t ncclNetPlugin_v8 = {
         .name = "Libfabric",
-        .init = nccl_net_ofi_init,
-        .devices = nccl_net_ofi_devices,
+        .init = nccl_net_ofi_init_v2,
+        .devices = nccl_net_ofi_devices_v2,
         .getProperties = getProperties_v8,
-        .listen = nccl_net_ofi_listen,
+        .listen = nccl_net_ofi_listen_v5,
         .connect = nccl_net_ofi_connect_v8,
         .accept = nccl_net_ofi_accept_v8,
-        .regMr = nccl_net_ofi_regMr,
-        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-        .deregMr = nccl_net_ofi_deregMr,
-        .isend = nccl_net_ofi_isend,
-        .irecv = nccl_net_ofi_irecv,
-        .iflush = nccl_net_ofi_iflush,
-        .test = nccl_net_ofi_test,
-        .closeSend = nccl_net_ofi_closeSend,
-        .closeRecv = nccl_net_ofi_closeRecv,
-        .closeListen = nccl_net_ofi_closeListen,
+        .regMr = nccl_net_ofi_regMr_v8,
+        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf_v6,
+        .deregMr = nccl_net_ofi_deregMr_v2,
+        .isend = nccl_net_ofi_isend_v5,
+        .irecv = nccl_net_ofi_irecv_v5,
+        .iflush = nccl_net_ofi_iflush_v5,
+        .test = nccl_net_ofi_test_v2,
+        .closeSend = nccl_net_ofi_closeSend_v2,
+        .closeRecv = nccl_net_ofi_closeRecv_v2,
+        .closeListen = nccl_net_ofi_closeListen_v2,
         .getDeviceMr = NULL,
         .irecvConsumed = NULL,
 };
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v9_t ncclNetPlugin_v9 = {
         .name = "Libfabric",
-        .init = nccl_net_ofi_init,
-        .devices = nccl_net_ofi_devices,
+        .init = nccl_net_ofi_init_v2,
+        .devices = nccl_net_ofi_devices_v2,
         .getProperties = getProperties_v9,
-        .listen = nccl_net_ofi_listen,
+        .listen = nccl_net_ofi_listen_v5,
         .connect = nccl_net_ofi_connect_v9,
         .accept = nccl_net_ofi_accept_v9,
-        .regMr = nccl_net_ofi_regMr,
-        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf,
-        .deregMr = nccl_net_ofi_deregMr,
+        .regMr = nccl_net_ofi_regMr_v8,
+        .regMrDmaBuf = nccl_net_ofi_regMrDmaBuf_v6,
+        .deregMr = nccl_net_ofi_deregMr_v2,
         .isend = nccl_net_ofi_isend_v9,
         .irecv = nccl_net_ofi_irecv_v9,
-        .iflush = nccl_net_ofi_iflush,
-        .test = nccl_net_ofi_test,
-        .closeSend = nccl_net_ofi_closeSend,
-        .closeRecv = nccl_net_ofi_closeRecv,
-        .closeListen = nccl_net_ofi_closeListen,
+        .iflush = nccl_net_ofi_iflush_v5,
+        .test = nccl_net_ofi_test_v2,
+        .closeSend = nccl_net_ofi_closeSend_v2,
+        .closeRecv = nccl_net_ofi_closeRecv_v2,
+        .closeListen = nccl_net_ofi_closeListen_v2,
         .getDeviceMr = NULL,
         .irecvConsumed = NULL,
         .makeVDevice = NULL,


### PR DESCRIPTION
Change our API version name scheme so that all interface functions include a version in the function name.  The version is the version in which that api was introduced (rather than the previous scheme, in which the version in the name was the last version in which the API was used).  This should make adding new API calls easier, in that the only required change will be adding a new API, and we no longer have to rename the old API to add the version.

This is motivated by the discussions in https://github.com/aws/aws-ofi-nccl/pull/820.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
