### PR TITLE
topo: always use the NIC link speed and width

### DIFF
--- a/include/nccl_ofi_math.h
+++ b/include/nccl_ofi_math.h
@@ -11,6 +11,8 @@
 #define NCCL_OFI_MATH_H_
 
 #include <algorithm>
+#include <limits>
+#include <type_traits>
 #include <stdint.h>
 
 
@@ -31,6 +33,37 @@ template <class T>
 constexpr bool NCCL_OFI_IS_POWER_OF_TWO(const T &x)
 {
 	return x && ((x & (x - 1)) == 0);
+}
+
+template<class T>
+constexpr T NCCL_OFI_ROUND_UP_TO_POWER_OF_TWO(const T &x) noexcept
+{
+	static_assert(std::is_integral_v<T>, "T must be an integral type");
+
+	using UnsignedT = std::make_unsigned_t<T>;
+
+	if (x <= T{1}) return T{1};
+
+	// Convert to unsigned for safe bit operations
+	UnsignedT un = static_cast<UnsignedT>(x);
+
+	// Check if already a power of 2
+	if (NCCL_OFI_IS_POWER_OF_TWO(un)) {
+		return x;
+	}
+	--un;
+
+	// Apply shifts based on the size of T
+	constexpr int bits = std::numeric_limits<UnsignedT>::digits;
+
+	if constexpr (bits >= 2)  { un |= un >> 1; }
+	if constexpr (bits >= 4)  { un |= un >> 2; }
+	if constexpr (bits >= 8)  { un |= un >> 4; }
+	if constexpr (bits >= 16) { un |= un >> 8; }
+	if constexpr (bits >= 32) { un |= un >> 16; }
+	if constexpr (bits >= 64) { un |= un >> 32; }
+
+	return static_cast<T>(++un);
 }
 
 

--- a/src/nccl_ofi_topo.cpp
+++ b/src/nccl_ofi_topo.cpp
@@ -1443,6 +1443,9 @@ static int write_nic(hwloc_obj_t node, FILE *file, int indent)
 	 * NICs are grouped, GPU topology node is attached to the NIC
 	 * topology node. */
 	if (group_size > 1) {
+		if (!NCCL_OFI_IS_POWER_OF_TWO(group_size)) {
+			group_size = NCCL_OFI_ROUND_UP_TO_POWER_OF_TWO(group_size);
+		}
 		hwloc_obj_t gpu = userdata->gpu_group_node;
 		size_t gpu_width;
 		size_t gpu_speed_idx;


### PR DESCRIPTION
Removes comparing the NIC link speed and width against the GPU and parent topology node link speed and width, and always use the NIC link speed and width when writing to the NCCL topology file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
