### PR TITLE
Implement vNIC Functionality from v9 and v10 of the NCCL API

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -274,6 +274,8 @@ typedef struct nccl_ofi_properties {
 	size_t max_p2p_bytes;
 	/** Max transfer size for collective operations **/
 	size_t max_coll_bytes;
+	/** Virtual device properties - original physical devices for virtual devices **/
+	ncclNetVDeviceProps_t vProps;
 } nccl_ofi_properties_t;
 
 /**
@@ -877,6 +879,14 @@ struct nccl_net_ofi_plugin {
 	size_t (*get_num_devices)(nccl_net_ofi_plugin_t *plugin);
 
 	int (*release_plugin)(nccl_net_ofi_plugin_t *plugin);
+
+	/**
+	 * Create virtual device from multiple physical devices
+	 *
+	 * Creates a virtual device that aggregates properties from
+	 * multiple physical devices. Returns the new device index.
+	 */
+	ncclResult_t (*makeVDevice)(nccl_net_ofi_plugin_t* plugin, int* deviceIndex, void* props);
 
 	/*
 	 * Determine whether to allocate the domain per process or per

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -66,5 +66,6 @@ ncclResult_t nccl_net_ofi_iwrite_inline_v5(void* sComm, void* src, size_t size,
 					   uint64_t dest, uint64_t mr_key, void** req);
 ncclResult_t nccl_net_ofi_iread_v5(void* rComm, void* dest, size_t size, void* mhandle,
 				   uint64_t src, uint64_t mr_key, void** req);
+ncclResult_t nccl_net_ofi_makevdevice(int* deviceIndex, void* props);
 
 #endif // End NET_OFI_API_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -376,6 +376,6 @@ OFI_NCCL_PARAM(PROGRESS_MODEL, progress_model,  "PROGRESS_MODEL", PROGRESS_MODEL
 /*
  * Skip nccl_ofi_topo_gen() when non-zero
  */
-OFI_NCCL_PARAM(bool, skip_topo_gen, "SKIP_TOPO_GEN", true);
+OFI_NCCL_PARAM(bool, enable_vnic_gen, "ENABLE_VNIC_GEN", true);
 
 #endif // End NCCL_OFI_PARAM_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -373,4 +373,9 @@ OFI_NCCL_PARAM_UINT(cm_num_rx_buffers, "CM_NUM_RX_BUFFERS", 32);
 OFI_NCCL_PARAM_VALUE_SET(PROGRESS_MODEL, (UNSPEC)(AUTO)(MANUAL))
 OFI_NCCL_PARAM(PROGRESS_MODEL, progress_model,  "PROGRESS_MODEL", PROGRESS_MODEL::UNSPEC)
 
+/*
+ * Skip nccl_ofi_topo_gen() when non-zero
+ */
+OFI_NCCL_PARAM(bool, skip_topo_gen, "SKIP_TOPO_GEN", true);
+
 #endif // End NCCL_OFI_PARAM_H_

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1191,7 +1191,8 @@ public:
 	nccl_net_ofi_rdma_device_t(nccl_net_ofi_plugin_t *plugin,
 				   int dev_id,
 				   struct fi_info *info_list,
-				   nccl_ofi_topo_t *topo);
+				   nccl_ofi_topo_t *topo,
+				   ncclNetVDeviceProps_t* props);
 
 	int release_device() override;
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1153,6 +1153,9 @@ struct nccl_net_ofi_rdma_device_rail_t {
 
 	/* Fabric handle */
 	struct fid_fabric *fabric;
+
+	/* Original physical device index this rail came from (for virtual devices) */
+	int source_dev_id;
 };
 
 

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -1042,10 +1042,5 @@ ncclResult_t nccl_net_ofi_makevdevice(int* deviceIndex, void* props)
 		return check_return(ncclInvalidUsage);
 	}
 	ncclResult_t result = check_return(plugin->makeVDevice(plugin, deviceIndex, props));
-
-	if (result == ncclSuccess && deviceIndex) {
-		NCCL_OFI_INFO(NCCL_INIT, "nccl_net_ofi_makevdevice: SUCCESS - Created virtual device with index %d\n", *deviceIndex);
-	}
-
 	return result;
 }

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -315,9 +315,8 @@ static int write_topo_file(nccl_ofi_topo_t *topo)
 		goto error;
 	}
 
-	// TODO: Disable this if vNic Path is enabled
 	/* Set topology file path environment variable `NCCL_TOPO_FILE` */
-	// env_manager::getInstance().insert_envvar("NCCL_TOPO_FILE", filename, true);
+	env_manager::getInstance().insert_envvar("NCCL_TOPO_FILE", filename, true);
 
 	goto exit;
 
@@ -7418,39 +7417,41 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 		goto error;
 	}
 
-	ret = nccl_ofi_topo_group(topo);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to group NICs");
-		goto error;
-	}
-
-	if (topo->max_group_size > MAX_NUM_RAILS) {
-		NCCL_OFI_WARN("Unexpected topo group size of %d (maximum %d)",
-			      topo->max_group_size, MAX_NUM_RAILS);
-		ret = -EINVAL;
-		goto error;
-	}
-	if (topo->max_group_size < 1) {
-		NCCL_OFI_WARN("Unexpected group size %d", topo->max_group_size);
-		ret = -EINVAL;
-		goto error;
-	}
-
-	if (topo->max_group_size > 1) {
-		*found_multiple_rails = true;
-	}
-
-	/**
-	 * NCCL's topology detection will set NIC PCIe link speed based on the
-	 * "leader" NIC for the GPU. For multi-rail platforms, we increase the
-	 * link speed reported to NCCL to account for the other rails. This
-	 * requires generating a topology file that will be passed to NCCL.
-	 */
-	if (topo->max_group_size > 1) {
-		ret = write_topo_file(topo);
+	if (!ofi_nccl_enable_vnic_gen()) {
+		ret = nccl_ofi_topo_group(topo);
 		if (ret != 0) {
-			NCCL_OFI_WARN("Failed to write NCCL topology file");
+			NCCL_OFI_WARN("Failed to group NICs");
 			goto error;
+		}
+
+		if (topo->max_group_size > MAX_NUM_RAILS) {
+			NCCL_OFI_WARN("Unexpected topo group size of %d (maximum %d)",
+		 topo->max_group_size, MAX_NUM_RAILS);
+			ret = -EINVAL;
+			goto error;
+		}
+		if (topo->max_group_size < 1) {
+			NCCL_OFI_WARN("Unexpected group size %d", topo->max_group_size);
+			ret = -EINVAL;
+			goto error;
+		}
+
+		if (topo->max_group_size > 1) {
+			*found_multiple_rails = true;
+		}
+
+		/**
+		 * NCCL's topology detection will set NIC PCIe link speed based on the
+		 * "leader" NIC for the GPU. For multi-rail platforms, we increase the
+		 * link speed reported to NCCL to account for the other rails. This
+		 * requires generating a topology file that will be passed to NCCL.
+		 */
+		if (topo->max_group_size > 1) {
+			ret = write_topo_file(topo);
+			if (ret != 0) {
+				NCCL_OFI_WARN("Failed to write NCCL topology file");
+				goto error;
+			}
 		}
 	}
 

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2480,6 +2480,7 @@ static int nccl_net_ofi_sendrecv_plugin_create(size_t num_devices,
 
 	plugin->base.release_plugin = nccl_net_ofi_sendrecv_plugin_fini;
 	plugin->base.complete_init = nccl_net_ofi_sendrecv_plugin_complete_init;
+	plugin->base.makeVDevice = nullptr;
 
 	*plugin_p = plugin;
 

--- a/src/nccl_ofi_topo.cpp
+++ b/src/nccl_ofi_topo.cpp
@@ -1018,11 +1018,6 @@ int nccl_ofi_topo_group(nccl_ofi_topo_t *topo)
 {
 	int ret = 0;
 
-	if (ofi_nccl_skip_topo_gen()) {
-		NCCL_OFI_INFO(NCCL_INIT, "nccl_ofi_topo_group() skipped by Mozar 1184 test");
-		return ret;
-	}
-
         ret = mark_topo_nodes_with_ofi_info_subtree(topo);
 	if (ret != 0) {
 		return ret;

--- a/src/nccl_ofi_topo.cpp
+++ b/src/nccl_ofi_topo.cpp
@@ -1018,6 +1018,11 @@ int nccl_ofi_topo_group(nccl_ofi_topo_t *topo)
 {
 	int ret = 0;
 
+	if (ofi_nccl_skip_topo_gen()) {
+		NCCL_OFI_INFO(NCCL_INIT, "nccl_ofi_topo_group() skipped by Mozar 1184 test");
+		return ret;
+	}
+
         ret = mark_topo_nodes_with_ofi_info_subtree(topo);
 	if (ret != 0) {
 		return ret;

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -131,6 +131,8 @@ static struct ec2_platform_data platform_data_map[] = {
 			{ "NCCL_NVLSTREE_MAX_CHUNKSIZE", "524288" },
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
+			{ "NCCL_NET_MERGE_LEVEL", "PORT" },
+			{ "NCCL_NET_FORCE_MERGE", "rdmap85s0,rdmap86s0;rdmap87s0,rdmap88s0;rdmap110s0,rdmap111s0;rdmap112s0,rdmap113s0;rdmap135s0,rdmap136s0;rdmap137s0,rdmap138s0;rdmap160s0,rdmap161s0;rdmap162s0,rdmap163s0" },
 		},
 	},
 	{
@@ -159,6 +161,7 @@ static struct ec2_platform_data platform_data_map[] = {
 			{ "NCCL_NVLSTREE_MAX_CHUNKSIZE", "524288" },
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
+			{ "NCCL_NET_MERGE_LEVEL", "PIX" },
 		},
 	},
 	{


### PR DESCRIPTION
*Description of changes:*
Implementing makeVDevice to enable the vNIC functionality from v9 and v10 of the API. This will offload the merging of the NICs to NCCL.

# **NOTE: PR IS A WIP**

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
