### PR TITLE
update: Updating latency value for p5 and p6 based on empirical search

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -82,11 +82,22 @@ static struct ec2_platform_data platform_data_map[] = {
 	{
 		.name = "p-series",
 		/*
-		 * we only want to match P5 and later, as earlier
+		 * we only want to match P5en and later, as earlier
 		 * platforms all either need to be ignored or special
 		 * cased.
 		 */
-		.regex = "^p([5-9]|[0-9]{2,}).*",
+		.regex = "^(p5en\\.48xlarge)|(^p([6-9]|[0-9]{2,}).*)",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 35.0,
+		.gdr_required = true,
+		.net_flush_required = false,
+		.default_protocol = "RDMA",
+		.domain_per_thread = 0,
+	},
+	{
+		.name = "p5/p5e",
+		.regex = "^p5(e?\\..*)",
 		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 75.0,

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -57,9 +57,10 @@ static int check_known_platforms(void)
 	ret += check_value(platform_data_list, len, "p3dn.24xlarge", "p3dn.24xlarge");
 	ret += check_value(platform_data_list, len, "p4d.24xlarge", "p4d.24xlarge");
 	ret += check_value(platform_data_list, len, "p4de.24xlarge", "p4de.24xlarge");
-	ret += check_value(platform_data_list, len, "p5.48xlarge", "p-series");
-	ret += check_value(platform_data_list, len, "p5e.48xlarge", "p-series");
+	ret += check_value(platform_data_list, len, "p5.48xlarge", "p5/p5e");
+	ret += check_value(platform_data_list, len, "p5e.48xlarge", "p5/p5e");
 	ret += check_value(platform_data_list, len, "p5en.48xlarge", "p-series");
+	ret += check_value(platform_data_list, len, "p6-b200.48xlarge", "p-series");
 	ret += check_value(platform_data_list, len, "g5.48xlarge", "g5.48xlarge");
 	ret += check_value(platform_data_list, len, "g6.16xlarge", NULL);
 


### PR DESCRIPTION
*Description of changes:*
Updating hard coded latency values for p5 and p6 to 35 us based on an empirical search and analysis difference configurations. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
