### PR TITLE
aws: Default to sendrecv protocol on g7e.8xlarge

### DIFF
--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -207,7 +207,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.default_dup_conns = 0,
 		.latency = 35.0,
 		.gdr_required = false,
-		.default_protocol = PROTOCOL::RDMA,
+		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },


### PR DESCRIPTION
*Description of changes:*

Switch to the sendrecv protocol on g7e.8xlarge. g7e.8xlarge does not support GPUDirect RDMA. The RDMA protocol requires FI_HMEM support without allowing the provider to use CUDA, which is impossible without GPUDirect RDMA support.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
