### PR TITLE
fix: Update release name for automated release process

### DIFF
--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -102,6 +102,7 @@ jobs:
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
+          name: AWS OFI NCCL ${{ github.ref_name }}
           draft: true
           prerelease: false
           body_path: RELEASE_NOTES.md


### PR DESCRIPTION
*Description of changes:*

Update release name for automated release process from `v1.*.*` to `AWS OFI NCCL v1.*.*` according to MCM instruction.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
