### PR TITLE
[v1.16.x] param: Enable domain-per-thread by default for AWS platforms

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -197,17 +197,14 @@ pipeline {
 
                     // p3dn tests
                     stages["4_p3dn_al2"] = get_test_stage_with_lock_container("4_p3dn_al2", env.BUILD_TAG, p3_p4_p5_base_os, "alinux2", "p3dn.24xlarge", p3dn_lock_label, num_instances, p3_p4_addl_args)
-                    stages["4_p3dn_ubuntu2004"] = get_test_stage_with_lock_container("4_p3dn_ubuntu2004", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2004", "p3dn.24xlarge", p3dn_lock_label, num_instances, p3_p4_addl_args)
                     stages["4_p3dn_ubuntu2204"] = get_test_stage_with_lock_container("4_p3dn_ubuntu2204", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2204", "p3dn.24xlarge", p3dn_lock_label, num_instances, p3_p4_addl_args)
 
                     // p4d tests
                     stages["4_p4d_alinux2"] = get_test_stage_with_lock_container("4_p4d_alinux2", env.BUILD_TAG, p3_p4_p5_base_os, "alinux2", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
-                    stages["4_p4d_ubuntu2004"] = get_test_stage_with_lock_container("4_p4d_ubuntu2004", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2004", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
                     stages["4_p4d_ubuntu2204"] = get_test_stage_with_lock_container("4_p4d_ubuntu2204", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2204", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
 
                     // p5 tests
                     stages["4_p5_alinux2"] = get_test_stage_with_lock_container("4_p5_alinux2", env.BUILD_TAG, p3_p4_p5_base_os, "alinux2", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
-                    stages["4_p5_ubuntu2004"] = get_test_stage_with_lock_container("4_p5_ubuntu2004", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2004", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
                     stages["4_p5_ubuntu2204"] = get_test_stage_with_lock_container("4_p5_ubuntu2204", env.BUILD_TAG, p3_p4_p5_base_os, "ubuntu2204", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
 
                     // g4dn tests
@@ -215,10 +212,10 @@ pipeline {
                     stages["4_g4dn_ubuntu2204_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204_tcp", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
 
                     // trn1 tests
-                    stages["4_trn1_ubuntu2004"] = get_test_stage_with_lock_persistent("4_trn1_ubuntu2004", env.BUILD_TAG, "ubuntu2004", "trn1.32xlarge", trn1_lock_label, num_instances, neuron_addl_args)
+                    stages["4_trn1_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn1_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn1.32xlarge", trn1_lock_label, num_instances, neuron_addl_args)
 
                     // trn1n tests
-                    stages["4_trn1n_ubuntu2004"] = get_test_stage_with_lock_persistent("4_trn1n_ubuntu2004", env.BUILD_TAG, "ubuntu2004", "trn1n.32xlarge", trn1n_lock_label, num_instances, neuron_addl_args)
+                    stages["4_trn1n_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn1n_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn1n.32xlarge", trn1n_lock_label, num_instances, neuron_addl_args)
 
                     parallel stages
                 }

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -80,7 +80,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = "SENDRECV",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -94,7 +94,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = "SENDRECV",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -108,7 +108,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 150.0,
 		.gdr_required = false,
 		.default_protocol = "SENDRECV",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {},
 	},
 	{
@@ -124,7 +124,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = "RDMA",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -141,7 +141,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = "SENDRECV",
-		.domain_per_thread = false,
+		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -152,7 +152,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = "RDMA",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -169,7 +169,7 @@ static struct ec2_platform_data platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = "SENDRECV",
-		.domain_per_thread = 0,
+		.domain_per_thread = 1,
 		.env = {},
 	},
 	{


### PR DESCRIPTION
Enable domain-per-thread by default on all AWS instance types. We previously only enabled it for AWS Trainium instance types, but we noticed a performance degradation when NCCL creates multiple proxy threads using the same EFA device.

As a consequence, this commit will disable support for user registration by default. We will need to do some refactoring to re-enable user registration mode with domain-per-thread.


(cherry picked from commit 241e29ee5b4697abfb16d2050ea6847dba8963fc)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
