### PR TITLE
ofiutils: enable requested key for local MRs

### DIFF
--- a/src/nccl_ofi_ofiutils.cpp
+++ b/src/nccl_ofi_ofiutils.cpp
@@ -402,26 +402,11 @@ void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av, int dev_
  */
 int nccl_ofi_mr_keys_need_own_key(struct fi_info* provider, bool *provide_own_mr_key)
 {
-	if (!(provider->caps & FI_RMA)) {
-		/* When FI_RMA is not requested, Libfabric considers
-		   memory registrations to be local only, and
-		   therefore the requested_key field is ignored and
-		   (unfortunately) a random key may be returned from
-		   fi_mr_key().  This totally screws up the code to
-		   provide a unique MR key, which is, according to
-		   Libfabric, unnecessary in this mode anyway, so fall
-		   back to the provider-specified key code, which
-		   should behave properly in either case. */
-		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s only configured for local registration.",
-			       provider->fabric_attr->prov_name);
-		*provide_own_mr_key = false;
-	}
-	else if (provider->domain_attr->mr_mode & FI_MR_PROV_KEY) {
+	if (provider->domain_attr->mr_mode & FI_MR_PROV_KEY) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s selects memory registration keys",
 			       provider->fabric_attr->prov_name);
 		*provide_own_mr_key = false;
-	}
-	else {
+	} else {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "Provider %s does not select memory registration keys",
 			       provider->fabric_attr->prov_name);
 		*provide_own_mr_key = true;


### PR DESCRIPTION
*Description of changes:*

According to the latest [libfabric documentation](https://github.com/ofiwg/libfabric/blob/ae8d1461d4e1bca88bdb0f59c7f5d172ef3eb1fe/man/fi_mr.3.md?plain=1#L725-L728), provider may need to use the requested key for local MRs. With [PR #833](https://github.com/aws/aws-ofi-nccl/pull/833), we are able to provide keys no matter whether the provider ignores them. Thus, we enable requested key for local MRs in case the provider need to use it.

This change has been tested with both Libfabric v1.22.0 and Libfabric V2.1.0 on P6 platform, and all passed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
