### PR TITLE
release: Begin v1.16.3 cycle

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,7 +6,7 @@
 #
 
 # Initialization
-AC_INIT([aws-ofi-nccl], [1.16.2], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
+AC_INIT([aws-ofi-nccl], [1.16.3a1], [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.cpp])
 AC_CONFIG_AUX_DIR([build-aux])


### PR DESCRIPTION
*Description of changes:*

Following the v1.16.2 release from the v1.16.x release branch, bump the release branch version to v1.16.3a1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
