### PR TITLE
param: Change min_stripe_size default from 128K to 64K

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -280,7 +280,7 @@ OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
 /*
  * Messages sized larger than this threshold will be striped across multiple rails
  */
-OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (128 * 1024));
+OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (64 * 1024));
 
 /*
  * The round robin scheduler has two round robin counts, for small (likely


### PR DESCRIPTION
Reduce the default minimum stripe size from 128K to 64K to improve performance of the NVLSTree algorithm. Testing showed striping across multiple rails benefits messages between 64MiB to 256MiB with this lower threshold value when NVLSTree algorithm is used.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
