### PR TITLE
test: Add unit test verifying c application can dlopen library

### DIFF
--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -8,3 +8,4 @@ region_based_tuner
 scheduler
 histogram
 histogram_binner
+dlopen_c_test

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
 LDADD = $(top_builddir)/src/libinternal_net_plugin.la
-noinst_HEADERS = test-common.h
+noinst_HEADERS = test-logger.h
 
 noinst_PROGRAMS = \
 	freelist \
@@ -21,7 +21,8 @@ noinst_PROGRAMS = \
 	ep_addr_list \
 	mr \
 	histogram_binner \
-	histogram
+	histogram \
+	dlopen_c_test
 
 if WANT_PLATFORM_AWS
 noinst_PROGRAMS += aws_platform_mapper
@@ -47,6 +48,7 @@ mr_SOURCES = mr.cpp
 aws_platform_mapper_SOURCES = aws_platform_mapper.cpp
 histogram_binner_SOURCES = histogram_binner.cpp
 histogram_SOURCES = histogram.cpp
+dlopen_c_test_SOURCES = dlopen_c_test.c
 
 TESTS = $(noinst_PROGRAMS)
 endif

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -4,7 +4,8 @@
 
 #include "config.h"
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include <stdio.h>
 #include <string.h>
 

--- a/tests/unit/dlopen_c_test.c
+++ b/tests/unit/dlopen_c_test.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <assert.h>
+#include <stdint.h>
+#include <dlfcn.h>
+#include <string.h>
+
+#include "test-logger.h"
+
+nccl_ofi_logger_t ofi_log_function = NULL;
+
+/*
+ * This is a simple C test that loads the shared object dynamically
+ * for the AWS OFI NCCL plugin
+ */
+
+int main(int argc, char *argv[])
+{
+	void *handle = NULL;
+	char *error = NULL;
+	int ret = 0;
+	char *lib_path = NULL;
+
+	/* Set up logging */
+	ofi_log_function = logger;
+
+	/* Try to load the appropriate shared object based on build configuration */
+#if HAVE_NEURON
+	lib_path = "../../src/.libs/libnccom-net.so";
+	NCCL_OFI_INFO(NCCL_INIT, "Testing Neuron build: attempting to load %s\n", lib_path);
+#elif HAVE_CUDA
+	lib_path = "../../src/.libs/libnccl-net-ofi.so";
+	NCCL_OFI_INFO(NCCL_INIT, "Testing standard build: attempting to load %s\n", lib_path);
+#else
+#error "Need either Neuron or Cuda"
+#endif
+
+	/* Open the shared object file */
+	handle = dlopen(lib_path, RTLD_NOW | RTLD_LOCAL);
+	if (!handle) {
+		NCCL_OFI_WARN("Error opening shared object: %s\n", dlerror());
+		return 1;
+	}
+
+	/* Log test progress */
+	NCCL_OFI_INFO(NCCL_INIT, "Successfully loaded AWS OFI NCCL plugin shared object");
+
+	/* Close the shared object */
+	dlclose(handle);
+
+	NCCL_OFI_INFO(NCCL_INIT, "Test completed successfully!\n");
+
+	return 0;
+}

--- a/tests/unit/ep_addr_list.cpp
+++ b/tests/unit/ep_addr_list.cpp
@@ -6,7 +6,8 @@
 
 #include <stdio.h>
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include "nccl_ofi_ep_addr_list.h"
 
 static void insert_addresses(nccl_ofi_ep_addr_list_t &ep_addr_list, size_t num_addr, int ep_num)

--- a/tests/unit/freelist.cpp
+++ b/tests/unit/freelist.cpp
@@ -6,7 +6,8 @@
 
 #include <stdio.h>
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include "nccl_ofi_freelist.h"
 
 void *simple_base;

--- a/tests/unit/histogram.cpp
+++ b/tests/unit/histogram.cpp
@@ -6,7 +6,8 @@
 
 #include <iostream>
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include "stats/histogram.h"
 
 

--- a/tests/unit/idpool.cpp
+++ b/tests/unit/idpool.cpp
@@ -7,7 +7,8 @@
 #include <stdexcept>
 #include <stdio.h>
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_math.h"
 

--- a/tests/unit/mr.cpp
+++ b/tests/unit/mr.cpp
@@ -6,7 +6,8 @@
 
 #include <stdlib.h>
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 #include "nccl_ofi_mr.h"
 
 static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,

--- a/tests/unit/msgbuff.cpp
+++ b/tests/unit/msgbuff.cpp
@@ -8,7 +8,8 @@
 
 #include "nccl_ofi_msgbuff.h"
 
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 
 int main(int argc, char *argv[])
 {

--- a/tests/unit/scheduler.cpp
+++ b/tests/unit/scheduler.cpp
@@ -11,7 +11,8 @@
 
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_scheduler.h"
-#include "test-common.h"
+#include "nccl_ofi.h"
+#include "test-logger.h"
 
 static inline int verify_xfer_info(nccl_net_ofi_xfer_info_t *xfer, nccl_net_ofi_xfer_info_t *ref_xfer, int xfer_id)
 {

--- a/tests/unit/test-logger.h
+++ b/tests/unit/test-logger.h
@@ -2,13 +2,12 @@
  * Copyright (c) 2018-2023 Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef TEST_COMMON_H_
-#define TEST_COMMON_H_
+#ifndef TEST_LOGGER_H_
+#define TEST_LOGGER_H_
 
 #include <stdarg.h>
 #include <stdio.h>
 
-#include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 
 static inline void logger(ncclDebugLogLevel level, unsigned long flags, const char *filefunc,
@@ -45,5 +44,5 @@ static inline void logger(ncclDebugLogLevel level, unsigned long flags, const ch
 	va_end(vargs);
 #pragma GCC diagnostic pop
 }
+#endif // End TEST_LOGGER_H_
 
-#endif // End TEST_COMMON_H_


### PR DESCRIPTION
This test checks whether plugin library can be loaded with dlopen from c application . The reason is that plugin formerly didn't link against libstdc++ and relied on application to provide required linkage. This has been fixed by recent commit but test was not added.

This test should only be merged after PR https://github.com/aws/aws-ofi-nccl/pull/897, which fixes above mentioned issue on neuron platforms, has been merged.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
