### PR TITLE
tuner: update all 0x0 p6 tuner regions.

### DIFF
--- a/src/tuner/nccl_ofi_regions.cpp
+++ b/src/tuner/nccl_ofi_regions.cpp
@@ -951,68 +951,76 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 
 			nccl_ofi_tuner_point_t extended_tree_ll =
 				extend_region((nccl_ofi_tuner_point_t){393216, 16},
-							  (nccl_ofi_tuner_point_t){393216, 1024},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+						(nccl_ofi_tuner_point_t){393216, 1024},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 			nccl_ofi_tuner_point_t extended_tree_ll128 =
-				extend_region((nccl_ofi_tuner_point_t){131596288, 1024},
-							  (nccl_ofi_tuner_point_t){144179200, 2048},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+				extend_region((nccl_ofi_tuner_point_t){96993280, 1024},
+						(nccl_ofi_tuner_point_t){106430464, 2048},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 			nccl_ofi_tuner_point_t extended_nvlstree_simple =
 				extend_region((nccl_ofi_tuner_point_t){10737418240, 512},
-							  (nccl_ofi_tuner_point_t){34359738368, 1500},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+						(nccl_ofi_tuner_point_t){34359738368, 1500},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 
 			const nccl_ofi_tuner_region_t regions[] = {
-				{.algorithm = NCCL_ALGO_TREE,
-				 .protocol = NCCL_PROTO_LL,
-				 .num_vertices = 4,
-				 .vertices = {{0, 16}, {393216, 16}, extended_tree_ll, {0, TUNER_MAX_RANKS}}},
-				{.algorithm = NCCL_ALGO_TREE,
-				 .protocol = NCCL_PROTO_LL128,
-				 .num_vertices = 9,
-				 .vertices = {
+			{.algorithm = NCCL_ALGO_TREE,
+				.protocol = NCCL_PROTO_LL,
+				.num_vertices = 4,
+				.vertices = {{0, 16}, {393216, 16}, extended_tree_ll, {0, TUNER_MAX_RANKS}}},
+			{.algorithm = NCCL_ALGO_TREE,
+				.protocol = NCCL_PROTO_LL128,
+				.num_vertices = 10,
+				.vertices = {
 					extended_tree_ll,
 					{393216, 16},
-					{12058624, 16},
-					{24641536, 32},
-					{59244544, 64},
-					{90701824, 128},
-					{131596288, 1024},
-					{144179200, 2048},
+					{4718592, 16},
+					{18350080, 32},
+					{40370176, 64},
+					{57147392, 128},
+					{72876032, 256},
+					{96993280, 1024},
+					{106430464, 2048},
 					extended_tree_ll128}},
-				{.algorithm = NCCL_ALGO_RING,
-				 .protocol = NCCL_PROTO_LL128,
-				 .num_vertices = 5,
-				 .vertices = {
+			{.algorithm = NCCL_ALGO_RING,
+				.protocol = NCCL_PROTO_LL128,
+				.num_vertices = 5,
+				.vertices = {
 					{90701824, 128},
-					{59244544, 64},
-					{24641536, 32},
+					{50855936, 64},
+					{18350080, 32},
 					{133693440, 32},
 					{120061952, 64}}},
-				{.algorithm = NCCL_ALGO_NVLS_TREE,
-				 .protocol = NCCL_PROTO_SIMPLE,
-				 .num_vertices = 13,
-				 .vertices = {
+			{.algorithm = NCCL_ALGO_NVLS_TREE,
+				.protocol = NCCL_PROTO_SIMPLE,
+				.num_vertices = 19,
+				.vertices = {
 					extended_tree_ll128,
-					{144179200, 2048},
-					{131596288, 1024},
+					{106430464, 2048},
+					{96993280, 1024},
+					{72876032, 256},
+					{57147392, 128},
+					{40370176, 64},
+					{18350080, 32},
+					{50855936, 64},
 					{90701824, 128},
 					{120061952, 64},
 					{133693440, 32},
-					{24641536, 32},
-					{12058624, 16},
+					{18350080, 32},
+					{4718592, 16},
 					{TUNER_MAX_SIZE, 16},
-					{468713472, 32},
+					{435159040, 32},
+					{1072693248, 64},
 					{10737418240, 512},
 					{34359738368, 1500},
 					extended_nvlstree_simple}},
-				{.algorithm = NCCL_ALGO_RING,
-				 .protocol = NCCL_PROTO_SIMPLE,
-				 .num_vertices = 4,
-				 .vertices = {
+			{.algorithm = NCCL_ALGO_RING,
+				.protocol = NCCL_PROTO_SIMPLE,
+				.num_vertices = 5,
+				.vertices = {
 					extended_nvlstree_simple,
 					{10737418240, 512},
-					{468713472, 32},
+					{1072693248, 64},
+					{435159040, 32},
 					{TUNER_MAX_SIZE, 16}}}};
 			ret = set_regions(region_ctx, collType, sizeof(regions) / sizeof(regions[0]), regions);
 			if (ret != ncclSuccess) {
@@ -1024,12 +1032,12 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 
 			nccl_ofi_tuner_point_t extended_ring_ll =
 				extend_region((nccl_ofi_tuner_point_t){74973184, 1024},
-							  (nccl_ofi_tuner_point_t){209190912, 2048},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+						(nccl_ofi_tuner_point_t){213385216, 2048},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 			nccl_ofi_tuner_point_t extended_ring_ll128 =
 				extend_region((nccl_ofi_tuner_point_t){8321499136, 512},
-							  (nccl_ofi_tuner_point_t){32212254720, 2048},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+						(nccl_ofi_tuner_point_t){32212254720, 2048},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 
 			const nccl_ofi_tuner_region_t regions[] = {
 				{.algorithm = NCCL_ALGO_RING,
@@ -1037,13 +1045,13 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 					.num_vertices = 10,
 					.vertices = {
 						{0, 16},
-						{196608, 16},
-						{196608, 32},
-						{393216, 64},
-						{8912896, 128},
+						{786432, 16},
+						{1572864, 32},
+						{2621440, 64},
+						{4718592, 128},
 						{17301504, 256},
 						{74973184, 1024},
-						{209190912, 2048},
+						{213385216, 2048},
 						extended_ring_ll,
 						{0, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_RING,
@@ -1051,16 +1059,16 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 					.num_vertices = 14,
 					.vertices = {
 						extended_ring_ll,
-						{209190912, 2048},
+						{213385216, 2048},
 						{74973184, 1024},
 						{17301504, 256},
-						{8912896, 128},
-						{393216, 64},
-						{196608, 32},
-						{196608, 16},
-						{234356736, 16},
-						{374341632, 32},
-						{829423616, 64},
+						{4718592, 128},
+						{2621440, 64},
+						{1572864, 32},
+						{786432, 16},
+						{198705152, 16},
+						{456130560, 32},
+						{871366656, 64},
 						{8321499136, 512},
 						{32212254720, 2048},
 						extended_ring_ll128}},
@@ -1071,11 +1079,10 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 						extended_ring_ll128,
 						{32212254720, 2048},
 						{8321499136, 512},
-						{829423616, 64},
-						{374341632, 32},
-						{234356736, 16},
+						{871366656, 64},
+						{456130560, 32},
+						{198705152, 16},
 						{TUNER_MAX_SIZE, 16}}}};
-
 			ret = set_regions(region_ctx, collType, sizeof(regions) / sizeof(regions[0]), regions);
 			if (ret != ncclSuccess) {
 				goto exit;
@@ -1085,44 +1092,46 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 			collType = ncclFuncReduceScatter;
 
 			nccl_ofi_tuner_point_t extended_ring_ll =
-				extend_region((nccl_ofi_tuner_point_t){78118912, 1024},
-							  (nccl_ofi_tuner_point_t){217579520, 2048},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+				extend_region((nccl_ofi_tuner_point_t){73924608, 1024},
+						(nccl_ofi_tuner_point_t){209190912, 2048},
+						(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 			nccl_ofi_tuner_point_t extended_ring_ll128 =
 				extend_region((nccl_ofi_tuner_point_t){4294967296, 256},
-							  (nccl_ofi_tuner_point_t){8589934592, 512},
-							  (nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
+							(nccl_ofi_tuner_point_t){8589934592, 512},
+							(nccl_ofi_tuner_point_t){TUNER_MAX_SIZE, TUNER_MAX_RANKS});
 
 			const nccl_ofi_tuner_region_t regions[] = {
 				{.algorithm = NCCL_ALGO_RING,
 					.protocol = NCCL_PROTO_LL,
-					.num_vertices = 10,
+					.num_vertices = 11,
 					.vertices = {
 						{0, 16},
-						{393216, 16},
-						{196608, 32},
-						{393216, 64},
-						{1572864, 128},
+						{786432, 16},
+						{1572864, 32},
+						{2621440, 64},
+						{4718592, 128},
 						{17301504, 256},
-						{78118912, 1024},
-						{217579520, 2048},
+						{35127296, 512},
+						{73924608, 1024},
+						{209190912, 2048},
 						extended_ring_ll,
 						{0, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_RING,
 					.protocol = NCCL_PROTO_LL128,
-					.num_vertices = 14,
+					.num_vertices = 15,
 					.vertices = {
 						extended_ring_ll,
-						{217579520, 2048},
-						{78118912, 1024},
+						{209190912, 2048},
+						{73924608, 1024},
+						{35127296, 512},
 						{17301504, 256},
-						{1572864, 128},
-						{393216, 64},
-						{196608, 32},
-						{393216, 16},
-						{187170816, 16},
-						{472907776, 32},
-						{594542592, 64},
+						{4718592, 128},
+						{2621440, 64},
+						{1572864, 32},
+						{786432, 16},
+						{219676672, 16},
+						{508559360, 32},
+						{592445440, 64},
 						{4294967296, 256},
 						{8589934592, 512},
 						extended_ring_ll128}},
@@ -1132,11 +1141,10 @@ static ncclResult_t region_init_internal_p6(nccl_ofi_tuner_region_context_t *reg
 					.vertices = {
 						extended_ring_ll128,
 						{4294967296, 256},
-						{594542592, 64},
-						{472907776, 32},
-						{187170816, 16},
+						{592445440, 64},
+						{508559360, 32},
+						{219676672, 16},
 						{TUNER_MAX_SIZE, 16}}}};
-
 			ret = set_regions(region_ctx, collType, sizeof(regions) / sizeof(regions[0]), regions);
 			if (ret != ncclSuccess) {
 				goto exit;


### PR DESCRIPTION
This change only updates those for 0x0 collectives on p6.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
