### PR TITLE
Revert "Fix memory registration cleanup order in CM resources destructor"

### DIFF
--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -147,6 +147,15 @@ cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, size_t _conn_msg_data_
 
 cm_resources::~cm_resources()
 {
+	/* Resources can be destructed in the usual reverse-order, with one exception:
+	   The endpoint must be closed first, since posted buffers and requests cannot
+	   be freed until the endpoint is closed.
+	 */
+	int ret = ep.close_ofi_ep();
+	if (ret != 0) {
+		NCCL_OFI_WARN("Failed to close OFI endpoint: %d", ret);
+	}
+
 	/* Free all requests. (A unique_ptr would be better here so these can be freed
 	   automatically) */
 	for (auto &req : rx_reqs) {


### PR DESCRIPTION
This reverts commit c386e7335fd66c512243d5c6bd090df170f3f91c.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
