### PR TITLE
ofi: manage Libfabric resource lifecycle with smart pointers

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -38,6 +38,7 @@ noinst_HEADERS = \
 	nccl_ofi_system.h \
 	nccl_ofi_topo.h \
 	nccl_ofi_tracepoint.h \
+	ofi/resource_wrapper.h \
 	platform-aws.h \
 	internal/tuner/nccl_defaults.h \
 	stats/histogram.h \

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -19,6 +19,7 @@
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
 #include "nccl_ofi_mr.h"
+#include "ofi/resource_wrapper.h"
 
 /*
  * NCCL_NET_HANDLE_MAXSIZE is a limited resource (and defined in NCCL).
@@ -148,7 +149,8 @@ struct nccl_net_ofi_req {
 	int (*test)(nccl_net_ofi_req_t *req, int *done, int *size);
 };
 
-struct nccl_net_ofi_mr_handle_t {
+class nccl_net_ofi_mr_handle_t {
+public:
 	/**
 	 * @brief	Default constructor
 	 */
@@ -458,7 +460,7 @@ public:
 	 * depending on the transport; in that case, this will be the domain object
 	 * associated with the "leader NIC".
 	 */
-	virtual struct fid_domain *get_ofi_domain_for_cm() = 0;
+	virtual ofi_domain_ptr &get_ofi_domain_for_cm() = 0;
 
 	/**
 	 * Retrieve an fid_cq object associated with this domain to be used for 
@@ -466,7 +468,7 @@ public:
 	 * on the transport; in that case, this will be the cq object associated with the
 	 * "leader NIC".
 	 */
-	virtual struct fid_cq *get_ofi_cq_for_cm() = 0;
+	virtual ofi_cq_ptr &get_ofi_cq_for_cm() = 0;
 
 	/* Create a new endpoint
 	 *

--- a/include/nccl_ofi_ofiutils.h
+++ b/include/nccl_ofi_ofiutils.h
@@ -8,6 +8,7 @@
 #include <rdma/fabric.h>
 
 #include "nccl_ofi_param.h"
+#include "ofi/resource_wrapper.h"
 
 /*
  * Memeory util functions to ensure that the compiler does not optimize
@@ -28,22 +29,68 @@ int nccl_ofi_ofiutils_get_providers(const char *prov_include,
 				    unsigned int *num_prov_infos);
 
 
-/*
- * @brief	Allocates and initialises libfabric endpoint and AV.
- *
- * @param cq:	Completion queue to which the new endpoint will be bound
- * @return	Endpoint ep
- * @return	Address vector av
- */
-int nccl_ofi_ofiutils_init_connection(struct fi_info *info, struct fid_domain *domain,
-				      struct fid_ep **ep,   struct fid_av **av,
-				      struct fid_cq *cq);
-
-/*
+/**
  * @brief	Release libfabric endpoint and address vector
  */
-void nccl_ofi_ofiutils_ep_release(struct fid_ep *ep, struct fid_av *av,
-				  int dev_id);
+void nccl_ofi_ofiutils_ep_release(ofi_ep_ptr& ep, ofi_av_ptr& av, int dev_id);
+
+/**
+ * @brief	Create and initialize libfabric fabric
+ *
+ * @param info:		Fabric info for fabric creation
+ * @return		Result containing error code and fabric pointer
+ */
+ofi_fabric_result nccl_ofi_ofiutils_fabric_create(struct fi_info *info);
+
+/**
+ * @brief	Create and initialize libfabric domain
+ *
+ * @param fabric:	Fabric handle
+ * @param info:		Fabric info for domain creation
+ * @return		Result containing error code and domain pointer
+ */
+ofi_domain_result nccl_ofi_ofiutils_domain_create(ofi_fabric_ptr& fabric, struct fi_info *info);
+
+/**
+ * @brief	Create and initialize libfabric endpoint
+ *
+ * @param info:		Fabric info for endpoint creation
+ * @param domain:	Fabric domain
+ * @param av:		Address vector to which the new endpoint will be bound
+ * @param cq:		Completion queue to which the new endpoint will be bound
+ * @return		Result containing error code and endpoint pointer
+ */
+ofi_ep_result nccl_ofi_ofiutils_ep_create(struct fi_info *info, ofi_domain_ptr &domain,
+					  ofi_av_ptr &av, ofi_cq_ptr &cq);
+
+/**
+ * @brief	Create and initialize libfabric address vector
+ *
+ * @param domain:	Domain handle
+ * @return		Result containing error code and address vector pointer
+ */
+ofi_av_result nccl_ofi_ofiutils_av_create(ofi_domain_ptr &domain);
+
+/**
+ * @brief	Create and initialize libfabric completion queue
+ *
+ * @param domain:	Domain handle
+ * @param cq_attr:	CQ attributes
+ * @return		Result containing error code and completion queue pointer
+ */
+ofi_cq_result nccl_ofi_ofiutils_cq_create(ofi_domain_ptr &domain, struct fi_cq_attr *cq_attr);
+
+/**
+ * @brief	Register memory region with libfabric using fi_mr_regattr
+ *
+ * @param domain:	Domain handle
+ * @param mr_attr:	Memory region attributes structure
+ * @param flags:	Registration flags
+ * @return		Result containing error code and memory region pointer
+ */
+ofi_mr_result nccl_ofi_ofiutils_mr_regattr(ofi_domain_ptr &domain, 
+					   struct fi_mr_attr *mr_attr, 
+					   uint64_t flags);
 
 /*
  * @brief	Free libfabric NIC info list.

--- a/include/ofi/resource_wrapper.h
+++ b/include/ofi/resource_wrapper.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef OFI_RESOURCE_WRAPPER_H_
+#define OFI_RESOURCE_WRAPPER_H_
+
+#include <memory>
+#include <rdma/fabric.h>
+#include "nccl_ofi_log.h"
+
+/**
+ * Unique pointer wrappers for Libfabric resources
+ *
+ * To automatically clean up Libfabric resources such as "fid_domain" and "fid_ep" during stack
+ * unwinding, we store the initialized resource in a unique_ptr with a custom destructor that
+ * calls "fi_close". For example, if an exception gets thrown in a constructor after Libfabric
+ * resources were already created, the custom destructor will get called during the stack
+ * unwinding and release the resources.
+ *
+ * This file defines the destructor and unique_ptr alias for each Libfabric resource type,
+ * as well as factory functions to create each type of Libfabric resource unique_ptr. This also
+ * defines the "ofi_result" struct as a custom return type to return both a Libfabric
+ * resource unique_ptr and the OFI API return code in a single object for cleaner error handling.
+ */
+
+/**
+ * @brief Macro to generate type name specializations
+ */
+#define OFI_TYPE_NAME_SPECIALIZE(resource_type) \
+	template<> inline const char* ofi_type_name<struct resource_type>() \
+	{ return #resource_type; }
+
+/**
+ * @brief Macro to declare all OFI type-related definitions
+ *
+ * This macro takes a short name (e.g., "domain") and generates the complete
+ * type system for the corresponding libfabric type (e.g., "fid_domain"):
+ * - ofi_domain_ptr, ofi_domain_deleter, ofi_domain_result
+ * - Proper struct fid_domain references for libfabric compatibility
+ */
+#define DECLARE_OFI_TYPE(short_name) \
+	OFI_TYPE_NAME_SPECIALIZE(fid_##short_name) \
+	using ofi_##short_name##_deleter = generic_ofi_deleter<struct fid_##short_name>; \
+	using ofi_##short_name##_ptr = std::unique_ptr<struct fid_##short_name, ofi_##short_name##_deleter>; \
+	using ofi_##short_name##_result = ofi_result<ofi_##short_name##_ptr>; \
+	inline ofi_##short_name##_ptr make_ofi_##short_name##_ptr(struct fid_##short_name* resource) { \
+		return ofi_##short_name##_ptr(resource); \
+	}
+
+/**
+ * @brief List of all supported OFI types (using short names)
+ */
+#define FOR_EACH_OFI_TYPE(macro) \
+	macro(ep) \
+	macro(av) \
+	macro(domain) \
+	macro(cq) \
+	macro(mr) \
+	macro(fabric)
+
+/**
+ * @brief Compile-time type name resolution for Libfabric resources
+ *
+ * Primary template generates compile error for unsupported types.
+ * Explicit specializations provide type-safe name mapping.
+ */
+template<typename fid_type>
+const char *ofi_type_name()
+{
+	static_assert(sizeof(fid_type) == 0, "Unsupported Libfabric resource type");
+	return nullptr;
+}
+
+/**
+ * @brief Generic template deleter for Libfabric resources
+ *
+ * Provides unified cleanup logic for all Libfabric fid_* resource types.
+ * Uses template specialization for type-safe resource name resolution.
+ */
+template<typename fid_type>
+struct generic_ofi_deleter {
+	void operator()(fid_type *resource) const
+	{
+		if (resource) {
+			int ret = fi_close(&resource->fid);
+			if (ret != 0) {
+				NCCL_OFI_WARN("Failed to close %s: %s",
+					      ofi_type_name<fid_type>(), fi_strerror(-ret));
+			}
+		}
+	}
+};
+
+/**
+ * @brief Result type for OFI resource creation operations
+ *
+ * Encapsulates both the error code and the created resource (if successful).
+ * Provides convenient methods for checking success/failure status.
+ */
+template<typename resource_ptr>
+class ofi_result {
+public:
+	int error_code;
+	resource_ptr resource;
+
+	// Constructors
+	ofi_result() : error_code(-1), resource(nullptr) {}
+	ofi_result(int err) : error_code(err), resource(nullptr) {}
+	ofi_result(resource_ptr &&res) : error_code(0), resource(std::move(res)) {}
+	ofi_result(int err, resource_ptr &&res) : error_code(err), resource(std::move(res)) {}
+
+	// Status checking methods
+	bool is_success() const { return error_code == 0 && resource != nullptr; }
+	bool is_failure() const { return !is_success(); }
+};
+
+FOR_EACH_OFI_TYPE(DECLARE_OFI_TYPE);
+
+#endif // OFI_RESOURCE_WRAPPER_H_


### PR DESCRIPTION
To ensure that Libfabric resources managed by transport datatypes are automatically cleaned up during stack unwinding, this wraps Libfabric resources in unique_ptr with custom destructors that call "fi_close". Adds and refactors existing "ofiutils" helper functions to create and initialize the unique_ptr Libfabric resources.

I only used the unique_ptr wrapper for classes that own the associated Libfabric resource, and continued using raw pointers for classes that just use the resource owned by someone else. I also avoided updating functions to take in the unique_ptr type as an argument, and instead continue to handle the raw Libfabric resource pointers (using the unique_ptr ".get()" function).

To support the unique_ptr requirement to not be copyable, this updates the RDMA transport protocol rail datatypes that own Libfabric resources to delete the copy constructor and copy assignment operator.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

