### PR TITLE
Rename GPU-related function names from 'cuda' to 'gpu' for consistency

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -9,17 +9,17 @@
 int nccl_net_ofi_gpu_init(void);
 
 /*
- * @brief	Gets the CUDA device associated with the buffer
+ * @brief	Gets the GPU device associated with the buffer
  *
  * @param	data
- *		Pointer to CUDA buffer.
+ *		Pointer to GPU buffer.
  *
- * @return	Valid CUDA device ID on success
+ * @return	Valid GPU device ID on success
  *		-1 on error
  * @return	0 on success
  *		-EINVAL on error
  */
-int nccl_net_ofi_get_cuda_device_for_addr(void *data, int *dev_id);
+int nccl_net_ofi_get_gpu_device_for_addr(void *data, int *dev_id);
 
 /*
  * @brief	wraps cudaFlushGPUDirectRDMAWrites() with default args.
@@ -34,7 +34,7 @@ int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void);
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size);
+int nccl_net_ofi_gpu_mem_alloc(void **ptr, size_t size);
 
 /*
  * @brief wraps cuMemFree()
@@ -42,13 +42,13 @@ int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size);
  *		-1 on error
  */
 
-int nccl_net_ofi_cuda_mem_free(void *ptr);
+int nccl_net_ofi_gpu_mem_free(void *ptr);
 /*
  * @brief wraps cuMemcpy() from host to device
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size);
+int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size);
 
 /*
  * @brief Uses cuMemGetHandleForAddressRange() to obtain
@@ -58,7 +58,7 @@ int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
 
 /*
  * @brief	query CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED
@@ -66,7 +66,7 @@ int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int
  * @return	true if attr is fetched successfully and true.
  *		    false otherwise.
  */
-bool nccl_net_ofi_cuda_have_dma_buf_attr(void);
+bool nccl_net_ofi_gpu_have_dma_buf_attr(void);
 
 /*
  * @brief	query CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_SUPPORTED
@@ -74,6 +74,6 @@ bool nccl_net_ofi_cuda_have_dma_buf_attr(void);
  * @return	true if attr is fetched successfully and true.
  *		    false otherwise
  */
-bool nccl_net_ofi_cuda_have_gdr_support_attr(void);
+bool nccl_net_ofi_gpu_have_gdr_support_attr(void);
 
 #endif  // End NCCL_OFI_CUDA_H_

--- a/include/nccl_ofi_rocm.h
+++ b/include/nccl_ofi_rocm.h
@@ -21,7 +21,7 @@ int nccl_net_ofi_gpu_init(void);
  * @return	0 on success
  *		-EINVAL on error
  */
-int nccl_net_ofi_get_cuda_device_for_addr(void *data, int *dev_id);
+int nccl_net_ofi_get_gpu_device_for_addr(void *data, int *dev_id);
 
 /*
  * @brief	wraps cudaFlushGPUDirectRDMAWrites() with default args.
@@ -35,21 +35,21 @@ int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void);
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size);
+int nccl_net_ofi_gpu_mem_alloc(void **ptr, size_t size);
 
 /*
  * @brief wraps hipFree()
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_mem_free(void *ptr);
+int nccl_net_ofi_gpu_mem_free(void *ptr);
 
 /*
  * @brief wraps hipMemcpy() from host to device
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size);
+int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size);
 
 /*
  * @brief Obtain the fd and offset for a dma buf.
@@ -57,9 +57,9 @@ int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
 
-bool nccl_net_ofi_cuda_have_dma_buf_attr(void);
-bool nccl_net_ofi_cuda_have_gdr_support_attr(void);
+bool nccl_net_ofi_gpu_have_dma_buf_attr(void);
+bool nccl_net_ofi_gpu_have_gdr_support_attr(void);
 
 #endif /* NCCL_OFI_ROCM_H_ */

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -167,7 +167,7 @@ int nccl_net_ofi_gpu_init(void)
 	              driverVersion,
 	              runtimeVersion);
 
-	if (HAVE_CUDA_GDRFLUSH_SUPPORT && nccl_net_ofi_cuda_have_gdr_support_attr() && ofi_nccl_cuda_flush_enable()) {
+	if (HAVE_CUDA_GDRFLUSH_SUPPORT && nccl_net_ofi_gpu_have_gdr_support_attr() && ofi_nccl_cuda_flush_enable()) {
 		NCCL_OFI_WARN("CUDA flush enabled");
 		cuda_flush = true;
 	} else {
@@ -194,7 +194,7 @@ int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void)
 #endif
 }
 
-int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size)
+int nccl_net_ofi_gpu_mem_alloc(void **ptr, size_t size)
 {
 	CUdeviceptr d_ptr;
 	CUresult ret = pfn_cuMemAlloc(&d_ptr, size);
@@ -206,19 +206,19 @@ int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size)
 	return 0;
 }
 
-int nccl_net_ofi_cuda_mem_free(void *ptr)
+int nccl_net_ofi_gpu_mem_free(void *ptr)
 {
 	CUresult ret = pfn_cuMemFree((CUdeviceptr)ptr);
 	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
+int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 {
 	CUresult ret = pfn_cuMemcpy((CUdeviceptr)dst, (CUdeviceptr)src, size);
 	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
 {
 #if HAVE_CUDA_DMABUF_SUPPORT
 	unsigned long long flags = 0;
@@ -246,7 +246,7 @@ int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int
 #endif
 }
 
-int nccl_net_ofi_get_cuda_device_for_addr(void *ptr, int *dev_id)
+int nccl_net_ofi_get_gpu_device_for_addr(void *ptr, int *dev_id)
 {
 	void *data[2];
 	CUpointer_attribute attributes[2];
@@ -266,7 +266,7 @@ int nccl_net_ofi_get_cuda_device_for_addr(void *ptr, int *dev_id)
 	return 0;
 }
 
-bool nccl_net_ofi_cuda_have_gdr_support_attr(void)
+bool nccl_net_ofi_gpu_have_gdr_support_attr(void)
 {
 #if HAVE_CUDA_GDRFLUSH_SUPPORT
 	if (pfn_cuCtxGetDevice == NULL || pfn_cuDeviceGetAttribute == NULL) {
@@ -292,7 +292,7 @@ bool nccl_net_ofi_cuda_have_gdr_support_attr(void)
 #endif
 }
 
-bool nccl_net_ofi_cuda_have_dma_buf_attr(void)
+bool nccl_net_ofi_gpu_have_dma_buf_attr(void)
 {
 #if HAVE_CUDA_DMABUF_SUPPORT
 	static_assert(CUDA_VERSION >= 11070, "Requires cudart>=11.7");

--- a/src/nccl_ofi_dmabuf.cpp
+++ b/src/nccl_ofi_dmabuf.cpp
@@ -65,7 +65,7 @@ int nccl_ofi_dmabuf_viable()
 	/* Disable DMA-BUF if using CUDA or ROCm and the platform does not report DMA-BUF
 	 * support in device attributes. */
 #if HAVE_GPU
-	if (!nccl_net_ofi_cuda_have_dma_buf_attr()) {
+	if (!nccl_net_ofi_gpu_have_dma_buf_attr()) {
 		NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
 		               "Will not attempt to use DMA-BUF, device does not support DMA-BUF.");
 		return false;

--- a/src/nccl_ofi_rocm.cpp
+++ b/src/nccl_ofi_rocm.cpp
@@ -49,7 +49,7 @@ int nccl_net_ofi_gpu_flush_gpudirect_rdma_writes(void)
 	return -EPERM;
 }
 
-int nccl_net_ofi_get_cuda_device_for_addr(void *data, int *dev_id)
+int nccl_net_ofi_get_gpu_device_for_addr(void *data, int *dev_id)
 {
 	int ret = 0;
 	int cuda_device = -1;
@@ -69,17 +69,17 @@ exit:
 	return ret;
 }
 
-bool nccl_net_ofi_cuda_have_gdr_support_attr(void)
+bool nccl_net_ofi_gpu_have_gdr_support_attr(void)
 {
 	return false;
 }
 
-bool nccl_net_ofi_cuda_have_dma_buf_attr(void)
+bool nccl_net_ofi_gpu_have_dma_buf_attr(void)
 {
 	return false;
 }
 
-int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size)
+int nccl_net_ofi_gpu_mem_alloc(void **ptr, size_t size)
 {
 	hipError_t ret = hipMalloc(ptr, size);
 	if (ret != hipSuccess) {
@@ -88,19 +88,19 @@ int nccl_net_ofi_cuda_mem_alloc(void **ptr, size_t size)
 	return 0;
 }
 
-int nccl_net_ofi_cuda_mem_free(void *ptr)
+int nccl_net_ofi_gpu_mem_free(void *ptr)
 {
 	hipError_t ret = hipFree(ptr);
 	return ret == hipSuccess ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_cuda_mem_copy_host_to_device(void *dst, void *src, size_t size)
+int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 {
 	hipError_t ret = hipMemcpy(dst, src, size, hipMemcpyHostToDevice);
 	return ret == hipSuccess ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_cuda_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
 {
 #if defined(HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD)
 	hipError_t ret = hipMemGetHandleForAddressRange(fd, (uintptr_t)aligned_ptr, aligned_size,

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -562,8 +562,8 @@ static int sendrecv_mr_buffers_register(nccl_net_ofi_sendrecv_domain_t *domain,
 			goto exit;
 		#endif
 
-		/* Get CUDA device ID */
-		ret = nccl_net_ofi_get_cuda_device_for_addr((void *)nccl_ofi_mr_ckey_baseaddr(ckey),
+		/* Get GPU device ID */
+		ret = nccl_net_ofi_get_gpu_device_for_addr((void *)nccl_ofi_mr_ckey_baseaddr(ckey),
 		                                            &mr_attr.device.cuda);
 		if (OFI_UNLIKELY(ret != 0)) {
 			goto exit;


### PR DESCRIPTION
The codebase had inconsistent naming for GPU-related functions, with some using 'cuda' in their names while others used 'gpu'. This inconsistency was particularly evident in the ROCm and CUDA implementation files, where functions like nccl_net_ofi_get_cuda_device_for_addr and nccl_net_ofi_gpu_init coexisted. To improve code readability and maintainability, all function names have been standardized to use 'gpu' instead of 'cuda', making the API more generic and consistent across different GPU backends (CUDA and ROCm). This change affects function declarations, definitions, and all their call sites throughout the codebase.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
