### PR TITLE
[DRAFT] rdma: close communicators with requests in flight

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -416,6 +416,8 @@ struct nccl_net_ofi_domain {
 
 	/* Domain state that indicates if tearing down is needed */
 	bool domain_active;
+
+	size_t ref_cnt;
 };
 
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -413,6 +413,9 @@ struct nccl_net_ofi_domain {
 	/* thread id of the thread that called get_domain().  Used as
 	   the hash key for the domain hash */
 	long creating_thread_id;
+
+	/* Domain state that indicates if tearing down is needed */
+	bool domain_active;
 };
 
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -759,6 +759,9 @@ struct nccl_net_ofi_rdma_ep {
 	/* thread id of the thread that called get_ep().  Used as the
 	   hash key for the endpoint hash */
 	long creating_thread_id;
+
+	/* Endpoint state that indicates if tearing down is needed */
+	bool endpoint_active;
 };
 
 /*

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -1070,6 +1070,7 @@ int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_
 	domain->release = nccl_net_ofi_domain_release;
 	domain->endpoint = NULL;
 	domain->creating_thread_id = 0;
+	domain->domain_active = true;
 
 	domain->mr_cache = NULL;
 	if (!ofi_nccl_mr_cache_disable()) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7316,6 +7316,11 @@ static int nccl_net_ofi_rdma_domain_create_endpoint(nccl_net_ofi_domain_t *base_
 		return -EINVAL;
 	}
 
+	if (OFI_UNLIKELY(domain->base.domain_active == false)) {
+		NCCL_OFI_WARN("Domain is inactive");
+		return -EINVAL;
+	}
+
 	device = rdma_domain_get_device(domain);
 	assert(device != NULL);
 
@@ -7417,6 +7422,10 @@ static int nccl_net_ofi_rdma_domain_create_endpoint(nccl_net_ofi_domain_t *base_
 	if (ret == 0) {
 		ret = init_max_write_inline_size_if_not_initialized(device, ep);
 	}
+	
+	nccl_net_ofi_mutex_lock(&domain->base.domain_lock);
+	++domain->base.ref_cnt;
+	nccl_net_ofi_mutex_unlock(&domain->base.domain_lock);
 
 error:
 	if (ret != 0) {


### PR DESCRIPTION
Right now RDMA protocol returns an error on attempt to close a communicator with inflight requests. This leads to NCCL leaking GPU memory with each comm close, as it short-circuits the rest of NCCL’s communicator memory cleanup.

This commit changes that behavior to continuing communicator cleanup by setting its data endpoint to inactive. When other communicators of the same endpoint are used, the endpoint state will be checked to indicate that cleanup is needed.

Pending syncup:
1. earlier on we planed to close only the data endpoint and keeping the CM/listen endpoint alive.  With CQ overrun discussions, this needs to be revisited. We are closing the domain alltogether which closes all endpoints

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
