### PR TITLE
cuda: Implement bidirectional CUDA 12/13 version compatibility

### DIFF
--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -11,7 +11,7 @@ AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
 AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
 AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
-LDADD = $(top_builddir)/src/libinternal_plugin.la $(MPI_LIBS) $(CUDA_LIBS)
+LDADD = $(top_builddir)/src/libinternal_plugin.la $(MPI_LIBS) $(CUDA_LIBS) $(CUDA_RUNTIME_LIBS)
 
 # this is a little jenky, but we've always assumed we had wrapper compilers
 # available for MPI.  We don't want to just override CXX to get mpicxx used,


### PR DESCRIPTION
Enable plugins compiled with CUDA 12 to work with CUDA 13 runtime and vice versa by:
* Selectively dlopen libcudart.so only for functions without driver equivalents
* Prioritize CUDA driver APIs over runtime APIs for better version stability
* Runtime fallback between CUDA 13 versioned and CUDA 12 legacy entry points

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
