### PR TITLE
tuner: tune nChannels at mid msg sizes for P6

### DIFF
--- a/contrib/python/ofi_nccl/tuner/cli/main.py
+++ b/contrib/python/ofi_nccl/tuner/cli/main.py
@@ -16,6 +16,7 @@ def show_all(library: pathlib.Path,
              min_nnodes: int = 2,
              max_nnodes: int = np.log2(2048),
              inc_nnodes: int = 2,
+             show_channels: bool = False,
              ):
     df = (
         pd.concat(
@@ -26,7 +27,7 @@ def show_all(library: pathlib.Path,
                 for platform in TunerPlatform
             ]
         )
-        .set_index(["nodes", "ranks", "message_size"])
+        .set_index(["nodes", "ranks", "message_size"] if not show_channels else ["nodes", "ranks", "message_size", "nchannels"])
         .sort_index()
         .dropna()
     )

--- a/contrib/python/ofi_nccl/tuner/cli/wrapper.py
+++ b/contrib/python/ofi_nccl/tuner/cli/wrapper.py
@@ -167,17 +167,18 @@ class Tuner:
 
         if result != 0:
             raise RuntimeError(f"Failed to get collective info. Error code: {result}")
-
-        decision = (np.nan, np.nan)
+        nchannels = nChannels.value
+        decision = (np.nan, np.nan, np.nan)
         for algo in NCCLAlgo:
             for proto in NCCLProto:
                 cost = cost_table_array[algo.value * len(NCCLProto) + proto.value]
                 if cost != float(1337):
-                    decision = (algo, proto)
+                    decision = (algo, proto, nchannels)
 
         return {
             "algo": decision[0],
             "proto": decision[1],
+            "nchannels": decision[2],
         }
 
     def analyze_message_range(self, coll_type: NCCLFunc, min_size: int, max_size: int):
@@ -206,6 +207,7 @@ class Tuner:
                     "message_size": size,
                     "algo": decision["algo"],
                     "proto": decision["proto"],
+                    "nchannels": decision["nchannels"],
                     "ranks": self.nranks,
                     "nodes": self.nnodes,
                     "platform": self.platform,

--- a/include/internal/tuner/nccl_defaults.h
+++ b/include/internal/tuner/nccl_defaults.h
@@ -60,6 +60,26 @@
 #define NCCL_OFI_TUNER_NCCL_LL128_ELEMS_PER_THREAD  (120ULL)
 
 /**
+ * @brief Number of elements per thread for NCCL_PROTO_LL128 shared memory.
+ */
+#define NCCL_OFI_TUNER_NCCL_LL128_SHMEM_ELEMS_PER_THREAD (8ULL)
+
+/**
+ * @brief Size of NCCL_PROTO_LL128 communication line.
+ */
+#define NCCL_OFI_TUNER_NCCL_LL128_LINESIZE (128ULL)
+
+/** 
+ * @brief Number of 64-bit elements per line (16 elements).
+ */
+#define NCCL_OFI_TUNER_NCCL_LL128_LINEELEMS (NCCL_OFI_TUNER_NCCL_LL128_LINESIZE / sizeof(uint64_t))
+
+/**
+ * @brief Number of data elements per line (15 elements, with 1 reserved for flags).
+ */
+#define NCCL_OFI_TUNER_NCCL_LL128_DATAELEMS (NCCL_OFI_TUNER_NCCL_LL128_LINEELEMS - 1)
+
+/**
  * @brief Expected data type size.
  */
 #define NCCL_OFI_TUNER_EXPECTED_DTYPE_SIZE          (4ULL)
@@ -68,5 +88,22 @@
  * @brief Buffer size for NCCL_PROTO_SIMPLE protocol.
  */
 #define NCCL_OFI_TUNER_NCCL_BUFFSIZE                (1 << 22)
+
+/** 
+ * @brief Round down log2 of an integer.
+ */
+inline int log2Down(int x) {
+	if (x <= 0) {
+		return -1;
+	} 
+	const int w = 8 * sizeof(unsigned int); /* Total bits */
+	const int n = __builtin_clz((unsigned int)x); /* Count leading zeros */
+	
+	return w - 1 - n;
+}
+
+inline int log2i(int x) {
+	return log2Down(x);
+}
 
 #endif  // NCCL_DEFAULTS_H_


### PR DESCRIPTION
### Changes
1. Add channel count to tuner unit test output matrix
2. Add logic to controls nChannels at mid msg sizes [4,32] MB for P6


### Tests
1. Unit test:
(`nchannels` is what tuner returns to NCCL. when nchannels==0, NCCL has another maxChannel variable to load the channel counts)
2.  4/8/16 node improvements are shown below(1MB incremental datapoints), this gives confidence that the nChannel decisions will mostly improve performance at larger ranks as well.  
```
❯ uv run show-tuner-decisions ~/workspace/aws-ofi-nccl/p6_nchannel_tuner/src/.libs/libnccl-net-ofi.so --min-ranks-per-node 8 --max-ranks-per-node 8 --min-nnodes 16 --max-nnodes 16 --show-channels 2>&1 | grep -A 100 "collective  algo   proto platform"
                                   collective  algo   proto platform
nodes ranks message_size nchannels
16    128   32           0.0        AllGather  Ring      Ll     P5en
16    128   32           0.0        AllGather  Ring      Ll       P6
16    128   3744915      0.0        AllGather  Ring   Ll128     P5en
16    128   12815929     0.0        AllGather  Ring   Ll128       P6
16    128   2147483649   0.0        AllGather  Ring  Simple     P5en
16    128   2624702237   0.0        AllGather  Ring  Simple       P6
                                       collective  algo   proto platform
nodes ranks message_size nchannels
16    128   32           0.0        ReduceScatter  Ring      Ll     P5en
16    128   32           0.0        ReduceScatter  Ring      Ll       P6
16    128   3744915      0.0        ReduceScatter  Ring   Ll128     P5en
16    128   12815929     0.0        ReduceScatter  Ring   Ll128       P6
16    128   2147483649   0.0        ReduceScatter  Ring  Simple     P5en
16    128   2624702237   0.0        ReduceScatter  Ring  Simple       P6
                                   collective       algo   proto platform
nodes ranks message_size nchannels
16    128   32           0.0        AllReduce       Tree      Ll     P5en
16    128   32           0.0        AllReduce       Tree   Ll128       P5
16    128   32           0.0        AllReduce       Tree      Ll       P6
16    128   262145       0.0        AllReduce       Tree   Ll128     P5en
16    128   262145       0.0        AllReduce       Tree   Ll128       P6
16    128   4194304      32.0       AllReduce       Tree   Ll128       P6
16    128   6912000      16.0       AllReduce       Tree   Ll128       P6
16    128   20736000     24.0       AllReduce       Tree   Ll128       P6
16    128   27648000     32.0       AllReduce       Tree   Ll128       P6
16    128   33554433     0.0        AllReduce       Tree   Ll128       P6
16    128   150994945    0.0        AllReduce       Ring   Ll128     P5en
16    128   301989889    0.0        AllReduce       Ring   Ll128       P5
16    128   465567745    0.0        AllReduce       Ring   Ll128       P6
16    128   536870913    0.0        AllReduce  Nvls_Tree  Simple     P5en
16    128   2147483649   0.0        AllReduce  Nvls_Tree  Simple       P5
16    128   2170214070   0.0        AllReduce       Ring  Simple       P6
16    128   3067833783   0.0        AllReduce       Ring  Simple     P5en
16    128   6442450945   0.0        AllReduce       Ring  Simple       P5
```

![nccl-tests-06-17-4n](https://github.com/user-attachments/assets/9c9505af-562d-4ab4-bd81-519a4d0eff54)
![nccl-tests-06-17-8n](https://github.com/user-attachments/assets/73e144bd-4674-4779-b5ce-0420236311be)
![nccl-tests-06-17-16n](https://github.com/user-attachments/assets/55e812a4-56c9-4e1d-a82a-48f205ebe478)



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.