### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -18,6 +18,10 @@ concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   amazonlinux:
     strategy:

--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -8,6 +8,10 @@ on:
     tags:
       - 'v*.*.*'
 
+permissions:
+  contents: write
+  packages: read
+
 jobs:
   build:
     strategy:

--- a/.github/workflows/tag-makedist.yaml
+++ b/.github/workflows/tag-makedist.yaml
@@ -6,6 +6,10 @@ on:
       - release/**
       - v**
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   amazonlinux:
     strategy:


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.