### PR TITLE
build: Force C++ library linkage for `libnccl-net-ofi`

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -67,6 +67,7 @@ else
   lib_LTLIBRARIES = libnccl-net-ofi.la
   libnccl_net_ofi_la_SOURCES =
   libnccl_net_ofi_la_LIBADD = libinternal_net_plugin.la
+  libnccl_net_ofi_la_LIBTOOLFLAGS = --tag=CXX
   libnccl_net_ofi_la_LDFLAGS = -module -avoid-version
 
 


### PR DESCRIPTION
Currently, `libnccl-net-ofi.la` does not depend on any C++ source files
(instead depending on an internal library, `libinternal_net_plugin.la`),
and so is built as a C library (using `gcc` instead of `g++`), which
means it is not linked against the C++ standard library. Add `--tag=CXX`
to force C++ linkage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
