### PR TITLE
nvtx: fix build error due to argument name

### DIFF
--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -150,7 +150,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req) do { \
+#define NCCL_OFI_TRACE_RECV_NVTX(dev, r_comm, size, request, nccl_req) do { \
 	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
 			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \


### PR DESCRIPTION
Commit 1c97c90 changed the macro `NCCL_OFI_TRACE_RECV_NVTX` argument name to `comm`, which conflicted with that name's use inside the macro. Change the name to `r_comm` to avoid the conflict.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
