### PR TITLE
topo: add NIC to numa domain on g5.48xlarge platforms

### DIFF
--- a/topology/g5.48xl-topo.xml
+++ b/topology/g5.48xl-topo.xml
@@ -21,5 +21,6 @@ virtual machine.
     <pci busid="0000:00:1b.0"/>
     <pci busid="0000:00:1c.0"/>
     <pci busid="0000:00:1d.0"/>
+    <pci busid="0000:00:15.0"/>
   </cpu>
 </system>


### PR DESCRIPTION
Since G5 platforms did not support PCIe technologies properly, the NIC generated by NCCL in the topology file reported a numa domain of -1. NCCL further assigns it the same system ID as the CPU. CPUs with the same system ID are not connected to each other during topology generation. This results in a seg fault during topology path computation as GPUs are not able to find a path to the NIC.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
