### PR TITLE
v1.16.x: add platform config for p5.4xlarge

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -134,6 +134,17 @@ static struct ec2_platform_data platform_data_map[] = {
 		},
 	},
 	{
+		.name = "p5.4xlarge",
+		.regex = NULL,
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 75.0,
+		.gdr_required = false,
+		.default_protocol = "SENDRECV",
+		.domain_per_thread = false,
+		.env = {},
+	},
+	{
 		.name = "p5/p5e",
 		.regex = "^p5(e?\\..*)",
 		.topology = NULL,

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -57,6 +57,7 @@ static int check_known_platforms(void)
 	ret += check_value(platform_data_list, len, "p3dn.24xlarge", "p3dn.24xlarge");
 	ret += check_value(platform_data_list, len, "p4d.24xlarge", "p4d.24xlarge");
 	ret += check_value(platform_data_list, len, "p4de.24xlarge", "p4de.24xlarge");
+	ret += check_value(platform_data_list, len, "p5.4xlarge", "p5.4xlarge");
 	ret += check_value(platform_data_list, len, "p5.48xlarge", "p5/p5e");
 	ret += check_value(platform_data_list, len, "p5e.48xlarge", "p5/p5e");
 	ret += check_value(platform_data_list, len, "p5en.48xlarge", "p-series");


### PR DESCRIPTION
To properly support using the OFI NCCL plugin on the AWS p5.4xlarge instance type, adds a new platform configuration specifying to use the SENDRECV transport protocol, and setting "gdr_required" to false.

Different than https://github.com/aws/aws-ofi-nccl/commit/eae9392852609192229100d9001660baf16d6ed5 since the protocol enum parameter added in https://github.com/aws/aws-ofi-nccl/pull/944 has not been ported to the `v1.16.x` branch yet.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
