### PR TITLE
rdma, sendrecv: deactivate domain when closing inflight communicators

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -417,6 +417,14 @@ struct nccl_net_ofi_domain {
 	 */
 	struct fid_cq *(*get_ofi_cq)(nccl_net_ofi_domain_t *domain);
 
+	/* Domain reference counter for resource management.
+	 *
+	 * In some modes (right now, endpoint_per_communicator), we create
+	 * multiple endpoints per domain. This counter tracks the number
+	 * of endpoints created on this domain. When it reaches 0, the
+	 * domain can be destroyed. */
+	size_t ref_cnt;
+
 /* Private */
 	/* pure virtual function called when resources associated with
 	 * the ep should be destroyed.  Device lock will be held when

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -376,6 +376,7 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_ep_t *base_ep = NULL;
+	bool created_ep = false;
 	if (ofi_handle->state.stage == COMM_CREATE_START) {
 		nccl_net_ofi_device_t *device = plugin->get_device(plugin, dev_id);
 		if (device == NULL) {
@@ -387,6 +388,7 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 		if (OFI_UNLIKELY(ret != 0)) {
 			return nccl_net_ofi_retval_translate(ret);
 		}
+		created_ep = true;
 	} else {
 		base_ep = ofi_handle->state.comm->ep;
 		if (OFI_UNLIKELY(base_ep == NULL)) {
@@ -400,7 +402,12 @@ ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, in
 		(nccl_net_ofi_send_comm_t **)sComm;
 	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm, trafficClass);
 
-	if (ret != 0) {
+	if (created_ep) {
+		/**
+		 * Release the ep if we acquired one before calling
+		 * base_ep->connect(). The protocol should have acquired its own
+		 * endpoint when creating the communictor.
+		 */
 		base_ep->release_ep(base_ep, false, false);
 	}
 

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -1087,6 +1087,7 @@ int nccl_net_ofi_domain_init(nccl_net_ofi_device_t *device, nccl_net_ofi_domain_
 	domain->endpoint = NULL;
 	domain->creating_thread_id = 0;
 	domain->ref_cnt = 0;
+	domain->domain_active = true;
 
 	domain->mr_cache = NULL;
 	if (!ofi_nccl_mr_cache_disable()) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7432,7 +7432,8 @@ static int nccl_net_ofi_rdma_domain_create_endpoint(nccl_net_ofi_domain_t *base_
 
 error:
 	if (ret != 0) {
-		ep->base.release_ep(&(ep->base), false, false);
+		nccl_net_ofi_rdma_endpoint_free(&(ep->base));
+		*base_ep = nullptr;
 	}
 
 	return ret;
@@ -7589,7 +7590,7 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 
 error:
 	if (ret != 0) {
-		domain->base.release(&(domain->base), false, false);
+		nccl_net_ofi_rdma_domain_free(&domain->base);
 		domain = NULL;
 	}
 

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -1,3 +1,4 @@
+inflight_close
 nccl_connection
 nccl_message_transfer
 ring

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -18,9 +18,10 @@ CXX = $(MPICXX)
 if ENABLE_FUNC_TESTS
 noinst_HEADERS = test-common.h
 
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring
+bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close
 
 nccl_connection_SOURCES = nccl_connection.cpp
 nccl_message_transfer_SOURCES = nccl_message_transfer.cpp
 ring_SOURCES = ring.cpp
+inflight_close_SOURCES = inflight_close.cpp
 endif

--- a/tests/functional/inflight_close.cpp
+++ b/tests/functional/inflight_close.cpp
@@ -1,0 +1,315 @@
+/*
+ * Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+/**
+ * Tests closing a communicator while there are still inflight requests
+ */
+
+#include "config.h"
+
+#include <algorithm>
+#include <vector>
+
+#include "test-common.h"
+
+#define PROC_NAME_IDX(i) (i * MPI_MAX_PROCESSOR_NAME)
+
+#define RESTART_ITERS 10
+
+static ncclResult_t run_iteration(int dev, int rank, int test_support_gdr, test_nccl_net_t *extNet,
+				  int num_ranks)
+{
+	ncclResult_t res = ncclSuccess;
+
+	NCCL_OFI_TRACE(NCCL_INIT, "Rank %d uses %d device for communication", rank, dev);
+
+	int buffer_type = NCCL_PTR_HOST;
+
+	if (test_support_gdr == 1) {
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+				"Network supports communication using CUDA buffers. Dev: %d", dev);
+		buffer_type = NCCL_PTR_CUDA;
+	}
+
+	char handle[NCCL_NET_HANDLE_MAXSIZE];
+	nccl_net_ofi_send_comm_t *sComm = nullptr;
+	nccl_net_ofi_listen_comm_t *lComm = nullptr;
+	nccl_net_ofi_recv_comm_t *rComm = nullptr;
+
+	/* Initialisation for data transfer */
+	nccl_net_ofi_req_t *req[NUM_REQUESTS] = {nullptr};
+	void *mhandle[NUM_REQUESTS] = {nullptr};
+	char *send_buf[NUM_REQUESTS] = {nullptr};
+	char *recv_buf[NUM_REQUESTS] = {nullptr};
+
+	/* Data sizes. 1M */
+	const size_t send_size = 1024 * 1024;
+	const size_t recv_size = 1024 * 1024;
+
+	/* For grouped recvs */
+	const int tag = 1;
+	const int nrecv = NCCL_OFI_MAX_RECVS;
+	size_t sizes[nrecv];
+	int tags[nrecv];
+
+	int peer_rank = 0;
+
+	test_nccl_net_device_handle_t *s_ignore, *r_ignore;
+	char src_handle[NCCL_NET_HANDLE_MAXSIZE] = {};
+
+	/* Listen API */
+	NCCL_OFI_INFO(NCCL_NET, "Server: Listening on dev %d", dev);
+	OFINCCLCHECKGOTO(extNet->listen(dev, (void *)&handle, (void **)&lComm), res, exit);
+
+	if (rank == 0) {
+		peer_rank = (rank + 1) % num_ranks;
+
+		/* MPI send */
+		MPI_Send(&handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD);
+
+		/* MPI recv */
+		MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR,
+				peer_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", peer_rank);
+		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
+
+		while (sComm == NULL || rComm == NULL) {
+			/* Connect API */
+			if (sComm == NULL) {
+				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
+								&s_ignore),
+						res, exit);
+			}
+
+			/* Accept API */
+			if (rComm == NULL) {
+				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
+						res, exit);
+			}
+		}
+
+		NCCL_OFI_INFO(NCCL_NET, "Successfully accepted connection from rank %d",
+				peer_rank);
+	} else {
+		peer_rank = (rank - 1) % num_ranks;
+
+		/* MPI recv */
+		MPI_Recv((void *)src_handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+
+		/* MPI send */
+		MPI_Send((void *)handle, NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, peer_rank, 0, MPI_COMM_WORLD);
+
+		NCCL_OFI_INFO(NCCL_NET, "Send connection request to rank %d", peer_rank);
+		NCCL_OFI_INFO(NCCL_NET, "Server: Start accepting requests");
+
+		while (sComm == NULL || rComm == NULL) {
+
+			/* Connect API */
+			if (sComm == NULL) {
+				OFINCCLCHECKGOTO(extNet->connect(dev, (void *)src_handle, (void **)&sComm,
+								&s_ignore),
+						res, exit);
+			}
+
+			/* Accept API */
+			if (rComm == NULL) {
+				OFINCCLCHECKGOTO(extNet->accept((void *)lComm, (void **)&rComm, &r_ignore),
+						res, exit);
+			}
+
+		}
+
+		NCCL_OFI_INFO(NCCL_NET, "Successfully accepted connection from rank %d",
+				peer_rank);
+	}
+
+	for (int recv_n = 0; recv_n < nrecv; recv_n++) {
+		sizes[recv_n] = recv_size;
+		tags[recv_n] = tag;
+	}
+
+	if (rank == 0) {
+
+		/* Send NUM_REQUESTS to peer */
+		NCCL_OFI_INFO(NCCL_NET, "Send %d requests to rank %d", NUM_REQUESTS,
+				peer_rank);
+		for (int idx = 0; idx < NUM_REQUESTS; idx++) {
+			OFINCCLCHECKGOTO(
+				allocate_buff((void **)&send_buf[idx], send_size, buffer_type),
+				res, exit);
+			OFINCCLCHECKGOTO(
+				initialize_buff((void *)send_buf[idx], send_size, buffer_type),
+				res, exit);
+
+			OFINCCLCHECKGOTO(extNet->regMr((void *)sComm, (void *)send_buf[idx],
+							send_size, buffer_type, &mhandle[idx]),
+					 res, exit);
+			NCCL_OFI_TRACE(NCCL_NET,
+					"Successfully registered send memory for request %d of rank %d",
+					idx, rank);
+			while (req[idx] == NULL) {
+				OFINCCLCHECKGOTO(extNet->isend((void *)sComm, (void *)send_buf[idx],
+								send_size, tag, mhandle[idx],
+								(void **)&req[idx]),
+						 res, exit);
+			}
+		}
+		NCCL_OFI_INFO(NCCL_NET, "Successfully sent %d requests to rank %d", NUM_REQUESTS,
+				peer_rank);
+	} else {
+
+		/* Receive NUM_REQUESTS from peer */
+		NCCL_OFI_INFO(NCCL_NET, "Rank %d posting %d receive buffers", rank,
+				NUM_REQUESTS);
+		for (int idx = 0; idx < NUM_REQUESTS; idx++) {
+			OFINCCLCHECKGOTO(
+				allocate_buff((void **)&recv_buf[idx], recv_size, buffer_type),
+				res, exit);
+			OFINCCLCHECKGOTO(extNet->regMr((void *)rComm, (void *)recv_buf[idx],
+							recv_size, buffer_type, &mhandle[idx]),
+					 res, exit);
+			NCCL_OFI_TRACE(NCCL_NET, "Successfully registered receive memory for request %d of rank %d", idx, rank);
+			while (req[idx] == NULL) {
+				OFINCCLCHECKGOTO(extNet->irecv((void *)rComm, nrecv,
+								(void **)&recv_buf[idx], sizes, tags,
+								&mhandle[idx], (void **)&req[idx]),
+						 res, exit);
+			}
+		}
+	}
+
+	/** Close communicators with inflight requests **/
+	for (int idx = 0; idx < NUM_REQUESTS; idx++) {
+		if (rank == 0) {
+			OFINCCLCHECKGOTO(extNet->deregMr((void *)sComm, mhandle[idx]), res,
+						exit);
+		} else {
+			OFINCCLCHECKGOTO(extNet->deregMr((void *)rComm, mhandle[idx]), res,
+						exit);
+		}
+	}
+
+	OFINCCLCHECKGOTO(extNet->closeSend((void *)sComm), res, exit);
+	sComm = NULL;
+	OFINCCLCHECKGOTO(extNet->closeRecv((void *)rComm), res, exit);
+	rComm = NULL;
+	OFINCCLCHECKGOTO(extNet->closeListen((void *)lComm), res, exit);
+	lComm = NULL;
+
+	for (int idx = 0; idx < NUM_REQUESTS; idx++) {
+		if (send_buf[idx]) {
+			OFINCCLCHECKGOTO(deallocate_buffer(send_buf[idx], buffer_type), res, exit);
+			send_buf[idx] = NULL;
+		}
+		if (recv_buf[idx]) {
+			OFINCCLCHECKGOTO(deallocate_buffer(recv_buf[idx], buffer_type), res, exit);
+			recv_buf[idx] = NULL;
+		}
+	}
+
+	NCCL_OFI_INFO(NCCL_NET, "Closed communicators and deallocated buffers for rank %d",
+		      rank);
+
+exit:
+	return res;
+}
+
+int main(int argc, char* argv[])
+{
+	int rank = -1, proc_name_len = -1, num_ranks = 0, local_rank = 0;
+	
+	test_nccl_properties_t props = {};
+
+	/* Plugin defines */
+	int ndev = -1;
+	test_nccl_net_t *extNet = NULL;
+
+	ofi_log_function = logger;
+
+	/* Indicates if NICs support GPUDirect */
+	std::vector<int> test_support_gdr;
+
+	/* All processors IDs, used to find out the local rank */
+	std::vector<char> all_proc_name;
+
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &num_ranks);
+	if (num_ranks != 2) {
+		NCCL_OFI_WARN("Expected two ranks but got %d. "
+			"The inflight_close functional test should be run with exactly two ranks.",
+			num_ranks);
+		return ncclInvalidArgument;
+	}
+
+	all_proc_name.resize(num_ranks * MPI_MAX_PROCESSOR_NAME);
+
+	MPI_Get_processor_name(&all_proc_name[PROC_NAME_IDX(rank)], &proc_name_len);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, all_proc_name.data(),
+			MPI_MAX_PROCESSOR_NAME, MPI_BYTE, MPI_COMM_WORLD);
+
+	/* Determine local rank */
+	for (int i = 0; i < num_ranks; i++) {
+		if (!strcmp(&all_proc_name[PROC_NAME_IDX(rank)],
+				&all_proc_name[PROC_NAME_IDX(i)])) {
+			if (i < rank) {
+				++local_rank;
+			}
+		}
+	}
+
+	/* Set CUDA device for subsequent device memory allocation, in case GDR is used */
+	NCCL_OFI_TRACE(NCCL_NET, "Using CUDA device %d for memory allocation", local_rank);
+
+	/* Get external Network from NCCL-OFI library */
+	extNet = get_extNet();
+	if (extNet == NULL) {
+		return ncclInternalError;
+	}
+
+	/* Init API */
+	OFINCCLCHECK(extNet->init(&logger));
+	NCCL_OFI_INFO(NCCL_NET, "Process rank %d started. NCCLNet device used on %s is %s.", rank,
+			&all_proc_name[PROC_NAME_IDX(rank)], extNet->name);
+
+	/* Devices API */
+	OFINCCLCHECK(extNet->devices(&ndev));
+	NCCL_OFI_INFO(NCCL_NET, "Received %d network devices", ndev);
+
+	test_support_gdr.resize(ndev);
+
+	/* Get Properties for the device */
+	for (int dev = 0; dev < ndev; dev++) {
+		OFINCCLCHECK(extNet->getProperties(dev, &props));
+		print_dev_props(dev, &props);
+
+		/* Set CUDA support */
+		test_support_gdr[dev] = is_gdr_supported_nic(props.ptrSupport);
+	}
+
+	/* Test all devices */
+	for (int dev_idx = 0; dev_idx < ndev; dev_idx++) {
+
+		for (int i = 0; i < RESTART_ITERS; ++i) {
+
+			int dev = dev_idx;
+			if (rank == 1) {
+				/* In rank 1 scan devices in the opposite direction */
+				dev = ndev - dev_idx - 1;
+			}
+
+			OFINCCLCHECK(run_iteration(dev, rank, test_support_gdr[dev], extNet,
+						   num_ranks));
+
+			MPI_Barrier(MPI_COMM_WORLD);
+
+		}
+	}
+
+	MPI_Finalize();
+	NCCL_OFI_INFO(NCCL_NET, "Test completed successfully for rank %d", rank);
+
+	return 0;
+}


### PR DESCRIPTION
Closing a communicator that still has requests inflight will deactivate
the domain, preventing use of all other communicators on the domain for
anything except closing the communicator.

This is necessary because, when closing a communicator, the only way to
ensure user memory is no longer accessed is to close the corresponding
endpoint.

This PR also contains some marginally related bug fixes along the way.

Marked as a draft because the new domain inactive functionality needs testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
