### PR TITLE
rdma: Improve error handling for null r_comm for receives

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -166,15 +166,6 @@ static inline void rdma_device_set_comm(nccl_net_ofi_rdma_device_t *device,
 	device->comms[local_comm_id] = comm;
 }
 
-/*
- * @brief	Get endpoint listen communicator with given comm_id
- */
-static inline nccl_net_ofi_rdma_listen_comm_t *rdma_device_get_listen_comm(nccl_net_ofi_rdma_device_t *device, uint32_t local_comm_id)
-{
-	nccl_net_ofi_rdma_listen_comm_t *l_comm = (nccl_net_ofi_rdma_listen_comm_t *)rdma_device_get_comm(device, local_comm_id);
-	assert(l_comm->base.base.type == NCCL_NET_OFI_LISTEN_COMM);
-	return l_comm;
-}
 
 /*
  * @brief	Get endpoint send communicator with given ID


### PR DESCRIPTION
Fails gracefully when r_comm is null in the following paths:

1. On eager receive. This can happen in a race condition where an eager
   message arrives after the recv comm has been closed, and the recv
   comm did not yet have any inflight requests (so the domain was not
   invalidated). However, it is not expected to happen given the way
   NCCL's communicator abort currently works, where all existing
   communicators are closed before a new communicator is created.

2. On write-with-immediate completion. This should never happen, because
   a write implies the receiver sent the control message, so there
   should be an `irecv` inflight, which means we should invalidate the
   domain in this case.

This is a follow-up to #953.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
