### PR TITLE
mr: do not page align memory registrations on neuron platform

### DIFF
--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -124,9 +124,22 @@ static inline nccl_ofi_mr_ckey_t nccl_ofi_mr_ckey_mk_dmabuf(int fd, uint64_t off
 }
 #endif
 
+/**
+ * Create memory registration iovec cache key of a memory region
+ *
+ * Default expectation on this cache key is that memory region covers
+ * full pages. For this, memory region that do not cover full pages is
+ * implicitly extended to the beginning of its first page and to the
+ * end of its last page. On neuron platforms, this behavior is not
+ * desired and no extension is performed.
+ *
+ * @return cache key
+ */
 static inline nccl_ofi_mr_ckey_t nccl_ofi_mr_ckey_mk_vec(void *iov_base, size_t iov_len)
 {
+#if !HAVE_NEURON
 	nccl_ofi_mr_ckey_round(&iov_len, &iov_base, "iovec");
+#endif
 	nccl_ofi_mr_ckey_t cache_key = {};
 	cache_key.iovec.iov_base = iov_base;
 	cache_key.iovec.iov_len = iov_len;

--- a/tests/unit/mr.cpp
+++ b/tests/unit/mr.cpp
@@ -151,9 +151,15 @@ int main(int argc, char *argv[])
 	}
 
 	/* Test of nccl_ofi_mr_ckey_mk_[vec|dmabuf] to build aligned keys */
+#if HAVE_NEURON
+	test_make_aligned_key(fake_page_size / 2, 16, fake_page_size / 2, 16);
+	test_make_aligned_key(fake_page_size / 2, fake_page_size, fake_page_size / 2, fake_page_size);
+	test_make_aligned_key(fake_page_size - 16, 17, fake_page_size - 16, 17);
+#else
 	test_make_aligned_key(fake_page_size / 2, 16, 0, fake_page_size);
 	test_make_aligned_key(fake_page_size / 2, fake_page_size, 0, fake_page_size * 2);
 	test_make_aligned_key(fake_page_size - 16, 17, 0, fake_page_size * 2);
+#endif
 
 	nccl_ofi_mr_cache_finalize(cache);
 


### PR DESCRIPTION
Due to contract with nvidia nccl, all memory pages that a memory region covers must be part of the memory registration of that region. Even when the region does not cover the page completely.

This may not be wanted behavior, e.g., because it allows sending a buffer that extends before or after the registered memory regions without libfabric rejecting that operation. Indeed, this behavior is not wanted on neuron platforms and this commit disables full memory page registration on neuron platforms but registers only the exact region instead.

#### Test
Tested with neuron auto test as well a mt/mp/mn pipeline test on trn1/trn2.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
