### PR TITLE
rdma: Fix endpoint-per-communicator rx buffer posting

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -4702,6 +4702,12 @@ static nccl_net_ofi_rdma_recv_comm_t *prepare_recv_comm(nccl_net_ofi_rdma_domain
 			}
 
 			nccl_net_ofi_rdma_ep_t *new_ep = (nccl_net_ofi_rdma_ep_t *)new_base_ep;
+
+			ret = post_rx_buffs(new_ep);
+			if (ret != 0) {
+				goto error;
+			}
+
 			new_ep->is_endpoint_per_communicator_ep = true;
 
 			ep_for_addr = &new_ep->base;


### PR DESCRIPTION
Recently (57f424b), we delayed posting of rx buffers from endpoint creation until connection establishment routines were called. This resulted in us never posting rx buffers for endpoints created in endpoint-per-communicator mode, resulting in a hang.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
