### PR TITLE
Remove unused nccl_net_ofi_cuda_get_base_addr function and associated CUDA function pointer

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -51,14 +51,6 @@ int nccl_net_ofi_cuda_mem_free(void *ptr);
 int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size);
 
 /*
- * @brief wraps cuMemGetAddressRange() to get the base addr and size
- * of a given pointer
- * @return	0 on success
- *		-1 on error
- */
-int nccl_net_ofi_cuda_get_base_addr(const void *ptr, void **base, size_t *size);
-
-/*
  * @brief Uses cuMemGetHandleForAddressRange() to obtain
  * the fd and offset for a dma buf. In case CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE
  * is not supported we retry with flags set to 0.

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -81,7 +81,6 @@ DECLARE_CUDA_FUNCTION(cuFlushGPUDirectRDMAWrites, 11030);
 #if HAVE_CUDA_DMABUF_SUPPORT
 DECLARE_CUDA_FUNCTION(cuMemGetHandleForAddressRange, 11070);
 #endif
-DECLARE_CUDA_FUNCTION(cuMemGetAddressRange, 3020);
 DECLARE_CUDA_FUNCTION(cuPointerGetAttributes, 7000);
 DECLARE_CUDA_FUNCTION(cuMemAlloc, 3020);
 DECLARE_CUDA_FUNCTION(cuMemFree, 3020);
@@ -152,7 +151,6 @@ int nccl_net_ofi_gpu_init(void)
 #if HAVE_CUDA_DMABUF_SUPPORT
 	RESOLVE_CUDA_FUNCTION(cuMemGetHandleForAddressRange, 11070);
 #endif
-	RESOLVE_CUDA_FUNCTION(cuMemGetAddressRange, 3020);
 	RESOLVE_CUDA_FUNCTION(cuPointerGetAttributes, 7000);
 	RESOLVE_CUDA_FUNCTION(cuMemAlloc, 3020);
 	RESOLVE_CUDA_FUNCTION(cuMemFree, 3020);
@@ -217,13 +215,6 @@ int nccl_net_ofi_cuda_mem_free(void *ptr)
 int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
 {
 	CUresult ret = pfn_cuMemcpy((CUdeviceptr)dst, (CUdeviceptr)src, size);
-	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
-}
-
-int nccl_net_ofi_cuda_get_base_addr(const void *ptr, void **base, size_t *size)
-{
-	CUresult ret;
-	ret = pfn_cuMemGetAddressRange((CUdeviceptr *)base, size, (CUdeviceptr)ptr);
 	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
 }
 


### PR DESCRIPTION
Remove unused nccl_net_ofi_cuda_get_base_addr function and associated CUDA function pointer

The nccl_net_ofi_cuda_get_base_addr function in nccl_ofi_cuda.cpp and its
declaration in nccl_ofi_cuda.h were never called from any code in the
codebase. This commit removes the function definition, its header
declaration, and the unused pfn_cuMemGetAddressRange CUDA function pointer
that was only used by this function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
