### PR TITLE
Remove owners stale owner entries

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,15 +9,6 @@
 # Multi-rail scheduler
 *scheduler*	@rauteric
 
-# Algorithm/protocol tuner
-/src/tuner/	@rajachan
-
 # autotools
 configure.ac	@bwbarrett
 /m4/		@bwbarrett
-
-# Github Workflows
-/.github/	@rajachan
-
-# AWS CI
-/.ci/aws	@a-szegel


### PR DESCRIPTION
As people have moved to other projects, some of our code owner entries have gotten stale.  Since some of these don't have single experts to replace them, just fall into the default case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
