### PR TITLE
update: Add git ppa to ubuntu container for latest git

### DIFF
--- a/docker/base/Dockerfile.ubuntu
+++ b/docker/base/Dockerfile.ubuntu
@@ -15,11 +15,12 @@ RUN apt-get update && \
     software-properties-common && \
     add-apt-repository universe && \
     add-apt-repository multiverse && \
+    add-apt-repository ppa:git-core/ppa && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \
     curl wget git build-essential gcc-multilib \
     libhwloc-dev make sudo lsb-release pciutils \
     libevent-core-2.1-7 libevent-pthreads-2.1-7 \
-    udev dmidecode ethtool iproute2 \
+    rpm udev dmidecode ethtool iproute2 \
     environment-modules tcl \
     libnl-3-200 libnl-3-dev \
     libnl-route-3-200 libnl-route-3-dev && \


### PR DESCRIPTION
*Description of changes:*
Updating the Ubuntu container to use the latest version of git. This will allow the automation of releases when pushing a tag to the aws-ofi-nccl repo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
