### PR TITLE
Tuner should have path to initialize parameters

### DIFF
--- a/include/nccl_ofi_param_impl.h
+++ b/include/nccl_ofi_param_impl.h
@@ -207,6 +207,10 @@ public:
 	{
 		std::lock_guard l(lock);
 
+		if (source != ParamSource::INVALID) {
+			return 0;
+		}
+
 		source = ParamSource::DEFAULT;
 
 		char *envval = getenv(envname);

--- a/src/tuner/nccl_ofi_tuner.cpp
+++ b/src/tuner/nccl_ofi_tuner.cpp
@@ -53,6 +53,14 @@ static ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugL
 		ofi_log_function = logFunction;
 	}
 
+	/* Ensure parameters are initialized.  When the tuner is loaded as a
+	   separate shared library, it gets its own copy of the parameter
+	   space that the net plugin init path does not reach. */
+	int param_ret = ofi_nccl_parameters_init();
+	if (OFI_UNLIKELY(param_ret != 0)) {
+		return ncclInternalError;
+	}
+
 	nccl_net_ofi_mutex_lock(&nccl_ofi_tuner_ctx_lock);
 
 	// Static instance ensures one-time initialization per process


### PR DESCRIPTION
The ofi_nccl_parameters_init() is only called in the net plugin path and so we need a way for the tuner to initialize the parameters if the way it is loaded creates a separate copy of the parameter space.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
