### PR TITLE
Fix EFA device id for DMA-BUF search

### DIFF
--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -604,9 +604,9 @@ int nccl_net_ofi_info_properties(nccl_net_ofi_plugin_t *plugin, struct fi_info *
 			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 				       "DMA-BUF disabled due to missing nic data");
 			props->dmabuf_support = false;
-		} else if (strcmp("efa0", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("efa1", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("efa2", nic_prov->nic->device_attr->device_id) == 0) {
+		} else if (strcmp("0xefa0", nic_prov->nic->device_attr->device_id) == 0 ||
+			   strcmp("0xefa1", nic_prov->nic->device_attr->device_id) == 0 ||
+			   strcmp("0xefa2", nic_prov->nic->device_attr->device_id) == 0) {
 			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 				       "DMA-BUF disabled due to EFA device id %s",
 				       nic_prov->nic->device_attr->device_id);


### PR DESCRIPTION
The Libfabric strings include the 0x prefix for the device id, which our simple string match didn't account for.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
