### PR TITLE
redesign: Improve multi-threaded domain performance

### DIFF
--- a/include/cm/nccl_ofi_cm.h
+++ b/include/cm/nccl_ofi_cm.h
@@ -226,16 +226,21 @@ public:
 	 *
 	 * @param domain:
 	 *      OFI domain object to which the CM endpoint will be bound.
-	 *      The CM will create its own endpoint, bound to the domain's CQ.
+	 *      The CM will create its own endpoint, bound to the CQ provided
+	 *      via the plugin endpoint argument.
 	 *      Ops submitted through the CM code will have a context pointer to
 	 *      nccl_net_ofi_context_t, with appropriate completion handling
 	 *      functions
+	 *
+	 * @param ep:
+	 * 	plugin endpoint object holding the CQ required for CM
 	 *
 	 * @param conn_msg_data_size:
 	 *      size of transport-specific part of connect and connect response
 	 *      messages
 	 */
-	nccl_ofi_connection_manager(nccl_net_ofi_domain_t &domain, size_t conn_msg_data_size);
+	nccl_ofi_connection_manager(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep,
+				    size_t conn_msg_data_size);
 
 	/**
 	 * Destructor. Finalizes CM endpoint and other state.

--- a/include/cm/nccl_ofi_cm_resources.h
+++ b/include/cm/nccl_ofi_cm_resources.h
@@ -52,8 +52,11 @@ public:
 	 *
 	 * @param domain:
 	 *      OFI domain against which to construct this ep
+	 *
+	 * @param ep:
+	 * 	plugin endpoint object holding the CQ required for CM
 	 */
-	endpoint(nccl_net_ofi_domain_t &domain);
+	endpoint(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep);
 	
 	/* Move constructor and assignment */
 	endpoint(endpoint&&) = default;
@@ -227,16 +230,21 @@ public:
 	 *
 	 * @param domain:
 	 *      OFI domain object to which the CM endpoint will be bound.
-	 *      The CM will create its own endpoint, bound to the domain's CQ.
+	 *      The CM will create its own endpoint, bound to the CQ provided
+	 *      via the plugin endpoint argument.
 	 *      Ops submitted through the CM code will have a context pointer to
 	 *      nccl_net_ofi_context_t, with appropriate completion handling
 	 *      functions
+	 *
+	 * @param ep:
+	 * 	plugin endpoint object holding the CQ the CM endpoint will bound to
 	 *
 	 * @param conn_msg_data_size:
 	 *      size of transport-specific part of connect and connect response
 	 *      messages
 	 */
-	cm_resources(nccl_net_ofi_domain_t &domain, size_t conn_msg_data_size);
+	cm_resources(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep,
+		     size_t conn_msg_data_size);
 
 	~cm_resources();
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -75,17 +75,6 @@
 /* Initial number of entries in the MR cache of a device */
 #define NCCL_OFI_MR_CACHE_INIT_SIZE     128
 
-/**
- * Check if domain is active
- *
- * Caller is assumed to hold the domain lock
- */
-#define CHECK_DOMAIN_ACTIVE(domain, fn_name) \
-	if (OFI_UNLIKELY(!domain->domain_active)) { \
-		NCCL_OFI_WARN("Called " fn_name " on request with inactive domain"); \
-		return -EINVAL; \
-	} \
-
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t {GDR_UNKNOWN, GDR_SUPPORTED, GDR_UNSUPPORTED};
 extern enum gdr_support_level_t support_gdr;
@@ -303,30 +292,17 @@ public:
 	 */
 	virtual struct fi_info *get_ofi_info_for_cm() = 0;
 
-	/**
-	 * @brief	Increment base device's unreleased_inactive_domain_counter
-	 */
-	inline void inc_unreleased_inactive_domain_counter()
-	{
-		++unreleased_inactive_domain_counter;
-	}
-
-	/**
-	 * @brief	Decrement base device's unreleased_inactive_domain_counter
-	 */
-	inline void dec_unreleased_inactive_domain_counter()
-	{
-		--unreleased_inactive_domain_counter;
-	}
-
 	/* Retrieve a domain associated with this device.  There may
 	 * be more than one domain per device, depending on a number
 	 * of performance tradeoffs (be sure to read the domain
 	 * description below).
 	 */
-	nccl_net_ofi_domain_t *get_domain();
+	nccl_net_ofi_domain_t *get_domain(unsigned int domain_key = 0);
 
-	nccl_net_ofi_ep_t *get_ep();
+	/* Retrieve an endpoint associated with this device under the requested
+	 * domain scope.
+	 */
+	nccl_net_ofi_ep_t *get_ep(unsigned int domain_key = 0);
 
 	/**
 	 * implementation of retreiving a domain from a device.  This code
@@ -335,7 +311,7 @@ public:
 	 * the device->get_ep call, hold the lock while we're also creating
 	 * the ep.
 	 */
-	nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain_impl();
+	nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain_impl(unsigned int domain_key = 0);
 
 	/**
 	 * @brief	Erase all domain_table elements matching the provided domain
@@ -395,7 +371,7 @@ protected:
 	 * implementation of get_domain() and should not be called
 	 * from the more general case.
 	 */
-	virtual nccl_net_ofi_domain_t *create_domain() = 0;
+	virtual nccl_net_ofi_domain_t *create_domain(unsigned int domain_key = 0) = 0;
 
 	/**
 	 * release all domains and endpoints. This function is a private
@@ -407,16 +383,7 @@ protected:
 	/**
 	 * hash table indexed by thread id of active domains.
 	 */
-	std::unordered_map<long, nccl_net_ofi_domain_t *> domain_table;
-
-	/**
-	 * Number of domains that have been deactivated but not freed
-	 *
-	 * This counter is used for a diagnostic when the device is finalized,
-	 * to track inactive domains (which aren't in the domain table) which
-	 * were never closed
-	 */
-	size_t unreleased_inactive_domain_counter = 0;
+	std::unordered_map<unsigned int, nccl_net_ofi_domain_t *> domain_table;
 
 	/** 
 	 * Track whether the cleanup_resources function was already called to avoid calling
@@ -455,14 +422,6 @@ public:
 	 * associated with the "leader NIC".
 	 */
 	virtual ofi_domain_ptr &get_ofi_domain_for_cm() = 0;
-
-	/**
-	 * Retrieve an fid_cq object associated with this domain to be used for 
-	 * connection management. There may be more than one fid_cq per domain, depending
-	 * on the transport; in that case, this will be the cq object associated with the
-	 * "leader NIC".
-	 */
-	virtual ofi_cq_ptr &get_ofi_cq_for_cm() = 0;
 
 	/* Create a new endpoint
 	 *
@@ -542,25 +501,26 @@ public:
 
 	pthread_mutex_t domain_lock;
 
-	/*
-	 * Boolean flag indicating whether the domain is still valid and usable
-	 *
-	 * When a communicator is closed with inflight requests, the domain is
-	 * marked inactive, preventing further use of communicators on the
-	 * domain. Transports should check the domain_active flag before using
-	 * OFI resources associated with the domain (CQs, endpoints, AVs)
-	 *
-	 * This flag is protected by domain_lock
+	/**
+	 * @brief       Erase all ep_table elements matching the provided ep
 	 */
-	bool domain_active;
+	void remove_ep_from_map(nccl_net_ofi_ep_t *ep);
 
 	/**
-	 * Invalidate domain. Marks the domain as inactive and removes it from the
-	 * thread->domain map, so future communicators do not use this domain.
-	 *
-	 * Caller is assumed to hold domain_lock
+	 * @brief       Increment base domain's unreleased_inactive_ep_counter
 	 */
-	virtual void invalidate();
+	inline void inc_unreleased_inactive_ep_counter()
+	{
+		++unreleased_inactive_ep_counter;
+	}
+
+	/**
+	 * @brief       Decrement base domain's unreleased_inactive_ep_counter
+	 */
+	inline void dec_unreleased_inactive_ep_counter()
+	{
+		--unreleased_inactive_ep_counter;
+	}
 
 protected:
 	/**
@@ -598,6 +558,30 @@ protected:
 	 * of endpoints created on this domain. When it reaches 0, the
 	 * domain can be destroyed. */
 	size_t ref_cnt;
+
+	/* The Domain index or a key in the device domain table */
+	unsigned int domain_key;
+
+	/**
+	 * release all endpoints. This function is a private
+	 * function, which is called only during cleanup_resources() to free allocated
+	 * endpoints.
+	 */
+	int release_all_ep();
+
+	/**
+	 * hash table indexed by thread id of active endpoints.
+	 */
+	std::unordered_map<long, nccl_net_ofi_ep_t *> ep_table;
+
+	/**
+	 * Number of endpoints that have been deactivated but not freed
+	 *
+	 * This counter is used for a diagnostic when the domain is closed,
+	 * to track inactive ednpoint (which aren't in the ep table) which
+	 * were never closed
+	 */
+	size_t unreleased_inactive_ep_counter = 0;
 
 	/** 
 	 * Track whether the cleanup_resources function was already called to avoid calling
@@ -668,6 +652,14 @@ public:
 			    int trafficClass) = 0;
 
 	/**
+	 * Retrieve an fid_cq object associated with this endpoint to be used for
+	 * connection management. There may be more than one fid_cq, depending
+	 * on the transport; in that case, this will be the cq object associated with the
+	 * "leader NIC".
+	 */
+	virtual ofi_cq_ptr &get_ofi_cq_for_cm() = 0;
+
+	/**
 	 * @brief	Release nccl_ofi_ep.
 	 *
 	 * Decrease reference counter. Release resources and free
@@ -696,6 +688,28 @@ public:
 	inline void decrement_ref_cnt() {
 		ref_cnt--;
 	}
+
+	pthread_mutex_t ep_lock;
+
+	/*
+	 * Boolean flag indicating whether the endpoint is still valid and usable
+	 *
+	 * When a communicator is closed with inflight requests, the endpoint is
+	 * marked inactive, preventing further use of communicators on the
+	 * endpoint. Transports should check the ep_active flag before using
+	 * OFI resources associated with the endpoint (CQs, endpoints, AVs)
+	 *
+	 * This flag is protected by ep_lock
+	 */
+	bool ep_active;
+
+	/**
+	 * Invalidate endpoint. Marks the endpoint as inactive and removes it from the
+	 * thread->ep map, so future communicators do not use this endpoint.
+	 *
+	 * Caller is assumed to hold ep_lock
+	 */
+	virtual void invalidate();
 
 protected:
 	/**
@@ -927,15 +941,6 @@ public:
 					 int dev_id,
 					 int num_devices,
 					 nccl_ofi_properties_t *props);
-
-	/*
-	 * Determine whether to allocate the domain per process or per
-	 * thread.
-	 * false: allocate domain per process
-	 * true: allocate domain per thread
-	 */
-	bool domain_per_thread;
-
 protected:
 	/* Array of devices */
 	std::vector<nccl_net_ofi_device_t *> p_devs;

--- a/include/nccl_ofi_api.h
+++ b/include/nccl_ofi_api.h
@@ -82,6 +82,8 @@ ncclResult_t nccl_net_ofi_devices_v2(int *ndev);
 ncclResult_t nccl_net_ofi_get_properties(int dev, struct nccl_ofi_properties *ofi_properties);
 ncclResult_t nccl_net_ofi_listen_v2(int dev, void *handle, void **listenComm);
 ncclResult_t nccl_net_ofi_listen_v5(int dev, void* handle, void **listenComm);
+ncclResult_t nccl_net_ofi_listen_v11_neuron(int dev, void* handle, void **listenComm,
+					    unsigned int domain_key, unsigned int resource_key);
 // Nvidia introduced the ability to have part of the communication driven by a
 // cuda kernel, which requires a version-specific device pointer be passed
 // through the accept/connect APIs.  Rather than list all those connect calls
@@ -89,6 +91,8 @@ ncclResult_t nccl_net_ofi_listen_v5(int dev, void* handle, void **listenComm);
 ncclResult_t nccl_net_ofi_connect_v2(int dev, void* handle, void **sendComm);
 ncclResult_t nccl_net_ofi_connect_v5(int dev, void* handle, void **sendComm);
 ncclResult_t nccl_net_ofi_connect_v10(int dev, void *handle, void **sendComm, int trafficClass);
+ncclResult_t nccl_net_ofi_connect_v11_neuron(int dev, void *handle, void **sendComm, int trafficClass,
+					     unsigned int domain_key, unsigned int resource_key);
 ncclResult_t nccl_net_ofi_accept_v2(void *listenComm, void **recvComm);
 ncclResult_t nccl_net_ofi_accept_v5(void* listenComm, void** recvComm);
 ncclResult_t nccl_net_ofi_regMr_v2(void *comm, void *data, int size, int type,

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -138,15 +138,6 @@ OFI_NCCL_PARAM_VALUE_SET(PROTOCOL, (SENDRECV)(RDMA))
 OFI_NCCL_PARAM(PROTOCOL, protocol, "PROTOCOL", PROTOCOL::SENDRECV);
 
 /*
- * Override the platform default for domain allocation, with
- * respect to the process or thread.
- *
- * 0: Allocate one domain per process
- * 1: Allocate one domain per thread
- */
-OFI_NCCL_PARAM(bool, domain_per_thread, "DOMAIN_PER_THREAD", false);
-
-/*
  * Disable the native RDMA write support check when using the "RDMA" protocol
  * for send/recv operations on AWS platforms. When the check is disabled, the
  * "RDMA" protocol can be used even on platforms where native RDMA write is not

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -46,7 +46,6 @@ protected:
 		float latency;
 		bool gdr_required;
 		PROTOCOL default_protocol;
-		bool domain_per_thread;
 		std::map<std::string, std::string> env;
 	};
 

--- a/src/cm/nccl_ofi_cm.cpp
+++ b/src/cm/nccl_ofi_cm.cpp
@@ -12,8 +12,8 @@
 #include "cm/nccl_ofi_cm.h"
 
 nccl_ofi_connection_manager::nccl_ofi_connection_manager
-	(nccl_net_ofi_domain_t &domain, size_t conn_msg_data_size) :
-	resources(domain, conn_msg_data_size)
+	(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep, size_t conn_msg_data_size) :
+	resources(domain, ep, conn_msg_data_size)
 {
 }
 

--- a/src/cm/nccl_ofi_cm_reqs.cpp
+++ b/src/cm/nccl_ofi_cm_reqs.cpp
@@ -162,6 +162,14 @@ nccl_ofi_cm_send_conn_resp_req::nccl_ofi_cm_send_conn_resp_req
 
 nccl_ofi_cm_send_conn_resp_req::~nccl_ofi_cm_send_conn_resp_req()
 {
+	/* TODO: Flush any pending send conn resp requests. This is required
+	 * for the `complete_immediately` mode where the receiver/rComm is
+	 * returned to the application without waiting for the send
+	 * complete for this request. If the application closes the
+	 * rComms immediately, then the sender rank will never receive
+	 * the response back from receiver and hence the application will
+	 * never be able to complete the sComm creation.
+	 */
 	resources.buff_mgr.free_conn_msg(send_elem);
 }
 

--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -6,12 +6,12 @@
 using namespace nccl_ofi_cm;
 
 
-endpoint::endpoint(nccl_net_ofi_domain_t &domain) :
+endpoint::endpoint(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep) :
 	ofi_domain(domain.get_ofi_domain_for_cm()),
 	mr_key_pool(*(domain.mr_rkey_pool))
 {
 	fi_info *info = domain.get_device()->get_ofi_info_for_cm();
-	ofi_cq_ptr &cq = domain.get_ofi_cq_for_cm();
+	ofi_cq_ptr &cq = ep.get_ofi_cq_for_cm();
 
 	auto av_result = nccl_ofi_ofiutils_av_create(this->ofi_domain);
 	if (OFI_UNLIKELY(av_result.is_failure())) {
@@ -122,8 +122,9 @@ int pending_requests_queue::process_pending_reqs()
 }
 
 
-cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, size_t _conn_msg_data_size) :
-	ep(domain),
+cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, nccl_net_ofi_ep_t &ep_arg,
+			   size_t _conn_msg_data_size) :
+	ep(domain, ep_arg),
 	conn_msg_data_size(_conn_msg_data_size),
 	buff_mgr(ep, get_conn_msg_size()),
 	callback_map(),

--- a/src/nccl_ofi_ofiutils.cpp
+++ b/src/nccl_ofi_ofiutils.cpp
@@ -475,7 +475,7 @@ ofi_mr_result nccl_ofi_ofiutils_mr_regattr(ofi_domain_ptr &domain,
 
 
 /**
- * @brief	Release libfabric endpoint, address vector, and completion queue
+ * @brief	Release libfabric endpoint, address vector
  */
 void nccl_ofi_ofiutils_ep_release(ofi_ep_ptr& ep, ofi_av_ptr& av, int dev_id)
 {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -35,14 +35,15 @@
 #include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_mr.h"
 
+
 /**
- * Check if domain is active
+ * Check if endpoint is active
  *
- * Caller is assumed to hold the domain lock
+ * Caller is assumed to hold the ep lock
  */
-#define CHECK_DOMAIN_ACTIVE(domain, fn_name) \
-	if (OFI_UNLIKELY(!domain->domain_active)) { \
-		NCCL_OFI_WARN("Called " fn_name " on request with inactive domain"); \
+#define CHECK_ENDPOINT_ACTIVE(endpoint, fn_name) \
+	if (OFI_UNLIKELY(!endpoint->ep_active)) { \
+		NCCL_OFI_WARN("Called " fn_name " on request with inactive endpoint"); \
 		return -EINVAL; \
 	} \
 
@@ -476,14 +477,13 @@ static int sendrecv_req_test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 		return -EINVAL;
 	}
 
-	nccl_net_ofi_sendrecv_domain_t *domain = ep->sendrecv_endpoint_get_domain();
-	pthread_wrapper domain_lock(&domain->domain_lock);
+	pthread_wrapper eplock(&ep->ep_lock);
 
-	CHECK_DOMAIN_ACTIVE(domain, "sendrecv_req_test");
+	CHECK_ENDPOINT_ACTIVE(ep, "sendrecv_req_test");
 
 	/* Process more completions unless the current request is completed */
 	if (req->state != NCCL_OFI_SENDRECV_REQ_COMPLETED) {
-		ret = sendrecv_cq_process(domain->cq.get());
+		ret = sendrecv_cq_process(ep->cq.get());
 		if (OFI_UNLIKELY(ret != 0))
 			goto exit;
 	}
@@ -690,7 +690,7 @@ exit:
  *		non-zero on error
  */
 static int sendrecv_mr_buffers_internal_register(nccl_net_ofi_sendrecv_domain_t *domain,
-						 fid_ep *ofi_ep,
+						 nccl_net_ofi_sendrecv_ep_t *ep,
 						 nccl_ofi_idpool_t *key_pool, int dev_id,
 						 void *data, size_t size, int type,
 						 nccl_net_ofi_sendrecv_mr_handle_t **mr_handle)
@@ -699,8 +699,8 @@ static int sendrecv_mr_buffers_internal_register(nccl_net_ofi_sendrecv_domain_t 
 	assert(NCCL_OFI_IS_PTR_ALIGNED(data, system_page_size));
 	assert(NCCL_OFI_IS_ALIGNED(size, system_page_size));
 
-	nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size);
-	return sendrecv_mr_buffers_register(domain, ofi_ep, key_pool, dev_id, &cache_key, type, mr_handle);
+	nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size, ep);
+	return sendrecv_mr_buffers_register(domain, ep->ofi_ep.get(), key_pool, dev_id, &cache_key, type, mr_handle);
 }
 
 
@@ -791,8 +791,6 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 
 	pthread_wrapper domain_lock(&domain->domain_lock);
 
-	CHECK_DOMAIN_ACTIVE(domain, "mr_base_reg");
-
 	int dev_id = device->dev_id;
 
 	int ret = 0;
@@ -806,7 +804,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 		 */
 		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = static_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(
-			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey));
+			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey, endpoint_mr));
 
 		if (ret_handle) {
 			/* Cache hit */
@@ -824,7 +822,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm_t *base_comm,
 	}
 
 	if (mr_cache) {
-		ret = nccl_ofi_mr_cache_insert_entry(mr_cache, ckey, ret_handle);
+		ret = nccl_ofi_mr_cache_insert_entry(mr_cache, ckey, endpoint_mr, ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			/* MR cache insert failed. Deregister memory region without
 			 * trying to delete MR cache entry.
@@ -928,9 +926,9 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 		return -EINVAL;
 	}
 
-	nccl_net_ofi_sendrecv_domain_t *domain = ep->sendrecv_endpoint_get_domain();
-	pthread_wrapper domain_lock(&domain->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain, "recv");
+	pthread_wrapper eplock(&ep->ep_lock);
+
+	CHECK_ENDPOINT_ACTIVE(ep, "recv");
 
 	/* Support only NCCL_OFI_MAX_REQUESTS inflight reqs. */
 	if (OFI_UNLIKELY(r_comm->num_inflight_reqs == NCCL_OFI_MAX_REQUESTS)) {
@@ -950,7 +948,7 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 	}
 
 	/* Progress NCCL OFI */
-	ret = sendrecv_cq_process(domain->cq.get());
+	ret = sendrecv_cq_process(ep->cq.get());
 	if (OFI_UNLIKELY(ret != 0))
 		goto error;
 
@@ -1016,13 +1014,13 @@ static int sendrecv_recv_comm_recv(nccl_net_ofi_recv_comm_t *recv_comm, int n, v
 
 void nccl_net_ofi_sendrecv_ep_t::sendrecv_endpoint_abort()
 {
-	pthread_wrapper domain_lock(&this->domain->domain_lock);
+	pthread_wrapper lock(&this->ep_lock);
 
 	int dev_id = this->domain->get_device()->dev_id;
 
 	nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, dev_id);
 
-	this->domain->invalidate();
+	this->invalidate();
 }
 
 
@@ -1098,9 +1096,10 @@ static int sendrecv_recv_comm_flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, 
 	auto **mr_handles = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t **>(mhandles);
 
 	auto *ep = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(r_comm->base.base.ep);
-	nccl_net_ofi_sendrecv_domain_t *domain_ptr = ep->sendrecv_endpoint_get_domain();
-	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain_ptr, "flush");
+
+	pthread_wrapper eplock(&ep->ep_lock);
+
+	CHECK_ENDPOINT_ACTIVE(ep, "flush");
 
 	if (ofi_nccl_gdr_flush_disable() || support_gdr == GDR_UNSUPPORTED)
 		goto exit;
@@ -1197,7 +1196,7 @@ static int sendrecv_recv_comm_flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, 
 			 * Process completions so that you have enough
 			 * resources for issuing fi_read
 			 */
-			ret = sendrecv_cq_process(domain_ptr->cq.get());
+			ret = sendrecv_cq_process(ep->cq.get());
 			if (OFI_UNLIKELY(ret != 0))
 				goto error;
 		} else {
@@ -1241,7 +1240,7 @@ static int sendrecv_recv_comm_flush(nccl_net_ofi_recv_comm_t *recv_comm, int n, 
  * 		error, on others
  */
 static int sendrecv_recv_comm_alloc_and_reg_flush_buff(nccl_net_ofi_sendrecv_domain_t *domain,
-						       fid_ep *ofi_ep,
+						       nccl_net_ofi_sendrecv_ep_t *ep,
 						       nccl_ofi_idpool_t *key_pool,
 						       nccl_net_ofi_sendrecv_flush_buffer_t *flush_buff,
 						       int dev_id)
@@ -1261,7 +1260,7 @@ static int sendrecv_recv_comm_alloc_and_reg_flush_buff(nccl_net_ofi_sendrecv_dom
 	}
 
 	/* Register flush dummy buffer for provider access */
-	ret = sendrecv_mr_buffers_internal_register(domain, ofi_ep, key_pool, dev_id,
+	ret = sendrecv_mr_buffers_internal_register(domain, ep, key_pool, dev_id,
 						    flush_buff->host_buffer,
 						    system_page_size,
 						    NCCL_PTR_HOST, &mr_handle);
@@ -1380,7 +1379,7 @@ static nccl_net_ofi_sendrecv_recv_comm_t *sendrecv_recv_comm_prepare(nccl_net_of
 	 */
 	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
 		r_comm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
-		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(domain, ep->ofi_ep.get(),
+		ret = sendrecv_recv_comm_alloc_and_reg_flush_buff(domain, ep,
 								  key_pool,
 								  &r_comm->flush_buff, dev_id);
 		if (OFI_UNLIKELY(ret != 0)) {
@@ -1446,9 +1445,9 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	nccl_net_ofi_sendrecv_domain_t *domain = ep->sendrecv_endpoint_get_domain();
 	assert(domain != NULL);
 
-	pthread_wrapper domain_lock(&domain->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain, "accept");
+	pthread_wrapper eplock(&ep->ep_lock);
 
+	CHECK_ENDPOINT_ACTIVE(ep, "accept");
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device =
@@ -1480,7 +1479,7 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 	case COMM_CONN_REQ_PENDING:
 
 		/* Progress NCCL OFI engine so that connection is accepted */
-		ret = sendrecv_cq_process(domain->cq.get());
+		ret = sendrecv_cq_process(ep->cq.get());
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
 		}
@@ -1536,7 +1535,7 @@ static int sendrecv_listen_comm_accept(nccl_net_ofi_listen_comm_t *listen_comm,
 		 * cleanup and return receive communicator. */
 
 		/* Progress our engine to get completions */
-		ret = sendrecv_cq_process(domain->cq.get());
+		ret = sendrecv_cq_process(ep->cq.get());
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
 		}
@@ -1639,10 +1638,12 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	nccl_net_ofi_sendrecv_listen_comm_t *l_comm = nullptr;
 	int dev_id = 0;
 	int num_addrs;
+
 	nccl_net_ofi_sendrecv_domain_t *domain_ptr = this->sendrecv_endpoint_get_domain();
 
-	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain_ptr, "listen");
+	pthread_wrapper eplock(&this->ep_lock);
+
+	CHECK_ENDPOINT_ACTIVE(this, "listen");
 
 	/* Retrieve and validate device */
 	nccl_net_ofi_sendrecv_device_t *device = domain_ptr->sendrecv_domain_get_device();
@@ -1687,7 +1688,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 	l_comm->local_ep = this->ofi_ep.get();
 	l_comm->local_ep_addr = local_ep_addr;
 
-	l_comm->listener = domain_ptr->cm->listen();
+	l_comm->listener = this->cm->listen();
 
 	/* Build handle */
 	*handle = l_comm->listener->get_handle();
@@ -1743,10 +1744,9 @@ static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *da
 		return -EINVAL;
 	}
 
-	nccl_net_ofi_sendrecv_domain_t *domain = ep->sendrecv_endpoint_get_domain();
-	pthread_wrapper domain_lock(&domain->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain, "send");
+	pthread_wrapper eplock(&ep->ep_lock);
 
+	CHECK_ENDPOINT_ACTIVE(ep, "send");
 
 	/* Support only NCCL_OFI_MAX_REQUESTS inflight requests. */
 	if (OFI_UNLIKELY(s_comm->num_inflight_reqs == NCCL_OFI_MAX_SEND_REQUESTS)) {
@@ -1787,7 +1787,7 @@ static int sendrecv_send_comm_send(nccl_net_ofi_send_comm_t *send_comm, void *da
 		      s_comm->remote_ep, s_comm->tag, sendrecv_req_get_ofi_context(req));
 	if (OFI_UNLIKELY(rc == -FI_EAGAIN)) {
 		/* Make progress for next try */
-		ret = sendrecv_cq_process(domain->cq.get());
+		ret = sendrecv_cq_process(ep->cq.get());
 		/* Return NULL request */
 		*base_req = NULL;
 		goto error;
@@ -2011,11 +2011,13 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 {
 	int ret = 0;
 	*send_comm = nullptr;
+
 	nccl_net_ofi_sendrecv_domain_t *domain_ptr = this->sendrecv_endpoint_get_domain();
 	assert(domain_ptr != nullptr);
 
-	pthread_wrapper domain_lock(&domain_ptr->domain_lock);
-	CHECK_DOMAIN_ACTIVE(domain_ptr, "connect");
+	pthread_wrapper eplock(&this->ep_lock);
+
+	CHECK_ENDPOINT_ACTIVE(this, "connect");
 
 	nccl_ofi_connection_info_t conn_info = { };
 	
@@ -2046,11 +2048,11 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 			return ret;
 		}
 
-		s_comm->connector = domain_ptr->cm->connect(*handle, &conn_info, sizeof(conn_info));
+		s_comm->connector = this->cm->connect(*handle, &conn_info, sizeof(conn_info));
 	}
 
 	/* Progress our engine to get completions */
-	ret = sendrecv_cq_process(this->sendrecv_endpoint_get_domain()->cq.get());
+	ret = sendrecv_cq_process(this->cq.get());
 	if (OFI_UNLIKELY(ret != 0)) {
 		free(s_comm);
 		return ret;
@@ -2101,6 +2103,14 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 	assert(!this->called_cleanup_resources);
 	this->called_cleanup_resources = true;
 
+	if (this->cm) {
+		delete this->cm;
+		this->cm = nullptr;
+	}
+
+	int dev_id = this->domain->get_device()->dev_id;
+	nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, dev_id);
+
 	assert(ret == 0);
 
 	return ret;
@@ -2136,6 +2146,19 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 	this->max_tag = device->max_tag;
 
 	ofi_domain_ptr &ofi_domain = this->sendrecv_endpoint_get_ofi_domain();
+
+	/* Create the completion queue */
+	struct fi_cq_attr cq_attr = {};
+	cq_attr.format = FI_CQ_FORMAT_TAGGED;
+	cq_attr.size = ofi_nccl_cq_size();
+	auto cq_result =  nccl_ofi_ofiutils_cq_create(ofi_domain, &cq_attr);
+	if (OFI_UNLIKELY(cq_result.is_failure())) {
+		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
+			       cq_result.error_code, fi_strerror(-cq_result.error_code));
+		throw std::runtime_error("SEND RECV endpoint constructor: ofi cq creation failed");
+	}
+	this->cq = std::move(cq_result.resource);
+
 	auto av_result = nccl_ofi_ofiutils_av_create(ofi_domain);
 	if (OFI_UNLIKELY(av_result.is_failure())) {
 		throw std::runtime_error("sendrecv endpoint constructor: failed to init av");
@@ -2143,25 +2166,35 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 	this->av = std::move(av_result.resource);
 
 	auto ep_result = nccl_ofi_ofiutils_ep_create(device->info, ofi_domain, this->av,
-						     domain_arg->cq);
+						     this->cq);
 	if (OFI_UNLIKELY(ep_result.is_failure())) {
 		throw std::runtime_error("sendrecv endpoint constructor: failed to init endpoint");
 	}
 	this->ofi_ep = std::move(ep_result.resource);
+
+	this->cm = new nccl_ofi_connection_manager(*domain_arg, *this,
+						   sizeof(nccl_ofi_connection_info_t));
 }
 
 
 int nccl_net_ofi_sendrecv_domain_t::cleanup_resources()
 {
 	int ret = 0;
+	int err_code = 0;
 
 	/* cleanup_resources should only be called once per domain instance */
 	assert(!this->called_cleanup_resources);
 	this->called_cleanup_resources = true;
 
-	if (this->cm) {
-		delete this->cm;
-		this->cm = nullptr;
+	if (!this->ep_table.empty()) {
+		NCCL_OFI_INFO(NCCL_NET, "%zu SENDRECV endpoints still active at close",
+			      this->ep_table.size());
+		err_code = this->release_all_ep();
+		if (err_code != 0) {
+			NCCL_OFI_WARN("Cleanup of SENDRECV domain failed. RC: %d, ERROR: %s",
+				      err_code, fi_strerror(-err_code));
+			ret = -EINVAL;
+		}
 	}
 
 	assert(ret == 0);
@@ -2178,11 +2211,10 @@ nccl_net_ofi_sendrecv_domain_t::~nccl_net_ofi_sendrecv_domain_t()
 }
 
 
-nccl_net_ofi_sendrecv_domain_t::nccl_net_ofi_sendrecv_domain_t(nccl_net_ofi_sendrecv_device_t *device_arg)
+nccl_net_ofi_sendrecv_domain_t::nccl_net_ofi_sendrecv_domain_t(nccl_net_ofi_sendrecv_device_t *device_arg,
+							       unsigned int domain_key_arg)
 	: nccl_net_ofi_domain_t(device_arg)
 {
-	struct fi_cq_attr cq_attr = {};
-
 	auto domain_result = nccl_ofi_ofiutils_domain_create(device_arg->fabric,
 							     device_arg->info);
 	if (OFI_UNLIKELY(domain_result.is_failure())) {
@@ -2191,26 +2223,13 @@ nccl_net_ofi_sendrecv_domain_t::nccl_net_ofi_sendrecv_domain_t(nccl_net_ofi_send
 		throw std::runtime_error("SENDRECV domain constructor: domain creation failed");
 	}
 	this->domain = std::move(domain_result.resource);
-
-	/* Create a domain-shared completion queue */
-	cq_attr.format = FI_CQ_FORMAT_TAGGED;
-	cq_attr.size = ofi_nccl_cq_size();
-	auto cq_result =  nccl_ofi_ofiutils_cq_create(this->domain, &cq_attr);
-	if (OFI_UNLIKELY(cq_result.is_failure())) {
-		NCCL_OFI_WARN("Couldn't open CQ. RC: %d, ERROR: %s",
-				cq_result.error_code, fi_strerror(-cq_result.error_code));
-		throw std::runtime_error("RDMA domain constructor: ofi cq creation failed");
-	}
-	this->cq = std::move(cq_result.resource);
-
-	this->cm = new nccl_ofi_connection_manager(*this,
-						   sizeof(nccl_ofi_connection_info_t));
+	this->domain_key = domain_key_arg;
 }
 
 
-nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_t::create_domain()
+nccl_net_ofi_domain_t *nccl_net_ofi_sendrecv_device_t::create_domain(unsigned int domain_key)
 {
-	auto *domain = new nccl_net_ofi_sendrecv_domain_t(this);
+	auto *domain = new nccl_net_ofi_sendrecv_domain_t(this, domain_key);
 
 	return domain;
 }

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -87,7 +87,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -101,7 +100,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -115,7 +113,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 150.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -126,7 +123,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -137,7 +133,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -154,7 +149,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		/*
 		 * Note: Based on empirical testing, setting the
 		 * NCCL_NETDEVS_POLICY=max:1 gives optimal performance
@@ -188,7 +182,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -205,7 +198,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -216,7 +208,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -230,7 +221,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -244,7 +234,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -255,7 +244,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = true,
 		.env = {},
 	},
 	{
@@ -266,7 +254,6 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = true,
 		.env = {},
 	},
 };
@@ -733,10 +720,6 @@ int PlatformAWS::init(const char **provider_filter)
 
 	if (select_efa && ofi_nccl_protocol.get_source() == ParamSource::DEFAULT && platform_data) {
 		ofi_nccl_protocol.set(platform_data->default_protocol);
-	}
-
-	if (ofi_nccl_domain_per_thread.get_source() == ParamSource::DEFAULT && platform_data) {
-		ofi_nccl_domain_per_thread.set(platform_data->domain_per_thread);
 	}
 
 	return ret;

--- a/tests/functional/nccl_connection.cpp
+++ b/tests/functional/nccl_connection.cpp
@@ -158,6 +158,8 @@ int main(int argc, char* argv[])
 					peer_rank);
 		}
 
+		MPI_Barrier(MPI_COMM_WORLD);
+
 		OFINCCLCHECK(extNet->closeListen((void *)lComm));
 		lComm = NULL;
 		OFINCCLCHECK(extNet->closeSend((void *)sComm));

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -99,7 +99,6 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.latency = 0.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
-		.domain_per_thread = 0,
 		.env = {},
 	},
 	{
@@ -110,7 +109,6 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.latency = 0.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::RDMA,
-		.domain_per_thread = 0,
 		.env = {},
 	},
 };

--- a/tests/unit/mr.cpp
+++ b/tests/unit/mr.cpp
@@ -13,8 +13,12 @@
 static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
 		 void *expected_val)
 {
-	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size);;
-	void *result = nccl_ofi_mr_cache_lookup_entry(cache, &ckey);
+	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
+	 * the the mr key create below. For now, we are
+	 * passing nullptr
+	 */
+	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);;
+	void *result = nccl_ofi_mr_cache_lookup_entry(cache, &ckey, false);
 	if (result != expected_val) {
 		NCCL_OFI_WARN("nccl_ofi_mr_cache_lookup_entry returned unexpected result. Expected: %p. Actual: %p",
 			expected_val, result);
@@ -31,8 +35,12 @@ static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
 		 void *handle, int expected_ret)
 {
-	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size);
-	int ret = nccl_ofi_mr_cache_insert_entry(cache, &ckey, handle);
+	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
+	 * the the mr key create below. For now, we are
+	 * passing nullptr
+	 */
+	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);
+	int ret = nccl_ofi_mr_cache_insert_entry(cache, &ckey, false, handle);
 	if (ret != expected_ret) {
 		NCCL_OFI_WARN("nccl_ofi_mr_cache_insert_entry returned unexpected result. Expected: %d. Actual: %d",
 			expected_ret, ret);
@@ -64,8 +72,12 @@ static inline bool test_delete_impl(nccl_ofi_mr_cache_t *cache, void *handle, in
 
 static inline bool test_make_aligned_key_impl(uintptr_t addr, size_t size, uintptr_t expected_base, size_t expected_size)
 {
+	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
+	 * the the mr key create below. For now, we are
+	 * passing nullptr
+	 */
 	/* iovec only */
-	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec((void*)addr, size);
+	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec((void*)addr, size, nullptr);
 	uintptr_t page_base = nccl_ofi_mr_ckey_baseaddr(&ckey);
 	size_t aligned_size = nccl_ofi_mr_ckey_len(&ckey);
 	if (page_base != expected_base || aligned_size != expected_size) {


### PR DESCRIPTION
1. Grouped ofi ep,av, and cq together and made them part of plugin EndPoint class
2. Maintained a per thread plugin EndPoint object
3. Added support for multiple domains per device based on application request
4. Updated the nccl net api interface to pass domain key to request for a new domain
5. Enabled 'FI_THREAD_COMPLETION' threading mode because now the completion
structures are created per thread.
6. Made Plugin endpoint ops thread safe to support multiple comms per thread scenario
7. Added endpoint state tracking to handle abrupt comm abort scenarios
8. Fixed `nccl_connect` test application to avoid race condition
   between the comm creation and closing between the sender and receiver ranks.
9. Implemented `ep_per_comm` feature to support rComms have a dedicated endpoint
but shared CQ.
10. Implemented an endpoint aware MR cache policy to support providers with FI_MR_ENDPOINT caps

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
