### PR TITLE
Update version number in v1.15.x release branch

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [GitHub-dev], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.15.0a1], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.cpp])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
Update the v1.15.x version number to v1.15.0a1 to differentiate the release branch from the head of master.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
