### PR TITLE
api: refactor base init/fini functionality into subroutines

### DIFF
--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -12,7 +12,7 @@
 struct nccl_ofi_properties;
 
 ncclResult_t nccl_net_ofi_init_v2(ncclDebugLogger_t logFunction);
-ncclResult_t nccl_net_ofi_init_no_atexit_fini_v6(ncclDebugLogger_t logFunction);
+ncclResult_t nccl_net_ofi_init_v6(ncclDebugLogger_t logFunction);
 ncclResult_t nccl_net_ofi_fini_v6();
 ncclResult_t nccl_net_ofi_devices_v2(int *ndev);
 ncclResult_t nccl_net_ofi_get_properties(int dev, struct nccl_ofi_properties *ofi_properties);

--- a/src/nccl_ofi_interface_neuron.cpp
+++ b/src/nccl_ofi_interface_neuron.cpp
@@ -77,7 +77,7 @@ extern "C" {
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v6_t ncclNetPlugin_v6 = {
 	.name = "AWS Libfabric",
-	.init = nccl_net_ofi_init_no_atexit_fini_v6,
+	.init = nccl_net_ofi_init_v6,
 	.fini = nccl_net_ofi_fini_v6,
 	.devices = nccl_net_ofi_devices_v2,
 	.getProperties = getProperties_v5,


### PR DESCRIPTION
*Description of changes:*

init and fini functions are exposed by multiple APIs. The implementation slightly differs but for both functions, common functionality is factored out by this commit. This readability as well as avoids future bugs since it minimizes exact same code at multiple places.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
