### PR TITLE
Reverting change min_stripe_size default from 128K to 64K

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -191,7 +191,7 @@ OFI_NCCL_PARAM_INT(disable_dmabuf, "DISABLE_DMABUF", 0);
 /*
  * Messages sized larger than this threshold will be striped across multiple rails
  */
-OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (64 * 1024));
+OFI_NCCL_PARAM_UINT(min_stripe_size, "MIN_STRIPE_SIZE", (128 * 1024));
 
 /*
  * The round robin scheduler has two round robin counts, for small (likely


### PR DESCRIPTION
This reverts commit 34c256e942ca274b9fd1238464d07b37c53ad43f.

*Description of changes:*
Reverting this commit due to performance seen in 16 node case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
