### PR TITLE
api: Update and increment send/recv functions to V9

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -558,7 +558,7 @@ struct nccl_net_ofi_send_comm {
 	 */
 	int (*deregMr)(nccl_net_ofi_send_comm_t *send_comm, nccl_net_ofi_mr_handle_t *mhandle);
 
-	int (*send)(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+	int (*send)(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 			     nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **req);
 
 	int (*close)(nccl_net_ofi_send_comm_t *send_comm);
@@ -591,7 +591,7 @@ struct nccl_net_ofi_recv_comm {
 	 */
 	int (*deregMr)(nccl_net_ofi_recv_comm_t *recv_comm, nccl_net_ofi_mr_handle_t *mhandle);
 
-	int (*recv)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, int *sizes, int *tags,
+	int (*recv)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, size_t *sizes, int *tags,
 			     nccl_net_ofi_mr_handle_t **mhandles, nccl_net_ofi_req_t **req);
 
 	int (*flush)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, int *sizes,

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -52,7 +52,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     Send,
     LTTNG_UST_TP_ARGS(
             int, dev,
-            int, size,
+            size_t, size,
             void *, comm,
             uint16_t, msg_seq_num,
             void *, request,
@@ -60,7 +60,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
@@ -238,14 +238,14 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_ARGS(
             int, dev,
             void *, comm,
-            int, size,
+            size_t, size,
             void *, request,
             void *, nccl_req
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
-            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -3524,7 +3524,7 @@ static int process_cq_if_pending(nccl_net_ofi_rdma_ep_t *ep)
 }
 
 static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
-			 int *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
+			 size_t *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
 			 nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
@@ -5854,7 +5854,7 @@ static inline int check_post_rx_buff_req(nccl_net_ofi_rdma_req_t *rx_buff_req)
  * @brief	Send a message. This "interface function" is called, indirectly, from
  *       	the application
  */
-static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 			 nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1068,7 +1068,7 @@ static inline nccl_net_ofi_sendrecv_req_t *sendrecv_allocate_req(nccl_ofi_freeli
 }
 
 static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
-				   int *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
+				   size_t *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
 				   nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
@@ -1846,7 +1846,7 @@ static int sendrecv_send_comm_dereg_mr(nccl_net_ofi_send_comm_t *send_comm,
 				  domain->base.mr_cache);
 }
 
-static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 				   nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;


### PR DESCRIPTION
*Description of changes:*

Rework of #820, updating the API of send/receive to v9 based on changes made in #853 . 
The default value of the size parameter in send/receive has been changed from `int` to `size_t`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
