### PR TITLE
Disable runtime connect for P5en/P6-B200

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -168,6 +168,15 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
 			{ "NCCL_NETDEVS_POLICY", "max:1" },
+			/* NCCL-tests v2.16.8 revealed inconsistent channel
+			 * initialization in NCCL, regressing 0x7
+			 * collectives. The issue manifests when channels
+			 * initialized for patterns like PAT with 2 NICs
+			 * and subsequently reused by ring algorithm.
+			 * Disabling runtime connect as temporary
+			 * workaround.
+			 */
+			{ "NCCL_RUNTIME_CONNECT", "0" },
 		},
 	},
 	{


### PR DESCRIPTION
Disable NCCL runtime connect for P5en/P6-B200 due to inconsistent channel initialization observed after NCCL-tests v2.16.8. The issue manifests when channels initialized for patterns like PAT with 2 NICs and subsequently reused by ring algorithm.

Added NCCL_RUNTIME_CONNECT=0 as temporary workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
