### PR TITLE
actions: Do not build Neuron without platform-aws

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -53,6 +53,7 @@ jobs:
           - public.ecr.aws/amazonlinux/amazonlinux:2023
         efainstaller:
           - latest
+          - 1.34.0
           - 1.25.0
         exclude:
           # Neuron requires platform-aws, which requires newer EFA installer
@@ -62,6 +63,11 @@ jobs:
           - efainstaller: latest
             platform-aws: enable
 
+          - efainstaller: 1.34.0
+            platform-aws: enable
+
+          # Platform-aws requires newer EFA installer, so disable it for builds
+          # with legacy EFA installer
           - efainstaller: 1.25.0
             platform-aws: disable
 

--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -54,6 +54,10 @@ jobs:
         efainstaller:
           - latest
           - 1.25.0
+        exclude:
+          # Neuron requires platform-aws, which requires newer EFA installer
+          - efainstaller: 1.25.0
+            sdk: neuron
         include:
           - efainstaller: latest
             platform-aws: enable


### PR DESCRIPTION
There is no use case for Neuron builds without AWS platform. Since AWS
platform builds of the plugin require EFA installer 1.34 or later, do
not attempt a Neuron build with older EFA installer.

Follow-up commit includes EFA installer 1.34 for increased testing coverage.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
