### PR TITLE
Update NVTX trace dimensions as a run-time config to avoid unncessary re-compilation.

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -379,4 +379,20 @@ OFI_NCCL_PARAM(PROGRESS_MODEL, progress_model,  "PROGRESS_MODEL", PROGRESS_MODEL
  */
 OFI_NCCL_PARAM(std::string, platform, "PLATFORM", "");
 
+/*
+ * NVTX Tracing dimension. Valid options are PER_COMM and PER_DEV, 
+ * with the default set to PER_COMM.
+ *
+ * PER_COMM: Collect NVTX traces in a "per-device" view, which associates sub-events with
+ * an EFA device, showing activity on each device.
+ *
+ * PER_DEV: Collect NVTX traces in a "per-communicator" view, which associates parent
+ * send/recv events with constituent events (segments, controls.
+ *
+ * This environment variable would not take any effect, 
+ * unless --with-nvtx / HAVE_NVTX compile time flag is enabled.
+ */
+OFI_NCCL_PARAM_VALUE_SET(NVTX_TRACE_DIMENSION, (PER_COMM)(PER_DEV))
+OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSION", NVTX_TRACE_DIMENSION::PER_COMM)
+
 #endif // End NCCL_OFI_PARAM_H_

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -51,7 +51,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 }
 
 #define NCCL_OFI_TRACE_SEND_NVTX(dev, size, comm, msg_seq_num, request, nccl_req) do { \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_send_comm_t*)comm) \
 			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		get_send_data(request)->trace_id = nvtx_start_domain(true, handle, "Send", 0xeb9234); \
@@ -59,7 +59,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 } while (0)
 
 #define NCCL_OFI_TRACE_SEND_END_NVTX(request) do { \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_send_comm_t*)(request->comm)) \
 			->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_end_domain(handle, get_send_data(request)->trace_id); \
@@ -68,11 +68,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_EAGER_SEND_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
@@ -80,11 +80,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_EAGER_SEND_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
@@ -92,11 +92,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_SEND_CTRL_RECV_NVTX(dev, rail_id, comm, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(s_comm->base.base.ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
@@ -104,11 +104,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_WRITE_CTRL_START_NVTX(dev, rail_id, comm, req, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_recv_comm_t *)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		get_recv_data(req)->write_ctrl_trace_id = nvtx_start_domain(true, handle, "Write_ctrl_start", 0x00ffff); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_recv_data(req)->write_ctrl_trace_id = nvtx_start_domain(true, handle, "Write_ctrl_start", 0x00ffff); \
 	} \
@@ -116,11 +116,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_WRITE_CTRL_END_NVTX(dev, rail_id, comm, req, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_recv_comm_t *)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_end_domain(handle, get_recv_data(req)->write_ctrl_trace_id); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_recv_data(req)->write_ctrl_trace_id);\
 	} \
@@ -128,11 +128,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_SEND_WRITE_SEG_START_NVTX(dev, rail_id, size, comm, msg_seq_num, request) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
@@ -140,18 +140,18 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_send_comm_t*)comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 } while(0)
 
 #define NCCL_OFI_TRACE_RECV_NVTX(dev, r_comm, size, request, nccl_req) do { \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
 			->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		get_recv_data(request)->trace_id = nvtx_start_domain(true, handle, "Recv", 0x34EB37); \
@@ -159,7 +159,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 } while(0)
 
 #define NCCL_OFI_TRACE_RECV_END_NVTX(request) do { \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm) \
 			->nvtx_domain[request->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_end_domain(handle, get_recv_data(request)->trace_id); \
@@ -168,11 +168,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = ((nccl_net_ofi_rdma_recv_comm_t *)request->comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(request->comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
@@ -180,11 +180,11 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 
 #define NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num) do { \
 	nvtxDomainHandle_t handle; \
-	if (NCCL_OFI_NVTX_TRACE_PER_COMM) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		handle = comm->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
-	if (NCCL_OFI_NVTX_TRACE_PER_DEV) { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
 		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->base.base.ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \

--- a/m4/check_pkg_nvtx.m4
+++ b/m4/check_pkg_nvtx.m4
@@ -38,22 +38,6 @@ AC_DEFUN([CHECK_PKG_NVTX], [
         [nvtx_tracing=1],
         [nvtx_tracing=0])
 
-  AC_ARG_ENABLE([nvtx_trace_per_comm], AS_HELP_STRING([--enable-nvtx-trace-per-comm],
-                                       [Collect NVTX traces in a "per-communicator" view, which associates parent
-                                       send/recv events with constituent events (segments, controls).]))
-  AS_IF([test "${enableval}" = "yes" -a "x${nvtx_tracing}" = "x1"], [nvtx_trace_per_comm=${nvtx_tracing}], [nvtx_trace_per_comm=0])
-
-  AC_ARG_ENABLE([nvtx_trace_per_dev],  AS_HELP_STRING([--enable-nvtx-trace-per-dev],
-                                       [Collect NVTX traces in a "per-device" view, which associates sub-events with
-                                       an EFA device, showing activity on each device.]))
-  AS_IF([test "${enableval}" = "yes" -a "x${nvtx_tracing}" = "x1"], [nvtx_trace_per_dev=${nvtx_tracing}], [nvtx_trace_per_dev=0])
-
-  AC_DEFINE_UNQUOTED([NCCL_OFI_NVTX_TRACE_PER_COMM], [$nvtx_trace_per_comm], [Defined to 1 if NVTX traces are collected per-communicator])
-  AC_DEFINE_UNQUOTED([NCCL_OFI_NVTX_TRACE_PER_DEV], [$nvtx_trace_per_dev], [Defined to 1 if NVTX traces are collected per-device])
-
-  AS_IF([test "${nvtx_trace_per_comm}" -ne 0 -a "${nvtx_trace_per_dev}" -ne 0],
-        AC_MSG_ERROR([Error: setting both nvtx_trace_per_comm and nvtx_trace_per_dev is currently not supported]))
-
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])
   AS_UNSET([check_pkg_CPPFLAGS_save])


### PR DESCRIPTION
***Issue #, if available:***
N/A

***Description of changes:***
Following the previous [thread](https://github.com/aws/aws-ofi-nccl/pull/732#issuecomment-2513288382), this PR aims to reduce unnecessary re-compilation by updating NVTX trace dimensions into a run-time config.

Like any other run-time config, it is activated via environment variable with `OFI_NCCL` prefix.

```
export OFI_NCCL_NVTX_TRACE_DIMENSION="PER_COMM" (default) or "PER_DEV".
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
