### PR TITLE
Defer memory deregistration when requests are inflight

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -539,6 +539,8 @@ typedef struct nccl_net_ofi_rdma_send_comm {
 	/* Array of `num_control_rails` communicator rails */
 	nccl_net_ofi_rdma_send_comm_rail_t *control_rails;
 
+	deferred_deregistration_queue *deferred_dereg_queue;
+
 } nccl_net_ofi_rdma_send_comm_t;
 
 /*
@@ -619,6 +621,8 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	nccl_net_ofi_rdma_recv_comm_rail_t *rails;
 	/* Array of `num_control_rails` communicator rails */
 	nccl_net_ofi_rdma_recv_comm_rail_t *control_rails;
+
+	deferred_deregistration_queue *deferred_dereg_queue;
 } nccl_net_ofi_rdma_recv_comm_t;
 
 typedef struct nccl_net_ofi_rdma_listen_comm {

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -67,6 +67,8 @@ typedef struct nccl_net_ofi_sendrecv_send_comm {
 
 	/* connecting peer information (nccl_ofi_connection_info_t) */
 	nccl_ofi_freelist_elem_t *conn_info;
+
+	deferred_deregistration_queue *deferred_dereg_queue;
 } nccl_net_ofi_sendrecv_send_comm_t;
 
 /* Metadata about dummy flush buffer */
@@ -92,6 +94,8 @@ typedef struct nccl_net_ofi_sendrecv_recv_comm {
 	struct fid_ep *local_ep;
 
 	nccl_net_ofi_sendrecv_flush_buffer_t flush_buff;
+
+	deferred_deregistration_queue *deferred_dereg_queue;
 } nccl_net_ofi_sendrecv_recv_comm_t;
 
 /**


### PR DESCRIPTION
As part of NCCL's abort process, when it closes communicators with inflight requests, it first deregisters the memory backing the channel buffer, and only then closes the communicator. However, the Libfabric spec does not allow deregistering backing memory while an operation using that memory is in progress, as this may result in invalid memory access.

As a workaround, when NCCL attempts to deregister memory on a communicator that still has inflight requests, add it to this deferred deregistration queue. These memory registrations will be deregistered after the communicator is closed, at which point the endpoint used by the communicator will be closed, and so it should be safe to deregister memory.

*Note*

This is a draft PR pending more testing of the inflight close path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
