### PR TITLE
ci: Update workflow to use pre-built docker containers

### DIFF
--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -1,0 +1,124 @@
+name: Update CI Containers
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  workflow_dispatch:
+
+jobs:
+  build-amazonlinux-containers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sdk: [cuda, neuron]
+        efainstaller: [latest, 1.25.0]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Build and push amazonlinux containers
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.al2023
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-al2023:${{ matrix.sdk }}-efa${{ matrix.efainstaller }}
+          build-args: |
+            ENABLE_CUDA=${{ matrix.sdk == 'cuda' }}
+            EFA_INSTALLER_VERSION=${{ matrix.efainstaller }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-ubuntu-containers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cc-variant: [latest, legacy]
+        cc: [gcc, clang]
+        tracing: [lttng, none]
+        sdk: [cuda, neuron]
+        include:
+          - cc-variant: latest
+            cc: clang
+            cc-version: 18
+          - cc-variant: latest
+            cc: gcc
+            cc-version: 13
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Build and push ubuntu containers
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.ubuntu
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.cc-variant }}-${{ matrix.tracing }}-efalattest
+          build-args: |
+            CC_TYPE=${{ matrix.cc }}
+            CC_VARIANT=${{ matrix.cc-variant }}
+            CC_VERSION=${{ matrix.cc-version }}
+            ENABLE_TRACING=${{ matrix.tracing == 'lttng' }}
+            ENABLE_CUDA=${{ matrix.sdk == 'cuda' }}
+            EFA_INSTALLER_VERSION=latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-codechecker-containers:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sdk: [cuda, neuron]
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          
+      - name: Build and push CodeChecker containers
+        uses: docker/build-push-action@v4
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.codechecker
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-codechecker:${{ matrix.sdk }}-latest
+          build-args: |
+            LLVM_VERSION=18
+            CODECHECKER_VERSION=v6.23.1
+            ENABLE_CUDA=${{ matrix.sdk == 'cuda' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/docker/base/Dockerfile.al2023
+++ b/docker/base/Dockerfile.al2023
@@ -1,0 +1,43 @@
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023
+
+# Accept build argument
+ARG ENABLE_CUDA=false
+ARG EFA_INSTALLER_VERSION=latest
+
+# Install ALL required base packages and development tools
+RUN yum -y update && \
+    yum -y install --allowerasing \
+    git \
+    tar \
+    util-linux \
+    findutils \
+    yum-utils \
+    hwloc-devel \
+    autoconf \
+    automake \
+    libtool \
+    gcc \
+    gcc-c++ \
+    make \
+    curl \
+    && yum clean all
+
+# Install CUDA if enabled
+RUN if [ "$ENABLE_CUDA" = "true" ]; then \
+        dnf config-manager --add-repo \
+        http://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo \
+        --save && \
+        yum -y clean expire-cache && \
+        yum -y install cuda-cudart-devel-12-6 cuda-crt-12-6 && \
+        yum clean all; \
+    fi
+
+# Install EFA
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-*.tar.gz && \
+    cd aws-efa-installer/RPMS/ALINUX2023/x86_64 && \
+    find . | grep rpm$ | xargs yum -y localinstall && \
+    cd ../../../.. && \
+    rm -rf aws-efa-installer*
+
+WORKDIR /workspace

--- a/docker/base/Dockerfile.codechecker
+++ b/docker/base/Dockerfile.codechecker
@@ -1,0 +1,111 @@
+FROM ubuntu:22.04
+
+# Implementation of https://github.com/whisperity/codechecker-action
+# This Dockerfile provides a pre-built environment for running CodeChecker analysis
+# with the same functionality as the GitHub Action
+
+ARG CODECHECKER_VERSION=v6.23.1
+ARG CC_VERSION=18
+ARG EFA_INSTALLER_VERSION=latest
+ARG ENABLE_CUDA=false
+
+# Install base packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository multiverse && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl \
+    wget \
+    git \
+    build-essential \
+    gcc-multilib \
+    libhwloc-dev \
+    lsb-release \
+    pciutils \
+    environment-modules \
+    tcl \
+    udev \
+    dmidecode \
+    ethtool \
+    iproute2 \
+    libevent-core-2.1-7 \
+    libevent-pthreads-2.1-7 \
+    libnl-3-200 \
+    libnl-3-dev \
+    libnl-route-3-200 \
+    libnl-route-3-dev \
+    python3-dev \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    cppcheck && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install LLVM/Clang - matches the version used in whisperity/codechecker-action
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh ${CC_VERSION} && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    clang-tidy-${CC_VERSION} \
+    clang-${CC_VERSION} \
+    clang-tools-${CC_VERSION} \
+    libclang-common-${CC_VERSION}-dev \
+    libclang-${CC_VERSION}-dev \
+    libllvm${CC_VERSION} \
+    llvm-${CC_VERSION} \
+    llvm-${CC_VERSION}-dev \
+    llvm-${CC_VERSION}-runtime && \
+    # Set up clang alternatives
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CC_VERSION} 100 && \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CC_VERSION} 100 && \
+    # Set up PATH and compiler environment
+    ln -s /usr/lib/llvm-${CC_VERSION}/bin/* /usr/local/bin/ && \
+    # Verify symbolic links
+    ls -la /usr/local/bin/clang* && \
+    ls -la /usr/local/bin/llvm* && \
+    # Make environment settings permanent
+    echo "export PATH=/usr/lib/llvm-${CC_VERSION}/bin:\${PATH}" >> /etc/bash.bashrc && \
+    echo "export CC=clang-${CC_VERSION}" >> /etc/bash.bashrc && \
+    echo "export CXX=clang++-${CC_VERSION}" >> /etc/bash.bashrc && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Node.js and Python dependencies
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | bash - && \
+    apt-get install -y nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    pip3 install portalocker multiprocess psutil sarif-tools
+
+# Install CodeChecker - same version as whisperity/codechecker-action
+RUN git clone --depth 1 --branch ${CODECHECKER_VERSION} https://github.com/Ericsson/CodeChecker.git && \
+    cd CodeChecker && \
+    make venv && \
+    . venv/bin/activate && \
+    BUILD_LOGGER_64_BIT_ONLY=YES make package && \
+    cp -r build/CodeChecker /opt/ && \
+    ln -s /opt/CodeChecker/bin/CodeChecker /usr/local/bin/CodeChecker && \
+    # Verify CodeChecker installation
+    CodeChecker version && \
+    cd .. && \
+    rm -rf CodeChecker
+
+# Install EFA
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-*.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod && \
+    cd .. && \
+    rm -rf aws-efa-installer*
+
+# Install CUDA if enabled
+RUN if [ "$ENABLE_CUDA" = "true" ]; then \
+        repo="ubuntu$(lsb_release -r | cut -d':' -f2 | xargs | sed 's/[.]//g')" && \
+        wget https://developer.download.nvidia.com/compute/cuda/repos/${repo}/$(uname -m)/cuda-keyring_1.1-1_all.deb && \
+        dpkg -i cuda-keyring_1.1-1_all.deb && \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-cudart-dev-12-6 cuda-crt-12-6 && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+WORKDIR /workspace

--- a/docker/base/Dockerfile.ubuntu
+++ b/docker/base/Dockerfile.ubuntu
@@ -1,0 +1,85 @@
+# docker/base/Dockerfile.ubuntu
+FROM ubuntu:22.04
+
+# Accept build arguments
+ARG CC_TYPE=gcc
+ARG CC_VARIANT=latest
+ARG CC_VERSION
+ARG ENABLE_TRACING=false
+ARG ENABLE_CUDA=false
+ARG EFA_INSTALLER_VERSION=latest
+
+# Enable all Ubuntu repositories and install base packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    software-properties-common && \
+    add-apt-repository universe && \
+    add-apt-repository multiverse && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    curl wget git build-essential gcc-multilib \
+    libhwloc-dev make sudo lsb-release pciutils \
+    libevent-core-2.1-7 libevent-pthreads-2.1-7 \
+    udev dmidecode ethtool iproute2 \
+    environment-modules tcl \
+    libnl-3-200 libnl-3-dev \
+    libnl-route-3-200 libnl-route-3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install EFA
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-*.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod && \
+    cd .. && \
+    rm -rf aws-efa-installer*
+
+# Install compiler based on arguments
+RUN apt-get update && \
+    if [ "$CC_TYPE" = "clang" ]; then \
+        if [ "$CC_VARIANT" = "latest" ]; then \
+            wget https://apt.llvm.org/llvm.sh && \
+            chmod +x llvm.sh && \
+            ./llvm.sh ${CC_VERSION} && \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            clang-${CC_VERSION} clang++-${CC_VERSION} && \
+            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-${CC_VERSION} 100 && \
+            update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-${CC_VERSION} 100; \
+        else \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            clang-14 lldb-14 lld-14 && \
+            update-alternatives --install /usr/bin/clang clang /usr/bin/clang-14 100 && \
+            update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-14 100; \
+        fi; \
+    elif [ "$CC_TYPE" = "gcc" ]; then \
+        if [ "$CC_VARIANT" = "latest" ]; then \
+            add-apt-repository -y ppa:ubuntu-toolchain-r/test && \
+            apt-get update && \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-${CC_VERSION} g++-${CC_VERSION} && \
+            update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-${CC_VERSION} 100 && \
+            update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-${CC_VERSION} 100; \
+        else \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y gcc g++; \
+        fi; \
+        update-alternatives --install /usr/bin/cc cc /usr/bin/gcc 100 && \
+        update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++ 100; \
+    fi && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install CUDA if enabled
+RUN if [ "$ENABLE_CUDA" = "true" ]; then \
+        repo="ubuntu$(lsb_release -r | cut -d':' -f2 | xargs | sed 's/[.]//g')" && \
+        wget https://developer.download.nvidia.com/compute/cuda/repos/${repo}/$(uname -m)/cuda-keyring_1.1-1_all.deb && \
+        dpkg -i cuda-keyring_1.1-1_all.deb && \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-cudart-dev-12-6 cuda-crt-12-6 && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Install lttng if enabled
+RUN if [ "$ENABLE_TRACING" = "true" ]; then \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y liblttng-ust-dev && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+WORKDIR /workspace


### PR DESCRIPTION
*Description of changes:*

- Created new workflow to build and maintain Docker containers, updated weekly
- Each build type has its own container in GitHub Container Registry:
  * aws-ofi-nccl-al2023
  * aws-ofi-nccl-ubuntu
  * aws-ofi-nccl-codechecker


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
