### PR TITLE
Moving ACKs to use inline fi_send instead of fi_write 

### DIFF
--- a/include/gin/nccl_ofi_gin.h
+++ b/include/gin/nccl_ofi_gin.h
@@ -88,13 +88,6 @@ struct nccl_ofi_gin_peer_rank_info {
 	 */
 	uint16_t next_delivered_signal_seq_num = 0;
 
-	/* Signal acks are zero-byte RDMA writes (with imm data)
-	   sent from receiver to sender. These writes are required to
-	   target a valid buffer on both sender and receiver, so this
-	   address tracks the empty buffer for each rank */
-	uint64_t write_ack_buff_addr_offset;
-	uint64_t write_ack_buff_mr_key[MAX_NUM_RAILS];
-
 	/* Flag, stored at initiator, indicating the given sequence number (mod
 	   max_requests) is in use at initiator side. This allows initiator to
 	   track in-use sequence numbers to avoid overflow and only mark
@@ -256,23 +249,28 @@ public:
 		const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg);
 
 	/**
-	 * Callback for write completion.
+	 * Callback for write completion (data signals only).
 	 *
 	 * @param src_addr: source address of the signal
 	 * @param rail_id: rail ID of the signal
-	 * @param is_ack_msg: true if this is an ACK message (bit 0 set)
-	 * @param msg_seq_num: sequence number of the signal. For ACK messages,
-	 *        this is the ack_seq_num (high-water mark of the acknowledged range).
+	 * @param msg_seq_num: sequence number of the signal
 	 * @param total_segms: total number of segments in the signal
 	 * @param len: length of the signal
 	 * @param is_ack_requested: whether the sender is requesting an ACK
-	 * @param ack_count: for ACK messages, the number of seq_nums in the
-	 *        acknowledged range. Unused for non-ACK messages.
 	 */
 	int handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
-					   bool is_ack_msg, uint16_t msg_seq_num,
-					   uint64_t total_segms, size_t len,
-					   bool is_ack_requested, uint16_t ack_count);
+					   uint16_t msg_seq_num, uint64_t total_segms,
+					   size_t len, bool is_ack_requested);
+
+	/**
+	 * Callback for ACK message received via fi_recv.
+	 *
+	 * @param src_addr: source address of the ACK sender
+	 * @param rail_id: rail on which the ACK was received
+	 * @param ack_msg: the received ACK message
+	 */
+	int handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
+				  const gin_ack_msg_t *ack_msg);
 
 private:
 	nccl_ofi_gin_resources &resources;
@@ -313,15 +311,15 @@ private:
 	size_t outstanding_ack_counter = 0;
 
 	/**
-	 * Send a writedata acknowledgement for a range of sequence numbers.
+	 * Send a range ACK via fi_send to the peer.
 	 *
 	 * @param gin_comm communicator to send the ACK on
 	 * @param peer_rank rank to send the acknowledgement to
 	 * @param ack_seq_num last (highest) sequence number in the acknowledged range
 	 * @param count number of seq_nums in the acknowledged range
 	 */
-	int writedata_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
-			  uint32_t ack_seq_num, uint32_t count);
+	int send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
+		     uint32_t ack_seq_num, uint32_t count);
 
 	/**
 	 * Freelist of buffers storing signal information (type

--- a/include/gin/nccl_ofi_gin_reqs.h
+++ b/include/gin/nccl_ofi_gin_reqs.h
@@ -152,32 +152,33 @@ private:
  * 1) updates gin_comm->outstanding_ack_counter
  * 2) deletes itself (returns to request pool)
  */
-class nccl_net_ofi_gin_writeack_req_t : public nccl_net_ofi_gin_op_req_t {
+class nccl_net_ofi_gin_sendack_req_t : public nccl_net_ofi_gin_op_req_t {
 public:
 	int handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/, fi_addr_t /*src_addr*/,
 			    uint16_t /*rail_id*/) override;
 
-	nccl_net_ofi_gin_writeack_req_t(nccl_ofi_gin_comm &gin_comm_arg, fid_ep *ep_arg,
-					int rail_id_arg, uint64_t imm_data_arg,
-					fi_addr_t remote_addr_arg, uint64_t dest_arg,
-					uint64_t key_arg)
+	nccl_net_ofi_gin_sendack_req_t(nccl_ofi_gin_comm &gin_comm_arg, fid_ep *ep_arg,
+					int rail_id_arg,
+					nccl_ofi_freelist::fl_entry *ack_elem_arg,
+					fi_addr_t remote_addr_arg,
+					nccl_ofi_freelist *ack_fl_arg)
 	    : nccl_net_ofi_gin_op_req_t(), gin_comm(gin_comm_arg), ep(ep_arg),
-	      imm_data(imm_data_arg), dest(dest_arg), key(key_arg), remote_addr(remote_addr_arg),
-	      rail_id(rail_id_arg)
-
+	      rail_id(rail_id_arg), ack_elem(ack_elem_arg),
+	      remote_addr(remote_addr_arg), ack_fl(ack_fl_arg)
 	{
 	}
 
 	int post() override;
 
+	virtual ~nccl_net_ofi_gin_sendack_req_t() override;
+
 private:
 	nccl_ofi_gin_comm &gin_comm;
 	struct fid_ep *ep;
-	uint64_t imm_data;
-	uint64_t dest;
-	uint64_t key;
-	fi_addr_t remote_addr;
 	int rail_id;
+	nccl_ofi_freelist::fl_entry *ack_elem;
+	fi_addr_t remote_addr;
+	nccl_ofi_freelist *ack_fl;
 };
 
 class nccl_net_ofi_gin_write_req_t;
@@ -388,7 +389,7 @@ union nccl_net_ofi_gin_union_req {
 private:
 	nccl_net_ofi_gin_base_req base_req;
 	nccl_net_ofi_gin_recv_req_t recv_req;
-	nccl_net_ofi_gin_writeack_req_t writeack_req;
+	nccl_net_ofi_gin_sendack_req_t sendack_req;
 	nccl_net_ofi_gin_iputsignal_req_t iputsignal_req;
 	nccl_net_ofi_gin_iputsignal_recv_req iputsignal_recv_req;
 	nccl_net_ofi_gin_write_req_t write_req;

--- a/include/gin/nccl_ofi_gin_resources.h
+++ b/include/gin/nccl_ofi_gin_resources.h
@@ -247,29 +247,9 @@ public:
 		return comm_id_pool.allocate_id();
 	}
 
-	void *get_write_ack_buffer_addr()
+	nccl_ofi_freelist *get_ack_send_fl()
 	{
-		return write_ack_buffer.addr;
-	}
-
-	/**
-	 * Get write ack buffer offset for RMA operations.
-	 *
-	 * For non-virt_addr_mr providers, this returns zero.
-	 */
-	uint64_t get_write_ack_buffer_addr_offset()
-	{
-		if (virt_addr_mr) {
-			void *addr = get_write_ack_buffer_addr();
-			return reinterpret_cast<uint64_t>(addr);
-		} else {
-			return 0;
-		}
-	}
-
-	nccl_ofi_gin_mr_handle_t *get_write_ack_buffer_mr_handle()
-	{
-		return write_ack_buffer.mr_handle;
+		return ack_send_fl.get();
 	}
 
 	/**
@@ -365,19 +345,6 @@ private:
 	nccl_ofi_gin_ep_t gin_ep;
 
 	/**
-	 * Represents a write ack buffer, a zero-sized buffer used to send/recv acks
-	 */
-	struct write_ack_buffer_t {
-		void *addr;
-		nccl_ofi_gin_mr_handle_t *mr_handle;
-
-		write_ack_buffer_t(nccl_ofi_gin_ep_t &ep);
-		~write_ack_buffer_t();
-	};
-
-	write_ack_buffer_t write_ack_buffer;
-
-	/**
 	 * Queue of pending Libfabric requests to be retried
 	 */
 	std::deque<nccl_net_ofi_gin_op_req_t *> pending_requests;
@@ -399,6 +366,9 @@ private:
 
 	/* Pool of buffers for recv requests */
 	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> rx_buff_fl;
+
+	/* Pool of registered buffers for ACK send messages */
+	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> ack_send_fl;
 
 	/* Reqs for RX buffers */
 	std::vector<nccl_net_ofi_gin_recv_req_t> recv_reqs;

--- a/include/gin/nccl_ofi_gin_types.h
+++ b/include/gin/nccl_ofi_gin_types.h
@@ -16,6 +16,14 @@ class nccl_ofi_gin_resources;
 struct nccl_ofi_gin_ep_rail_t;
 
 /**
+ * Message types for GIN sends (metadata and ACK messages).
+ */
+enum gin_msg_type_t : uint8_t {
+	GIN_MSG_TYPE_METADATA = 0,
+	GIN_MSG_TYPE_ACK = 1,
+};
+
+/**
  * Represents metadata associated with a put-signal request. This is sent from
  * the put-signal initiator to the target.
  */
@@ -48,52 +56,45 @@ static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
 	      "nccl_net_ofi_gin_signal_metadata_msg_t must be exactly 32 bytes for inline send");
 
 /**
+ * ACK message sent via fi_send from receiver to sender.
+ *
+ * The receiver dispatches by checking cq_entry->len against
+ * sizeof(gin_ack_msg_t), then verifies the msg_type tag.
+ */
+struct gin_ack_msg_t {
+	/* Message type identifier — must be set explicitly (freelist memory) */
+	gin_msg_type_t msg_type;
+	uint8_t reserved;
+	/* Number of seq_nums in the acknowledged range */
+	uint16_t count;
+	/* comm_id on the sender side (so the sender can look up the comm) */
+	uint16_t comm_id;
+	/* Last (highest) sequence number in the acknowledged range */
+	uint16_t ack_seq_num;
+};
+
+static_assert(sizeof(gin_ack_msg_t) == 8, "gin_ack_msg_t must be exactly 8 bytes for inline send");
+
+/**
  * Constants
  */
 #define MAX_NUM_RAILS (4)
 
 /**
- * Immediate data format (32 bits).
+ * Immediate data format (32 bits) for RDMA write-with-immediate signals.
  *
- * Bit 0 distinguishes message type: 0 = non-ACK, 1 = ACK.
- * Bits 1-10 (comm_id) and bits 11-21 (seq_num) are common to both formats.
- *
- * Non-ACK (bit 0 = 0):
+ * ACKs are no longer sent via immediate data — they use fi_send with
+ * gin_ack_msg_t.  The immediate data is used only for data signals:
  *
  *  31        27  26  25      22 21             11 10            1  0
  *  [  unused  ] [ar] [seg_cnt ] [  msg_seq_num  ] [   comm_id   ] [0]
  *
- * ACK (bit 0 = 1):
- *
- *  31                        22 21             11 10            1  0
- *  [        ack_count         ] [  ack_seq_num  ] [   comm_id   ] [1]
+ * Bit 0 is reserved (always 0 for data signals).
  *
  * comm_id is 10 bits (1024 values). At most NCCL_GIN_MAX_CONTEXTS (4)
  * gin_comms share an endpoint, so at most 4 comm_id values are in use
  * per endpoint at any time. 10 bits provides ample headroom.
- *
- * ack_seq_num is the high-water mark of the ACK range. ack_count is the
- * number of seq_nums in the range; the sender computes
- * start_seq = (ack_seq_num - count + 1) & SEQ_MASK. ack_count is 10 bits
- * (max 1023), which is sufficient to cover up to half the sequence number
- * space (2^11 / 2 = 1024). This is the theoretical maximum in-flight range
- * and is intentionally not tied to the GFD queue depth or ACK interval,
- * which may change independently.
- *
- * Both ack_seq_num and count are needed so each ACK is self-contained.
- * A simpler scheme using only ack_seq_num would require the sender to track
- * last_acked_seq_num and clear from there to ack_seq_num. This breaks because
- * EFA does not guarantee fi_writedata completion ordering: a stale ACK
- * (e.g. ack_seq_num=0) arriving after a newer ACK (e.g. ack_seq_num=5) causes
- * the sender to walk from last_acked_seq_num=6 forward through the entire
- * sequence space back to 0, clearing in-flight requests that have not
- * been delivered — corrupting data. By encoding both ack_seq_num and count,
- * each ACK describes an independent range and no cumulative state is needed
- * on the sender, so reordered ACKs are harmless.
  */
-
-/* Bit 0: message type. 0 = non-ACK, 1 = ACK */
-#define GIN_IMM_IS_ACK(data)   ((data) & 1)
 
 /* Common fields (same position in both formats) */
 #define GIN_IMM_TYPE_BITS      1
@@ -121,15 +122,10 @@ static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
 	(((ack_req) << GIN_IMM_ACK_REQ_SHIFT) | ((nseg) << GIN_IMM_SEG_CNT_SHIFT) |               \
 	 ((seq) << GIN_IMM_SEQ_SHIFT) | ((comm_id) << GIN_IMM_COMM_SHIFT))
 
-/* ACK fields above the common fields */
-#define GIN_IMM_ACK_COUNT_BITS  10
-#define GIN_IMM_ACK_COUNT_SHIFT (GIN_IMM_SEQ_SHIFT + GIN_IMM_SEQ_BITS)
-#define GIN_IMM_ACK_COUNT_MASK  ((1 << GIN_IMM_ACK_COUNT_BITS) - 1)
-
-#define GIN_IMM_ACK_GET_COUNT(data) (((data) >> GIN_IMM_ACK_COUNT_SHIFT) & GIN_IMM_ACK_COUNT_MASK)
-#define GIN_IMM_ACK_DATA(comm_id, seq, count)                                                      \
-	(((count) << GIN_IMM_ACK_COUNT_SHIFT) | ((seq) << GIN_IMM_SEQ_SHIFT) |                     \
-	 ((comm_id) << GIN_IMM_COMM_SHIFT) | 1)
+/* ACK count field width — used by the coalescing logic in deliver_all
+   to cap the range span per ACK. */
+#define GIN_ACK_COUNT_BITS 10
+#define GIN_ACK_COUNT_MASK ((1 << GIN_ACK_COUNT_BITS) - 1)
 
 /* ACK interval for PUT-only messages. Send an ACK every N consecutive PUTs
    to prevent sequence number wraparound. */

--- a/include/gin/nccl_ofi_gin_types.h
+++ b/include/gin/nccl_ofi_gin_types.h
@@ -5,6 +5,7 @@
 #ifndef NCCL_OFI_GIN_TYPES_H
 #define NCCL_OFI_GIN_TYPES_H
 
+#include <stddef.h>
 #include <stdint.h>
 
 /**
@@ -28,17 +29,8 @@ enum gin_msg_type_t : uint8_t {
  * the put-signal initiator to the target.
  */
 struct nccl_net_ofi_gin_signal_metadata_msg_t {
-	/* Signal information (if applicable) */
-	uint64_t signal_base_address;
-	uint64_t signal_offset;
-	uint64_t signal_value;
-
-	/* A comm identitifer that uniquely identifies the comm
-	 * on the receiver side */
-	uint32_t remote_comm_id;
-
-	/* Message sequence number */
-	uint16_t msg_seq_num;
+	/* Message type identifier — must be GIN_MSG_TYPE_METADATA */
+	gin_msg_type_t msg_type;
 
 	/* Number of completions the target will receive
 	 *
@@ -48,8 +40,17 @@ struct nccl_net_ofi_gin_signal_metadata_msg_t {
 	 * 2: For put-signal (data + signal) */
 	uint8_t num_segments;
 
-	/* Adding 1 byte padding to align the struct DO NOT USE*/
-	uint8_t padding;
+	/* Message sequence number */
+	uint16_t msg_seq_num;
+
+	/* A comm identitifer that uniquely identifies the comm
+	 * on the receiver side */
+	uint32_t remote_comm_id;
+
+	/* Signal information (if applicable) */
+	uint64_t signal_base_address;
+	uint64_t signal_offset;
+	uint64_t signal_value;
 };
 
 static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
@@ -57,9 +58,6 @@ static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
 
 /**
  * ACK message sent via fi_send from receiver to sender.
- *
- * The receiver dispatches by checking cq_entry->len against
- * sizeof(gin_ack_msg_t), then verifies the msg_type tag.
  */
 struct gin_ack_msg_t {
 	/* Message type identifier — must be set explicitly (freelist memory) */
@@ -74,6 +72,10 @@ struct gin_ack_msg_t {
 };
 
 static_assert(sizeof(gin_ack_msg_t) == 8, "gin_ack_msg_t must be exactly 8 bytes for inline send");
+static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, msg_type) == 0,
+	      "msg_type must be at offset 0 for type-based dispatch");
+static_assert(offsetof(gin_ack_msg_t, msg_type) == 0,
+	      "msg_type must be at offset 0 for type-based dispatch");
 
 /**
  * Constants

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -22,24 +22,7 @@ struct gin_connect_handle {
 	 * structs. The member `num_rails` indicates
 	 * the number of entries that are in use. */
 	nccl_ofi_addr ep_names[MAX_NUM_RAILS];
-
-	/* Write ack buffer addr and its mr_key */
-	uint64_t write_ack_buff_addr_offset;
-	uint64_t write_ack_buff_mr_key[MAX_NUM_RAILS];
 };
-
-static inline void set_write_ack_buff_info(nccl_ofi_gin_resources &resources,
-					   gin_connect_handle &handle)
-{
-	handle.write_ack_buff_addr_offset = resources.get_write_ack_buffer_addr_offset();
-	auto *mr_handle = resources.get_write_ack_buffer_mr_handle();
-
-	for (size_t i = 0; i < resources.get_ep().get_num_rails(); ++i) {
-		uint64_t key = fi_mr_key(mr_handle->get_mr(i));
-		assert_always(key != FI_KEY_NOTAVAIL);
-		handle.write_ack_buff_mr_key[i] = key;
-	}
-}
 
 nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
 				     nccl_net_ofi_send_comm *s_comm_,
@@ -185,8 +168,6 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 		set_rail_address(gin_ep.get_rail(i), my_gin_handle.ep_names[i]);
 	}
 
-	set_write_ack_buff_info(gin_comm->resources, my_gin_handle);
-
 	gin_comm->rank_comms.resize(nranks);
 
 	/**
@@ -207,7 +188,6 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 		const gin_connect_handle &gin_handle = all_handles[i];
 		nccl_ofi_gin_peer_rank_info &remote_rank_comm = gin_comm->rank_comms[i];
 		remote_rank_comm.comm_id = gin_handle.comm_id;
-		remote_rank_comm.write_ack_buff_addr_offset = gin_handle.write_ack_buff_addr_offset;
 
 		for (int r = 0; r < num_rails; ++r) {
 			ret = rail_addr_insert(gin_ep.get_rail(r), gin_handle.ep_names[r],
@@ -217,8 +197,6 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 				delete gin_comm;
 				return ret;
 			}
-			remote_rank_comm.write_ack_buff_mr_key[r] =
-				gin_handle.write_ack_buff_mr_key[r];
 		}
 	}
 
@@ -226,10 +204,10 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 	return 0;
 }
 
-int nccl_ofi_gin_comm::writedata_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
-				     uint32_t ack_seq_num, uint32_t count)
+int nccl_ofi_gin_comm::send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
+			       uint32_t ack_seq_num, uint32_t count)
 {
-	assert(count <= GIN_IMM_ACK_COUNT_MASK);
+	assert(count <= GIN_ACK_COUNT_MASK);
 
 	/* For now, always send acks on rail 0.
 	   TODO round-robin this like the payload data itself. */
@@ -237,15 +215,34 @@ int nccl_ofi_gin_comm::writedata_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_
 
 	auto &rank_comm = gin_comm.rank_comms[peer_rank];
 	uint32_t peer_comm_id = rank_comm.comm_id;
-	uint32_t imm_data = GIN_IMM_ACK_DATA(peer_comm_id, ack_seq_num, count);
 
 	auto &ep = gin_comm.resources.get_ep();
+	auto *ack_fl = gin_comm.resources.get_ack_send_fl();
+
+	auto *ack_elem = ack_fl->entry_alloc();
+	if (!ack_elem) {
+		NCCL_OFI_WARN("Failed to allocate ACK send buffer");
+		return -ENOMEM;
+	}
+
+	auto *ack_msg = static_cast<gin_ack_msg_t *>(ack_elem->ptr);
+	ack_msg->msg_type = GIN_MSG_TYPE_ACK;
+	ack_msg->reserved = 0;
+	ack_msg->comm_id = static_cast<uint16_t>(peer_comm_id);
+	ack_msg->ack_seq_num = static_cast<uint16_t>(ack_seq_num);
+	ack_msg->count = static_cast<uint16_t>(count);
 
 	auto *ofi_ep = ep.get_rail(rail_id).ofi_ep.get();
 
-	auto *req = gin_comm.resources.get_req_from_pool<nccl_net_ofi_gin_writeack_req_t>(
-		gin_comm, ofi_ep, rail_id, imm_data, rank_comm.address[rail_id],
-		rank_comm.write_ack_buff_addr_offset, rank_comm.write_ack_buff_mr_key[rail_id]);
+	nccl_net_ofi_gin_sendack_req_t *req;
+	try {
+		req = gin_comm.resources.get_req_from_pool<nccl_net_ofi_gin_sendack_req_t>(
+			gin_comm, ofi_ep, rail_id, ack_elem,
+			rank_comm.address[rail_id], ack_fl);
+	} catch (...) {
+		ack_fl->entry_free(ack_elem);
+		throw;
+	}
 
 	NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, &gin_comm, peer_rank, ack_seq_num);
 
@@ -683,13 +680,13 @@ int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 		/* Flush if adding this seq_num would overflow the 10-bit
 		   ack_count field. range_span uses GIN_IMM_SEQ_MASK for
 		   correct wraparound in the 11-bit sequence space.
-		   ack_count uses GIN_IMM_ACK_COUNT_MASK to match the
+		   ack_count uses GIN_ACK_COUNT_MASK to match the
 		   10-bit field it is encoded into. */
 		if (any_ack_requested) {
 			uint32_t range_span = ((next_seq_num - first_acked_seq_num + 1) & GIN_IMM_SEQ_MASK);
-			if (range_span > GIN_IMM_ACK_COUNT_MASK) {
-				uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_IMM_ACK_COUNT_MASK);
-				ret = writedata_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
+			if (range_span > GIN_ACK_COUNT_MASK) {
+				uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_ACK_COUNT_MASK);
+				ret = send_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
 				if (OFI_UNLIKELY(ret != 0)) {
 					return ret;
 				}
@@ -732,11 +729,11 @@ int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 	}
 
 	/* Flush any remaining accumulated range ACK. ack_count uses
-	   GIN_IMM_ACK_COUNT_MASK to match the 10-bit field; the
+	   GIN_ACK_COUNT_MASK to match the 10-bit field; the
 	   mid-loop overflow guard ensures the value always fits. */
 	if (any_ack_requested) {
-		uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_IMM_ACK_COUNT_MASK);
-		ret = writedata_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
+		uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_ACK_COUNT_MASK);
+		ret = send_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
 	}
 
 	return ret;
@@ -777,39 +774,43 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 	return ret;
 }
 
+int nccl_ofi_gin_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
+					     const gin_ack_msg_t *ack_msg)
+{
+	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
+	uint16_t ack_seq_num = ack_msg->ack_seq_num;
+	uint16_t count = ack_msg->count;
+	assert(count > 0);
+
+	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
+
+	/* Self-contained range ACK: clear ack_outstanding from start_seq
+	   to ack_seq_num. Each ACK carries ack_seq_num and a count so
+	   the sender needs no cumulative state (e.g. last_acked_seq_num).
+	   This is critical because EFA does not guarantee fi_send
+	   ordering — ACKs from different deliver_all calls can arrive
+	   in any order. A single ack_seq_num would require cumulative
+	   state that breaks under reordering. */
+	uint16_t start_seq = (ack_seq_num - count + 1) & GIN_IMM_SEQ_MASK;
+
+	uint16_t seq = start_seq;
+	while (true) {
+		clear_ack_outstanding(peer_rank, seq);
+		if (seq == ack_seq_num) {
+			break;
+		}
+		seq = (seq + 1) & GIN_IMM_SEQ_MASK;
+	}
+	return 0;
+}
+
 int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
-						      bool is_ack_msg, uint16_t msg_seq_num,
-						      uint64_t total_segms, size_t len,
-						      bool is_ack_requested, uint16_t ack_count)
+						      uint16_t msg_seq_num, uint64_t total_segms,
+						      size_t len, bool is_ack_requested)
 {
 	int ret = 0;
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
-	if (is_ack_msg) {
-		assert(len == 0);
-
-		/* Self-contained range ACK: clear ack_outstanding from start_seq
-		   to ack_seq_num. Each ACK carries ack_seq_num and a count so
-		   the sender needs no cumulative state (e.g. last_acked_seq_num).
-		   This is critical because EFA does not guarantee fi_writedata
-		   ordering — ACKs from different deliver_all calls can arrive
-		   in any order. A single ack_seq_num would require cumulative
-		   state that breaks under reordering. */
-		uint16_t ack_seq_num = msg_seq_num;
-		uint16_t start_seq = (ack_seq_num - ack_count + 1) & GIN_IMM_SEQ_MASK;
-
-		NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
-
-		uint16_t seq = start_seq;
-		while (true) {
-			clear_ack_outstanding(peer_rank, seq);
-			if (seq == ack_seq_num) {
-				break;
-			}
-			seq = (seq + 1) & GIN_IMM_SEQ_MASK;
-		}
-		return 0;
-	}
 
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -518,6 +518,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		metadata_send->msg_seq_num = msg_seq_num;
 		metadata_send->num_segments = nseg;
 		metadata_send->remote_comm_id = remote_comm_id;
+		metadata_send->msg_type = GIN_MSG_TYPE_METADATA;
 		metadata_send->signal_base_address =
 			(signalMhandle ? signalMhandle->remote_mr[dst_rank].address : 0);
 		metadata_send->signal_offset = signalOff;
@@ -834,6 +835,7 @@ int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16
 		/* Fill in the fields related to metadata */
 		req->metadata.msg_seq_num = msg_seq_num;
 		req->metadata.num_segments = req->total_segments;
+		req->metadata.msg_type = GIN_MSG_TYPE_METADATA;
 	}
 
 	ret = iput_signal_deliver_all(peer_rank);

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -80,42 +80,52 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 
 	if (cq_entry->flags & FI_REMOTE_WRITE) {
 		/* RDMA write-immediate completion */
-		bool is_ack_msg = GIN_IMM_IS_ACK(cq_entry->data);
 		uint32_t comm_id = GIN_IMM_GET_COMM_ID(cq_entry->data);
 		uint16_t msg_seq_num = GIN_IMM_GET_SEQ_NUM(cq_entry->data);
 
 		auto &gin_comm = resources.get_comm(comm_id);
 
-		uint64_t total_segms = 0;
-		bool is_ack_requested = false;
-		uint16_t ack_count = 0;
-
-		if (is_ack_msg) {
-			ack_count = GIN_IMM_ACK_GET_COUNT(cq_entry->data);
-		} else {
-			total_segms = GIN_IMM_GET_SEG_CNT(cq_entry->data);
-			is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
-		}
+		uint64_t total_segms = GIN_IMM_GET_SEG_CNT(cq_entry->data);
+		bool is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
 		size_t len = cq_entry->len;
 
-		ret = gin_comm.handle_signal_write_completion(src_addr, rail_id_arg, is_ack_msg,
-							      msg_seq_num, total_segms, len,
-							      is_ack_requested, ack_count);
+		ret = gin_comm.handle_signal_write_completion(src_addr, rail_id_arg,
+							      msg_seq_num, total_segms,
+							      len, is_ack_requested);
 		if (ret != 0) {
 			NCCL_OFI_WARN("gin_handle_signal_write_completion failure");
 			return ret;
 		}
 	} else {
-		auto *msg =
-			static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(rx_buff_elem->ptr);
+		/* Dispatch by length and message type. Once metadata gains
+		   a msg_type field, length check can be dropped. */
+		if (cq_entry->len == sizeof(gin_ack_msg_t) &&
+		    static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr)->msg_type == GIN_MSG_TYPE_ACK) {
+			auto *ack_msg =
+				static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr);
 
-		/* Get the gin comm */
-		auto &gin_comm = resources.get_comm(msg->remote_comm_id);
+			auto &gin_comm = resources.get_comm(ack_msg->comm_id);
 
-		ret = gin_comm.handle_signal_metadata_completion(src_addr, rail_id_arg, msg);
-		if (ret != 0) {
-			NCCL_OFI_WARN("gin_handle_signal_metadata_completion failure");
-			return ret;
+			ret = gin_comm.handle_ack_completion(src_addr, rail_id_arg,
+							     ack_msg);
+			if (ret != 0) {
+				NCCL_OFI_WARN("handle_ack_completion failure");
+				return ret;
+			}
+		} else {
+			/* Metadata message */
+			auto *msg = static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(
+				rx_buff_elem->ptr);
+
+			auto &gin_comm = resources.get_comm(msg->remote_comm_id);
+
+			ret = gin_comm.handle_signal_metadata_completion(src_addr,
+									 rail_id_arg, msg);
+			if (ret != 0) {
+				NCCL_OFI_WARN(
+					"gin_handle_signal_metadata_completion failure");
+				return ret;
+			}
 		}
 	}
 
@@ -149,7 +159,7 @@ int nccl_net_ofi_gin_recv_req_t::post_or_add_pending()
 	return ret;
 }
 
-int nccl_net_ofi_gin_writeack_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/,
+int nccl_net_ofi_gin_sendack_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/,
 						     fi_addr_t /*src_addr*/,
 						     uint16_t /*rail_id_arg*/)
 {
@@ -160,23 +170,27 @@ int nccl_net_ofi_gin_writeack_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_e
 	return 0;
 }
 
-int nccl_net_ofi_gin_writeack_req_t::post()
+int nccl_net_ofi_gin_sendack_req_t::post()
 {
-	auto *write_ack_buff = gin_comm.get_resources().get_write_ack_buffer_addr();
+	auto *ack_handle =
+		static_cast<nccl_ofi_gin_mr_handle_t *>(ack_elem->mr_handle);
 
-	auto *desc = fi_mr_desc(
-		gin_comm.get_resources().get_write_ack_buffer_mr_handle()->get_mr(rail_id));
-
-	ssize_t rc = fi_writedata(ep, write_ack_buff, 0, desc, imm_data, remote_addr, dest, key,
-				  &ctx.ofi_ctx);
+	ssize_t rc = fi_send(ep, ack_elem->ptr, sizeof(gin_ack_msg_t),
+			     fi_mr_desc(ack_handle->get_mr(rail_id)), remote_addr,
+			     &ctx.ofi_ctx);
 
 	if (rc != 0 && rc != -FI_EAGAIN) {
-		NCCL_OFI_WARN("Failed to post write ack. RC: %zd", rc);
+		NCCL_OFI_WARN("Failed to post ACK send. RC: %zd", rc);
 	} else if (rc == 0) {
 		gin_comm.increment_outstanding_ack_counter();
 	}
 
 	return rc;
+}
+
+nccl_net_ofi_gin_sendack_req_t::~nccl_net_ofi_gin_sendack_req_t()
+{
+	ack_fl->entry_free(ack_elem);
 }
 
 int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -97,10 +97,9 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 			return ret;
 		}
 	} else {
-		/* Dispatch by length and message type. Once metadata gains
-		   a msg_type field, length check can be dropped. */
-		if (cq_entry->len == sizeof(gin_ack_msg_t) &&
-		    static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr)->msg_type == GIN_MSG_TYPE_ACK) {
+		/* Dispatch by msg_type — at offset 0 in both message structs. */
+		auto msg_type = static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr)->msg_type;
+		if (msg_type == GIN_MSG_TYPE_ACK) {
 			auto *ack_msg =
 				static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr);
 
@@ -112,8 +111,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 				NCCL_OFI_WARN("handle_ack_completion failure");
 				return ret;
 			}
-		} else {
-			/* Metadata message */
+		} else if (msg_type == GIN_MSG_TYPE_METADATA) {
 			auto *msg = static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(
 				rx_buff_elem->ptr);
 
@@ -126,6 +124,9 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 					"gin_handle_signal_metadata_completion failure");
 				return ret;
 			}
+		} else {
+			NCCL_OFI_WARN("Unknown GIN message type %d", msg_type);
+			return -EINVAL;
 		}
 	}
 

--- a/src/gin/nccl_ofi_gin_resources.cpp
+++ b/src/gin/nccl_ofi_gin_resources.cpp
@@ -412,38 +412,6 @@ nccl_ofi_gin_mr_handle_t::~nccl_ofi_gin_mr_handle_t()
 	}
 }
 
-nccl_ofi_gin_resources::write_ack_buffer_t::write_ack_buffer_t(nccl_ofi_gin_ep_t &ep)
-{
-	// Create write-ack buffer (target of write acks)
-	int ret = nccl_net_ofi_alloc_mr_buffer(system_page_size, &this->addr);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to allocate write ack buffer; RC: %d", ret);
-		throw std::runtime_error("Failed to allocate write ack buffer");
-	}
-
-	auto ckey = nccl_ofi_mr_ckey_mk_vec(this->addr, system_page_size, nullptr);
-
-	ret = ep.reg_mr(&ckey, NCCL_PTR_HOST, &mr_handle);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to register write ack buffer; RC: %d", ret);
-		nccl_net_ofi_dealloc_mr_buffer(this->addr, system_page_size);
-		throw std::runtime_error("Failed to register write ack buffer");
-	}
-}
-
-nccl_ofi_gin_resources::write_ack_buffer_t::~write_ack_buffer_t()
-{
-	int ret = 0;
-
-	delete this->mr_handle;
-
-	ret = nccl_net_ofi_dealloc_mr_buffer(this->addr, system_page_size);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Failed to deallocate write ack buffer; RC: %d", ret);
-		assert(ret == 0);
-	}
-}
-
 void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail, size_t num_buffers)
 {
 	for (size_t i = 0; i < num_buffers; i++) {
@@ -457,8 +425,9 @@ void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail,
 
 nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
     : ep_holder(ep_arg), gin_comms(), comm_id_pool(GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
-      write_ack_buffer(gin_ep), req_fl(nullptr, &freelist_deleter),
-      rx_buff_fl(nullptr, &freelist_deleter)
+      req_fl(nullptr, &freelist_deleter),
+      rx_buff_fl(nullptr, &freelist_deleter),
+      ack_send_fl(nullptr, &freelist_deleter)
 {
 	auto num_rails = gin_ep.get_num_rails();
 
@@ -473,6 +442,12 @@ nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
 					       gin_ep.freelist_regmr_fn, gin_ep.freelist_deregmr_fn,
 					       &gin_ep, 1, "GIN Rx Buffers", true);
 	this->rx_buff_fl.reset(rx_buff_fl_tmp);
+
+	/* Create freelist for ACK send buffers */
+	this->ack_send_fl.reset(new nccl_ofi_freelist(sizeof(gin_ack_msg_t), 64, 64, 0, nullptr,
+						      nullptr, gin_ep.freelist_regmr_fn,
+						      gin_ep.freelist_deregmr_fn, &gin_ep, 1,
+						      "GIN ACK Send", true));
 
 	/* Create the receive pool for all rails */
 	recv_reqs.reserve(num_buffers);


### PR DESCRIPTION
*Description of changes:*

Changed sending mechanism from fi_write to fi_send. This involves having the struct be less than 32B and initializing a freelist instead of the MR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
