### PR TITLE
param: Enable domain-per-thread by default for AWS platforms

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -80,7 +80,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -94,7 +94,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -108,7 +108,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 150.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -124,7 +124,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -141,7 +141,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -152,7 +152,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -169,7 +169,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {},
 	},
 	{


### PR DESCRIPTION
Enable domain-per-thread by default on all AWS instance types. We previously only enabled it for AWS Trainium instance types, but we noticed a performance degradation when NCCL creates multiple proxy threads using the same EFA device.

As a consequence, this commit will disable support for user registration
by default. We will need to do some refactoring to re-enable user
registration mode with domain-per-thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
