### PR TITLE
rdma: Add INFO print when topo file is already set

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -361,9 +361,9 @@ static int write_topo_file(nccl_ofi_topo_t *topo)
 	 * file until the child process exits.
 	 */
 	if (getenv("NCCL_TOPO_FILE")) {
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-			       "NCCL_TOPO_FILE environment variable is already set to %s",
-			       getenv("NCCL_TOPO_FILE"));
+		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+			      "NCCL_TOPO_FILE environment variable is already set to %s",
+			      getenv("NCCL_TOPO_FILE"));
 		goto exit;
 	}
 


### PR DESCRIPTION
When `NCCL_TOPO_FILE` is already set in the environment (either by the user, or by the parent process in case of `fork()`), print an INFO log message instead of a TRACE log message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
