### PR TITLE
Update the <pci link_speed> entry to match kernel 5.7+

### DIFF
--- a/src/nccl_ofi_topo.cpp
+++ b/src/nccl_ofi_topo.cpp
@@ -31,7 +31,7 @@ const char *speed_name = "max_link_speed";
 const char *width_name = "max_link_width";
 
 /* `pcie_gen[i]` defines the speed of a PCIe lane of PCIe generation `i+1` */
-const char *pcie_gen[] = {"2.5", "5", "8", "16", "32", "64"};
+const char *pcie_gen[] = {"2.5", "5.0", "8.0", "16.0", "32.0", "64.0"};
 
 /*
  * @brief Create vector of nccl_ofi_topo_data_t structs
@@ -1350,7 +1350,7 @@ static int write_pci_tag(FILE *file, int indent,
 			 "%*s"
 			 "<pci "
 			 "busid=\"%04x:%02x:%02x.%01x\" "
-			 "link_speed=\"%s GT/s PCIe/s\" "
+			 "link_speed=\"%s GT/s PCIe\" "
 			 "link_width=\"%zu\"/>\n",
 			 indent,
 			 "",


### PR DESCRIPTION
Fix a small typo to make sure the link_speed is reported as expected in [topo.cc](https://github.com/NVIDIA/nccl/blob/7c12c627c62ef4e5a2485777a8d9dce58f3f562f/src/graph/topo.cc#L410).

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
