### PR TITLE
Fixed configure.ac and get_version.sh to support Git Worktrees

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -323,7 +323,7 @@ AC_DEFINE_UNQUOTED([NCCL_OFI_WANT_THREAD_ANALYSIS], [$tsa_define],
 werror_flags="-Werror"
 AC_ARG_ENABLE([werror],
    [AS_HELP_STRING([--enable-werror], [(Developer) Enable setting -Werror.  Off by default, unless building from Git tree.])])
-AS_IF([test -d "${srcdir}/.git" -a -z "${enable_werror}"],
+AS_IF([test -e "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Found .git directory.  Adding ${werror_flags} to CXXFLAGS.])
        CXXFLAGS="${werror_flags} ${CXXFLAGS} "],
       [test "${enable_werror}" = "yes"],

--- a/m4/get_version.sh
+++ b/m4/get_version.sh
@@ -13,7 +13,7 @@ if test -f .release_version ; then
 fi
 
 # pull the version from git
-if test -d .git ; then
+if git rev-parse --git-dir > /dev/null 2>&1 ; then
     # am I on a tag?
     version=`git tag --points-at HEAD`
     if test ${?} -ne 0 ; then


### PR DESCRIPTION
configure.ac has been changed to check for the existence of the git file. In the normal case this is a directory, but in the worktree case this is a pointer to the .git directory which resides elsewhere.

m4/get_version.sh has been changed to use git rev-parse instead of test. The rev-parse function supports both repos as well as worktrees.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
