### PR TITLE
fix: Force C++ library linkage for `libnccl-net-ofi` on neuron

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -54,6 +54,7 @@ if ENABLE_NEURON
   lib_LTLIBRARIES = libnccom-net.la
   libnccom_net_la_SOURCES =
   libnccom_net_la_LIBADD = libinternal_net_plugin.la
+  libnccom_net_la_LIBTOOLFLAGS = --tag=CXX
   libnccom_net_la_LDFLAGS = -module -avoid-version
 else
   noinst_LTLIBRARIES += libinternal_net_cudart_plugin.la


### PR DESCRIPTION
Currently, `libnccl-net-ofi.la` does not depend on any C++ source files (instead depending on an internal library,
`libinternal_net_plugin.la`) when build for neuron platforms, and so is built as a C library (using `gcc` instead of `g++`), which means it is not linked against the C++ standard library. Add `--tag=CXX` to force C++ linkage.

This fix has previously added for non-neuron platforms. This PR adds same fix when neuron is enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
