### PR TITLE
lttng: Add req_type to ProcessCompletions trace

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -23,8 +23,8 @@
 	lttng_ust_tracepoint(nccl_ofi_plugin, Flush, request, nccl_req); \
 } while(0)
 
-#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(dev,request,ctx) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, dev,request,ctx); \
+#define NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(dev,req_direction,request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletionsSendRecv, dev,req_direction,request,ctx); \
 } while(0)
 
 /***** RDMA PROTOCL *****/
@@ -94,8 +94,8 @@
 	NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num); \
 } while(0)
 
-#define NCCL_OFI_TRACE_COMPLETIONS(dev,request,ctx) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletions, dev,request,ctx); \
+#define NCCL_OFI_TRACE_COMPLETIONS(dev,req_type,request,ctx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, ProcessCompletionsRdma, dev,req_type,request,ctx); \
 } while(0)
 
 #define NCCL_OFI_TRACE_FLUSH(request, nccl_req) do { \

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -306,17 +306,35 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
-
 LTTNG_UST_TRACEPOINT_EVENT(
     nccl_ofi_plugin,
-    ProcessCompletions,
+    ProcessCompletionsSendRecv,
     LTTNG_UST_TP_ARGS(
 	    int, dev,
+            int, req_direction,
             void *, request,
             void *, ctx
     ),
     LTTNG_UST_TP_FIELDS(
 	    lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, req_direction, req_direction)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    ProcessCompletionsRdma,
+    LTTNG_UST_TP_ARGS(
+	    int, dev,
+            int, req_type,
+            void *, request,
+            void *, ctx
+    ),
+    LTTNG_UST_TP_FIELDS(
+	    lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(int, req_type, req_type)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer(uint64_t, ctx, (uint64_t)ctx)
     )

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -729,7 +729,7 @@ static inline int inc_req_completion(nccl_net_ofi_rdma_req_t *req,
 		req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
 
 		/* Trace this completion */
-		NCCL_OFI_TRACE_COMPLETIONS(req->dev_id, req, req);
+		NCCL_OFI_TRACE_COMPLETIONS(req->dev_id, req->type, req, req);
 	}
 
 	nccl_net_ofi_mutex_unlock(&req->req_lock);

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -200,7 +200,7 @@ static int sendrecv_req_handle_cq_entry(nccl_net_ofi_context_t *ctx,
 
 	nccl_net_ofi_sendrecv_req_t *req = container_of(ctx, nccl_net_ofi_sendrecv_req_t, ctx);
 
-	NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req->dev_id, req, &ctx->ofi_ctx);
+	NCCL_OFI_TRACE_COMPLETIONS_SENDRECV(req->dev_id, req->direction, req, &ctx->ofi_ctx);
 
 	if (cq_entry->flags & FI_RECV) {
 		sendrecv_req_update(req, NCCL_OFI_SENDRECV_REQ_COMPLETED, cq_entry->len);


### PR DESCRIPTION
Updated as of June 19, 2025.

In order to more easily differentiate between SENDRECV and RDMA transport
LTTng ProcessCompletions traces associated with send requests or with
recv requests, this splits ProcessCompletions into separate
ProcessCompletionsSendRecv and ProcessCompletionsRdma traces.

ProcessCompletionsRdma adds the request type (enum
nccl_net_ofi_rdma_req_type_t) as a field to the LTTng tracepoint
(req_type). Now, when processing ProcessCompletionsRdma traces you can
identify send requests which will have req_type NCCL_OFI_RDMA_SEND
(enum value of 2) and recv requests which have req_type
NCCL_OFI_RDMA_RECV (enum value of 3).

The SENDRECV transport analog to the RMDA transport request type is the
request direction (enum nccl_net_ofi_sendrecv_req_direction_t).
ProcessCompletionsSendRecv adds the request direction as a field to the
tracepoint (req_direction). Send requests will have request direction
NCCL_OFI_SENDRECV_SEND (enum value 1), and recv requests will have
request direction  NCCL_OFI_SENDRECV_RECV (enum value 2).

I split ProcessCompletions into separate tracepoints to avoid having a
field with overloaded meaning depending on the transport type. E.g. if I
just added a req_type field to ProcessCompletions to be used by both
SENDRECV and RDMA transports, there would be ambiguity for whether a
req_type value of 2 represented NCCL_OFI_RDMA_SEND or
NCCL_OFI_SENDRECV_RECV.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
