### PR TITLE
Introduce a new functional test for NCCL abort hanging.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,9 @@
 /libtool
 **/.libs
 include/config.h*
+**/*.out
+/install/
+.vscode/
 
 # Below this line is an unmodified copy of
 # https://github.com/github/gitignore/blob/main/Autotools.gitignore

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -26,6 +26,7 @@ dependencies with the following flags:
   --with-cuda=PATH        Path to non-standard CUDA installation
   --with-mpi=PATH         Path to non-standard MPI installation
   --with-hwloc=PATH       Path to non-standard HWLOC installation
+  --with-nccl=PATH        Path to non-standard NCCL installation
 ```
 
 By default, the configure script attempts to auto-detect whether it is running

--- a/configure.ac
+++ b/configure.ac
@@ -147,6 +147,7 @@ CHECK_ENABLE_MEMFD_CREATE()
 
 # do we want our tests?
 CHECK_PKG_MPI([found_mpi="yes"], [found_mpi="no"])
+CHECK_PKG_NCCL([found_nccl="yes"], [found_nccl="no"])
 
 AC_ARG_ENABLE([tests],
    [AS_HELP_STRING([--disable-tests], [Disable build of unit/functional test binaries])])
@@ -155,8 +156,8 @@ build_unit_tests=yes
 build_func_tests=yes
 AS_IF([test "${enable_tests}" == "no"],
       [build_unit_tests=no build_func_tests=no])
-AS_IF([test "${enable_tests}" != "no" -a "${found_mpi}" = "no" ],
-      [AC_MSG_WARN([Cannot build functional tests without MPI. Disabling functional tests.])
+AS_IF([test "${enable_tests}" != "no" -a \("${found_mpi}" = "no" -o "${found_nccl}" = "no"\)],
+      [AC_MSG_WARN([Cannot build functional tests without MPI or NCCL. Disabling functional tests.])
        build_func_tests=no])
 AS_IF([test "${enable_tests}" != "no" -a "${have_device_interface}" = "neuron" ],
       [AC_MSG_WARN([Functional tests not available on neuron, disabling.])

--- a/m4/check_pkg_nccl.m4
+++ b/m4/check_pkg_nccl.m4
@@ -1,0 +1,56 @@
+# -*- autoconf -*-
+#
+# Copyright (c) 2025      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+AC_DEFUN([CHECK_PKG_NCCL], [
+      check_pkg_found=yes
+      check_pkg_CPPFLAGS_save="${CPPFLAGS}"
+      check_pkg_LDFLAGS_save="${LDFLAGS}"
+      check_pkg_LIBS_save="${LIBS}"
+
+      AC_ARG_WITH([nccl],
+            [AS_HELP_STRING([--with-nccl=PATH], [Path to non-standard NCCL installation])])
+
+      AS_IF([test -n "${with_nccl}"], 
+            [NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --with-nccl=${with_nccl}"])
+
+      AS_IF([test -z "${with_nccl}" -o "${with_nccl}" = "yes"],
+            [],
+            [test "${with_nccl}" = "no"],
+            [check_pkg_found=no],
+            [AS_IF([test -d ${with_nccl}/lib64], 
+                  [check_pkg_libdir="lib64"], 
+                  [check_pkg_libdir="lib"])
+            NCCL_CPPFLAGS="-isystem ${with_nccl}/include"
+            CPPFLAGS="${NCCL_CPPFLAGS} ${CUDA_CPPFLAGS} ${CPPFLAGS}"
+            NCCL_LDFLAGS="-L${with_nccl}/${check_pkg_libdir}"
+            LDFLAGS="${NCCL_LDFLAGS} ${LDFLAGS}"
+            NCCL_LIBS="-lnccl"
+            LIBS="${NCCL_LIBS} ${LIBS}"])
+
+      AS_IF([test "${check_pkg_found}" = "yes"],
+            [AC_CHECK_HEADERS([nccl.h], 
+            [],
+            [check_pkg_found=no])])
+
+      AS_IF([test "${check_pkg_found}" = "yes"],
+            [$1], # found_nccl="yes"
+            [$2]) # found_nccl="no"
+
+      AC_SUBST([NCCL_CPPFLAGS])
+      AC_SUBST([NCCL_LDFLAGS])
+      AC_SUBST([NCCL_LIBS])
+
+      CPPFLAGS="${check_pkg_CPPFLAGS_save}"
+      LDFLAGS="${check_pkg_LDFLAGS_save}"
+      LIBS="${check_pkg_LIBS_save}"
+
+      AS_UNSET([check_pkg_found])
+      AS_UNSET([check_pkg_libdir])
+      AS_UNSET([check_pkg_CPPFLAGS_save])
+      AS_UNSET([check_pkg_LDFLAGS_save])
+      AS_UNSET([check_pkg_LIBS_save])
+])

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -9,18 +9,19 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
-AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
-AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
-LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
+AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS) $(NCCL_CPPFLAGS)
+AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS) $(NCCL_LDFLAGS)
+LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS) $(NCCL_LIBS)
 CC = $(MPICC)
 CXX = $(MPICXX)
 
 if ENABLE_FUNC_TESTS
 noinst_HEADERS = test-common.h
 
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring
+bin_PROGRAMS = nccl_connection nccl_message_transfer nccl_abort ring 
 
 nccl_connection_SOURCES = nccl_connection.cpp
 nccl_message_transfer_SOURCES = nccl_message_transfer.cpp
+nccl_abort_SOURCES = nccl_abort.cpp
 ring_SOURCES = ring.cpp
 endif

--- a/tests/functional/nccl_abort.cpp
+++ b/tests/functional/nccl_abort.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+/*
+ * This test validates functionality of NCCL & plugin, specifically upon ncclCommAbort().
+ */
+
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstdint>
+#include <unistd.h>
+#include "config.h"
+#include "cuda_runtime.h"
+#include "mpi.h"
+#include "nccl.h"
+
+#define DELAY_INCREMENT 100000
+#define DELAY_START 100000
+#define DELAY_END 1000000
+
+#define MPICHECK(cmd)                                \
+    do                                               \
+    {                                                \
+        int e = cmd;                                 \
+        if (e != MPI_SUCCESS)                        \
+        {                                            \
+            printf("Failed: MPI error %s:%d '%d'\n", \
+                   __FILE__, __LINE__, e);           \
+            exit(EXIT_FAILURE);                      \
+        }                                            \
+    } while (0)
+
+#define CUDACHECK(cmd)                                         \
+    do                                                         \
+    {                                                          \
+        cudaError_t e = cmd;                                   \
+        if (e != cudaSuccess)                                  \
+        {                                                      \
+            printf("Failed: CUDA error %s:%d '%s'\n",          \
+                   __FILE__, __LINE__, cudaGetErrorString(e)); \
+            exit(EXIT_FAILURE);                                \
+        }                                                      \
+    } while (0)
+
+#define NCCLCHECK(cmd)                                         \
+    do                                                         \
+    {                                                          \
+        ncclResult_t e = cmd;                                  \
+        if (e != ncclSuccess && e != ncclInProgress)           \
+        {                                                      \
+            printf("Failed: NCCL error %s:%d '%s'\n",          \
+                   __FILE__, __LINE__, ncclGetErrorString(e)); \
+            exit(EXIT_FAILURE);                                \
+        }                                                      \
+    } while (0)
+
+static unsigned long djb2Hash(char *str)
+{
+    unsigned long hash = 5381;
+    int c;
+    while ((c = (int)*str++))
+        hash = ((hash << 5) + hash) + c;
+    return hash;
+}
+
+static void getHostName(char *hostname)
+{
+    gethostname(hostname, HOST_NAME_MAX);
+    hostname[HOST_NAME_MAX] = '\0';
+}
+
+static void testAbortDoesNotHang(unsigned int delay_usec)
+{
+    // Initialize MPI ranks.
+    int myRank, nRanks, localRank = 0;
+    MPICHECK(MPI_Comm_rank(MPI_COMM_WORLD, &myRank));
+    MPICHECK(MPI_Comm_size(MPI_COMM_WORLD, &nRanks));
+
+    // Calculate and select a GPU based on the derived localRank.
+    uint64_t hostHashes[nRanks];
+    char hostname[HOST_NAME_MAX + 1];
+    getHostName(hostname);
+    hostHashes[myRank] = djb2Hash(hostname);
+    MPICHECK(MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, hostHashes, sizeof(uint64_t), MPI_BYTE, MPI_COMM_WORLD));
+    for (int p = 0; p < nRanks; p++)
+    {
+        if (p == myRank)
+            break;
+        if (hostHashes[p] == hostHashes[myRank])
+            localRank++;
+    }
+    CUDACHECK(cudaSetDevice(localRank));
+
+    // Initialize NCCL communicator.
+    ncclUniqueId id;
+    ncclResult_t ret;
+    ncclComm_t comm;
+    ncclConfig_t config = NCCL_CONFIG_INITIALIZER;
+    config.blocking = 0; // Important to keep the communicator non-blocking, such that the ncclCommAbort() does not wait for A2A collective to finish.
+    if (myRank == 0)
+        NCCLCHECK(ncclGetUniqueId(&id));
+    MPICHECK(MPI_Bcast(&id, sizeof(id), MPI_BYTE, 0, MPI_COMM_WORLD));
+    NCCLCHECK(ncclCommInitRankConfig(&comm, nRanks, id, myRank, &config));
+    do
+    {
+        NCCLCHECK(ncclCommGetAsyncError(comm, &ret));
+    } while (ret == ncclInProgress);
+
+    // Perform the actual A2A NCCL collective operation.
+    // We choose A2A here, as it forms a full-mesh sendComm and recvComm across all ranks.
+    // This setup maximizes the odds of raising the hanging bug fixed by PR #875.
+    char *sendbuff, *recvbuff;
+    cudaStream_t stream;
+    int size = 32 * 1024 * 1024; // 32 MiB.
+    size_t count = size / nRanks;
+    CUDACHECK(cudaMalloc(&sendbuff, size));
+    CUDACHECK(cudaMalloc(&recvbuff, size));
+    CUDACHECK(cudaStreamCreate(&stream));
+    NCCLCHECK(ncclGroupStart());
+    for (int r = 0; r < nRanks; r++)
+    {
+        NCCLCHECK(ncclSend(((char *)sendbuff) + r * count, count, ncclChar, r, comm, stream));
+        NCCLCHECK(ncclRecv(((char *)recvbuff) + r * count, count, ncclChar, r, comm, stream));
+    }
+    NCCLCHECK(ncclGroupEnd());
+
+    // Sleep for N micro-seconds (parameterized argument), then abort.
+    // If all resources are properly cleaned-up, below call should not fail nor hang.
+    usleep(delay_usec);
+    NCCLCHECK(ncclCommAbort(comm));
+    CUDACHECK(cudaStreamSynchronize(stream));
+    CUDACHECK(cudaStreamDestroy(stream));
+}
+
+int main(int argc, char *argv[])
+{
+    MPICHECK(MPI_Init(&argc, &argv));
+    for (unsigned int delay_usec = DELAY_START; delay_usec <= DELAY_END; delay_usec += DELAY_INCREMENT)
+    {
+        printf("Test run for delay usec: %u starting.\n", delay_usec);
+        testAbortDoesNotHang(delay_usec);
+        MPICHECK(MPI_Barrier(MPI_COMM_WORLD)); // Barrier for all processes to iterate over one delay value at a time.
+    }
+    MPICHECK(MPI_Finalize());
+    return 0;
+}


### PR DESCRIPTION
Adds a new functional test (alongside `check_pkg_nccl` as as pre-requisite for calling NCCL collective APIs from our functional tests), to verify the Abort + hanging fix addressed by PR #875.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.