### PR TITLE
Adding LTTNG/NVTX tracing support for GIN plugin

### DIFF
--- a/include/gin/nccl_ofi_gin.h
+++ b/include/gin/nccl_ofi_gin.h
@@ -11,6 +11,7 @@
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_gdrcopy.h"
+#include "nccl_ofi_tracepoint.h"
 
 /**
  * Context that is shared across all GIN communicators and created during GIN
@@ -170,9 +171,21 @@ public:
 			  nccl_net_ofi_send_comm_t *s_comm_, nccl_net_ofi_recv_comm_t *r_comm_,
 			  nccl_ofi_device_copy &copy_ctx_);
 
+	~nccl_ofi_gin_comm();
+
 	nccl_ofi_gin_resources &get_resources()
 	{
 		return resources;
+	}
+
+	int get_rank() const
+	{
+		return rank;
+	}
+
+	int get_dev() const
+	{
+		return dev;
 	}
 
 	/**
@@ -271,6 +284,7 @@ private:
 
 	int rank;
 	int nranks;
+	int dev;
 
 	/* AllGather ring for metadata exchange */
 	nccl_ofi_gin_allgather_comm ag_comm;
@@ -326,6 +340,12 @@ private:
 	int iput_signal_deliver_all(uint32_t peer_rank);
 
 	friend class nccl_ofi_gin_listen_comm;
+
+public:
+	/* NVTX tracing support - public for macro access (parallel to RDMA struct pattern) */
+#if HAVE_NVTX_TRACING
+	nvtxDomainHandle_t nvtx_domain[NCCL_OFI_N_NVTX_DOMAIN_PER_COMM];
+#endif
 };
 
 #endif

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -121,4 +121,67 @@
 	NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(request); \
 } while(0)
 
+/***** GIN PROTOCOL *****/
+
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_iput_signal_begin, dev, size, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN_NVTX(comm, rank, msg_seq_num, size, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(dev, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_iput_signal_end, dev, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END_NVTX(request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_write_begin, dev, rail_id, size, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_WRITE_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, size, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_WRITE_END(dev, rail_id, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_write_end, dev, rail_id, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_begin, dev, rail_id, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_end, dev, rail_id, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_recv_write, dev, rail_id, size, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_RECV_WRITE_NVTX(comm, rail_id, rank, msg_seq_num, size, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_RECV_METADATA(dev, rail_id, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_recv_metadata, dev, rail_id, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(comm, rail_id, rank, msg_seq_num, request); \
+} while(0)
+
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_signal_delivery_begin, dev, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_signal_delivery_end, dev, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(request); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, comm, rank, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_ack_recv, dev, rail_id, comm, rank, msg_seq_num); \
+	NCCL_OFI_TRACE_GIN_ACK_RECV_NVTX(comm, rail_id, rank, msg_seq_num); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, comm, rank, msg_seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_ack_send, dev, rail_id, comm, rank, msg_seq_num); \
+	NCCL_OFI_TRACE_GIN_ACK_SEND_NVTX(comm, rail_id, rank, msg_seq_num); \
+} while(0)
+
 #endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -409,6 +409,252 @@ LTTNG_UST_TRACEPOINT_EVENT(
     )
 )
 
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_iput_signal_begin,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            size_t, size,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(size_t, size, size)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_iput_signal_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_write_begin,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            size_t, size,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(size_t, size, size)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_write_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_metadata_send_begin,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_metadata_send_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_recv_write,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            size_t, size,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(size_t, size, size)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_recv_metadata,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_signal_delivery_begin,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_signal_delivery_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_ack_recv,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_ack_send,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            uint16_t, rail_id,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+    )
+)
+
 #endif /* !defined(LTTNG_H) || defined(LTTNG_UST_TRACEPOINT_HEADER_MULTI_READ) */
 
 #include <lttng/tracepoint-event.h>

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -5,6 +5,8 @@
 #ifndef NVTX_H
 #define NVTX_H
 
+#include "nccl_ofi_param.h"
+
 #if HAVE_NVTX_TRACING
 #include <nvtx3/nvToolsExt.h>
 
@@ -210,6 +212,87 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	nvtx_mark_domain(NULL, "Pending_remove", 0xFF8C00); \
 } while(0)
 
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN_NVTX(comm, rank, msg_seq_num, size, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		(request)->trace_id = nvtx_start_domain(true, handle, "gin_iputSignal", 0xFF6B35); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END_NVTX(request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (&(request)->gin_comm)->nvtx_domain[(request)->msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, (request)->trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_WRITE_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, size, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		(request)->trace_id = nvtx_start_domain(true, handle, "gin_write", 0xFF4500); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtx_end_domain(0, (request)->trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		(request)->trace_id = nvtx_start_domain(true, handle, "gin_metadata_send", 0x4169E1); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtx_end_domain(0, (request)->trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_RECV_WRITE_NVTX(comm, rail_id, rank, msg_seq_num, size, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "gin_recv_write", 0x00CED1); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(comm, rail_id, rank, msg_seq_num, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "gin_recv_metadata", 0x9370DB); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		(request)->signal_delivery_trace_id = nvtx_start_domain(true, handle, "gin_signal_delivery", 0x32CD32); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtx_end_domain(0, (request)->signal_delivery_trace_id); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_ACK_RECV_NVTX(comm, rail_id, rank, msg_seq_num) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "gin_ack_recv", 0xFFD700); \
+	} \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_ACK_SEND_NVTX(comm, rail_id, rank, msg_seq_num) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "gin_ack_send", 0xFFA500); \
+	} \
+} while(0)
+
 #else
 
 #define NCCL_OFI_TRACE_SEND_NVTX(...)
@@ -229,6 +312,18 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 #define NCCL_OFI_TRACE_WRITE_NVTX(...)
 #define NCCL_OFI_TRACE_PENDING_INSERT_NVTX(...)
 #define NCCL_OFI_TRACE_PENDING_REMOVE_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_WRITE_BEGIN_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_RECV_WRITE_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_ACK_RECV_NVTX(...)
+#define NCCL_OFI_TRACE_GIN_ACK_SEND_NVTX(...)
 
 #endif
 

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -5,6 +5,7 @@
 #include "gin/nccl_ofi_gin.h"
 
 #include "nccl_ofi_assert.h"
+#include "nccl_ofi_tracepoint.h"
 
 /**
  * The highest value of NSEG is used to flag an ack message
@@ -62,7 +63,7 @@ nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int 
 				     nccl_net_ofi_recv_comm_t *r_comm_,
 				     nccl_ofi_device_copy &copy_ctx_)
     : resources(resources_arg), resource_releaser { resources }, rank(rank_), nranks(nranks_),
-      ag_comm(s_comm_, r_comm_, rank_, nranks_), copy_ctx(copy_ctx_),
+      dev(s_comm_->base.dev_id), ag_comm(s_comm_, r_comm_, rank_, nranks_), copy_ctx(copy_ctx_),
       metadata_fl(nullptr, &freelist_deleter)
 {
 	auto &ep = resources.get_ep();
@@ -78,6 +79,16 @@ nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int 
 
 	metadata_fl.reset(metadata_fl_ptr);
 
+#if HAVE_NVTX_TRACING
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) {
+		for (int i = 0; i < NCCL_OFI_N_NVTX_DOMAIN_PER_COMM; ++i) {
+			char name[64];
+			snprintf(name, 64, "aws-ofi-nccl gin_comm %p_%d", this, i);
+			this->nvtx_domain[i] = nvtxDomainCreateA(name);
+		}
+	}
+#endif
+
 	this->local_comm_id = resources.alloc_comm_id(); /* TODO free */
 	if (OFI_UNLIKELY(this->local_comm_id == FI_KEY_NOTAVAIL)) {
 		NCCL_OFI_WARN("No comm id available");
@@ -86,6 +97,17 @@ nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int 
 
 	resources.set_comm(local_comm_id, *this);
 	resources.increment_ref_cnt();
+}
+
+nccl_ofi_gin_comm::~nccl_ofi_gin_comm()
+{
+#if HAVE_NVTX_TRACING
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) {
+		for (int i = 0; i < NCCL_OFI_N_NVTX_DOMAIN_PER_COMM; ++i) {
+			nvtxDomainDestroy(this->nvtx_domain[i]);
+		}
+	}
+#endif
 }
 
 static inline void set_rail_address(nccl_ofi_gin_ep_rail_t &rail, nccl_ofi_addr &out_addr)
@@ -241,6 +263,8 @@ int nccl_ofi_gin_comm::writedata_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_
 	auto *req = gin_comm.resources.get_req_from_pool<nccl_net_ofi_gin_writeack_req_t>(
 		gin_comm, ofi_ep, rail_id, imm_data, rank_comm.address[rail_id],
 		rank_comm.write_ack_buff_addr_offset, rank_comm.write_ack_buff_mr_key[rail_id]);
+
+	NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, &gin_comm, peer_rank, msg_seq_num);
 
 	int ret = req->post();
 	if (ret == -FI_EAGAIN) {
@@ -420,6 +444,13 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 
 	int ret = 0;
 	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs {};
+	nccl_net_ofi_gin_metadata_send_req_t *send_req = nullptr;
+
+	/* Create umbrella request first for tracing */
+	auto *req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_req_t>(
+		*this, dst_rank, msg_seq_num, write_reqs, nullptr);
+
+	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
 
 	if (size > 0) {
 		/* Post write-immediate request with user data */
@@ -446,10 +477,12 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 				gin_ep.get_rail(xfer_info->rail_id).ofi_ep.get(),
 				(void *)((uintptr_t)src + xfer_info->offset), xfer_info->msg_size,
 				desc, data, rank_comm.address[xfer_info->rail_id],
-				dest + xfer_info->offset,
-				dest_remote_mr.mr_key[xfer_info->rail_id]);
+				dest + xfer_info->offset, dest_remote_mr.mr_key[xfer_info->rail_id],
+				this, dev, dst_rank, msg_seq_num);
 
 			write_reqs[wr_it++] = write_req;
+			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, xfer_info->rail_id, xfer_info->msg_size,
+						       this, dst_rank, msg_seq_num, write_req);
 			ret = write_req->post();
 			if (ret == -FI_EAGAIN) {
 				resources.add_pending_req(write_req);
@@ -458,14 +491,17 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 				NCCL_OFI_WARN("Write failed for seq_num %hu", msg_seq_num);
 				resources.return_req_to_pool(write_req);
 				nccl_net_ofi_release_schedule(scheduler, schedule);
+				resources.return_req_to_pool(req);
 				return ret;
 			}
 		}
 		nccl_net_ofi_release_schedule(scheduler, schedule);
 	}
 
+	/* Update umbrella request with write_reqs */
+	req->write_reqs = write_reqs;
+
 	nccl_ofi_freelist_elem_t *metadata_elem = nullptr;
-	nccl_net_ofi_gin_metadata_send_req_t *send_req = nullptr;
 
 	if (signalOp != 0) {
 		/* Post metadata send with signal information */
@@ -473,6 +509,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		metadata_elem = nccl_ofi_freelist_entry_alloc(metadata_fl.get());
 		if (!metadata_elem) {
 			NCCL_OFI_WARN("Failed to allocate metadata freelist entry");
+			resources.return_req_to_pool(req);
 			return -ENOMEM;
 		}
 
@@ -495,8 +532,11 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
 			gin_ep.get_rail(rail_id).ofi_ep.get(), rail_id, metadata_elem,
-			rank_comm.address[rail_id], metadata_fl.get());
+			rank_comm.address[rail_id], metadata_fl.get(), this, dev, dst_rank,
+			msg_seq_num);
 
+		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, this, dst_rank, msg_seq_num,
+						       send_req);
 		ret = send_req->post();
 		if (ret == -FI_EAGAIN) {
 			resources.add_pending_req(send_req);
@@ -504,12 +544,13 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		} else if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Metadata send failed for seq_num %hu", msg_seq_num);
 			resources.return_req_to_pool(send_req);
+			resources.return_req_to_pool(req);
 			return ret;
 		}
 	}
 
-	auto *req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_req_t>(
-		*this, dst_rank, msg_seq_num, write_reqs, send_req);
+	/* Update umbrella request with send_req */
+	req->send_req = send_req;
 
 	rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = true;
 	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
@@ -600,16 +641,20 @@ int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint6
 		       req->metadata.msg_seq_num);
 
 	if (req->metadata_received) {
+		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
+							 req->metadata.msg_seq_num, req);
 		ret = do_gin_signal(req->metadata);
-		if (ret != 0) {
-			return ret;
-		}
-	} else {
-		/* No signal associated with this op (true for iput) */
+		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
+						       req->metadata.msg_seq_num, req);
+	}
+
+	if (ret != 0) {
+		return ret;
 	}
 
 	/* Write ack */
 	ret = writedata_ack(*this, peer_rank, req->metadata.msg_seq_num);
+
 	if (ret != 0) {
 		return ret;
 	}
@@ -671,26 +716,24 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 
 	auto it = outstanding_iput_signal_recv_reqs.find(map_key);
+	nccl_net_ofi_gin_iputsignal_recv_req *req;
 	if (it == outstanding_iput_signal_recv_reqs.end()) {
-		auto *req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_recv_req>();
+		req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_recv_req>();
 
 		req->num_seg_completions = 1;
 		req->total_segments = metadata_msg->num_segments;
 		req->metadata = *metadata_msg;
 		req->metadata_received = true;
 		outstanding_iput_signal_recv_reqs[map_key] = req;
-
-		ret = iput_signal_deliver_all(peer_rank);
-
 	} else {
-		auto *req = it->second;
+		req = it->second;
 
 		req->metadata = *metadata_msg;
-
 		req->metadata_received = true;
 		req->num_seg_completions += 1;
-		ret = iput_signal_deliver_all(peer_rank);
 	}
+	NCCL_OFI_TRACE_GIN_RECV_METADATA(dev, rail_id, this, peer_rank, msg_seq_num, req);
+	ret = iput_signal_deliver_all(peer_rank);
 
 	return ret;
 }
@@ -704,6 +747,8 @@ int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
 	if (total_segms == WRITEDATA_ACK_NSEG) {
 		assert(len == 0);
+
+		NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, msg_seq_num);
 
 		auto &rank_comm = rank_comms[peer_rank];
 		assert_always(rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] ==
@@ -722,12 +767,12 @@ int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16
 		req->num_seg_completions = 1;
 		req->total_segments = total_segms;
 		outstanding_iput_signal_recv_reqs[map_key] = req;
-
 	} else {
 		req = it->second;
 		assert(req->total_segments == total_segms);
 		req->num_seg_completions += 1;
 	}
+	NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, len, this, peer_rank, msg_seq_num, req);
 
 	if (req->num_seg_completions == req->total_segments) {
 		/* Fill in the fields related to metadata */

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -7,6 +7,7 @@
 #include "gin/nccl_ofi_gin.h"
 #include "gin/nccl_ofi_gin_reqs.h"
 #include "gin/nccl_ofi_gin_resources.h"
+#include "nccl_ofi_tracepoint.h"
 
 int nccl_net_ofi_gin_op_req_t::op_req_ctx::handle_cq_entry(struct fi_cq_entry *cq_entry_base,
 							   fi_addr_t src_addr, uint16_t rail_id)
@@ -209,6 +210,8 @@ int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)
 	if (*done) {
 		NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on initiator",
 			       this->msg_seq_num);
+		NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
+						   msg_seq_num, this);
 		gin_comm.get_resources().return_req_to_pool(this);
 	}
 


### PR DESCRIPTION
*Description of changes:*
We are adding LTTNG and NVTX tracing support for GIN in the plugin. The implementation is parallel to the RDMA tracing with some exceptions; we follow a standard of `gin_*`  in labelling the annotations and `*_begin` and `*_end` for ranges when tracing time. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
