### PR TITLE
Follow-up on endpoint c++ refactor

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -638,10 +638,8 @@ protected:
 	 * @brief	Cleanup endpoint resources.
 	 * 
 	 * Virtual function to clean up and release each transport type's endpoint resources.
-	 * Should not throw exceptions, and instead returns an error code on success or failure
-	 * to make it safe to call in endpoint destructors. Set called_cleanup_resources to true
-	 * at the start of the function to make sure it is only called once per endpoint
-	 * instance.
+	 * Set called_cleanup_resources to true at the start of the function to make sure it
+	 * is only called once per endpoint instance.
 	 * 
 	 * @return	0 if successfully, negative error code on failure.
 	 */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -900,7 +900,7 @@ public:
 
 	inline nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain()
 	{
-		return (nccl_net_ofi_rdma_domain_t *) domain;
+		return static_cast<nccl_net_ofi_rdma_domain_t *>(domain);
 	}
 
 	inline nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device()

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1086,7 +1086,7 @@ public:
 	   receive communicator */
 	bool is_endpoint_per_communicator_ep;
 
-private:
+protected:
 	/**
 	 * @brief	Initialize rx buffer data of endpoint
 	 *

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -863,10 +863,20 @@ public:
 	/**
 	 * @brief	Destructor.
 	 * 
-	 * Overrides base endpoint class virtual destructor, releases endpoint rails
-	 * and freelists.
+	 * Overrides base endpoint class virtual destructor, asserts that "cleanup_resources"
+	 * had already been called to clean up RDMA endpoint resources before the destructor
+	 * was called.
+	 * 
+	 * TODO: Make protected once no longer needed to be directly called in 
+	 * nccl_net_ofi_rdma_domain_t::create_endpoint.
 	 */
 	~nccl_net_ofi_rdma_ep_t() override;
+
+	/**
+	 * TODO: Make protected once no longer needed to be directly called in 
+	 * nccl_net_ofi_rdma_domain_t::create_endpoint.
+	 */
+	int cleanup_resources() override;
 
 	int listen(nccl_net_ofi_conn_handle_t *handle,
 		   nccl_net_ofi_listen_comm_t **listen_comm) override;
@@ -1075,9 +1085,6 @@ public:
 	/* true if the current endpoint is a endpoint_per_communicator
 	   receive communicator */
 	bool is_endpoint_per_communicator_ep;
-
-protected:
-	int cleanup_resources() override;
 
 private:
 	/**

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -174,14 +174,6 @@ public:
 	 */
 	nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_domain_t *domain_arg);
 
-	/**
-	 * @brief	Destructor.
-	 * 
-	 * Overrides base endpoint class virtual destructor, releases freelist and 
-	 * endpoint resources.
-	 */
-	~nccl_net_ofi_sendrecv_ep_t() override;
-
 	int listen(nccl_net_ofi_conn_handle_t *handle,
 		   nccl_net_ofi_listen_comm_t **listen_comm) override;
 
@@ -222,6 +214,15 @@ public:
 	struct fid_av *av = nullptr;
 
 protected:
+	/**
+	 * @brief	Destructor.
+	 * 
+	 * Overrides base endpoint class virtual destructor, asserts that "cleanup_resources"
+	 * had already been called to clean up SENDRECV endpoint resources before the
+	 * destructor was called.
+	 */
+	~nccl_net_ofi_sendrecv_ep_t() override;
+
 	int cleanup_resources() override;
 };
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -183,7 +183,7 @@ public:
 
 	inline nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain()
 	{
-		return (nccl_net_ofi_sendrecv_domain_t *) domain;
+		return static_cast<nccl_net_ofi_sendrecv_domain_t *>(domain);
 	}
 
 	inline nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device()

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -201,6 +201,20 @@ public:
 		return sendrecv_endpoint_get_domain()->domain;
 	}
 
+	/**
+	 * Abort an endpoint when a communicator using it still has inflight requests
+	 *
+	 * This function will
+	 * 1. Close the OFI resources (ep, av) associated with the endpoint
+	 * 2. Mark the associated domain as inactive to prevent further use of domain
+	 *    resources, such as completion queue
+	 *
+	 * After this function returns, the endpoint will still have non-OFI resources
+	 * allocated (freelists, rx requests, etc.), but will not be usable except to
+	 * release it (release_ep).
+	 */
+	void sendrecv_endpoint_abort();
+
 	/* Current available tag ID */
 	uint64_t tag;
 

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -1165,16 +1165,16 @@ nccl_net_ofi_domain_t::~nccl_net_ofi_domain_t()
 int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
 {
 	int ret = 0;
-	nccl_net_ofi_domain_t *domain_ptr = domain;
+	nccl_net_ofi_domain_t *domain_ptr = this->domain;
 
 	if (!skip_lock) {
 		nccl_net_ofi_mutex_lock(&domain_ptr->domain_lock);
 	}
 
-	decrement_ref_cnt();
+	this->decrement_ref_cnt();
 
 	/* Store ref_cnt in local variable in case the endpoint gets deleted */
-	int local_ref_cnt = ref_cnt;
+	int local_ref_cnt = this->ref_cnt;
 	
 	if (local_ref_cnt == 0 || force_cleanup) {
 		/* If this was the endpoint we stored in domain for connection
@@ -1187,7 +1187,7 @@ int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
 			NCCL_OFI_INFO(NCCL_NET, "Endpoint %p still have ref count %d when released",
 				      this, local_ref_cnt);
 		}
-		ret = cleanup_resources();
+		ret = this->cleanup_resources();
 		delete this;
 	}
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -4941,8 +4941,9 @@ int nccl_net_ofi_rdma_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	}
 
 	/* Build listen_comm */
-	l_comm = (nccl_net_ofi_rdma_listen_comm_t *)calloc(1,
-							   sizeof(nccl_net_ofi_rdma_listen_comm_t));
+	l_comm = static_cast<nccl_net_ofi_rdma_listen_comm_t *>(calloc(
+		1,
+		sizeof(nccl_net_ofi_rdma_listen_comm_t)));
 	if (OFI_UNLIKELY(l_comm == nullptr)) {
 		NCCL_OFI_WARN("Couldn't allocate listen_comm for dev %d", dev_id);
 		ret = -ENOMEM;
@@ -6270,7 +6271,7 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 	/* Extract connection state of the communicator */
 	save_comm_state_t *comm_state = &(handle->state);
 	nccl_net_ofi_rdma_send_comm_t *s_comm =
-		(nccl_net_ofi_rdma_send_comm_t *)comm_state->comm;
+		reinterpret_cast<nccl_net_ofi_rdma_send_comm_t *>(comm_state->comm);
 
 	nccl_net_ofi_rdma_domain_t *domain_ptr = this->rdma_endpoint_get_domain();
 

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1005,31 +1005,17 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 }
 
 
-/**
- * Abort an endpoint when a communicator using it still has inflight requests
- *
- * This function will
- * 1. Close the OFI resources (ep, av) associated with the endpoint
- * 2. Mark the associated domain as inactive to prevent further use of domain
- *    resources, such as completion queue
- *
- * After this function returns, the endpoint will still have non-OFI resources
- * allocated (freelists, rx requests, etc.), but will not be usable except to
- * release it (release_ep).
- */
-static inline void sendrecv_endpoint_abort(nccl_net_ofi_sendrecv_ep_t *ep)
+void nccl_net_ofi_sendrecv_ep_t::sendrecv_endpoint_abort()
 {
-	nccl_net_ofi_sendrecv_domain_t *domain_ptr = ep->sendrecv_endpoint_get_domain();
+	pthread_wrapper domain_lock(&this->domain->domain_lock);
 
-	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
+	int dev_id = this->domain->get_device()->dev_id;
 
-	int dev_id = domain_ptr->get_device()->dev_id;
+	nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, dev_id);
+	this->ofi_ep = nullptr;
+	this->av = nullptr;
 
-	nccl_ofi_ofiutils_ep_release(ep->ofi_ep, ep->av, dev_id);
-	ep->ofi_ep = NULL;
-	ep->av = NULL;
-
-	domain_ptr->invalidate();
+	this->domain->invalidate();
 }
 
 
@@ -1054,7 +1040,7 @@ static int sendrecv_recv_comm_close(nccl_net_ofi_recv_comm_t *recv_comm)
 		NCCL_OFI_WARN("Closing recv_comm %p with inflight requests. Invalidating domain",
 			      r_comm);
 
-		sendrecv_endpoint_abort(ep);
+		ep->sendrecv_endpoint_abort();
 	}
 
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
@@ -1849,7 +1835,7 @@ static int sendrecv_send_comm_close(nccl_net_ofi_send_comm_t *send_comm)
 		NCCL_OFI_WARN("Closing send_comm %p with inflight requests. Invalidating domain",
 			      s_comm);
 
-		sendrecv_endpoint_abort(ep);
+		ep->sendrecv_endpoint_abort();
 	}
 
 	nccl_ofi_freelist_fini(s_comm->nccl_ofi_reqs_fl);

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1652,7 +1652,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	nccl_net_ofi_sendrecv_listen_comm_t *l_comm = nullptr;
 	int dev_id = 0;
 	int num_addrs;
-	nccl_net_ofi_sendrecv_domain_t *domain_ptr = sendrecv_endpoint_get_domain();
+	nccl_net_ofi_sendrecv_domain_t *domain_ptr = this->sendrecv_endpoint_get_domain();
 
 	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
 	CHECK_DOMAIN_ACTIVE(domain_ptr, "listen");
@@ -1666,13 +1666,13 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 
 	dev_id = device->base.dev_id;
 
-	local_ep_name = sendrecv_get_local_address(ofi_ep);
+	local_ep_name = sendrecv_get_local_address(this->ofi_ep);
 	if (local_ep_name == nullptr) {
 		return -EINVAL;
 	}
 
 	/* Insert local EP address to AV. This will be used to issue local read operations */
-	num_addrs = fi_av_insert(av, (void *)local_ep_name, 1, &local_ep_addr, 0, NULL);
+	num_addrs = fi_av_insert(this->av, (void *)local_ep_name, 1, &local_ep_addr, 0, NULL);
 
 	/* Only 1 address should be inserted into the AV */
 	if (OFI_UNLIKELY(num_addrs != 1)) {
@@ -1697,7 +1697,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	l_comm->base.base.dev_id = dev_id;
 	l_comm->base.accept = sendrecv_listen_comm_accept;
 	l_comm->base.close = sendrecv_listen_comm_close;
-	l_comm->local_ep = ofi_ep;
+	l_comm->local_ep = this->ofi_ep;
 	l_comm->local_ep_addr = local_ep_addr;
 
 	l_comm->listener = domain_ptr->cm->listen();
@@ -2024,7 +2024,7 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 {
 	int ret = 0;
 	*send_comm = nullptr;
-	nccl_net_ofi_sendrecv_domain_t *domain_ptr = sendrecv_endpoint_get_domain();
+	nccl_net_ofi_sendrecv_domain_t *domain_ptr = this->sendrecv_endpoint_get_domain();
 	assert(domain_ptr != nullptr);
 
 	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
@@ -2063,7 +2063,7 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 	}
 
 	/* Progress our engine to get completions */
-	ret = sendrecv_cq_process(sendrecv_endpoint_get_domain()->cq);
+	ret = sendrecv_cq_process(this->sendrecv_endpoint_get_domain()->cq);
 	if (OFI_UNLIKELY(ret != 0)) {
 		free(s_comm);
 		return ret;
@@ -2109,18 +2109,18 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 {
 	int ret = 0;
-	called_cleanup_resources = true;
+	this->called_cleanup_resources = true;
 	nccl_net_ofi_sendrecv_device_t *device = nullptr;
 
 	/* Validate device */
-	device = sendrecv_endpoint_get_device();
+	device = this->sendrecv_endpoint_get_device();
 	if (OFI_UNLIKELY(device == nullptr)) {
 		NCCL_OFI_WARN("Invalid device provided");
 		ret = -EINVAL;
 	} else {
-		nccl_ofi_ofiutils_ep_release(ofi_ep, av, device->base.dev_id);
-		ofi_ep = nullptr;
-		av = nullptr;		
+		nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, device->base.dev_id);
+		this->ofi_ep = nullptr;
+		this->av = nullptr;		
 	}
 
 	assert(ret == 0);
@@ -2132,8 +2132,8 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 nccl_net_ofi_sendrecv_ep_t::~nccl_net_ofi_sendrecv_ep_t()
 {
 	int ret = 0;
-	if (!called_cleanup_resources) {
-		ret = cleanup_resources();
+	if (!this->called_cleanup_resources) {
+		ret = this->cleanup_resources();
 	}
 
 	if (ret != 0) {
@@ -2160,14 +2160,14 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 	assert(device != nullptr);
 
 	/* Initialize endpoint tag */
-	tag = 0;
-	max_tag = device->max_tag;
+	this->tag = 0;
+	this->max_tag = device->max_tag;
 
-	struct fid_domain *ofi_domain = sendrecv_endpoint_get_ofi_domain();
+	struct fid_domain *ofi_domain = this->sendrecv_endpoint_get_ofi_domain();
 	ret = nccl_ofi_ofiutils_init_connection(device->info,
 						ofi_domain,
-						&ofi_ep,
-						&av,
+						&this->ofi_ep,
+						&this->av,
 						domain_arg->cq);
 	if (ret != 0) {
 		throw std::runtime_error("sendrecv endpoint constructor: failed to init endpoint");

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2109,6 +2109,9 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 {
 	int ret = 0;
+
+	/* cleanup_resources should only be called once per endpoint instance */
+	assert(!this->called_cleanup_resources);
 	this->called_cleanup_resources = true;
 	nccl_net_ofi_sendrecv_device_t *device = nullptr;
 
@@ -2131,14 +2134,9 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 
 nccl_net_ofi_sendrecv_ep_t::~nccl_net_ofi_sendrecv_ep_t()
 {
-	int ret = 0;
-	if (!this->called_cleanup_resources) {
-		ret = this->cleanup_resources();
-	}
-
-	if (ret != 0) {
-		NCCL_OFI_WARN("SENDRECV transport endpoint destructor failed");
-	}
+	/* cleanup_resources should always be called to clean-up endpoint resources before
+	   the destructor is called */
+	assert(this->called_cleanup_resources);
 }
 
 

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1683,9 +1683,9 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	free(local_ep_name);
 
 	/* Build listen_comm */
-	l_comm = (nccl_net_ofi_sendrecv_listen_comm_t *)calloc(
+	l_comm = static_cast<nccl_net_ofi_sendrecv_listen_comm_t *>(calloc(
 		1,
-		sizeof(nccl_net_ofi_sendrecv_listen_comm_t));
+		sizeof(nccl_net_ofi_sendrecv_listen_comm_t)));
 	if (OFI_UNLIKELY(l_comm == nullptr)) {
 		NCCL_OFI_WARN("Couldn't allocate listen_comm for dev %d", dev_id);
 		return -ENOMEM;
@@ -1705,7 +1705,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	/* Build handle */
 	*handle = l_comm->listener->get_handle();
 
-	*listen_comm = (nccl_net_ofi_listen_comm_t *)l_comm;
+	*listen_comm = reinterpret_cast<nccl_net_ofi_listen_comm_t *>(l_comm);
 	return 0;
 }
 
@@ -2043,7 +2043,7 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 	/* Extract connection state of the communicator */
 	save_comm_state_t *comm_state = &(handle->state);
 	nccl_net_ofi_sendrecv_send_comm_t *s_comm =
-		(nccl_net_ofi_sendrecv_send_comm_t *)comm_state->comm;
+		reinterpret_cast<nccl_net_ofi_sendrecv_send_comm_t *>(comm_state->comm);
 
 	/* Connection establishment is not done yet */
 	if (comm_state->stage == COMM_CONNECTED) {


### PR DESCRIPTION
Follow-up on #851 and #938 to further refactor the endpoint classes. Updates endpoint code to match decisions made in the domain C++ refactor such as:
* re-introduce using the `this` keyword in endpoint members
* refactor transport-specific endpoint destructors to not cleanup resources (always expect an endpoint instance to be cleaned up before calling `delete`).
* update C-style casts in endpoint members to C++ casts (`static_cast` and `reinterpret_cast`)

Also refactors the stand-alone `sendrecv_endpoint_abort` function to be a SENDRECV endpoint member function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.