### PR TITLE
fix: Set CQ size to match EFA RDM path

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -225,6 +225,11 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE",
  */
 OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
 
+/* 
+ * Completion queue size. Defaults to EFA RDM path size.
+ */
+OFI_NCCL_PARAM_UINT(cq_size, "CQ_SIZE", 12288);
+
 /*
  * Protocol to use for send/recv operations.  Valid options are
  * SENDRECV and RDMA, with SENDRECV the default.  Default param is

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7522,6 +7522,7 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 		   opened on this domain rail */
 		struct fi_cq_attr cq_attr = {};
 		cq_attr.format = FI_CQ_FORMAT_DATA;
+		cq_attr.size = ofi_nccl_cq_size();
 		ret = fi_cq_open(domain_rail->domain, &cq_attr, &domain_rail->cq, NULL);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2478,6 +2478,7 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_ne
 
 	/* Create a domain-shared completion queue */
 	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = ofi_nccl_cq_size();
 	ret = fi_cq_open(domain->domain, &cq_attr, &domain->cq, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",


### PR DESCRIPTION
*Description of changes:*

The efa-direct path was using a smaller default CQ size (1K). Update fi_cq_open to use the same CQ size as the EFA RDM path by explicitly setting cq_attr->size.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
