### PR TITLE
rdma: Optimize flush performance

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -45,6 +45,43 @@ int nccl_net_ofi_cuda_get_num_devices(void);
  */
 int nccl_net_ofi_cuda_get_active_device_idx(void);
 
+/*
+ * @brief wraps cuMemAlloc()
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size);
+
+/*
+ * @brief wraps cuMemFree()
+ * @return	0 on success
+ *		-1 on error
+ */
+
+int nccl_net_ofi_cuda_mem_free(void *ptr);
+/*
+ * @brief wraps cuMemcpy() from host to device
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size);
+
+/*
+ * @brief wraps cuMemGetAddressRange() to get the base addr and size
+ * of a given pointer
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_get_base_addr(const void *ptr, void **base, size_t *size);
+
+/*
+ * @brief Uses cuMemGetHandleForAddressRange() to obtain
+ * the fd and offset for a dma buf. In case CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
+ * is not supported we retry with flags set to 0.
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_get_dma_buf_fd(void *ptr, size_t size, int *fd, size_t *offset);
 
 /*
  * @brief	query CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED

--- a/include/nccl_ofi_dmabuf.h
+++ b/include/nccl_ofi_dmabuf.h
@@ -7,4 +7,6 @@
 
 int nccl_ofi_dmabuf_viable(void);
 
+int nccl_ofi_dmabuf_viable_and_supported(struct fi_info *nic_prov);
+
 #endif  // NCCL_OFI_DMABUF_H_

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -9,6 +9,18 @@
 
 #include "nccl_ofi_param.h"
 
+/*
+ * Memeory util functions to ensure that the compiler does not optimize
+ * these memory accesses.
+ */
+#define ACCESS_ONCE(x) (*(volatile __typeof__(x) *)&(x))
+
+#define READ_ONCE(x) \
+({ __typeof__(x) ___x = ACCESS_ONCE(x); ___x; })
+
+#define WRITE_ONCE(x, val) \
+do { ACCESS_ONCE(x) = (val); } while (0)
+
 int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 				    uint32_t required_version,
 				    struct fi_info *hints,

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -83,6 +83,14 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         AC_MSG_RESULT(${chk_result})
         ])
 
+  check_cuda_dmabuf_mapping_type_pcie=0
+  AS_IF([test "${check_pkg_found}" = "yes"],
+            [AC_CHECK_DECL([CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE],
+            [check_cuda_dmabuf_mapping_type_pcie=1],
+            [check_cuda_dmabuf_mapping_type_pcie=0],
+            [[#include <cuda.h>]])
+      ])
+
   AS_IF([test "${check_pkg_found}" = "yes"],
         [check_pkg_define=1
          $1],
@@ -91,6 +99,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
 
   AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
   AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF_SUPPORT], [${check_cuda_dmabuf_define}], [Defined to 1 if CUDA DMA-BUF support is available])
+  AC_DEFINE_UNQUOTED([HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE], [${check_cuda_dmabuf_mapping_type_pcie}], [Defined to 1 if CUDA DMA mapping type PCIE support is available])
   AC_DEFINE_UNQUOTED([HAVE_CUDA_GDRFLUSH_SUPPORT], [${check_cuda_gdr_flush_define}], [Defined to 1 if CUDA cuFlushGPUDirectRDMAWrites support is available])
   AM_CONDITIONAL([HAVE_CUDA], [test "${check_pkg_found}" = "yes"])
 

--- a/src/nccl_ofi_dmabuf.cpp
+++ b/src/nccl_ofi_dmabuf.cpp
@@ -8,6 +8,7 @@
 #include <stdio.h>
 #include <sys/utsname.h>
 
+#include "nccl_ofi.h"
 #include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_param.h"
@@ -90,4 +91,48 @@ int nccl_ofi_dmabuf_viable()
 	NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 	               "Attempting to use DMA-BUF capable providers. set OFI_NCCL_DISABLE_DMABUF=1 to disable");
 	return true;
+}
+
+/*
+* Consolidate dmabuf viable checks with other firmwware related checks
+*/
+int nccl_ofi_dmabuf_viable_and_supported(struct fi_info *nic_prov) {
+
+	bool dmabuf_support = ((nic_prov->caps & FI_HMEM) != 0) &&
+		FI_VERSION_GE(nic_prov->fabric_attr->api_version, FI_VERSION(1, 20)) &&
+		nccl_ofi_dmabuf_viable();
+
+	if (dmabuf_support && strncmp("efa", nic_prov->fabric_attr->prov_name, strlen("efa")) == 0) {
+		// Generations 1-3 of EFA have a firmware issue that can result
+		// in communication failures with MRs that cover a large number
+		// of page entries.  This is not usually a problem, because page
+		// merging greatly reduces the number of page entries in the MR.
+		// However, the RDMA subsystem in the Linux kernel did not
+		// properly execute page merging for dmabuf entries until a
+		// recent patch
+		// (https://web.git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git/commit/?id=486055f5e09df9),
+		// and the lack of page merging increased the probability of
+		// hitting the EFA issue.  Testing for the fixed kernel version
+		// is effectively impossible (the issue can also be fixed in the
+		// EFA kmod itself, and backports are likely, so a simple kernel
+		// version check is insufficient), so instead we only support
+		// dmabuf by default in Generation 4 of EFA.  When the
+		// communication failure issue is resolved in previous
+		// generations, this code will be removed and dmabuf will be
+		// available by default everywhere.
+		if (nic_prov->nic == NULL || nic_prov->nic->device_attr == NULL) {
+			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+				       "DMA-BUF disabled due to missing nic data");
+			dmabuf_support = false;
+		} else if (strcmp("0xefa0", nic_prov->nic->device_attr->device_id) == 0 ||
+			   strcmp("0xefa1", nic_prov->nic->device_attr->device_id) == 0 ||
+			   strcmp("0xefa2", nic_prov->nic->device_attr->device_id) == 0) {
+			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
+				       "DMA-BUF disabled due to EFA device id %s",
+				       nic_prov->nic->device_attr->device_id);
+			dmabuf_support = false;
+		}
+	}
+
+	return dmabuf_support;
 }

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -608,42 +608,7 @@ int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov
 
 	props->max_mr_key_size = nic_prov->domain_attr->mr_key_size;
 
-	props->dmabuf_support = ((nic_prov->caps & FI_HMEM) != 0) &&
-		FI_VERSION_GE(nic_prov->fabric_attr->api_version, FI_VERSION(1, 20)) &&
-		nccl_ofi_dmabuf_viable()
-		;
-	if (props->dmabuf_support && strncmp("efa", nic_prov->fabric_attr->prov_name, strlen("efa")) == 0) {
-		// Generations 1-3 of EFA have a firmware issue that can result
-		// in communication failures with MRs that cover a large number
-		// of page entries.  This is not usually a problem, because page
-		// merging greatly reduces the number of page entries in the MR.
-		// However, the RDMA subsystem in the Linux kernel did not
-		// properly execute page merging for dmabuf entries until a
-		// recent patch
-		// (https://web.git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git/commit/?id=486055f5e09df9),
-		// and the lack of page merging increased the probability of
-		// hitting the EFA issue.  Testing for the fixed kernel version
-		// is effectively impossible (the issue can also be fixed in the
-		// EFA kmod itself, and backports are likely, so a simple kernel
-		// version check is insufficient), so instead we only support
-		// dmabuf by default in Generation 4 of EFA.  When the
-		// communication failure issue is resolved in previous
-		// generations, this code will be removed and dmabuf will be
-		// available by default everywhere.
-		if (nic_prov->nic == NULL || nic_prov->nic->device_attr == NULL) {
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-				       "DMA-BUF disabled due to missing nic data");
-			props->dmabuf_support = false;
-		} else if (strcmp("0xefa0", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("0xefa1", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("0xefa2", nic_prov->nic->device_attr->device_id) == 0) {
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-				       "DMA-BUF disabled due to EFA device id %s",
-				       nic_prov->nic->device_attr->device_id);
-			props->dmabuf_support = false;
-		}
-	}
-
+       props->dmabuf_support = nccl_ofi_dmabuf_viable_and_supported(nic_prov);
 	if (props->dmabuf_support) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET, "DMA-BUF support is advertised in properties.");
 	}


### PR DESCRIPTION
This commit optimizes rdma flush performance using the result of rdma read to determine flush completion.
We start by allocating a page-size gpu memory and setting it to a sentinel value. The flush operation will trigger a read from this gpu memory to the host buffer. Further to test if the flush request has completed, check if the host buffer has been updated to the sentinel value.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
