### PR TITLE
packaging/deb: remove multi-arch from deb package library path

### DIFF
--- a/contrib/debian-template/control
+++ b/contrib/debian-template/control
@@ -12,8 +12,6 @@ Rules-Requires-Root: no
 Package: libnccl-ofi
 Section: contrib/libs
 Architecture: any
-Multi-Arch: same
-Pre-Depends: ${misc:Pre-Depends}
 Depends: ${misc:Depends}, ${shlib:Depends}
 Description: NCCL libfabric plugin
  AWS OFI NCCL is a plug-in which enables EC2 developers to use libfabric as a

--- a/contrib/debian-template/rules
+++ b/contrib/debian-template/rules
@@ -1,13 +1,16 @@
 #!/usr/bin/make -f
 
-include /usr/share/dpkg/default.mk
+include /usr/share/dpkg/architecture.mk
+include /usr/share/dpkg/buildflags.mk
+include /usr/share/dpkg/pkg-info.mk
 
 export DEB_BUILD_MAINT_OPTIONS = hardening=+all optimize=+lto
-MULTIARCH_DIR := $(shell dpkg-architecture -q DEB_HOST_MULTIARCH)
+
+OFI_NCCL_PREFIX=/opt/amazon/ofi-nccl
 
 override_dh_missing:
 	find debian/ -name *.la -delete
-	mkdir -p debian/libnccl-ofi/etc/ld.so.conf.d && echo "/opt/amazon/ofi-nccl/lib/$(MULTIARCH_DIR)/" >> debian/libnccl-ofi/etc/ld.so.conf.d/100_ofinccl.conf
+	mkdir -p debian/libnccl-ofi/etc/ld.so.conf.d && echo "${OFI_NCCL_PREFIX}/lib" >> debian/libnccl-ofi/etc/ld.so.conf.d/100_ofinccl.conf
 	dh_missing --fail-missing
 
 override_dh_shlibdeps:
@@ -16,7 +19,8 @@ override_dh_shlibdeps:
 override_dh_auto_configure:
 	dh_auto_configure -- \
 		--with-libfabric=/opt/amazon/efa \
-		--prefix=/opt/amazon/ofi-nccl \
+		--prefix=${OFI_NCCL_PREFIX} \
+		--libdir=${OFI_NCCL_PREFIX}/lib \
 		--enable-platform-aws \
 		--with-cuda=/usr/local/cuda \
 		--enable-cudart-dynamic \


### PR DESCRIPTION
To align the OFI NCCL plugin DEB library installation path with the paths of other packages the plugin gets bundled with, this removes automatically configuring the DEB package to follow Debian multi-arch guidelines, and instead hard-codes the DEB library path to "/opt/amazon/ofi-nccl/lib".

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
