### PR TITLE
rmda: enable READ and REMOTE_READ flags for both host and accelerator buffers

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -485,16 +485,17 @@ static int set_mr_req_attr(uint64_t mr_key,
 	/* Add FI_WRITE (source of fi_write) and FI_REMOTE_WRITE (target of fi_write) 
 	   for RDMA send/recv buffers */
 	mr_attr->access |= (FI_WRITE | FI_REMOTE_WRITE);
+	/* Add FI_READ (destination buffer for RMA read) and FI_REMOTE_READ
+	   (source buffer for RMA read) for buffers of both eager mode and flush. */
+	mr_attr->access |= (FI_READ | FI_REMOTE_READ);
 	nccl_ofi_mr_ckey_fill_mr_attrs(ckey, mr_attr, flags);
 
 	switch (type) {
 	case NCCL_PTR_HOST:
-		mr_attr->access |= FI_READ;
 		mr_attr->iface = FI_HMEM_SYSTEM;
 		break;
 #if HAVE_CUDA
 	case NCCL_PTR_CUDA:
-		mr_attr->access |= FI_REMOTE_READ;
 		mr_attr->iface = FI_HMEM_CUDA;
 
 		/* Get CUDA device ID */
@@ -508,7 +509,6 @@ static int set_mr_req_attr(uint64_t mr_key,
 #endif
 #if HAVE_NEURON
 	case NCCL_PTR_NEURON:
-		mr_attr->access |= FI_REMOTE_READ;
 		mr_attr->iface = FI_HMEM_NEURON;
 		/*
 		 * Store a sentinel; libfabric requires this to be initialized Libfabric


### PR DESCRIPTION
*Description of changes*:

RDMA protocol supports both eager mode and flush:
* For eager mode, protocol will read from host memory and put data into accelerator memory. Thus, host memory needs to be set with FI_REMOTE_READ flag and accelerator memory needs to be set with FI_READ flag.
* For flush, protocol will read from accelerator memory and put data into host memory. Thus, host memory needs to be set with FI_READ flag and accelerator memory needs to be set with FI_REMOTE_READ flag.

This PR enables FI_READ and FI_REMOTE_READ access flags for both host memory and accelerator memory to support both eager mode and flush.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
