### PR TITLE
aws: Default to rdma protocol on trn1

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -243,7 +243,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.default_dup_conns = 0,
 		.latency = 75.0,
 		.gdr_required = true,
-		.default_protocol = PROTOCOL::SENDRECV,
+		.default_protocol = PROTOCOL::RDMA,
 		.domain_per_thread = true,
 		.env = {},
 	},


### PR DESCRIPTION
Switch to the rdma protocol on trn1.  While there is a regression in short message performance, we have decided that the cost of maintaining the unique sendrecv + multiple proxy threads per process design just for trn1 does not justify the performance delta.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
