### PR TITLE
platform: reorder p5/p5e entry and update p-series entry

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -112,28 +112,6 @@ static struct ec2_platform_data platform_data_map[] = {
 		.env = {},
 	},
 	{
-		.name = "p-series",
-		/*
-		 * we only want to match P5en and later, as earlier
-		 * platforms all either need to be ignored or special
-		 * cased.
-		 */
-		.regex = "^(p5en\\.48xlarge)|(^p([6-9]|[0-9]{2,}).*)",
-		.topology = NULL,
-		.default_dup_conns = 0,
-		.latency = 35.0,
-		.gdr_required = true,
-		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
-		.env = {
-			{ "NCCL_BUFFSIZE", "8388608" },
-			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
-			{ "NCCL_NVLSTREE_MAX_CHUNKSIZE", "524288" },
-			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
-			{ "NCCL_NET_FORCE_FLUSH", "0" },
-		},
-	},
-	{
 		.name = "p5.4xlarge",
 		.regex = NULL,
 		.topology = NULL,
@@ -150,6 +128,29 @@ static struct ec2_platform_data platform_data_map[] = {
 		.topology = NULL,
 		.default_dup_conns = 0,
 		.latency = 75.0,
+		.gdr_required = true,
+		.default_protocol = PROTOCOL::RDMA,
+		.domain_per_thread = true,
+		.env = {
+			{ "NCCL_BUFFSIZE", "8388608" },
+			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
+			{ "NCCL_NVLSTREE_MAX_CHUNKSIZE", "524288" },
+			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
+			{ "NCCL_NET_FORCE_FLUSH", "0" },
+		},
+	},
+	{
+		.name = "p-series",
+		/*
+		 * While the regex will match against P5 and later
+		 * instance families, we expect this to only apply
+		 * to P5en and later, due to previous entries to
+		 * match P5 and P5e.
+		 */
+		.regex = "^p([5-9]|[0-9]{2,}).*",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
 		.domain_per_thread = true,


### PR DESCRIPTION
*Description of changes:*

Reorder the `p5/p5e` entry to be before `p-series` entry, and simplify the "p5en and later" regex for `p-series` entry.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
