### PR TITLE
Refactor domain types to use C++ inheritance

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -466,10 +466,6 @@ struct nccl_net_ofi_domain {
 	   requests and all connection-establishment requests, but may
 	   have additional endpoints for the rx side of rdma writes. */
 	nccl_net_ofi_ep_t *endpoint;
-
-	/* thread id of the thread that called get_domain().  Used as
-	   the hash key for the domain hash */
-	long creating_thread_id;
 };
 
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -915,10 +915,6 @@ public:
 	   receive communicator */
 	bool is_endpoint_per_communicator_ep;
 
-	/* thread id of the thread that called get_ep().  Used as the
-	   hash key for the endpoint hash */
-	long creating_thread_id;
-
 protected:
 	int cleanup_resources() override;
 

--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -7,11 +7,11 @@ using namespace nccl_ofi_cm;
 
 
 endpoint::endpoint(nccl_net_ofi_domain_t &domain) :
-	ofi_domain(domain.get_ofi_domain(&domain)),
+	ofi_domain(domain.get_ofi_domain_for_cm()),
 	mr_key_pool(*(domain.mr_rkey_pool))
 {
-	fi_info *info = domain.device->get_ofi_info(domain.device);
-	fid_cq *cq = domain.get_ofi_cq(&domain);
+	fi_info *info = domain.get_device()->get_ofi_info(domain.get_device());
+	fid_cq *cq = domain.get_ofi_cq_for_cm();
 	int ret = nccl_ofi_ofiutils_init_connection(info, ofi_domain, &this->ofi_ep, &this->av, cq);
 	if (ret != 0) {
 		/* We can't return an error. If not caught, this is going to propagate up and


### PR DESCRIPTION
Replaces the C-style inheritance of having a base domain instance as the first member of the transport domain types with the C++ approach of making nccl_net_ofi_domain_t a parent class with virtual functions that the transport domain types override. Refactors the allocation and free functions for the base and transport domain types to be constructors and destructors, and adds helper member functions for interacting with protected member variables.

Also refactors all stand-alone functions that should belong to the RDMA domain type to become member functions. Helper functions for the RDMA domain constructor and destructor were kept as protected functions.

#### `this` keyword usage
Comparing this PR against my endpoint refactor PR #851, I returned to using the `this` keyword consistently in domain member functions defined outside of the class declaration. I decided to use `this` consistently again because in the current state of the codebase, many of the functions defined and called in domain members are stand-alone functions for the device struct, communicator structs, etc that don't always have clear ownership. Since there can be ambiguity in a domain member function definition about whether any called functions are other domain members or stand-alone functions, I would prefer to be over-use `this` make function ownership as clear as possible. Once most of the stand-alone functions have been turned into member functions (e.g. after refactoring the device/communicator/plugin structs) and have clear ownership, then I can go back and trim the usage of `this`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
