### PR TITLE
gin: Add explicit needs_ack flag to reduce ACK overhead

### DIFF
--- a/include/gin/nccl_ofi_gin.h
+++ b/include/gin/nccl_ofi_gin.h
@@ -102,6 +102,11 @@ struct nccl_ofi_gin_peer_rank_info {
 	   which has delivered the signal atomic.
 	   */
 	bool active_put_signal[NCCL_OFI_MAX_REQUESTS];
+	
+	/* Counter for consecutive PUT-only messages without ACK.
+	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
+	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
+	size_t consecutive_puts_without_ack = 0;
 };
 
 /**
@@ -197,9 +202,14 @@ public:
 		outstanding_ack_counter--;
 	}
 
-	bool query_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num)
+	bool query_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num) const
 	{
 		return rank_comms[peer_rank].active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS];
+	}
+
+	void clear_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num)
+	{
+		rank_comms[peer_rank].active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = false;
 	}
 
 	/* Wait for any outstanding requests as necessary. Should be called before
@@ -253,10 +263,12 @@ public:
 	 * @param rail_id: rail ID of the signal
 	 * @param msg_seq_num: sequence number of the signal
 	 * @param total_segms: total number of segments in the signal
+	 * @param is_ack_requested: whether the sender is requesting an ACK
 	 * @param len: length of the signal
 	 */
 	int handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
-					   uint16_t msg_seq_num, uint64_t total_segms, size_t len);
+					   uint16_t msg_seq_num, uint64_t total_segms,
+					   bool is_ack_requested, size_t len);
 
 private:
 	nccl_ofi_gin_resources &resources;

--- a/include/gin/nccl_ofi_gin_reqs.h
+++ b/include/gin/nccl_ofi_gin_reqs.h
@@ -191,9 +191,10 @@ public:
 	nccl_net_ofi_gin_iputsignal_req_t(
 		nccl_ofi_gin_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg,
 		std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs_arg,
-		nccl_net_ofi_gin_metadata_send_req_t *send_req_arg)
+		nccl_net_ofi_gin_metadata_send_req_t *send_req_arg,
+		bool is_ack_requested_arg)
 	    : write_reqs(write_reqs_arg), send_req(send_req_arg), gin_comm(gin_comm_arg),
-	      peer_rank(peer_rank_arg), msg_seq_num(msg_seq_num_arg)
+	      peer_rank(peer_rank_arg), msg_seq_num(msg_seq_num_arg), is_ack_requested(is_ack_requested_arg)
 	{
 	}
 
@@ -217,6 +218,8 @@ private:
 	uint32_t peer_rank;
 	/* Message sequence number */
 	uint16_t msg_seq_num;
+	/* True if sender is requesting an ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
+	bool is_ack_requested;
 };
 
 /**
@@ -252,6 +255,11 @@ private:
 	 * True if metadata has been populated.
 	 */
 	bool metadata_received;
+
+	/**
+	 * True if sender is requesting an ACK
+	 */
+	bool is_ack_requested = false;
 
 	/**
 	 * Metadata received as part of this request

--- a/include/gin/nccl_ofi_gin_types.h
+++ b/include/gin/nccl_ofi_gin_types.h
@@ -49,19 +49,28 @@ struct nccl_net_ofi_gin_signal_metadata_msg_t {
 /**
  * Format of immediate data:
  *
- * | 4-bit segment count | 18-bit comm ID | 10-bit msg_seq_num |
+ * | 4-bit segment count | 1-bit ack_requested | 17-bit comm ID | 10-bit msg_seq_num |
  */
 #define GIN_IMM_NUM_SEQ_BITS_SIZE 10
-#define GIN_IMM_COMM_BITS_SIZE 18
+#define GIN_IMM_COMM_BITS_SIZE 17
 #define GIN_MAX_COMMS (1 << GIN_IMM_COMM_BITS_SIZE)
-#define GIN_IMM_SEG_SHIFT (GIN_IMM_NUM_SEQ_BITS_SIZE + GIN_IMM_COMM_BITS_SIZE)
+#define GIN_IMM_ACK_REQUESTED_SHIFT (GIN_IMM_NUM_SEQ_BITS_SIZE + GIN_IMM_COMM_BITS_SIZE)
+#define GIN_IMM_SEG_SHIFT (GIN_IMM_ACK_REQUESTED_SHIFT + 1)
 #define GIN_IMM_NUM_SEG_BITS_SIZE 4
 #define GIN_IMM_SEQ_MASK ((1 << GIN_IMM_NUM_SEQ_BITS_SIZE) - 1)
 #define GIN_IMM_GET_SEQ_NUM(data) ((data) & GIN_IMM_SEQ_MASK)
 #define GIN_IMM_GET_COMM_ID(data)                                                                  \
 	(((data) >> GIN_IMM_NUM_SEQ_BITS_SIZE) & ((1 << GIN_IMM_COMM_BITS_SIZE) - 1))
+#define GIN_IMM_GET_ACK_REQUESTED(data) (((data) >> GIN_IMM_ACK_REQUESTED_SHIFT) & 1)
 #define GIN_IMM_GET_SEG_CNT(data) ((data) >> GIN_IMM_SEG_SHIFT)
-#define GIN_IMM_GET_IMM_DATA(comm_id, msg_seq_num, nseg)                                           \
-	(((nseg) << GIN_IMM_SEG_SHIFT) | ((comm_id) << GIN_IMM_NUM_SEQ_BITS_SIZE) | (msg_seq_num))
+#define GIN_IMM_GET_IMM_DATA(comm_id, msg_seq_num, nseg, is_ack_requested)                         \
+	(((nseg) << GIN_IMM_SEG_SHIFT) | ((is_ack_requested) << GIN_IMM_ACK_REQUESTED_SHIFT) |     \
+	 ((comm_id) << GIN_IMM_NUM_SEQ_BITS_SIZE) | (msg_seq_num))
+
+/* ACK interval for PUT-only messages. Send an ACK every N consecutive PUTs
+   to prevent sequence number wraparound. */
+#define GIN_ACK_INTERVAL 64
+static_assert(GIN_ACK_INTERVAL <= (1 << GIN_IMM_NUM_SEQ_BITS_SIZE),
+	      "GIN_ACK_INTERVAL must not exceed sequence number space");
 
 #endif

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -242,7 +242,7 @@ int nccl_ofi_gin_comm::writedata_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_
 
 	auto &rank_comm = gin_comm.rank_comms[peer_rank];
 	uint32_t peer_comm_id = rank_comm.comm_id;
-	uint32_t imm_data = GIN_IMM_GET_IMM_DATA(peer_comm_id, msg_seq_num, WRITEDATA_ACK_NSEG);
+	uint32_t imm_data = GIN_IMM_GET_IMM_DATA(peer_comm_id, msg_seq_num, WRITEDATA_ACK_NSEG, 0);
 
 	auto &ep = gin_comm.resources.get_ep();
 
@@ -416,6 +416,23 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		return -EBUSY;
 	}
 
+	/* Determine if this message needs an ACK:
+	 * - SIGNAL or PUT-SIGNAL: always needs ACK
+	 * - PUT-only: needs ACK every N consecutive PUTs */
+	bool is_signal = (signalOp != 0);
+	bool is_ack_requested = false;
+
+	if (is_signal) {
+		is_ack_requested = true;
+		rank_comm.consecutive_puts_without_ack = 0;
+	} else {
+		rank_comm.consecutive_puts_without_ack++;
+		if (rank_comm.consecutive_puts_without_ack >= GIN_ACK_INTERVAL) {
+			is_ack_requested = true;
+			rank_comm.consecutive_puts_without_ack = 0;
+		}
+	}
+
 	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
 	/* Determine how many segments to send */
 	uint16_t nseg = 0;
@@ -428,9 +445,9 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 	NCCL_OFI_TRACE(NCCL_NET,
 		       "iputSignal srcOff %lu srcMhandle %p size %zu dstOff %lu"
 		       " dstMhandle %p dst_rank %u signalOff %lu signalMhandle %p"
-		       " signalValue %lu signalOp %u seq_num %hu",
+		       " signalValue %lu signalOp %u seq_num %hu is_ack_requested %d",
 		       srcOff, srcMhandle, size, dstOff, dstMhandle, dst_rank, signalOff,
-		       signalMhandle, signalValue, signalOp, msg_seq_num);
+		       signalMhandle, signalValue, signalOp, msg_seq_num, is_ack_requested);
 
 	int ret = 0;
 	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs {};
@@ -438,7 +455,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 
 	/* Create umbrella request first for tracing */
 	auto *req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_req_t>(
-		*this, dst_rank, msg_seq_num, write_reqs, nullptr);
+		*this, dst_rank, msg_seq_num, write_reqs, nullptr, is_ack_requested);
 
 	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
 
@@ -454,7 +471,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		nseg += schedule->num_xfer_infos;
 		assert_always(nseg > 0);
 
-		uint64_t data = GIN_IMM_GET_IMM_DATA(remote_comm_id, msg_seq_num, nseg);
+		uint64_t data = GIN_IMM_GET_IMM_DATA(remote_comm_id, msg_seq_num, nseg, is_ack_requested);
 
 		auto &dest_remote_mr = dstMhandle->remote_mr[dst_rank];
 		uint64_t dest = dest_remote_mr.address_offset + dstOff;
@@ -542,7 +559,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 	/* Update umbrella request with send_req */
 	req->send_req = send_req;
 
-	rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = true;
+	rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = is_ack_requested;
 	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
 
 	*request = req;
@@ -642,11 +659,12 @@ int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint6
 		return ret;
 	}
 
-	/* Write ack */
-	ret = writedata_ack(*this, peer_rank, req->metadata.msg_seq_num);
-
-	if (ret != 0) {
-		return ret;
+	/* Send ACK only if this message requested one */
+	if (req->is_ack_requested) {
+		ret = writedata_ack(*this, peer_rank, req->metadata.msg_seq_num);
+		if (ret != 0) {
+			return ret;
+		}
 	}
 
 	/* Remove this request entry from the map */
@@ -714,6 +732,7 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 		req->total_segments = metadata_msg->num_segments;
 		req->metadata = *metadata_msg;
 		req->metadata_received = true;
+		req->is_ack_requested = true;  // Metadata always requests ACK
 		outstanding_iput_signal_recv_reqs[map_key] = req;
 	} else {
 		req = it->second;
@@ -730,7 +749,7 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 
 int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
 						      uint16_t msg_seq_num, uint64_t total_segms,
-						      size_t len)
+						      bool is_ack_requested, size_t len)
 {
 	int ret = 0;
 
@@ -756,6 +775,7 @@ int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16
 
 		req->num_seg_completions = 1;
 		req->total_segments = total_segms;
+		req->is_ack_requested = is_ack_requested;
 		outstanding_iput_signal_recv_reqs[map_key] = req;
 	} else {
 		req = it->second;

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -86,10 +86,11 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 
 		uint16_t msg_seq_num = GIN_IMM_GET_SEQ_NUM(cq_entry->data);
 		uint64_t total_segms = GIN_IMM_GET_SEG_CNT(cq_entry->data);
+		bool is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
 		size_t len = cq_entry->len;
 
 		ret = gin_comm.handle_signal_write_completion(src_addr, rail_id_arg, msg_seq_num,
-							      total_segms, len);
+							      total_segms, is_ack_requested, len);
 		if (ret != 0) {
 			NCCL_OFI_WARN("gin_handle_signal_write_completion failure");
 			return ret;
@@ -205,9 +206,15 @@ int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)
 
 	bool reqs_done = all_writes_done && !send_req;
 	if (reqs_done) {
-		bool ack_outstanding = gin_comm.query_ack_outstanding(peer_rank, msg_seq_num);
-
-		*done = !ack_outstanding;
+		if (is_ack_requested) {
+			/* This message requested ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
+			bool ack_outstanding = gin_comm.query_ack_outstanding(peer_rank, msg_seq_num);
+			*done = !ack_outstanding;
+		} else {
+			/* This message doesn't need ACK (most PUTs) */
+			gin_comm.clear_ack_outstanding(peer_rank, msg_seq_num);
+			*done = 1;
+		}
 	}
 
 	if (*done) {


### PR DESCRIPTION
*Description of changes:*
Implement ACK control mechanism using explicit needs_ack flag in immediate data. Send ACKs only for:
- SIGNAL messages (always)
- PUT-SIGNAL messages (always)
- Every 64th consecutive PUT-only message

Changes:
- Modified immediate data format: 4-bit nseg, 1-bit needs_ack, 17-bit comm_id, 10-bit seq_num (32 bits total)
- Added consecutive_puts_without_ack counter to track PUT sequences
- Sender sets needs_ack flag and encodes in immediate data
- Receiver extracts needs_ack from immediate data and sends ACK only when flag is set
- Sender waits for ACK only when needs_ack=true, otherwise completes immediately after TX

This reduces unnecessary ACKs for PUT-only messages.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
