### PR TITLE
[v1.15.x] Cherry-pick recent commits

### DIFF
--- a/3rd-party/Makefile.am
+++ b/3rd-party/Makefile.am
@@ -16,6 +16,7 @@ noinst_HEADERS = \
 	nccl/cuda/include/nccl/net_v7.h \
 	nccl/cuda/include/nccl/net_v8.h \
 	nccl/cuda/include/nccl/net_v9.h \
+	nccl/cuda/include/nccl/net_v10.h \
 	nccl/cuda/include/nccl/tuner.h \
 	nccl/cuda/include/nccl/tuner_v1.h \
 	nccl/cuda/include/nccl/tuner_v2.h \

--- a/3rd-party/nccl/cuda/include/nccl/net.h
+++ b/3rd-party/nccl/cuda/include/nccl/net.h
@@ -25,7 +25,9 @@ typedef enum {NCCL_LOG_NONE=0, NCCL_LOG_VERSION=1, NCCL_LOG_WARN=2, NCCL_LOG_INF
 typedef enum {NCCL_INIT=1, NCCL_COLL=2, NCCL_P2P=4, NCCL_SHM=8, NCCL_NET=16, NCCL_GRAPH=32, NCCL_TUNING=64, NCCL_ENV=128, NCCL_ALLOC=256, NCCL_CALL=512, NCCL_ALL=~0} ncclDebugLogSubSys;
 
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
+typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* phandle, int64_t pluginId, void* extData);
 
+#include "net_v10.h"
 #include "net_v9.h"
 #include "net_v8.h"
 #include "net_v7.h"

--- a/3rd-party/nccl/cuda/include/nccl/net_device.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_device.h
@@ -28,6 +28,6 @@ typedef struct {
 
 typedef ncclNetDeviceHandle_v7_t ncclNetDeviceHandle_v8_t;
 typedef ncclNetDeviceHandle_v8_t ncclNetDeviceHandle_v9_t;
-typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_t;
-
+typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_v10_t;
+typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_t;
 #endif

--- a/3rd-party/nccl/cuda/include/nccl/net_v10.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_v10.h
@@ -2,17 +2,27 @@
  * Copyright (c) 2017-2022, NVIDIA CORPORATION. All rights reserved.
  */
 
-#ifndef NCCL_NET_V9_H_
-#define NCCL_NET_V9_H_
+#ifndef NET_V10_H_
+#define NET_V10_H_
 
+#include "types.h"
 #include "net_device.h"
 
-#define NCCL_NET_MAX_DEVS_PER_NIC_V9 4
-#define NCCL_NET_MAX_DEVS_PER_NIC NCCL_NET_MAX_DEVS_PER_NIC_V9
+#define NCCL_NET_MAX_DEVS_PER_NIC_V10 4
 typedef struct {
   int ndevs;
-  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V9];
-} ncclNetVDeviceProps_v9_t;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V10];
+} ncclNetVDeviceProps_v10_t;
+typedef ncclNetVDeviceProps_v10_t ncclNetVDeviceProps_t;
+
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v10_t;
+typedef ncclNetCommConfig_v10_t ncclNetCommConfig_t;
+
 
 typedef struct {
   char* name;                      // Used mostly for logging.
@@ -29,21 +39,21 @@ typedef struct {
   int maxRecvs;                    // Maximum number of grouped receives.
   ncclNetDeviceType netDeviceType; // Network offload type
   int netDeviceVersion;            // Version number for network offload
-  ncclNetVDeviceProps_v9_t vProps;
+  ncclNetVDeviceProps_v10_t vProps;
   size_t maxP2pBytes;              // Max transfer size for point-to-point operations
   size_t maxCollBytes;             // Max transfer size for collective operations
-} ncclNetProperties_v9_t;
-
+} ncclNetProperties_v10_t;
+typedef ncclNetProperties_v10_t ncclNetProperties_t;
 
 typedef struct {
   // Name of the network (mainly for logs)
   const char* name;
   // Initialize the network.
-  ncclResult_t (*init)(ncclDebugLogger_t logFunction);
+  ncclResult_t (*init)(ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
   // Return the number of adapters.
   ncclResult_t (*devices)(int* ndev);
   // Get various device properties.
-  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v9_t* props);
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v10_t* props);
   // Create a receiving object and provide a handle to connect to it. The
   // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
   // between ranks to create a connection.
@@ -53,13 +63,13 @@ typedef struct {
   // should return successfully with sendComm == NULL with the expectation that
   // it will be called again until sendComm != NULL.
   // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
-  ncclResult_t (*connect)(int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v9_t** sendDevComm);
+  ncclResult_t (*connect)(int dev, ncclNetCommConfig_v10_t* config, void* handle, void** sendComm, ncclNetDeviceHandle_v10_t** sendDevComm);
   // Finalize connection establishment after remote peer has called connect.
   // This call must not block for the connection to be established, and instead
   // should return successfully with recvComm == NULL with the expectation that
   // it will be called again until recvComm != NULL.
   // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
-  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v9_t** recvDevComm);
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v10_t** recvDevComm);
   // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
   // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
   ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
@@ -68,10 +78,10 @@ typedef struct {
   ncclResult_t (*deregMr)(void* comm, void* mhandle);
   // Asynchronous send to a peer.
   // May return request == NULL if the call cannot be performed (or would block)
-  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void** request);
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
   // Asynchronous recv from a peer.
   // May return request == NULL if the call cannot be performed (or would block)
-  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** request);
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
   // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
   // visible to the GPU
   ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
@@ -91,7 +101,7 @@ typedef struct {
 
   // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
   // what index this new vNIC exists at
-  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_t* props);
-} ncclNet_v9_t;
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v10_t* props);
+} ncclNet_v10_t;
 
 #endif // end include guard

--- a/3rd-party/nccl/cuda/include/nccl/types.h
+++ b/3rd-party/nccl/cuda/include/nccl/types.h
@@ -5,6 +5,25 @@
 #ifndef NCCL_TYPES_H_
 #define NCCL_TYPES_H_
 
+/* Reduction operation selector */
+typedef enum { ncclNumOps_dummy = 5 } ncclRedOp_dummy_t;
+typedef enum { ncclSum          = 0,
+               ncclProd         = 1,
+               ncclMax          = 2,
+               ncclMin          = 3,
+               ncclAvg          = 4,
+               /* ncclNumOps: The number of built-in ncclRedOp_t values. Also
+                * serves as the least possible value for dynamic ncclRedOp_t's
+                * as constructed by ncclRedOpCreate*** functions. */
+               ncclNumOps       = 5,
+               /* ncclMaxRedOp: The largest valid value for ncclRedOp_t.
+                * It is defined to be the largest signed value (since compilers
+                * are permitted to use signed enums) that won't grow
+                * sizeof(ncclRedOp_t) when compared to previous NCCL versions to
+                * maintain ABI compatibility. */
+               ncclMaxRedOp		= 0x7fffffff>>(32-8*sizeof(ncclRedOp_dummy_t))
+} ncclRedOp_t;
+
 /* Data types */
 typedef enum { ncclInt8       = 0, ncclChar       = 0,
                ncclUint8      = 1,

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -472,7 +472,8 @@ struct nccl_net_ofi_ep {
 	 */
 	int (*connect)(nccl_net_ofi_ep_t *ep,
 				nccl_net_ofi_conn_handle_t *handle,
-				nccl_net_ofi_send_comm_t **send_comm);
+				nccl_net_ofi_send_comm_t **send_comm,
+				int trafficClass);
 
 	/*
 	 * @brief	Release nccl_ofi_ep.
@@ -544,6 +545,7 @@ struct nccl_net_ofi_listen_comm {
 
 struct nccl_net_ofi_send_comm {
 	nccl_net_ofi_comm_t base;
+	// TODO: Potentially store this here: int trafficClass;
 
 	/*
 	 * @brief	Register memory region on send communicator (both Host and CUDA)

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -810,4 +810,9 @@ long nccl_net_ofi_gettid(void);
  */
 int nccl_net_ofi_configure_nccl_proto_simple(const char *log_reason);
 
+/*
+ * generate host hash for topology file
+ */
+uint64_t getHostHash(void);
+
 #endif // End NCCL_OFI_H_

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -22,6 +22,7 @@ ncclResult_t nccl_net_ofi_listen_v5(int dev, void* handle, void **listenComm);
 // here, we just declare them in the nvidia interface file to keep this list sane.
 ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void **sendComm);
 ncclResult_t nccl_net_ofi_connect_v5(int dev, void* handle, void **sendComm);
+ncclResult_t nccl_net_ofi_connect_v10(int dev, void *handle, void **sendComm, int trafficClass);
 ncclResult_t nccl_net_ofi_accept_v2(void *listenComm, void **recvComm);
 ncclResult_t nccl_net_ofi_accept_v5(void* listenComm, void** recvComm);
 ncclResult_t nccl_net_ofi_regMr_v2(void *comm, void *data, int size, int type,
@@ -37,12 +38,16 @@ ncclResult_t nccl_net_ofi_isend_v5(void *sendComm, void* data, int size, int tag
 				   void** request);
 ncclResult_t nccl_net_ofi_isend_v9(void *sendComm, void* data, size_t size, int tag, void *mhandle,
 				   void** request);
+ncclResult_t nccl_net_ofi_isend_v10(void* sendComm, void* data, size_t size, int tag, void* mhandle,
+                                    void* phandle, void** request);
 ncclResult_t nccl_net_ofi_irecv_v2(void* recvComm, void* data, int size, void* mhandle,
 				   void** request);
 ncclResult_t nccl_net_ofi_irecv_v5(void* recvComm, int n, void** buffers, int* sizes, int *tags,
 				   void** mhandles, void** request);
 ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** buffers, size_t* sizes, int *tags,
 				   void** mhandles, void** request);
+ncclResult_t nccl_net_ofi_irecv_v10(void* recvComm, int n, void** data, size_t* sizes, int* tags,
+                                    void** mhandles, void** phandles, void** request);
 ncclResult_t nccl_net_ofi_test_v2(void *request, int *done, int *size);
 ncclResult_t nccl_net_ofi_flush_v2(void* recvComm, void* data, int size, void* mhandle);
 ncclResult_t nccl_net_ofi_iflush_v4(void* recvComm, void* data, int size, void* mhandle,

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -225,6 +225,11 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE",
  */
 OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
 
+/* 
+ * Completion queue size. Defaults to EFA RDM path size.
+ */
+OFI_NCCL_PARAM_UINT(cq_size, "CQ_SIZE", 12288);
+
 /*
  * Protocol to use for send/recv operations.  Valid options are
  * SENDRECV and RDMA, with SENDRECV the default.  Default param is

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -150,7 +150,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req) do { \
+#define NCCL_OFI_TRACE_RECV_NVTX(dev, r_comm, size, request, nccl_req) do { \
 	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
 			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -18,6 +18,7 @@ sources = \
 	nccl_ofi_topo.cpp \
 	nccl_ofi_mr.cpp \
 	nccl_ofi_msgbuff.cpp \
+	nccl_ofi_nccl_compat.cpp \
 	nccl_ofi_freelist.cpp \
 	nccl_ofi_idpool.cpp \
 	nccl_ofi_ofiutils.cpp \

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -68,6 +68,7 @@ else
   lib_LTLIBRARIES = libnccl-net-ofi.la
   libnccl_net_ofi_la_SOURCES =
   libnccl_net_ofi_la_LIBADD = libinternal_net_plugin.la
+  libnccl_net_ofi_la_LIBTOOLFLAGS = --tag=CXX
   libnccl_net_ofi_la_LDFLAGS = -module -avoid-version
 
 

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -289,6 +289,12 @@ ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void** sendComm)
 }
 
 
+ncclResult_t nccl_net_ofi_connect_v5(int dev_id, void *handle, void **sComm)
+{
+    return nccl_net_ofi_connect_v10(dev_id, handle, sComm, -1);
+}
+
+
 /*
  * @brief	Non-blocking connect which returns sComm as NULL
  *		with an expectation that it will be called again until 
@@ -313,7 +319,7 @@ ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void** sendComm)
  * @return	0, on success
  * 		error, on others
  */
-ncclResult_t nccl_net_ofi_connect_v5(int dev_id, void *handle, void **sComm)
+ncclResult_t nccl_net_ofi_connect_v10(int dev_id, void *handle, void **sComm, int trafficClass)
 {
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == NULL)) {
@@ -353,7 +359,7 @@ ncclResult_t nccl_net_ofi_connect_v5(int dev_id, void *handle, void **sComm)
 	/* Connect */
 	nccl_net_ofi_send_comm_t **send_comm =
 		(nccl_net_ofi_send_comm_t **)sComm;
-	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm);
+	int ret = base_ep->connect(base_ep, (nccl_net_ofi_conn_handle_t *)handle, send_comm, trafficClass);
 
 	if (ret != 0) {
 		base_ep->release_ep(base_ep, false, false);
@@ -610,6 +616,15 @@ ncclResult_t nccl_net_ofi_isend_v9(void* sendComm, void* data, size_t size,
 	return nccl_net_ofi_retval_translate(ret);
 }
 
+
+ncclResult_t nccl_net_ofi_isend_v10(void* sendComm, void* data, size_t size,
+					int tag, void* mhandle, void* phandle, void** request)
+{
+	// TODO: Add support for network profiling events via pHandles.
+	return nccl_net_ofi_isend_v9(sendComm, data, size, tag, mhandle, request);
+}
+
+
 ncclResult_t nccl_net_ofi_irecv_v2(void* recvComm, void* data, int size,
 				   void* mhandle, void** request)
 {
@@ -681,6 +696,15 @@ ncclResult_t nccl_net_ofi_irecv_v9(void* recvComm, int n, void** data,
 	int ret = recv_comm->recv(recv_comm, n, data, sizes, tags, handles, base_req);
 	return nccl_net_ofi_retval_translate(ret);
 }
+
+
+ncclResult_t nccl_net_ofi_irecv_v10(void* recvComm, int n, void** data, size_t* sizes, int* tags,
+				   void** mhandles, void** phandles, void** request)
+{
+	// TODO: Add support for network profiling events via pHandles.
+	return nccl_net_ofi_irecv_v9(recvComm, n, data, sizes, tags, mhandles, request);
+}
+
 
 ncclResult_t nccl_net_ofi_test_v2(void* req, int* done, int* size)
 {

--- a/src/nccl_ofi_nccl_compat.cpp
+++ b/src/nccl_ofi_nccl_compat.cpp
@@ -1,0 +1,152 @@
+/*************************************************************************
+ * Copyright (c) 2016-2020, NVIDIA CORPORATION. All rights reserved.
+ *
+
+ Redistribution and use in source and binary forms, with or without
+ modification, are permitted provided that the following conditions
+ are met:
+  * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+  * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+  * Neither the name of NVIDIA CORPORATION, Lawrence Berkeley National
+    Laboratory, the U.S. Department of Energy, nor the names of their
+    contributors may be used to endorse or promote products derived
+    from this software without specific prior written permission.
+
+ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+ EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+ CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ The U.S. Department of Energy funded the development of this software
+ under subcontract 7078610 with Lawrence Berkeley National Laboratory.
+ *
+ ************************************************************************/
+
+/*
+ * Note: Code in this file was taken directly from NCCL to guarantee that
+ * getHostHash() returns the same value in our generated topology as the NCCL
+ * generated topology, because NCCL does not properly add the host_hash field to
+ * a minimal topology file.  THe path to removing this code is to remove the
+ * need to generate topology files at all on NCCL versions that support
+ * multinode NVL, which thankfully are also the versions that support the vNIC
+ * interface.
+ */
+
+#include "config.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "nccl_ofi.h"
+
+// The hash isn't just a function of the bytes but also where the bytes are split
+// into different calls to eatHash().
+static inline void eatHash(uint64_t acc[2], const void* bytes, size_t size) {
+  char const* ptr = (char const*)bytes;
+  acc[0] ^= size;
+  while (size != 0) {
+    // Mix the accumulator bits.
+    acc[0] += acc[1];
+    acc[1] ^= acc[0];
+    acc[0] ^= acc[0] >> 31;
+    acc[0] *= 0x9de62bbc8cef3ce3;
+    acc[1] ^= acc[1] >> 32;
+    acc[1] *= 0x485cd6311b599e79;
+    // Read in a chunk of input.
+    size_t chunkSize = size < sizeof(uint64_t) ? size : sizeof(uint64_t);
+    uint64_t x = 0;
+    memcpy(&x, ptr, chunkSize);
+    ptr += chunkSize;
+    size -= chunkSize;
+    // Add to accumulator.
+    acc[0] += x;
+  }
+}
+
+static inline uint64_t digestHash(uint64_t const acc[2]) {
+  uint64_t h = acc[0];
+  h ^= h >> 31;
+  h *= 0xbac3bd562846de6b;
+  h += acc[1];
+  h ^= h >> 32;
+  h *= 0x995a187a14e7b445;
+  return h;
+}
+
+static inline uint64_t getHash(const void* bytes, size_t size) {
+  uint64_t acc[2] = {1, 1};
+  eatHash(acc, bytes, size);
+  return digestHash(acc);
+}
+
+static int getHostName(char* hostname, int maxlen, const char delim) {
+  if (gethostname(hostname, maxlen) != 0) {
+    strncpy(hostname, "unknown", maxlen);
+    return -1;
+  }
+  int i = 0;
+  while ((hostname[i] != delim) && (hostname[i] != '\0') && (i < maxlen-1)) i++;
+  hostname[i] = '\0';
+  return 0;
+}
+
+static uint64_t hostHashValue = 0;
+/* Generate a hash of the unique identifying string for this host
+ * that will be unique for both bare-metal and container instances
+ * Equivalent of a hash of;
+ *
+ * $(hostname)$(cat /proc/sys/kernel/random/boot_id)
+ *
+ * This string can be overridden by using the NCCL_HOSTID env var.
+ */
+#define HOSTID_FILE "/proc/sys/kernel/random/boot_id"
+static void getHostHashOnce() {
+  char hostHash[1024];
+  const char *hostId;
+
+  // Fall back is the full hostname if something fails
+  (void) getHostName(hostHash, sizeof(hostHash), '\0');
+  int offset = strlen(hostHash);
+
+  if ((hostId = getenv("NCCL_HOSTID")) != NULL) {
+    strncpy(hostHash, hostId, sizeof(hostHash)-1);
+    hostHash[sizeof(hostHash)-1] = '\0';
+  } else {
+    FILE *file = fopen(HOSTID_FILE, "r");
+    if (file != NULL) {
+      char *p;
+      if (fscanf(file, "%ms", &p) == 1) {
+        strncpy(hostHash+offset, p, sizeof(hostHash)-offset-1);
+        free(p);
+      }
+      fclose(file);
+    }
+  }
+
+  // Make sure the string is terminated
+  hostHash[sizeof(hostHash)-1]='\0';
+
+  hostHashValue = getHash(hostHash, strlen(hostHash));
+}
+
+uint64_t getHostHash(void) {
+  static pthread_once_t once = PTHREAD_ONCE_INIT;
+  pthread_once(&once, getHostHashOnce);
+  return hostHashValue;
+}
+
+

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6833,8 +6833,9 @@ static int post_send_conn(nccl_net_ofi_rdma_send_comm_t *s_comm,
  * communicator rails using the received connect responce message.
  */
 static int connect(nccl_net_ofi_ep_t *base_ep,
-			    nccl_net_ofi_conn_handle_t *handle,
-			    nccl_net_ofi_send_comm_t **send_comm)
+		   nccl_net_ofi_conn_handle_t *handle,
+		   nccl_net_ofi_send_comm_t **send_comm,
+		   int trafficClass)
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_req_state_t conn_resp_req_state;
@@ -7001,6 +7002,8 @@ static int connect(nccl_net_ofi_ep_t *base_ep,
 	++num_open_comms;
 	nccl_net_ofi_mutex_unlock(&comm_cleanup_list_lock);
 
+	// TODO: Integrate the trafficClass by potentially storing it in the send_comm
+	// structure or a endpoint structure.
 	*send_comm = &s_comm->base;
 
 	return ret;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7522,6 +7522,7 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_create_domain(nccl_net_of
 		   opened on this domain rail */
 		struct fi_cq_attr cq_attr = {};
 		cq_attr.format = FI_CQ_FORMAT_DATA;
+		cq_attr.size = ofi_nccl_cq_size();
 		ret = fi_cq_open(domain_rail->domain, &cq_attr, &domain_rail->cq, NULL);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2189,7 +2189,8 @@ static ssize_t sendrecv_send_comm_send_connect_message(nccl_net_ofi_sendrecv_sen
 
 static int sendrecv_endpoint_connect(nccl_net_ofi_ep_t *base_ep,
 				     nccl_net_ofi_conn_handle_t *handle,
-				     nccl_net_ofi_send_comm_t **send_comm)
+				     nccl_net_ofi_send_comm_t **send_comm,
+				     int trafficClass)
 {
 	int ret = 0;
 	ssize_t rc = 0;
@@ -2300,6 +2301,8 @@ static int sendrecv_endpoint_connect(nccl_net_ofi_ep_t *base_ep,
 		return -EINVAL;
 	};
 
+	// TODO: Integrate the trafficClass by potentially storing it in the send_comm
+	// structure or a endpoint structure.
 	*send_comm = &s_comm->base;
 	assert((nccl_net_ofi_comm_t *)s_comm == req->comm);
 	conn_info = (nccl_ofi_connection_info_t *)s_comm->conn_info->ptr;

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2478,6 +2478,7 @@ static nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_create_domain(nccl_ne
 
 	/* Create a domain-shared completion queue */
 	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = ofi_nccl_cq_size();
 	ret = fi_cq_open(domain->domain, &cq_attr, &domain->cq, NULL);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",


### PR DESCRIPTION
Cherry-picked below commits from head of master branch:
```
fd4cbfb fix: Set CQ size to match EFA RDM path
2729a5f build: Force C++ library linkage for `libnccl-net-ofi`
4c548c5 nvtx: fix build error due to argument name
085f9c9 api: Integrating v10 api
f16f5bd update: Adding v10 api to 3rd party headers
3a85eba topo: Add host_hash field to generated topology
```

Which should make `v1.15.x` match the `HEAD~1` of master as of the time of cutting this PR (excluding commit `param: Change min_stripe_size default from 128K to 64K` #878).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
