### PR TITLE
Add accessors to device and domain for OFI objects

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -306,6 +306,13 @@ struct nccl_net_ofi_device {
 	 */
 	nccl_net_ofi_domain_t *(*get_domain)(nccl_net_ofi_device_t *dev);
 
+	/**
+	 * Retrieve an fi_info object associated with this device. There may be
+	 * more than one info per device, depending on the transport; in that
+	 * case, this will be the info object associated with the "leader NIC"
+	 */
+	struct fi_info *(*get_ofi_info)(nccl_net_ofi_device_t *dev);
+
 	int (*get_ep)(nccl_net_ofi_device_t *base_dev,
 		      nccl_net_ofi_ep_t **ep);
 
@@ -394,6 +401,21 @@ struct nccl_net_ofi_domain {
 	nccl_ofi_idpool_t *mr_rkey_pool;
 
 	pthread_mutex_t domain_lock;
+
+	/**
+	 * Retrieve an fid_domain object associated with this domain. There may
+	 * be more than one fid_domain per domain, depending on the transport;
+	 * in that case, this will be the domain object associated with the
+	 * "leader NIC"
+	 */
+	struct fid_domain *(*get_ofi_domain)(nccl_net_ofi_domain_t *domain);
+
+	/**
+	 * Retrieve an fid_cq object associated with this domain. There may be
+	 * more than one cq per domain, depending on the transport; in that
+	 * case, this will be the info object associated with the "leader NIC"
+	 */
+	struct fid_cq *(*get_ofi_cq)(nccl_net_ofi_domain_t *domain);
 
 /* Private */
 	/* pure virtual function called when resources associated with

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7462,6 +7462,20 @@ cleanup:
 }
 
 
+static inline struct fid_domain *rdma_domain_get_ofi_domain(nccl_net_ofi_domain_t *base_domain) {
+	auto domain = reinterpret_cast<nccl_net_ofi_rdma_domain_t *>(base_domain);
+	auto domain_rail_0 = rdma_domain_get_rail(domain, 0);
+	return domain_rail_0->domain;
+};
+
+
+static inline struct fid_cq *rdma_domain_get_ofi_cq(nccl_net_ofi_domain_t *base_domain) {
+	auto domain = reinterpret_cast<nccl_net_ofi_rdma_domain_t *>(base_domain);
+	auto domain_rail_0 = rdma_domain_get_rail(domain, 0);
+	return domain_rail_0->cq;
+};
+
+
 static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_ofi_device_t *base_dev)
 {
 	int ret = 0;
@@ -7488,6 +7502,8 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 
 	domain->base.free = nccl_net_ofi_rdma_domain_free;
 	domain->base.create_endpoint = nccl_net_ofi_rdma_domain_create_endpoint;
+	domain->base.get_ofi_domain = rdma_domain_get_ofi_domain;
+	domain->base.get_ofi_cq = rdma_domain_get_ofi_cq;
 
 	domain->num_rails = device->num_rails;
 
@@ -7734,6 +7750,13 @@ nccl_net_ofi_rdma_device_release(nccl_net_ofi_device_t *base_device)
 }
 
 
+static inline struct fi_info *rdma_device_get_ofi_info(nccl_net_ofi_device_t *dev) {
+	auto device = reinterpret_cast<nccl_net_ofi_rdma_device_t *>(dev);
+	auto device_rail_0 = rdma_device_get_rail(device, 0);
+	return device_rail_0->info;
+};
+
+
 /**
  * Create an rdma device object
  */
@@ -7760,6 +7783,7 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	device->base.get_mr_key = get_mr_key;
 	device->base.release = nccl_net_ofi_rdma_device_release;
 	device->base.create_domain = nccl_net_ofi_rdma_device_create_domain;
+	device->base.get_ofi_info = rdma_device_get_ofi_info;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2447,6 +2447,18 @@ static int nccl_net_ofi_sendrecv_domain_free(nccl_net_ofi_domain_t *base_domain)
 }
 
 
+static inline struct fid_domain *sendrecv_domain_get_ofi_domain(nccl_net_ofi_domain_t *base_domain)
+{
+	return reinterpret_cast<nccl_net_ofi_sendrecv_domain_t *>(base_domain)->domain;
+}
+
+
+static inline struct fid_cq *sendrecv_domain_get_ofi_cq(nccl_net_ofi_domain_t *base_domain)
+{
+	return reinterpret_cast<nccl_net_ofi_sendrecv_domain_t *>(base_domain)->cq;
+}
+
+
 static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_net_ofi_device_t *base_device)
 {
 	int ret;
@@ -2461,6 +2473,8 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_ne
 
 	domain->base.free = nccl_net_ofi_sendrecv_domain_free;
 	domain->base.create_endpoint = nccl_net_ofi_sendrecv_domain_create_endpoint;
+	domain->base.get_ofi_domain = sendrecv_domain_get_ofi_domain;
+	domain->base.get_ofi_cq = sendrecv_domain_get_ofi_cq;
 
 	ret = nccl_net_ofi_domain_init(base_device, &domain->base);
 	if (ret != 0) {
@@ -2575,6 +2589,13 @@ nccl_net_ofi_sendrecv_device_release(nccl_net_ofi_device_t *base_device)
 	return 0;
 }
 
+
+static inline struct fi_info *sendrecv_device_get_ofi_info(nccl_net_ofi_device_t *device)
+{
+	return reinterpret_cast<nccl_net_ofi_sendrecv_device_t *>(device)->info;
+}
+
+
 /**
  * Create a sendrecv device object
  */
@@ -2603,6 +2624,7 @@ nccl_net_ofi_sendrecv_device_create(nccl_net_ofi_plugin_t *plugin,
 	device->base.release = nccl_net_ofi_sendrecv_device_release;
 	device->base.get_mr_key = NULL;
 	device->base.create_domain = nccl_net_ofi_sendrecv_device_create_domain;
+	device->base.get_ofi_info = sendrecv_device_get_ofi_info;
 
 	/* at this point, we can safely call the destructor to clean
 	 * up */


### PR DESCRIPTION
- device->get_ofi_info(): get fi_info * associated with this device
- domain->get_ofi_domain(): get fid_domain * associated with this plugin
  domain
- domain->get_ofi_cq(): get fid_cq * associated with this plugin domain

For RDMA protocol, these accessors return objects associated with the
"leader NIC" of the multi-rail group.

This will be useful for the upcoming connection manager, which can take
a `nccl_net_ofi_domain_t` object as a parameter, instead of individual
Libfabric objects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
