### PR TITLE
rdma: Ensure OFI provider provides CQ data

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6969,6 +6969,10 @@ static void get_hints(struct fi_info *hints)
 	 * acks during shutdown, so allow users to override requested model. */
 	hints->domain_attr->control_progress = nccl_ofi_translate_progress_enum(ofi_nccl_progress_model.get());
 	hints->domain_attr->data_progress = nccl_ofi_translate_progress_enum(ofi_nccl_progress_model.get());
+
+	/* The RDMA transport requires fi_writedata support with 32 bits (4
+	   bytes) of immediate data */
+	hints->domain_attr->cq_data_size = 4;
 }
 
 
@@ -7163,7 +7167,15 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 
 	if ((ssize_t)ofi_nccl_eager_max_size() > (ssize_t)ofi_nccl_min_stripe_size()) {
 		NCCL_OFI_WARN("Invalid value for EAGER_MAX_SIZE");
-		return ncclInvalidArgument;
+		return -ENOTSUP;
+	}
+
+	/* We requested 4 bytes for cq_data_size. getinfo should not have
+	   returned a provider that doesn't meet this requirement, but double
+	   check here. */
+	if (provider_list->domain_attr->cq_data_size < 4) {
+		NCCL_OFI_WARN("Provider does not support 4 bytes of immediate data, required for RDMA transport");
+		return -ENOTSUP;
 	}
 
 	/* 


### PR DESCRIPTION
RDMA transport requires 4 bytes of immediate data for `fi_writedata`. This patch adds this requirements to hints, and checks that the provider provides sufficient CQ data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
