### PR TITLE
packaging/rpm: remove ldconfig_scriptlets in RPM spec

### DIFF
--- a/contrib/fedora/aws-ofi-nccl.spec
+++ b/contrib/fedora/aws-ofi-nccl.spec
@@ -47,7 +47,9 @@ autoreconf -ivf
 mkdir -p %{buildroot}/etc/ld.so.conf.d && \
     echo "%{_libdir}" >> %{buildroot}/etc/ld.so.conf.d/100_ofinccl.conf
 find %{buildroot} -name '*.la' -exec rm -f {} ';'
-%ldconfig_scriptlets
+
+%post -p /sbin/ldconfig
+%postun -p /sbin/ldconfig
 
 %files
 %{_libdir}/*.so


### PR DESCRIPTION
According to Fedora packaging documentation, the "%ldconfig_scriptlets" macro does not have any effect on Fedora, and packages that put linker configuration files in /etc/ld.so.conf.d must call "ldconfig" in "%post" and "%postun". This updates the aws-ofi-nccl.spec RPM spec file with the correct "ldconfig" calls.

Fedora docs: https://docs.fedoraproject.org/en-US/packaging-guidelines/Scriptlets/#_snippets

> Packages which place linker configuration files in /etc/ld.so.conf.d MUST call ldconfig in %post and %postun (on all Fedora releases) even if they install no actual libraries. They MUST NOT use the %ldconfig, %ldconfig_post, %ldconfig_postun or %ldconfig_scriptlets macros to do this, since these macros do not have any effect on Fedora. Instead simply call ldconfig directly in both %post and %postun as well as adding the necessary dependencies when necessary

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
