### PR TITLE
tuner: Adjust P6 region tuner for 0x0 32 rank

### DIFF
--- a/src/tuner/nccl_ofi_regions.cpp
+++ b/src/tuner/nccl_ofi_regions.cpp
@@ -991,13 +991,14 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 				 .num_vertices = 4,
 				 .vertices = {{87031808, 16},
 						{107374182400, 16},
-						{107374182400, 32},
-						{562036736, 32}}},
+						{107374182400, 16},
+						{87031808, 16}}},
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_SIMPLE,
-				 .num_vertices = 4,
+				 .num_vertices = 5,
 				 .vertices = {{562036736, 32},
-						{107374182400, 32},
+						{87031808, 16},
+						{107374182400, 16},
 						{107374182400, 6408.141},
 						{17179869184, 1024}}}};
 			ret = set_regions(region_ctx, collType, sizeof(regions) / sizeof(regions[0]), regions);


### PR DESCRIPTION
*Description of changes:*

Adjust P6 region tuner switch point for 0x0 32 rank with large message sizes so that it can choose Ring instead of Nvlstree algorithm for a better performance.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
