### PR TITLE
rdma: Add ROCm support to RDMA protocol

### DIFF
--- a/include/nccl_ofi_rocm.h
+++ b/include/nccl_ofi_rocm.h
@@ -31,18 +31,33 @@ int nccl_net_ofi_get_cuda_device_for_addr(void *data, int *dev_id);
 int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void);
 
 /*
- * @brief	wraps cudaGetDevice()
+ * @brief wraps hipMalloc()
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_get_num_devices(void);
+int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size);
 
 /*
- * @brief	query CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED
- * @return	true if attr is fetched successfully and true.
- *		    false otherwise.
+ * @brief wraps hipFree()
+ * @return	0 on success
+ *		-1 on error
  */
-int nccl_net_ofi_cuda_get_active_device_idx(void);
+int nccl_net_ofi_cuda_mem_free(void *ptr);
+
+/*
+ * @brief wraps hipMemcpy() from host to device
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size);
+
+/*
+ * @brief Obtain the fd and offset for a dma buf.
+ * The ptr and size provided as input must be aligned to page size
+ * @return	0 on success
+ *		-1 on error
+ */
+int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
 
 bool nccl_net_ofi_cuda_have_dma_buf_attr(void);
 bool nccl_net_ofi_cuda_have_gdr_support_attr(void);

--- a/src/nccl_ofi_dmabuf.cpp
+++ b/src/nccl_ofi_dmabuf.cpp
@@ -14,6 +14,8 @@
 #include "nccl_ofi_param.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
+#elif HAVE_ROCM
+#include "nccl_ofi_rocm.h"
 #endif
 
 /*
@@ -60,12 +62,12 @@ int nccl_ofi_dmabuf_viable()
 		return false;
 	}
 
-	/* Disable DMA-BUF if using CUDA and CUDA does not report DMA-BUF
+	/* Disable DMA-BUF if using CUDA or ROCm and the platform does not report DMA-BUF
 	 * support in device attributes. */
-#if HAVE_CUDA
+#if HAVE_GPU
 	if (!nccl_net_ofi_cuda_have_dma_buf_attr()) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-		               "Will not attempt to use DMA-BUF, CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED was false.");
+		               "Will not attempt to use DMA-BUF, device does not support DMA-BUF.");
 		return false;
 	}
 #endif

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -1095,7 +1095,7 @@ static inline int handle_flush_comp(nccl_net_ofi_rdma_req_t *req)
 	ret = inc_req_completion(req, 0, flush_data->total_num_compls);
 #endif
 
-#if HAVE_CUDA
+#if HAVE_GPU
 
 	rdma_req_flush_data_t *flush_data = get_flush_data(req);
 	int num_completions = ++(req->ncompls);
@@ -2386,7 +2386,7 @@ static int test(nccl_net_ofi_req_t *base_req, int *done, int *size)
 	*/
 	if (req->state != NCCL_OFI_RDMA_REQ_COMPLETED
 		&& OFI_LIKELY(req->state != NCCL_OFI_RDMA_REQ_ERROR)) {
-#if HAVE_CUDA
+#if HAVE_GPU
 		if (req->type == NCCL_OFI_RDMA_FLUSH) {
 			/*
 			 * Check if the flush is complete and mark it as complete
@@ -3208,7 +3208,7 @@ int nccl_net_ofi_rdma_domain_t::dealloc_and_dereg_flush_buff()
 	 * Clean up the flush buffer only if it was mapped correctly
 	 */
 	if (this->flush_buff.buffer != MAP_FAILED) {
-#if HAVE_CUDA
+#if HAVE_GPU
 		ret = nccl_net_ofi_cuda_mem_free(this->flush_buff.buffer_base);
 #endif
 #if HAVE_NEURON
@@ -3271,12 +3271,12 @@ int nccl_net_ofi_rdma_domain_t::alloc_and_reg_flush_buff(int dev_id)
 	}
 #endif
 
-#if HAVE_CUDA
+#if HAVE_GPU
 	int rc;
 	NCCL_OFI_TRACE(NCCL_NET, "Registering buffer in GPU for flush operations");
 
 	/*
-	* We allocate twice the system page size since CUDA memory allocation
+	* We allocate twice the system page size since GPU memory allocation
 	* does not guarantee that the allocated memory will be system page aligned.
 	* Post allocation, we calculate the page aligned ptr and perform
 	* memory registrations on it.
@@ -5408,7 +5408,7 @@ static int post_flush_req(nccl_net_ofi_rdma_req_t *req)
  exit:
 	return (int)rc;
 }
-#elif HAVE_CUDA
+#elif HAVE_GPU
 static int post_flush_req(nccl_net_ofi_rdma_req_t *req)
 {
 	nccl_net_ofi_rdma_recv_comm_t *r_comm = (nccl_net_ofi_rdma_recv_comm_t *)req->comm;
@@ -5454,10 +5454,6 @@ static int post_flush_req(nccl_net_ofi_rdma_req_t *req)
 
  exit:
 	return (int)rc;
-}
-#else
-static int post_flush_req(nccl_net_ofi_rdma_req_t *req) {
-	return -FI_EOPNOTSUPP;
 }
 #endif
 

--- a/src/nccl_ofi_rocm.cpp
+++ b/src/nccl_ofi_rocm.cpp
@@ -49,20 +49,6 @@ int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void)
 	return -EPERM;
 }
 
-int nccl_net_ofi_cuda_get_num_devices(void)
-{
-	int count = -1;
-	hipError_t res = hipGetDeviceCount(&count);
-	return res == hipSuccess ? count : -1;
-}
-
-int nccl_net_ofi_cuda_get_active_device_idx(void)
-{
-	int index = -1;
-	hipError_t res = hipGetDevice(&index);
-	return res == hipSuccess ? index : -1;
-}
-
 int nccl_net_ofi_get_cuda_device_for_addr(void *data, int *dev_id)
 {
 	int ret = 0;
@@ -91,4 +77,37 @@ bool nccl_net_ofi_cuda_have_gdr_support_attr(void)
 bool nccl_net_ofi_cuda_have_dma_buf_attr(void)
 {
 	return false;
+}
+
+int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size)
+{
+	hipError_t ret = hipMalloc(ptr, size);
+	if (ret != hipSuccess) {
+		return -EINVAL;
+	}
+	return 0;
+}
+
+int nccl_net_ofi_cuda_mem_free(void *ptr)
+{
+	hipError_t ret = hipFree(ptr);
+	return ret == hipSuccess ? 0 : -EINVAL;
+}
+
+int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
+{
+	hipError_t ret = hipMemcpy(dst, src, size, hipMemcpyHostToDevice);
+	return ret == hipSuccess ? 0 : -EINVAL;
+}
+
+int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
+{
+#if defined(HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD)
+	hipError_t ret = hipMemGetHandleForAddressRange(fd, (uintptr_t)aligned_ptr, aligned_size,
+						      HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+	*offset = 0;
+	return ret == hipSuccess ? 0 : -EINVAL;
+#else
+	return -ENOTSUP;
+#endif
 }


### PR DESCRIPTION
Extend RDMA protocol support to ROCm GPUs, completing the ROCm integration that was previously limited to the sendrecv protocol. This change enables the RDMA path for AMD GPUs.

The RDMA protocol requires direct GPU memory operations (allocation, deallocation, host-to-device copies) and buffer registration that were previously only available for CUDA. ROCm provides equivalent functionality through the HIP runtime, but uses different API calls and memory semantics.

Add ROCm memory management functions to nccl_ofi_rocm.cpp:
- nccl_net_ofi_cuda_mem_alloc() wraps hipMalloc()
- nccl_net_ofi_cuda_mem_free() wraps hipFree()
- nccl_net_ofi_cuda_mem_copy_host_to_device() wraps hipMemcpy()
- nccl_net_ofi_cuda_get_dma_buf_fd() wraps hipMemGetHandleForAddressRange()

Tested with MI250X.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
