### PR TITLE
Enable the AWS tuner by default on AWS platforms

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -49,7 +49,6 @@ noinst_LTLIBRARIES = libinternal_net_plugin.la
 libinternal_net_plugin_la_SOURCES = $(sources)
 libinternal_net_plugin_la_CPPFLAGS = -I$(abs_top_srcdir)/include
 libinternal_net_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-libinternal_net_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
 libinternal_net_plugin_la_CPPFLAGS += -DXML_DIR=\"${pkgdatadir}/xml\"
 
 libinternal_net_plugin_la_LDFLAGS = -static -avoid-version
@@ -65,7 +64,6 @@ else
   libinternal_net_cudart_plugin_la_SOURCES = nccl_ofi_cuda.cpp
   libinternal_net_cudart_plugin_la_CPPFLAGS = $(CUDA_CPPFLAGS)
   libinternal_net_cudart_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-  libinternal_net_cudart_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
   libinternal_net_cudart_plugin_la_CPPFLAGS += -I$(abs_top_srcdir)/include
   libinternal_net_cudart_plugin_la_LDFLAGS = -whole-archive -static -avoid-version $(CUDA_LDFLAGS)
   libinternal_net_cudart_plugin_la_LIBADD = $(CUDA_LIBS)
@@ -105,13 +103,12 @@ tuner_sources =  \
 libinternal_tuner_plugin_la_SOURCES = $(tuner_sources)
 libinternal_tuner_plugin_la_LDFLAGS = -avoid-version
 libinternal_tuner_plugin_la_CPPFLAGS = -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-libinternal_tuner_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
 libinternal_tuner_plugin_la_CPPFLAGS += -I$(top_srcdir)/include
 
 # NCCL tuner plugin
 lib_LTLIBRARIES += libnccl-ofi-tuner.la
 libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)
-libnccl_ofi_tuner_la_CPPFLAGS = -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include -isystem $(abs_top_srcdir)/3rd-party/uthash/include -I$(top_srcdir)/include
+libnccl_ofi_tuner_la_CPPFLAGS = -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include -I$(top_srcdir)/include
 libnccl_ofi_tuner_la_LDFLAGS = -module -avoid-version
 
 endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -4,9 +4,11 @@
 # See LICENSE.txt for license information
 #
 
-#
-# net plugin
-#
+AM_CPPFLAGS = -I$(abs_top_srcdir)/include
+AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
+AM_CPPFLAGS += $(CUDA_CPPFLAGS)
+AM_CPPFLAGS += -DXML_DIR=\"${pkgdatadir}/xml\"
+
 sources = \
 	cm/nccl_ofi_cm.cpp \
 	cm/nccl_ofi_cm_resources.cpp \
@@ -39,77 +41,81 @@ endif
 if ENABLE_NEURON
   sources += nccl_ofi_interface_neuron.cpp
 else
-  sources += nccl_ofi_interface_nvidia.cpp
+  sources += \
+	nccl_ofi_cuda.cpp \
+	nccl_ofi_interface_nvidia.cpp
+
+  # add the tuner sources into the library
+if WANT_PLATFORM_AWS
+    sources +=  \
+	tuner/nccl_ofi_regions.cpp \
+	tuner/nccl_ofi_tuner.cpp \
+	tuner/nccl_ofi_model.cpp
+endif
 endif
 
 # Build an internal-only library that can be used by unit tests as
 # well as the actual nccl_net.so / nccom_net.so libraries.  This saves
 # us writing dlopen() handlers for simple unit tests.
-noinst_LTLIBRARIES = libinternal_net_plugin.la
-libinternal_net_plugin_la_SOURCES = $(sources)
-libinternal_net_plugin_la_CPPFLAGS = -I$(abs_top_srcdir)/include
-libinternal_net_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-libinternal_net_plugin_la_CPPFLAGS += -DXML_DIR=\"${pkgdatadir}/xml\"
+noinst_LTLIBRARIES = libinternal_plugin.la
+libinternal_plugin_la_SOURCES = $(sources)
+libinternal_plugin_la_LDFLAGS = -static  $(CUDA_LDFLAGS)
+libinternal_plugin_la_LIBADD = $(CUDA_LIBS)
 
-libinternal_net_plugin_la_LDFLAGS = -static -avoid-version
 
 if ENABLE_NEURON
   lib_LTLIBRARIES = libnccom-net.la
   libnccom_net_la_SOURCES =
-  libnccom_net_la_LIBADD = libinternal_net_plugin.la
+  libnccom_net_la_LIBADD = libinternal_plugin.la
   libnccom_net_la_LIBTOOLFLAGS = --tag=CXX
   libnccom_net_la_LDFLAGS = -module -avoid-version
 else
-  noinst_LTLIBRARIES += libinternal_net_cudart_plugin.la
-  libinternal_net_cudart_plugin_la_SOURCES = nccl_ofi_cuda.cpp
-  libinternal_net_cudart_plugin_la_CPPFLAGS = $(CUDA_CPPFLAGS)
-  libinternal_net_cudart_plugin_la_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-  libinternal_net_cudart_plugin_la_CPPFLAGS += -I$(abs_top_srcdir)/include
-  libinternal_net_cudart_plugin_la_LDFLAGS = -whole-archive -static -avoid-version $(CUDA_LDFLAGS)
-  libinternal_net_cudart_plugin_la_LIBADD = $(CUDA_LIBS)
-  libinternal_net_plugin_la_LIBADD = libinternal_net_cudart_plugin.la
   lib_LTLIBRARIES = libnccl-net-ofi.la
   libnccl_net_ofi_la_SOURCES =
-  libnccl_net_ofi_la_LIBADD = libinternal_net_plugin.la
+  libnccl_net_ofi_la_LIBADD = libinternal_plugin.la
   libnccl_net_ofi_la_LIBTOOLFLAGS = --tag=CXX
   libnccl_net_ofi_la_LDFLAGS = -module -avoid-version
 
-
+# We always install libnccl-net-ofi.so.  To use the default shared library,
+# either NCCL_NET_PLUGIN=libnccl-net-ofi.so or NCCL_NET_PLUGIN=ofi must be set.
+#
+# To enable the OFI plugin by default, a symlink libnccl-net.so is created.  If
+# NCCL_NET_PLUGIN is not set, NCCL will attempt to dlopen libnccl-net.so, with
+# dlopen() searching the default search path.  This behavior is optional, as
+# some situations (like the NGC containers) may have multiple network plugins.
+#
+# Recent versions of NCCL include a tuner interface for algorithm/protocol
+# selection.  The tuner code lives in the net plugin, but a symlink is created
+# to libnccl-ofi-tuner.so when the tuner is built (when on AWS).  Differenct
+# versions of NCCL have different tuner loading behaviors:
+#
+#  2.19 - 2.20    Tuner only loaded if NCCL_TUNER_PLUGIN is set to a filename
+#  2.21 -         First look for NCCL_TUNER_PLUGIN, then look for tuner interface
+#                 in the net plugin
+#
+# By bundling the tuner in the net plugin, we cause the tuner to be used by
+# default on NCCL 2.21 or later.
+symlink_files =
 if ENABLE_NCCL_NET_SYMLINK
+symlink_files += libnccl-net.so
+endif
+if WANT_PLATFORM_AWS
+symlink_files += libnccl-ofi-tuner.so
+endif
+
+install_plugin_symlinks = { \
+  test -z "$$files" \
+    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
+    || { for file in $$files ; do \
+	echo " ( cd '$$dir' && rm -f $$file && $(LN_S) libnccl-net-ofi.so $$file )"; \
+         $(am__cd) "$$dir" && rm -f $$file && $(LN_S) libnccl-net-ofi.so $$file ; \
+	done } \
+  }
+
 install-exec-hook:
-	cd $(DESTDIR)$(libdir) && rm -f libnccl-net.so && $(LN_S) libnccl-net-ofi.so libnccl-net.so
+	@files="$(symlink_files)" ; dir='$(DESTDIR)$(libdir)' ; $(install_plugin_symlinks)
 
 uninstall-local:
-	@files=libnccl-net.so ; dir='$(DESTDIR)$(libdir)' ; $(am__uninstall_files_from_dir)
-endif
-endif
+	@files="$(symlink_files)" ; dir='$(DESTDIR)$(libdir)' ; $(am__uninstall_files_from_dir)
 
-
-#
-# Tuner
-#
-
-if WANT_PLATFORM_AWS
-if !ENABLE_NEURON
-
-noinst_LTLIBRARIES += libinternal_tuner_plugin.la
-tuner_sources =  \
-	tuner/nccl_ofi_regions.cpp \
-	tuner/nccl_ofi_tuner.cpp \
-	tuner/nccl_ofi_model.cpp \
-	nccl_ofi_param.cpp \
-	nccl_ofi_system.cpp
-
-libinternal_tuner_plugin_la_SOURCES = $(tuner_sources)
-libinternal_tuner_plugin_la_LDFLAGS = -avoid-version
-libinternal_tuner_plugin_la_CPPFLAGS = -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-libinternal_tuner_plugin_la_CPPFLAGS += -I$(top_srcdir)/include
-
-# NCCL tuner plugin
-lib_LTLIBRARIES += libnccl-ofi-tuner.la
-libnccl_ofi_tuner_la_SOURCES = $(tuner_sources)
-libnccl_ofi_tuner_la_CPPFLAGS = -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include -I$(top_srcdir)/include
-libnccl_ofi_tuner_la_LDFLAGS = -module -avoid-version
-
-endif
 endif

--- a/src/tuner/nccl_ofi_tuner.cpp
+++ b/src/tuner/nccl_ofi_tuner.cpp
@@ -25,7 +25,6 @@
 #include "tuner/nccl_ofi_tuner.h"
 
 pthread_mutex_t nccl_ofi_tuner_ctx_lock = PTHREAD_MUTEX_INITIALIZER;
-ncclDebugLogger_t ofi_log_function = NULL;
 
 static ncclResult_t nccl_ofi_tuner_destroy(void *context)
 {
@@ -54,7 +53,9 @@ static ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugL
 	int is_force_type_model = 0;
 	enum nccl_ofi_tuner_platform tuner_platform;
 
-	ofi_log_function = logFunction;
+	if (ofi_log_function == NULL) {
+		ofi_log_function = logFunction;
+	}
 
 	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
 

--- a/src/tuner/nccl_ofi_tuner.cpp
+++ b/src/tuner/nccl_ofi_tuner.cpp
@@ -68,13 +68,13 @@ static ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugL
 		goto exit;
 	}
 
-	if (strcmp(ofi_nccl_tuner_force_type.get(), "Internal") == 0) {
+	if (strcasecmp(ofi_nccl_tuner_force_type.get(), "Internal") == 0) {
 		/* fallback to NCCL internal tuner */
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING,
 			      "NCCL_OFI_TUNER_TYPE is Internal, Fall back to NCCL's tuner for platform : %s",
 			      platform_type);
 		goto exit;
-	} else if (strcmp(ofi_nccl_tuner_force_type.get(), "Model") == 0) {
+	} else if (strcasecmp(ofi_nccl_tuner_force_type.get(), "Model") == 0) {
 		is_force_type_model = 1;
 	}
 

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -10,7 +10,7 @@ AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
 AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
-LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
+LDADD = $(top_builddir)/src/libinternal_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
 CC = $(MPICC)
 CXX = $(MPICXX)
 

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -8,7 +8,6 @@
 
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
 AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
 LDADD = $(top_builddir)/src/libinternal_net_plugin.la $(MPI_LIBS) $(CUDA_LIBS)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -9,7 +9,6 @@
 if ENABLE_UNIT_TESTS
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/uthash/include
 LDADD = $(top_builddir)/src/libinternal_net_plugin.la
 noinst_HEADERS = test-logger.h
 

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -9,7 +9,7 @@
 if ENABLE_UNIT_TESTS
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-LDADD = $(top_builddir)/src/libinternal_net_plugin.la
+LDADD = $(top_builddir)/src/libinternal_plugin.la
 noinst_HEADERS = test-logger.h
 
 noinst_PROGRAMS = \
@@ -36,7 +36,6 @@ if WANT_PLATFORM_AWS
   LDADD += $(CUDA_LIBS)
   noinst_PROGRAMS += region_based_tuner
   region_based_tuner_SOURCES = region_based_tuner.cpp
-  region_based_tuner_LDADD = $(top_builddir)/src/libinternal_tuner_plugin.la
 endif
 endif
 


### PR DESCRIPTION
As the title says, enable the tuner by default on supported AWS platforms, by including the tuner code in the net plugin.  This will cause NCCL 2.21 and later to load the tuner by default unless a more specific tuner is specified by the user ([see the NCCL docs](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/env.html#nccl-tuner-plugin)).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
