### PR TITLE
Revert "rdma: Enable round robin of control messages"

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -330,7 +330,7 @@ OFI_NCCL_PARAM_INT(rdma_max_posted_control_buffers, "RDMA_MAX_POSTED_CONTROL_BUF
  * Whether to spread the control message across multiple rails in round robin fashion or
  * send it consistenly on one rail.
  */
-OFI_NCCL_PARAM_INT(rdma_rr_ctrl_msg, "RR_CTRL_MSG", 1);
+OFI_NCCL_PARAM_INT(rdma_rr_ctrl_msg, "RR_CTRL_MSG", 0);
 
 /*
  * Internode network latency reported to NCCL. Defaults to 0, unless the configured


### PR DESCRIPTION
This reverts commit b1cd96f67f3ed8c797b32fba588b8c9e8fc53aba.

Observed perf regression at 512MB and 1G msg size after this commit, thus reverting.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
