### PR TITLE
build: Replace net/tuner plugin symlinks with libs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -253,11 +253,16 @@ AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Adding ${werror_flags} to CXXFLAGS.])
        CXXFLAGS="${werror_flags} ${CXXFLAGS} "])
 
+AC_ARG_ENABLE([nccl-net-library],
+      [AS_HELP_STRING([--disable-nccl-net-library],
+           [Do not create shared library libnccl-net.so that is the same as libnccl-net-ofi.so.
+            Useful in cases where you are trying to install multiple plugins in the same container.])])
 AC_ARG_ENABLE([nccl-net-symlink],
       [AS_HELP_STRING([--disable-nccl-net-symlink],
-           [Do not create symlink libnccl-net.so to point at libnccl-net-ofi.so.  Useful in cases where
-	   you are trying to install multiple plugins in the same container.])])
-AM_CONDITIONAL([ENABLE_NCCL_NET_SYMLINK], [test "${enable_nccl_net_symlink}" != "no"])
+           [Deprecated, is equivalent to --disable-nccl-net-library. Do not create
+            shared library libnccl-net.so that is the same as libnccl-net-ofi.so.
+            Useful in cases where you are trying to install multiple plugins in the same container.])])
+AM_CONDITIONAL([ENABLE_NCCL_NET_LIBRARY], [test "${enable_nccl_net_library}" != "no" && test "${enable_nccl_net_symlink}" != "no"])
 
 AC_SUBST([NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS])
 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -80,15 +80,15 @@ else
 # We always install libnccl-net-ofi.so.  To use the default shared library,
 # either NCCL_NET_PLUGIN=libnccl-net-ofi.so or NCCL_NET_PLUGIN=ofi must be set.
 #
-# To enable the OFI plugin by default, a symlink libnccl-net.so is created.  If
+# To enable the OFI plugin by default, a libnccl-net.so library is created.  If
 # NCCL_NET_PLUGIN is not set, NCCL will attempt to dlopen libnccl-net.so, with
 # dlopen() searching the default search path.  This behavior is optional, as
 # some situations (like the NGC containers) may have multiple network plugins.
 #
 # Recent versions of NCCL include a tuner interface for algorithm/protocol
-# selection.  The tuner code lives in the net plugin, but a symlink is created
-# to libnccl-ofi-tuner.so when the tuner is built (when on AWS).  Differenct
-# versions of NCCL have different tuner loading behaviors:
+# selection.  The tuner code lives in the net plugin, but a libnccl-ofi-tuner.so
+# library is created when the tuner is built (when on AWS).
+# Different versions of NCCL have different tuner loading behaviors:
 #
 #  2.19 - 2.20    Tuner only loaded if NCCL_TUNER_PLUGIN is set to a filename
 #  2.21 -         First look for NCCL_TUNER_PLUGIN, then look for tuner interface
@@ -96,30 +96,27 @@ else
 #
 # By bundling the tuner in the net plugin, we cause the tuner to be used by
 # default on NCCL 2.21 or later.
-symlink_files =
-if ENABLE_NCCL_NET_SYMLINK
-symlink_files += libnccl-net.so
+if ENABLE_NCCL_NET_LIBRARY
+  lib_LTLIBRARIES += libnccl-net.la
+  libnccl_net_la_SOURCES =
+  libnccl_net_la_LIBADD = libinternal_plugin.la
+  libnccl_net_la_LIBTOOLFLAGS = --tag=CXX
+  libnccl_net_la_LDFLAGS = -module -avoid-version
 endif
 if WANT_PLATFORM_AWS
 # NCCL standardized on the libnccl-tuner-<interface> format after we released a
-# plugin with the tuner named libnccl-ofi-tuner.so.  Since they're all symlinks
-# anyway, do both.
-symlink_files += libnccl-ofi-tuner.so libnccl-tuner-ofi.so
+# plugin with the tuner named libnccl-ofi-tuner.so.  Create separate libraries
+# for each name.
+  lib_LTLIBRARIES += libnccl-ofi-tuner.la libnccl-tuner-ofi.la
+  libnccl_ofi_tuner_la_SOURCES =
+  libnccl_ofi_tuner_la_LIBADD = libinternal_plugin.la
+  libnccl_ofi_tuner_la_LIBTOOLFLAGS = --tag=CXX
+  libnccl_ofi_tuner_la_LDFLAGS = -module -avoid-version
+
+  libnccl_tuner_ofi_la_SOURCES =
+  libnccl_tuner_ofi_la_LIBADD = libinternal_plugin.la
+  libnccl_tuner_ofi_la_LIBTOOLFLAGS = --tag=CXX
+  libnccl_tuner_ofi_la_LDFLAGS = -module -avoid-version
 endif
-
-install_plugin_symlinks = { \
-  test -z "$$files" \
-    || { test ! -d "$$dir" && test ! -f "$$dir" && test ! -r "$$dir"; } \
-    || { for file in $$files ; do \
-	echo " ( cd '$$dir' && rm -f $$file && $(LN_S) libnccl-net-ofi.so $$file )"; \
-         $(am__cd) "$$dir" && rm -f $$file && $(LN_S) libnccl-net-ofi.so $$file ; \
-	done } \
-  }
-
-install-exec-hook:
-	@files="$(symlink_files)" ; dir='$(DESTDIR)$(libdir)' ; $(install_plugin_symlinks)
-
-uninstall-local:
-	@files="$(symlink_files)" ; dir='$(DESTDIR)$(libdir)' ; $(am__uninstall_files_from_dir)
 
 endif


### PR DESCRIPTION
To ensure that the "libnccl-net.so" and OFI NCCL plugin tuner paths can properly be cached by "ldconfig", this replaces the symbolic links from those paths to the "libnccl-net-ofi.so" shared library with separate shared library files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.