### PR TITLE
scheduler: move schduler to domain level

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -802,9 +802,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	 * and its base struct. */
 	nccl_net_ofi_device_t base;
 
-	/* Message scheduler */
-	nccl_net_ofi_scheduler_t *scheduler;
-
 	/* Number of rails */
 	uint16_t num_rails;
 
@@ -850,6 +847,9 @@ typedef struct nccl_net_ofi_rdma_domain {
 
 	/* List of endpoints and set of addresses they have connections to */
 	nccl_ofi_ep_addr_list_t *ep_addr_list;
+
+	/* Message scheduler */
+	nccl_net_ofi_scheduler_t *scheduler;
 } nccl_net_ofi_rdma_domain_t;
 
 


### PR DESCRIPTION
sheduler was in device level and used two locks. One is freelist lock and the other is scheduler->rr_lock. When a device has multiple threads and is shared by them, there is lock contention problem in send posting. As a short term solution, move scheduler to domain not to share the scheduler resources by multiple threads.

*Issue #, if available:*
N/A

*Description of changes:*
sheduler was in device level and used two locks. One is freelist lock and the other is scheduler->rr_lock. When a device has multiple threads and is shared by them, there is lock contention problem in send posting. As a short term solution, move scheduler to domain not to share the scheduler resources by multiple threads.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
