### PR TITLE
Remove invalidated domain from domain table

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -4064,7 +4064,7 @@ void nccl_net_ofi_rdma_ep_t::rdma_endpoint_abort()
 
 	release_rdma_ep_resources(dev_id);
 
-	base_domain->domain_active = false;
+	base_domain->invalidate(base_domain);
 }
 
 /**

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1035,7 +1035,7 @@ static inline void sendrecv_endpoint_abort(nccl_net_ofi_sendrecv_ep_t *ep)
 	ep->ofi_ep = NULL;
 	ep->av = NULL;
 
-	base_domain->domain_active = false;
+	base_domain->invalidate(base_domain);
 }
 
 


### PR DESCRIPTION
When a domain is invalidated (due to communicator close with inflight requests, remove the domain from domain table, so future calls to `get_ep` do not reuse the domain. This allows creating new communicators without having closed all previous communicators.

Tested in the abort case -- this code seems to allow creation of new communicators, even if previous communicators weren't fully cleaned up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
