### PR TITLE
rdma: wait for flush comps when freeing recv comm

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -607,6 +607,13 @@ typedef struct nccl_net_ofi_rdma_recv_comm {
 	nccl_ofi_cm_receiver *receiver;
 
 	uint64_t num_inflight_reqs;
+
+	/**
+	 * Number of outstanding flush requests that have been marked as completed
+	 * without getting a completion event
+	 */
+	uint64_t num_pending_flush_comps;
+
 	nccl_ofi_freelist_t *nccl_ofi_reqs_fl;
 
 	/* Comm ID provided by the local endpoint */


### PR DESCRIPTION
With the RDMA protocol flush optimizations added in 9ddf233, the plugin can mark flush requests as completed before getting their completion events. In this case, we release the request resources and decrement num_inflight_reqs only after getting the completion event. This can lead to situation where NCCL believes all requests have been completed and tries to close the receive communicator before we got all completion events. During clean-up we find that num_inflight_reqs is non-zero, leading us to believe that we are in an abort flow where NCCL is closing the communicator before completing all requests, and we invalidate our domain.

To avoid incorrectly entering the abort flow, we track the number of outstanding flush requests that have been marked as completed before getting completion events separately from num_inflight_reqs, and during clean-up we wait on destroying the recv communicator until we got all outstanding flush request completions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
