### PR TITLE
param: Add OFI_NCCL_PROGRESS to specify progress mode

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -119,6 +119,17 @@ extern bool data_progress_auto;
 /* Size of system memory pages */
 extern size_t system_page_size;
 
+/* Requested progress mode to be used.
+ *
+ * During initialization, check the progress mode environment variable
+ * to determine the mode that the plugin will request from the provider.
+ *
+ * Valid values are FI_PROGRESS_UNSPEC, FI_PROGRESS_MANUAL, and
+ * FI_PROGRESS_AUTO; default is FI_PROGRESS_UNSPEC (set by the
+ * param OFI_NCCL_PROGRESS (Values: UNSPEC, MANUAL, and AUTO))
+ */
+extern enum fi_progress nccl_ofi_progress_mode;
+
 class nccl_net_ofi_ep_t;
 
 struct nccl_net_ofi_plugin;
@@ -475,10 +486,10 @@ class nccl_net_ofi_ep_t {
 public:
 	/**
 	 * @brief	Default constructor.
-	 * 
+	 *
 	 * Initialize resources associated with the endpoint base class.
 	 * Expectation is that this will be called by a transport's endpoint
-	 * constructor 
+	 * constructor
 	 */
 	nccl_net_ofi_ep_t(nccl_net_ofi_domain_t *domain);
 
@@ -555,13 +566,13 @@ protected:
 
 	/**
 	 * @brief	Cleanup endpoint resources.
-	 * 
+	 *
 	 * Virtual function to clean up and release each transport type's endpoint resources.
 	 * Should not throw exceptions, and instead returns an error code on success or failure
 	 * to make it safe to call in endpoint destructors. Set called_cleanup_resources to true
 	 * at the start of the function to make sure it is only called once per endpoint
 	 * instance.
-	 * 
+	 *
 	 * @return	0 if successfully, negative error code on failure.
 	 */
 	virtual int cleanup_resources() = 0;
@@ -569,12 +580,12 @@ protected:
 	/* Backpointer to the domain associated with this ep. */
 	nccl_net_ofi_domain_t *domain = nullptr;
 
-	/** 
+	/**
 	 * Track whether the cleanup_resources function was already called to avoid calling
-	 * multiple time on the same endpoint instance. It being set to true does not 
+	 * multiple time on the same endpoint instance. It being set to true does not
 	 * indicate that the endpoint resources were successfully released since this is set
 	 * to true regardless of whether cleanup_resources finished successfully or not.
-	 */ 
+	 */
 	bool called_cleanup_resources = false;
 
 	/* Endpoint reference counter for resource management.

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -131,7 +131,7 @@ OFI_NCCL_PARAM_INT(mr_cache_disable, "MR_CACHE_DISABLE",
  */
 OFI_NCCL_PARAM_INT(cq_read_count, "CQ_READ_COUNT", 4);
 
-/* 
+/*
  * Completion queue size. Defaults to EFA RDM path size.
  */
 OFI_NCCL_PARAM_UINT(cq_size, "CQ_SIZE", 12288);
@@ -332,7 +332,7 @@ OFI_NCCL_PARAM_INT(force_num_rails, "FORCE_NUM_RAILS", 0);
 
 /*
  * 1 to enable early completion, 0 to disable it.
- * Default at -1 to follow the data progress model, given that 
+ * Default at -1 to follow the data progress model, given that
  * early completion feature is contigent on FI_PROGRESS_AUTO data progress model
  * i.e. enabled when FI_PROGRESS_AUTO, otherwise disabled
  */
@@ -365,5 +365,11 @@ OFI_NCCL_PARAM_INT(disable_close_message, "DISABLE_CLOSE_MESSAGE", 1);
  * complete more quickly, especially with large numbers of ranks.
  */
 OFI_NCCL_PARAM_UINT(cm_num_rx_buffers, "CM_NUM_RX_BUFFERS", 32);
+
+/*
+ * Progress mode requested.  Valid options are AUTO, MANUAL,
+ * and UNSPEC, with the default set to UNSPEC.
+ */
+OFI_NCCL_PARAM_STR(progress, "PROGRESS", "UNSPEC");
 
 #endif // End NCCL_OFI_PARAM_H_

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -64,6 +64,9 @@ bool virt_addr_mr = false;
 /* Indicates if provider's data progress model is FI_PROGRESS_AUTO */
 bool data_progress_auto = false;
 
+/* Indicates the progress mode to be requested. */
+enum fi_progress nccl_ofi_progress_mode = FI_PROGRESS_UNSPEC;
+
 /* Size of a memory page */
 size_t system_page_size = 0;
 
@@ -198,6 +201,28 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	} else if (ofi_nccl_protocol.get_source() == ParamSource::API) {
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using transport protocol %s (platform set)",
 			      ofi_nccl_protocol.get());
+	}
+
+	/* Set the progress mode based on OFI_NCCL_PROGRESS.  The default
+	 * is UNSPEC to use the provider's default mode.  We hard
+	 * poll for completion until there are no outstanding receive
+	 * requests.  If a provider defaults with async progress,
+	 * then we don't really care and should let it do that. */
+	if (ofi_nccl_progress.get_source() != ParamSource::DEFAULT) {
+		const char *progress_mode = ofi_nccl_progress.get();
+		if (strcasecmp(progress_mode, "UNSPEC") == 0) {
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using progress mode FI_PROGRESS_UNSPEC");
+		} else if (strcasecmp(progress_mode, "MANUAL") == 0) {
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using progress mode FI_PROGRESS_MANUAL");
+			nccl_ofi_progress_mode = FI_PROGRESS_MANUAL;
+		} else if (strcasecmp(progress_mode, "AUTO") == 0) {
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using progress mode FI_PROGRESS_AUTO");
+			nccl_ofi_progress_mode = FI_PROGRESS_AUTO;
+		} else {
+			NCCL_OFI_WARN("Invalid progress mode specified %s", progress_mode);
+			ret = -ENOTSUP;
+			goto exit;
+		}
 	}
 
 	if (ofi_nccl_protocol.get_source() != ParamSource::DEFAULT) {
@@ -1149,7 +1174,7 @@ int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
 
 	/* Store ref_cnt in local variable in case the endpoint gets deleted */
 	int local_ref_cnt = ref_cnt;
-	
+
 	if (local_ref_cnt == 0 || force_cleanup) {
 		/* If this was the endpoint we stored in domain for connection
 		   management, remove that reference as well */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -439,7 +439,7 @@ exit:
  * @return	Populated I/O vector, on success
  * @return	0 on success
  *		non-zero on error
- */ 
+ */
 static int set_mr_req_attr(uint64_t mr_key,
 			   nccl_ofi_mr_ckey_ref ckey, uint64_t *flags,
 			   int type, struct fi_mr_attr *mr_attr)
@@ -447,7 +447,7 @@ static int set_mr_req_attr(uint64_t mr_key,
 	int ret = 0;
 	mr_attr->access = FI_SEND | FI_RECV;
 
-	/* Add FI_WRITE (source of fi_write) and FI_REMOTE_WRITE (target of fi_write) 
+	/* Add FI_WRITE (source of fi_write) and FI_REMOTE_WRITE (target of fi_write)
 	   for RDMA send/recv buffers */
 	mr_attr->access |= (FI_WRITE | FI_REMOTE_WRITE);
 	/* Add FI_READ (destination buffer for RMA read) and FI_REMOTE_READ
@@ -543,10 +543,10 @@ static inline int get_properties(nccl_net_ofi_device_t *base_dev,
 	assert(is_max_write_inline_size_initialized);
 	props->max_write_inline_size = max_write_inline_size;
 
-	/* 
+	/*
 	 * Actual max tansfer size is the min size between the interface and
 	 * libfabric's data transfer layer
-	 * 
+	 *
 	 * ext-net v9 API interfaces updated the sizes to size_t type. But sizes in
 	 * the actual plugin implementations are using int type, thus the max
 	 * max for interface is INT_MAX
@@ -816,7 +816,7 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req_t *req,
 	assert(req->type == NCCL_OFI_RDMA_RECV_SEGMS);
 	int ret = 0;
 	bool segms_received;
-	
+
 	nccl_net_ofi_mutex_lock(&req->req_lock);
 
 	/* Sum up segment sizes */
@@ -827,7 +827,7 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req_t *req,
 	/* The arrival of the last segment is treated as a single
 	 * request completion of the parent request */
 	segms_received = req->ncompls == total_nsegms;
-	
+
 	/* Mark receive segments request and receive request as completed */
 	if (segms_received) {
 		rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(req);
@@ -842,7 +842,7 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req_t *req,
 		 * unlocking receive segment request after it has been
 		 * freed in `test()` */
 		nccl_net_ofi_mutex_unlock(&req->req_lock);
-		
+
 		/* Add completion to parent request */
 		ret = inc_req_completion(recv_req, req->size, recv_data->total_num_compls);
 	} else {
@@ -1296,7 +1296,7 @@ exit:
 
 /**
  * @brief	Get request associated with RDMA write immediate data
- * 
+ *
  * @param	ep, to look up r_comm from ID encoded in data
  * @param	data, the immediate data
  */
@@ -1984,7 +1984,7 @@ static inline int free_base_req(uint64_t *num_inflight_reqs,
 {
 	int ret = 0;
 	nccl_ofi_freelist_elem_t *elem = NULL;
-	
+
 	if (OFI_UNLIKELY(req == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Provided null request for cleanup");
@@ -6594,7 +6594,7 @@ int nccl_net_ofi_rdma_ep_t::init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *
 		domain_rail = rdma_domain_get_rail(domain_arg, rail_id);
 		rail = rdma_endpoint_get_rail(rail_id);
 
-		ret = nccl_net_ofi_rdma_ep_t::ep_rail_init(dev_id, rail_id, rail_dev, 
+		ret = nccl_net_ofi_rdma_ep_t::ep_rail_init(dev_id, rail_id, rail_dev,
 							   domain_rail, rail, FI_TC_UNSPEC);
 		if (ret != 0) {
 			NCCL_OFI_WARN("Initializing rail %d failed", rail_id);
@@ -6772,7 +6772,7 @@ static int nccl_net_ofi_rdma_domain_create_endpoint(nccl_net_ofi_domain_t *base_
 	/* Allocate endpoint */
 	ep = new nccl_net_ofi_rdma_ep_t(domain);
 
-	NCCL_OFI_TRACE(NCCL_NET, "RDMA endpoint %p for dev #%d is created", ep, 
+	NCCL_OFI_TRACE(NCCL_NET, "RDMA endpoint %p for dev #%d is created", ep,
 		       device->base.dev_id);
 
 	*new_ep = ep;
@@ -7370,11 +7370,12 @@ static void get_hints(struct fi_info *hints)
 	hints->domain_attr->threading = FI_THREAD_SAFE;
 
 	/* Set progress mode to unspec to use the provider's default
-	 * mode.  We hard poll for completion, but if a provider is
+	 * mode.  OFI_NCCL_PROGRESS can override the unspec default.
+	 * We hard poll for completion, but if a provider is
 	 * faster with async progress, then we don't really care and
 	 * should let it do that. */
-	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	hints->domain_attr->control_progress = nccl_ofi_progress_mode;
+	hints->domain_attr->data_progress = nccl_ofi_progress_mode;
 }
 
 
@@ -7581,12 +7582,12 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	/* 
+	/*
 	* NCCL Net v9 API Optimization for LL/LL128 Protocols
-	* 
+	*
 	* Background:
-	* When using LL (Low Latency) or LL128 protocols, NCCL sets the request pointer 
-	* to NCCL_NET_OPTIONAL_RECV_COMPLETION in irecv() calls. This indicates that 
+	* When using LL (Low Latency) or LL128 protocols, NCCL sets the request pointer
+	* to NCCL_NET_OPTIONAL_RECV_COMPLETION in irecv() calls. This indicates that
 	* the plugin can complete a receiver request early without plugin explicitly
 	* polling the CQ to validate data arrival. This is achievable because NCCL itself
 	* following LL protocol semantics will validate data arrival by checking the flag bytes.

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -101,10 +101,10 @@ static inline int sendrecv_get_properties(nccl_net_ofi_device_t *base_dev,
 	 */
 	props->regIsGlobal = 0;
 
-	/* 
+	/*
 	 * Actual max tansfer size is the min size between the interface and
 	 * libfabric's data transfer layer
-	 * 
+	 *
 	 * ext-net v9 API interfaces updated the sizes to size_t type. But sizes in
 	 * the actual plugin implementations are using int type, thus the max
 	 * max for interface is INT_MAX
@@ -1482,7 +1482,7 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 
 	const nccl_ofi_connection_info_t *conn_msg = nullptr;
 	nccl_ofi_connection_info_t conn_resp_msg = { };
-	
+
 	/*
 	 * Take appropriate actions based on connection stage of communicator.
 	 *
@@ -2037,7 +2037,7 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 	CHECK_DOMAIN_ACTIVE(domain_ptr, "connect");
 
 	nccl_ofi_connection_info_t conn_info = { };
-	
+
 	/* Retrieve and validate devices */
 	nccl_net_ofi_sendrecv_device_t *device = sendrecv_domain_get_device(domain_ptr);
 	if (OFI_UNLIKELY(device == nullptr)) {
@@ -2126,7 +2126,7 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 	} else {
 		nccl_ofi_ofiutils_ep_release(ofi_ep, av, device->base.dev_id);
 		ofi_ep = nullptr;
-		av = nullptr;		
+		av = nullptr;
 	}
 
 	assert(ret == 0);
@@ -2468,9 +2468,10 @@ static void sendrecv_get_hints(struct fi_info *hints, int req_gdr)
 
 	hints->domain_attr->threading = FI_THREAD_SAFE;
 
-	/* Set progress mode to unspec to use the provider's default mode. */
-	hints->domain_attr->control_progress = FI_PROGRESS_UNSPEC;
-	hints->domain_attr->data_progress = FI_PROGRESS_UNSPEC;
+	/* Set progress mode to unspec to use the provider's default mode.
+	 * OFI_NCCL_PROGRESS can override the unspec default. */
+	hints->domain_attr->control_progress = nccl_ofi_progress_mode;
+	hints->domain_attr->data_progress = nccl_ofi_progress_mode;
 
 	/* Set MR mode bits to indicate FI_MR_BASIC registration */
 	hints->domain_attr->mr_mode |= FI_MR_VIRT_ADDR | FI_MR_ALLOCATED | FI_MR_PROV_KEY;


### PR DESCRIPTION
*Issue #, if available:* #908

*Description of changes:* Added OFI_NCCL_PROGRESS parameter to all the user to specify a progress mode instead of using the default of FI_PROGRESS_UNSPEC.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
