### PR TITLE
cm: Fix provider-specific cleanup order in cm_resources destructor

### DIFF
--- a/src/cm/nccl_ofi_cm_resources.cpp
+++ b/src/cm/nccl_ofi_cm_resources.cpp
@@ -152,11 +152,33 @@ cm_resources::cm_resources(nccl_net_ofi_domain_t &domain, size_t _conn_msg_data_
 
 cm_resources::~cm_resources()
 {
-	/* Resources can be destructed in the usual reverse-order, with one exception:
-	   The endpoint must be closed first, since posted buffers and requests cannot
-	   be freed until the endpoint is closed.
+	/* Libfabric imposes two key cleanup constraints:
+	 *
+	 * 1. Memory registrations (MRs) associated with an endpoint must be closed
+	 *    before the endpoint itself.
+	 *
+	 * 2. Memory buffers used with Libfabric transmission interfaces must not be
+	 *    released, deregistered, or reused until either a completion event is
+	 *    received or fi_close() on the endpoint returns. For receive buffers,
+	 *    this typically requires cancellation support, which not all providers
+	 *    implement.
+	 *
+	 * For non-FI_MR_ENDPOINT providers:
+	 *   We close the endpoint here before buffer cleanup. The first constraint
+	 *   does not apply (MRs are not bound to the endpoint), and closing the
+	 *   endpoint satisfies the second constraint.
+	 *
+	 * For FI_MR_ENDPOINT providers:
+	 *   We skip closing the endpoint here, as there are MRs still associated
+	 *   with this endpoint. The remaining cleanup code is not entirely correct,
+	 *   as the MR cleanup that happens as part of buffer class destruction only
+	 *   obeys the first rule, and not the second. To properly support
+	 *   FI_MR_ENDPOINT, the buffers also need to be cancelled, but this code
+	 *   appears to work with CXI, so is a reasonable first step.
 	 */
-	ep.close_ofi_ep();
+	if (!endpoint_mr) {
+		ep.close_ofi_ep();
+	}
 
 	/* Free all requests. (A unique_ptr would be better here so these can be freed
 	   automatically) */


### PR DESCRIPTION
*Description of changes:*

Add conditional endpoint closing based on FI_MR_ENDPOINT capability to ensure correct cleanup order for different libfabric providers.

For non-FI_MR_ENDPOINT providers, the endpoint must be closed before freeing posted buffers and requests, maintaining the original behavior.

For FI_MR_ENDPOINT providers, memory registrations bound to the endpoint must be deregistered before the endpoint is destroyed. This is now handled by natural C++ destruction order: buff_mgr destructor frees MRs first, then the endpoint destructor closes the endpoint.

This fix addresses the issue introduced in commit 9e0f5ba where removing the explicit ep.close_ofi_ep() call broke non-FI_MR_ENDPOINT providers, while also maintaining the fix for FI_MR_ENDPOINT providers where MRs were being deregistered after their associated endpoint was already destroyed.

The solution allows FI_MR_ENDPOINT providers to continue iterating on more sophisticated cleanup mechanisms if needed, while ensuring correct behavior for both provider types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
