### PR TITLE
Revert "Fix memory registration cleanup order in CM resources destructor

### DIFF
--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -152,6 +152,12 @@ cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, size_t _conn_msg_data_
 
 cm_resources::~cm_resources()
 {
+	/* Resources can be destructed in the usual reverse-order, with one exception:
+	   The endpoint must be closed first, since posted buffers and requests cannot
+	   be freed until the endpoint is closed.
+	 */
+	ep.close_ofi_ep();
+
 	/* Free all requests. (A unique_ptr would be better here so these can be freed
 	   automatically) */
 	for (auto &req : rx_reqs) {


### PR DESCRIPTION
This reverts commit 9e0f5ba9684de274672d2e87945c0e7d11af3b12.
Reverting it to be on sync with the release 1.17.x branch



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
