### PR TITLE
rdma,sendrecv: refactor completion queue to the domain

### DIFF
--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -15,18 +15,19 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 /*
  * @brief	Allocates and initialises libfabric endpoint and AV.
  *
+ * @param cq:	Completion queue to which the new endpoint will be bound
  * @return	Endpoint ep
  * @return	Address vector av
  */
 int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *domain,
 				      struct fid_ep **ep,   struct fid_av **av,
-				      struct fid_cq **cq);
+				      struct fid_cq *cq);
 
 /*
  * @brief	Release libfabric endpoint and address vector
  */
 void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av,
-				  struct fid_cq *cq, int dev_id);
+				  int dev_id);
 
 /*
  * @brief	Free libfabric NIC info list.

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -669,9 +669,6 @@ struct nccl_net_ofi_ep_rail {
 	/* Address vector handle */
 	struct fid_av *av;
 
-	/* Completion Queue handle */
-	struct fid_cq *cq;
-
 	/*
 	 * Rx buffer management
 	 */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -125,9 +125,6 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Address vector handle */
 	struct fid_av *av;
 
-	/* Completion Queue handle */
-	struct fid_cq *cq;
-
 	/* free list for control messages */
 	nccl_ofi_freelist_t *conn_msg_fl;
 } nccl_net_ofi_sendrecv_ep_t;
@@ -143,6 +140,10 @@ typedef struct nccl_net_ofi_sendrecv_domain {
 
 	/* Access Domain handle */
 	struct fid_domain *domain;
+
+	/* Completion Queue handle */
+	struct fid_cq *cq;
+
 } nccl_net_ofi_sendrecv_domain_t;
 
 


### PR DESCRIPTION
We currently do not create more than one cq per (OFI) domain, so the cq was effectively at the domain level anyway. This commit updates cq references to point to the domain (rail) instead of the endpoint.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
