### PR TITLE
ofiutils: Use `FI_TRANSMIT` to bind CQ to EP

### DIFF
--- a/src/nccl_ofi_ofiutils.cpp
+++ b/src/nccl_ofi_ofiutils.cpp
@@ -242,7 +242,7 @@ int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *d
 	}
 
 	/* Bind CQ to endpoint */
-	ret = fi_ep_bind(*ep, &(cq->fid), FI_SEND | FI_RECV);
+	ret = fi_ep_bind(*ep, &(cq->fid), FI_TRANSMIT | FI_RECV);
 	if (OFI_UNLIKELY(ret != 0)) {
 		NCCL_OFI_WARN("Couldn't bind EP-CQ. RC: %d, ERROR: %s",
 			      ret, fi_strerror(-ret));


### PR DESCRIPTION
The Libfabric manual
(https://ofiwg.github.io/libfabric/main/man/fi_endpoint.3.html) states that `FI_TRANSMIT` should be used for `fi_ep_bind`, not `FI_SEND`. The two are synonymous today, but updating to match the spec.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
