### PR TITLE
doc: Remove Ubuntu 20.04 as supported operating system

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ reports if that is the case.
 The plugin is regularly tested on the following operating systems:
 
 * Amazon Linux 2 and Amazon Linux 2023
-* Ubuntu 20.04 LTS, 22.04 LTS and 24.04 LTS.
+* Ubuntu 22.04 LTS and 24.04 LTS.
 
 Other operating systems are likely to work, but are not included in our regular
 regression testing. If you find an issue unique to another operating system,


### PR DESCRIPTION
*Description of changes:*
Update README.md to reflect fact that we no longer support Ubuntu 20.04 as a supported operating system.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
