### PR TITLE
ci: Do not filter paths for PRs

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -7,27 +7,7 @@ on:
       - master
       - main
       - v*
-    paths:
-      - "configure.ac"
-      - "Makefile.am"
-      - "autogen.sh"
-      - "include/**"
-      - "m4/**"
-      - "src/**"
-      - "tests/**"
-      - "topology/**"
-      - ".github/workflows/**"
   pull_request:
-    paths:
-      - "configure.ac"
-      - "Makefile.am"
-      - "autogen.sh"
-      - "include/**"
-      - "m4/**"
-      - "src/**"
-      - "tests/**"
-      - "topology/**"
-      - ".github/workflows/**"
 env:
   # note, related to issue around actions/checkout@v4, linked below. This
   # environment variable is also now needed, as of july 2024.


### PR DESCRIPTION
There's not a great reason to filter CI on PRs, and the filters cause large PRs to not run GH actions, which isn't what we want.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
