### PR TITLE
[v1.15.x] Cherry-pick commits to have v1.15.x match head of master

### DIFF
--- a/contrib/scripts/generate_debian_changelog.sh
+++ b/contrib/scripts/generate_debian_changelog.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+fmt=" \
+tagname=%(refname:short) \
+tagger_name=%(taggername:mailmap) \
+tagger_email=%(taggeremail:mailmap) \
+tagger_when=%(taggerdate) \
+committer_name=%(committername:mailmap) \
+committer_email=%(committeremail:mailmap) \
+committer_when=%(committerdate) \
+"
+
 if [ $# -eq 0 ]; then
 	tag=HEAD
 else
@@ -12,8 +22,7 @@ if [ $? -ne 0 ]; then
 	exit 0
 fi
 
-git log --use-mailmap --no-walk --format="tagname='%D' tagger_name='%aN' tagger_email='<%aE>' tagger_when='%ad' committer_name='%cN' committer_email='<%cE>' committer_when='%cd'" \
-    --date="format:%a %b %-d %T %Y %z" $(git tag --merged "$tag") | sed "s/tagname='tag: \([^,']*\)'/tagname='\1'/" | {
+git for-each-ref --shell --sort=-v:refname --format "$fmt" --merged "$tag" | {
 	while read line; do
 		eval $line
 		(echo ${tagname} | grep -qE '^v[0-9]') || continue

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -558,7 +558,7 @@ struct nccl_net_ofi_send_comm {
 	 */
 	int (*deregMr)(nccl_net_ofi_send_comm_t *send_comm, nccl_net_ofi_mr_handle_t *mhandle);
 
-	int (*send)(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+	int (*send)(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 			     nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **req);
 
 	int (*close)(nccl_net_ofi_send_comm_t *send_comm);
@@ -591,7 +591,7 @@ struct nccl_net_ofi_recv_comm {
 	 */
 	int (*deregMr)(nccl_net_ofi_recv_comm_t *recv_comm, nccl_net_ofi_mr_handle_t *mhandle);
 
-	int (*recv)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, int *sizes, int *tags,
+	int (*recv)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, size_t *sizes, int *tags,
 			     nccl_net_ofi_mr_handle_t **mhandles, nccl_net_ofi_req_t **req);
 
 	int (*flush)(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **data, int *sizes,

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -278,6 +278,12 @@ struct nccl_net_ofi_device {
 	int dev_id;
 
 	/*
+	 * Globally unique identifier for the device. An opaque identifier
+	 * returned to NCCL without assumptions about individual platforms.
+	 */
+	uint64_t guid;
+
+	/*
 	 * name of the device - should include the provider name, but may be
 	 * augmented (in the case of mrail).  Set during the transport's
 	 * initialization, and should be read-only from that point.

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -15,18 +15,19 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 /*
  * @brief	Allocates and initialises libfabric endpoint and AV.
  *
+ * @param cq:	Completion queue to which the new endpoint will be bound
  * @return	Endpoint ep
  * @return	Address vector av
  */
 int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *domain,
 				      struct fid_ep **ep,   struct fid_av **av,
-				      struct fid_cq **cq);
+				      struct fid_cq *cq);
 
 /*
  * @brief	Release libfabric endpoint and address vector
  */
 void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av,
-				  struct fid_cq *cq, int dev_id);
+				  int dev_id);
 
 /*
  * @brief	Free libfabric NIC info list.

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -49,6 +49,15 @@ int platform_config_endpoint(struct fi_info *info, struct fid_ep *ep) __attribut
  */
 void platform_sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups) __attribute__((weak));
 
+/*
+ * Platform-specific guid property setter
+ *
+ * This overrides the default guid setter (nccl_net_ofi_device_set_guid()) which
+ * is based on network device index and IP address. Platforms can set
+ * device->guid to be any 64-bit value as they seem fit to uniquely identify the
+ * network device.
+ */
+void platform_device_set_guid(struct fi_info *info, struct nccl_net_ofi_device *device) __attribute__((weak));
 
 /*
  * does the platform have an opinion on domain_per_thread configuration?

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -802,9 +802,6 @@ typedef struct nccl_net_ofi_rdma_device {
 	 * and its base struct. */
 	nccl_net_ofi_device_t base;
 
-	/* Message scheduler */
-	nccl_net_ofi_scheduler_t *scheduler;
-
 	/* Number of rails */
 	uint16_t num_rails;
 
@@ -850,6 +847,9 @@ typedef struct nccl_net_ofi_rdma_domain {
 
 	/* List of endpoints and set of addresses they have connections to */
 	nccl_ofi_ep_addr_list_t *ep_addr_list;
+
+	/* Message scheduler */
+	nccl_net_ofi_scheduler_t *scheduler;
 } nccl_net_ofi_rdma_domain_t;
 
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -669,9 +669,6 @@ struct nccl_net_ofi_ep_rail {
 	/* Address vector handle */
 	struct fid_av *av;
 
-	/* Completion Queue handle */
-	struct fid_cq *cq;
-
 	/*
 	 * Rx buffer management
 	 */

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -125,9 +125,6 @@ typedef struct nccl_net_ofi_sendrecv_ep {
 	/* Address vector handle */
 	struct fid_av *av;
 
-	/* Completion Queue handle */
-	struct fid_cq *cq;
-
 	/* free list for control messages */
 	nccl_ofi_freelist_t *conn_msg_fl;
 } nccl_net_ofi_sendrecv_ep_t;
@@ -143,6 +140,10 @@ typedef struct nccl_net_ofi_sendrecv_domain {
 
 	/* Access Domain handle */
 	struct fid_domain *domain;
+
+	/* Completion Queue handle */
+	struct fid_cq *cq;
+
 } nccl_net_ofi_sendrecv_domain_t;
 
 

--- a/include/nccl_ofi_system.h
+++ b/include/nccl_ofi_system.h
@@ -19,6 +19,13 @@
  */
 uint32_t nccl_ofi_get_unique_node_id(void);
 
+
+/*
+ * @brief   Generic device GUID setter based on network device index and IP
+ *          address of the host. Platforms can override with with
+ *          platform_device_set_guid() as needed.
+ */
+void nccl_net_ofi_device_set_guid(struct fi_info *info, struct nccl_net_ofi_device *device);
 /*
  * @brief   Reads the product name from the DMI information.
  *          The caller must free the returned string.

--- a/include/nccl_ofi_system.h
+++ b/include/nccl_ofi_system.h
@@ -6,6 +6,20 @@
 #define NCCL_OFI_SYSTEM_H_
 
 /*
+ * @brief   Retrieves a unique ID for the current node. This is based on the IP
+ *          address of the first non-loopback network interface.  For IPv4 addresses,
+ *          returns the address directly as a 32-bit value.  For IPv6 addresses
+ *          (used only when no IPv4 is available), returns a 32-bit reduction of
+ *          the IPv6 address. Prioritizes IPv4 over IPv6 addresses.
+ *
+ * @return  uint32_t representation of a node-unique ID.
+ *
+ * @throws  std::runtime_error if no suitable interface is found or if the system
+ *          call to retrieve network interfaces fails
+ */
+uint32_t nccl_ofi_get_unique_node_id(void);
+
+/*
  * @brief   Reads the product name from the DMI information.
  *          The caller must free the returned string.
  *          Provides the manufacturer-assigned product name

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -23,6 +23,13 @@ struct ec2_platform_data {
 };
 
 
+struct platform_aws_node_guid {
+	uint8_t func_idx;
+	uint8_t per_card_pci_bus;
+	uint16_t per_card_pci_domain;
+	uint32_t func_mac_low_bytes;
+};
+
 /*
  * @brief        Get the platform data map
  *

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -52,7 +52,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     Send,
     LTTNG_UST_TP_ARGS(
             int, dev,
-            int, size,
+            size_t, size,
             void *, comm,
             uint16_t, msg_seq_num,
             void *, request,
@@ -60,7 +60,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
@@ -238,14 +238,14 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_ARGS(
             int, dev,
             void *, comm,
-            int, size,
+            size_t, size,
             void *, request,
             void *, nccl_req
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
-            lttng_ust_field_integer(int, size, size)
+            lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
     )

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -3524,7 +3524,7 @@ static int process_cq_if_pending(nccl_net_ofi_rdma_ep_t *ep)
 }
 
 static int recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
-			 int *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
+			 size_t *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
 			 nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
@@ -5854,7 +5854,7 @@ static inline int check_post_rx_buff_req(nccl_net_ofi_rdma_req_t *rx_buff_req)
  * @brief	Send a message. This "interface function" is called, indirectly, from
  *       	the application
  */
-static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+static int send(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 			 nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7699,14 +7699,6 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	/* at this point, we can safely call the destructor to clean
 	 * up */
 
-	/* Ensure that number of rails are the same across devices */
-	length = ofi_info_list_length(info_list);
-	if (topo->max_group_size != length) {
-		NCCL_OFI_WARN("Wrong number of NICs for device %i. Expected %i but got %i",
-			      dev_id, topo->max_group_size, length);
-		goto error;
-	}
-
 	/* allow the user to force the number of rails used by the
 	 * device.  If the target number is smaller than the number of
 	 * rails, just pick the first target_length rails.  If the
@@ -7719,6 +7711,7 @@ static nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_device_create(
 	 * between NICs, rather than sending target_length/length
 	 * messages on the same NIC before moving to the next NIC.
 	 */
+	length = ofi_info_list_length(info_list);
 	target_length = ofi_nccl_force_num_rails();
 	if (target_length != 0) {
 		int original_length = length;

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1068,7 +1068,7 @@ static inline nccl_net_ofi_sendrecv_req_t *sendrecv_allocate_req(nccl_ofi_freeli
 }
 
 static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, void **buffers,
-				   int *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
+				   size_t *sizes, int *tags, nccl_net_ofi_mr_handle_t **mhandles,
 				   nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;
@@ -1846,7 +1846,7 @@ static int sendrecv_send_comm_dereg_mr(nccl_net_ofi_send_comm_t *send_comm,
 				  domain->base.mr_cache);
 }
 
-static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *data, int size, int tag,
+static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *data, size_t size, int tag,
 				   nccl_net_ofi_mr_handle_t *mhandle, nccl_net_ofi_req_t **base_req)
 {
 	int ret = 0;

--- a/src/nccl_ofi_system.cpp
+++ b/src/nccl_ofi_system.cpp
@@ -107,6 +107,18 @@ uint32_t nccl_ofi_get_unique_node_id(void)
 	return ip_addr;
 }
 
+void nccl_net_ofi_device_set_guid(struct fi_info *info, struct nccl_net_ofi_device *device)
+{
+        uint32_t node_id = nccl_ofi_get_unique_node_id();
+
+        /*
+         * Use device_index as lower 8 bits
+         * Use node_id as next 32 bits (bits 8-39)
+         * Upper 24 bits remain 0
+         */
+        device->guid = (static_cast<uint64_t>(node_id) << 8) | device->dev_id;
+}
+
 const char *nccl_net_ofi_get_product_name(void)
 {
 	char file[] = SYSFS_PRODUCT_NAME_STR;

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -498,16 +498,19 @@ int platform_init(const char **provider_filter)
 	if ((platform_data && !platform_data->net_flush_required) &&
 	    NULL == getenv("NCCL_NET_FORCE_FLUSH")) {
 
-		/* Hopper GPUs do not require a network flush, but NCCL versions <2.19.1
-		* still enable flush by default on any GPU type.
-		* For GPU generations earlier than Hopper, NCCL always enables flush, while
-		* for Hopper GPUs flush is enabled or disabled depending on the value of
-		* the NCCL_NET_FORCE_FLUSH environment variable. The default value for this
-		* variable is 1 for NCCL versions <2.19.1, which forces flush when it is not
-		* needed, so it is safe to set it to 0 if it is not explicitly set.
-		*/
+		/*
+		 * Certain GPU architectures do not require a network flush, but
+		 * NCCL versions <2.19.1 still enable flush by default on any
+		 * GPU type.  For GPU generations earlier than Hopper, NCCL
+		 * always enables flush, while for Hopper GPUs flush is enabled
+		 * or disabled depending on the value of the
+		 * NCCL_NET_FORCE_FLUSH environment variable. The default value
+		 * for this variable is 1 for NCCL versions <2.19.1, which
+		 * forces flush when it is not needed, so it is safe to set it
+		 * to 0 if it is not explicitly set.
+		 */
 
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting NCCL_NET_FORCE_FLUSH=0 for Hopper GPUs");
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Setting NCCL_NET_FORCE_FLUSH=0 since this platform does not require a network flush.");
 		ret = setenv("NCCL_NET_FORCE_FLUSH", "0", 0);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Unable to set NCCL_NET_FORCE_FLUSH");

--- a/topology/g5.48xl-topo.xml
+++ b/topology/g5.48xl-topo.xml
@@ -21,5 +21,6 @@ virtual machine.
     <pci busid="0000:00:1b.0"/>
     <pci busid="0000:00:1c.0"/>
     <pci busid="0000:00:1d.0"/>
+    <pci busid="0000:00:15.0"/>
   </cpu>
 </system>


### PR DESCRIPTION
Cherry-picked below commits from head of master branch:
```
ad2cf10 rdma: Do not send close message for unused r_comm
4825229 rdma: Refactor recv_comm_process_all_finalizing
a7dedd7 aws: Provide a more appropriate GUID to NCCL
3b1171d system: Add utility to generate a unique node identifier.
c887c00 rdma: Allow for devices with varying number of rails
9010983 rdma,sendrecv: refactor completion queue to the domain
a19783c topo: add NIC to numa domain on g5.48xlarge platforms
e8e1641 Revert "build: remove git mailmap usage"
cc47fda scheduler: move schduler to domain level
8c0c882 api: Update and increment send/recv functions
```
Which should make `v1.15.x` match the head of `master` (as of the time of cutting this PR).

---

With force push added:
```
ba9b7c9 platform: Generalize log message indicating network flush behavior
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
