### PR TITLE
[V1.15.x] Cherry-pick Ubuntu 24.04 README update 

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,12 +36,12 @@ reports if that is the case.
 
 The plugin is regularly tested on the following operating systems:
 
-* Amazon Linux 2023
-* Amazon Linux 2
-* Ubuntu 20.04 LTS and 22.04 LTS
+* Amazon Linux 2 and Amazon Linux 2023
+* Ubuntu 20.04 LTS, 22.04 LTS and 24.04 LTS.
 
-Other operating systems are likely to work; there is very little
-distribution-specific code in the plugin.
+Other operating systems are likely to work, but are not included in our regular
+regression testing. If you find an issue unique to another operating system,
+GitHub issues or (better yet) patches are appreciated.
 
 To build the plugin, you need to have
 [Libfabric](http://github.com/ofiwg/libfabric/) and


### PR DESCRIPTION
We included this in the release notes and README in the v1.14.x release branch, but did not update the README in master.

Back-porting this change to the `v1.15.x` release branch.

(cherry picked from commit 4037f5e6c454d9f2099792d54106dcb683ad9740)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
