### PR TITLE
Fix memory registration cleanup order in CM resources destructor

### DIFF
--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -152,12 +152,6 @@ cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, size_t _conn_msg_data_
 
 cm_resources::~cm_resources()
 {
-	/* Resources can be destructed in the usual reverse-order, with one exception:
-	   The endpoint must be closed first, since posted buffers and requests cannot
-	   be freed until the endpoint is closed.
-	 */
-	ep.close_ofi_ep();
-
 	/* Free all requests. (A unique_ptr would be better here so these can be freed
 	   automatically) */
 	for (auto &req : rx_reqs) {


### PR DESCRIPTION
The connection manager's cm_resources destructor was closing the libfabric endpoint before freeing the conn_msg_buffer_manager, which caused memory registrations (MRs) to be deregistered after their associated endpoint was already destroyed.

Memory registrations for CM buffers are created early during plugin sendrecv initialization through the following call chain (sendrecv transport):

1.  nccl_net_ofi_create_plugin()
2.  nccl_net_ofi_device_t::get_domain()
3.  nccl_net_ofi_device_t::nccl_net_ofi_device_get_domain_impl()
4.  nccl_net_ofi_sendrecv_device_t::create_domain()
5.  nccl_net_ofi_sendrecv_domain_t constructor (creates libfabric domain and CQ)
6.  new nccl_ofi_connection_manager(*this, sizeof(...))
7.  nccl_ofi_connection_manager constructor
8.  cm_resources::cm_resources(domain, conn_msg_data_size) (member initializer)
9.  conn_msg_buffer_manager::conn_msg_buffer_manager(ep, size)
10. nccl_ofi_freelist_init_mr(...)
11. nccl_ofi_freelist_add(...)
12. endpoint::reg_mr(ep_ptr, base_ptr, size, &mr_handle)
13. fi_mr_reg()
14. fi_mr_bind(&ep->fid, ...)  [if endpoint_mr flag set]
15. fi_mr_enable()

In endpoint::reg_mr(), when the endpoint_mr flag is set (which it is for providers like CXI), fi_mr_bind() is called to bind the memory registration to the libfabric endpoint, followed by fi_mr_enable() to activate it. This creates a hard dependency: the MR cannot outlive the endpoint it's bound to.

The bug appears as warnings in cxip_ep_close (which is invoked when callling fi_close) that the endpoints reference count is non-zero.  It is non-zero because MRs remain bound to the endpoint.

The original destructor manually closed the endpoint first (via ep.close_ofi_ep()), expecting this would allow posted buffers to be freed. However, buff_mgr held registered memory that needed to be deregistered before the endpoint closure, not after.

Upon destruction, the old code path was:
1. ~cm_resources() body runs
2. ep.close_ofi_ep() called -> fi_close(ofi_ep) destroys the endpoint
3. Destructor body completes
4. C++ destroys members in reverse order:
   - ~buff_mgr() runs -> nccl_ofi_freelist_fini() -> endpoint::dereg_mr()
   - Attempts to deregister MRs that are still bound to the now-closed endpoint
   - Provider (cxip_ep_close) prints an error because MRs still refer to it.

The fix converts buff_mgr from a stack-allocated member to a std::unique_ptr, allowing explicit control over its destruction order in the destructor body. Now the cleanup sequence is:

1. Free rx_reqs (which may reference buff_mgr buffers)
2. Explicitly destroy buff_mgr via reset() - this triggers nccl_ofi_freelist_fini() which calls endpoint::dereg_mr() to deregister all MRs while the endpoint is still valid
3. Close the endpoint via ep.close_ofi_ep()
4. Let ep member destruct normally

This ensures MRs are properly cleaned up before fi_close() is called on the underlying libfabric endpoint, respecting the provider's resource hierarchy and preventing use-after-free violations.

All references to buff_mgr throughout the codebase (in nccl_ofi_cm_reqs.cpp) are updated from dot notation to arrow notation to accommodate the pointer change.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
