### PR TITLE
nvtx: fixup usage of refactor endpoint functions

### DIFF
--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -73,7 +73,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
 } while (0)
@@ -85,7 +85,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 } while(0)
@@ -97,7 +97,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)s_comm->base.base.ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(s_comm->base.base.ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
 } while (0)
@@ -109,7 +109,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_send_ctrl_data(req)->trace_id = nvtx_start_domain(true, handle, "Send_ctrl_start", 0x00ffff); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_send_ctrl_data(req)->trace_id = nvtx_start_domain(true, handle, "Send_ctrl_start", 0x00ffff); \
 	} \
 } while (0)
@@ -121,7 +121,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_send_ctrl_data(req)->trace_id); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_ctrl_data(req)->trace_id);\
 	} \
 } while (0)
@@ -133,7 +133,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
 } while(0)
@@ -145,7 +145,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)comm->ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 } while(0)
@@ -173,7 +173,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)request->comm->ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(request->comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
 } while(0)
@@ -185,7 +185,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
-		handle = (rdma_endpoint_get_device((nccl_net_ofi_rdma_ep_t *)r_comm->base.base.ep))->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->base.base.ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 } while(0)


### PR DESCRIPTION
When refactoring the endpoint types to be C++ classes (#851), I had not updated the NVTX trace implementation code, leading to incorrectly calling the "rdma_endpoint_get_device" function as a stand-alone function instead of a member of the RDMA endpoint class. This commits fixes those calls so that the OFI NCCL plugin successfully compiles with NVTX tracing enabled.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
