### PR TITLE
fix OFI teardown ordering to eliminate -FI_EBUSY on shutdown

### DIFF
--- a/include/cm/nccl_ofi_cm_resources.h
+++ b/include/cm/nccl_ofi_cm_resources.h
@@ -199,14 +199,12 @@ public:
 	/* Endpoint for CM operations */
 	endpoint ep;
 
-private:
-	/* Size of the transport-specific data in the connect messages This must
-	   be initialized before get_conn_msg{_data}_size() is called. */
-	size_t conn_msg_data_size;
-
-public:
-	/* Manages registered connect-message buffers */
-	conn_msg_buffer_manager buff_mgr;
+	/* Manages registered connect-message buffers
+	 * Use unique_ptr so we can control destruction order explicitly.  The
+	 * buff_mgr must be destroyed BEFORE the endpoint is closed. Memory
+	 * registrations must be deregistered before closing the endpoint.
+	 */
+	std::unique_ptr<conn_msg_buffer_manager> buff_mgr;
 
 	/**
 	 * Map from ID to callback functions for connect (resp) msg rx events.
@@ -260,6 +258,10 @@ public:
 	size_t get_conn_msg_size() { return sizeof(nccl_ofi_cm_conn_msg) + conn_msg_data_size; }
 
 private:
+	/* Size of the transport-specific data in the connect messages This must
+	   be initialized before get_conn_msg{_data}_size() is called. */
+	size_t conn_msg_data_size;
+
 	uint64_t next_connector_id;
 
 	/* List of requests for CM rx buffers */

--- a/src/cm/nccl_ofi_cm_reqs.cpp
+++ b/src/cm/nccl_ofi_cm_reqs.cpp
@@ -70,13 +70,13 @@ nccl_ofi_cm_req::nccl_ofi_cm_req()
 
 nccl_ofi_cm_rx_req::nccl_ofi_cm_rx_req(cm_resources &_resources) :
 	resources(_resources),
-	rx_elem(resources.buff_mgr.allocate_conn_msg())
+	rx_elem(resources.buff_mgr->allocate_conn_msg())
 { }
 
 
 nccl_ofi_cm_rx_req::~nccl_ofi_cm_rx_req()
 {
-	resources.buff_mgr.free_conn_msg(rx_elem);
+	resources.buff_mgr->free_conn_msg(rx_elem);
 }
 
 int nccl_ofi_cm_rx_req::progress()
@@ -90,7 +90,7 @@ int nccl_ofi_cm_rx_req::progress()
 nccl_ofi_cm_send_conn_req::nccl_ofi_cm_send_conn_req(cm_resources &_resources, fi_addr_t _dest_addr,
 				std::function<void()> _done_callback) :
 	resources(_resources),
-	send_elem(resources.buff_mgr.allocate_conn_msg()),
+	send_elem(resources.buff_mgr->allocate_conn_msg()),
 	dest_addr(_dest_addr),
 	done_callback(_done_callback)
 { }
@@ -100,7 +100,7 @@ nccl_ofi_cm_send_conn_req::nccl_ofi_cm_send_conn_req(cm_resources &_resources, f
  */
 nccl_ofi_cm_send_conn_req::~nccl_ofi_cm_send_conn_req()
 {
-	resources.buff_mgr.free_conn_msg(send_elem);
+	resources.buff_mgr->free_conn_msg(send_elem);
 }
 
 
@@ -126,7 +126,7 @@ nccl_ofi_cm_send_conn_resp_req::nccl_ofi_cm_send_conn_resp_req
 	 std::function<void()> _done_callback) :
 
 	resources(_resources),
-	send_elem(resources.buff_mgr.allocate_conn_msg()),
+	send_elem(resources.buff_mgr->allocate_conn_msg()),
 	dest_addr(_dest_addr),
 	done_callback(_done_callback)
 {
@@ -162,7 +162,7 @@ nccl_ofi_cm_send_conn_resp_req::nccl_ofi_cm_send_conn_resp_req
 
 nccl_ofi_cm_send_conn_resp_req::~nccl_ofi_cm_send_conn_resp_req()
 {
-	resources.buff_mgr.free_conn_msg(send_elem);
+	resources.buff_mgr->free_conn_msg(send_elem);
 }
 
 int nccl_ofi_cm_send_conn_resp_req::progress()

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2092,6 +2092,15 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 	assert(!this->called_cleanup_resources);
 	this->called_cleanup_resources = true;
 
+	/* Close OFI resources in the correct dependency order:
+	 * 1. ofi_ep (depends on av, cq, domain)
+	 * 2. av (depends on domain)
+	 * The cq and domain are owned by the domain object and will be
+	 * cleaned up when the domain is destroyed.
+	 */
+	this->ofi_ep.reset();
+	this->av.reset();
+
 	assert(ret == 0);
 
 	return ret;


### PR DESCRIPTION
Ensure dependent libfabric objects are destroyed in correct order to avoid fi_close() returning -FI_EBUSY:

1. Cancel/free posted RX requests
2. Deregister MRs (buffer manager reset)
3. Close endpoint (unbinds from CQ/AV)
4. Release AV, then CQ, domain, fabric

Convert buffer manager to unique_ptr for early destruction.   Reordered
member initialization to match declaration (fixes -Wreorder). Added explicit
endpoint cleanup sequencing for send/recv paths.

This fixes previous EBUSY shutdown warnings for fid_ep, fid_av, fid_cq and fid_domain because their resources had not been cleaned up.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
