### PR TITLE
gin: Bundle ACKs with metadata messages

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -20,6 +20,7 @@ noinst_HEADERS = \
 	nccl_ofi_config_bottom.h \
 	nccl_ofi_cuda.h \
 	nccl_ofi_device_copy.h \
+	nccl_ofi_dlist.h \
 	nccl_ofi_dmabuf.h \
 	nccl_ofi_environ.h \
 	nccl_ofi_ep_addr_list.h \

--- a/include/gin/nccl_ofi_gin.h
+++ b/include/gin/nccl_ofi_gin.h
@@ -8,6 +8,7 @@
 #include "gin/nccl_ofi_gin_allgather.h"
 #include "gin/nccl_ofi_gin_resources.h"
 #include "gin/nccl_ofi_gin_types.h"
+#include "nccl_ofi_dlist.h"
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_gdrcopy.h"
@@ -63,6 +64,19 @@ struct nccl_ofi_gin_resource_releaser {
 };
 
 /**
+ * Pending bundled ack: accumulated in deliver_all,
+ * sent with the next outgoing metadata message to this peer.
+ * On the pending_ack_list iff node.next != nullptr.
+ */
+struct nccl_ofi_gin_pending_ack_info {
+	nccl_ofi_dlist_node node;
+	uint32_t peer_rank = 0;
+	uint16_t seq_num = 0;
+	uint16_t ack_count = 0;
+	uint32_t start = 0;
+};
+
+/**
  * Represents per-peer-rank data associated with a collective communicator.
  *
  * The collective communicator stores a vector of these structures, of size
@@ -100,6 +114,8 @@ struct nccl_ofi_gin_peer_rank_info {
 	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
 	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
 	size_t consecutive_puts_without_ack = 0;
+
+	nccl_ofi_gin_pending_ack_info pending_ack;
 };
 
 /**
@@ -205,9 +221,22 @@ public:
 		rank_comms[peer_rank].active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = false;
 	}
 
+	void clear_ack_range(uint32_t peer_rank, uint16_t ack_seq_num, uint16_t ack_count)
+	{
+		uint16_t seq = (ack_seq_num - ack_count + 1) & GIN_IMM_SEQ_MASK;
+		while (true) {
+			clear_ack_outstanding(peer_rank, seq);
+			if (seq == ack_seq_num) break;
+			seq = (seq + 1) & GIN_IMM_SEQ_MASK;
+		}
+	}
+
 	/* Wait for any outstanding requests as necessary. Should be called before
 	   the GIN comm is destructed. */
 	int await_pending_requests();
+
+	/* Flush bundled acks that were not sent with metadata. Called from progress. */
+	int flush_stale_acks();
 
 	/**
 	 * iputSignal API. Transfers some user data (determined by memory registrations
@@ -310,6 +339,11 @@ private:
 	   Used to wait for remaining acknowledgements on communicator close. */
 	size_t outstanding_ack_counter = 0;
 
+	/* Active queue of peers with pending acks.
+	   Only these are visited by flush_stale_acks(). */
+	nccl_ofi_dlist pending_ack_list;
+	uint32_t progress_counter = 0;
+
 	/**
 	 * Send a range ACK via fi_send to the peer.
 	 *
@@ -333,6 +367,7 @@ private:
 	int iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 					    nccl_net_ofi_gin_iputsignal_recv_req *req);
 
+	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num);
 	int iput_signal_deliver_all(uint32_t peer_rank);
 
 	friend class nccl_ofi_gin_listen_comm;

--- a/include/gin/nccl_ofi_gin_types.h
+++ b/include/gin/nccl_ofi_gin_types.h
@@ -28,54 +28,6 @@ enum gin_msg_type_t : uint8_t {
  * Represents metadata associated with a put-signal request. This is sent from
  * the put-signal initiator to the target.
  */
-struct nccl_net_ofi_gin_signal_metadata_msg_t {
-	/* Message type identifier — must be GIN_MSG_TYPE_METADATA */
-	gin_msg_type_t msg_type;
-
-	/* Number of completions the target will receive
-	 *
-	 * This will be either 1 or 2
-	 * 1: if this is a signal without any associated data (zero-sized
-	 *    put-signal) or data without any signal (put)
-	 * 2: For put-signal (data + signal) */
-	uint8_t num_segments;
-
-	/* Message sequence number */
-	uint16_t msg_seq_num;
-
-	/* A comm identitifer that uniquely identifies the comm
-	 * on the receiver side */
-	uint32_t remote_comm_id;
-
-	/* Signal information (if applicable) */
-	uint64_t signal_base_address;
-	uint64_t signal_offset;
-	uint64_t signal_value;
-};
-
-static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
-	      "nccl_net_ofi_gin_signal_metadata_msg_t must be exactly 32 bytes for inline send");
-
-/**
- * ACK message sent via fi_send from receiver to sender.
- */
-struct gin_ack_msg_t {
-	/* Message type identifier — must be set explicitly (freelist memory) */
-	gin_msg_type_t msg_type;
-	uint8_t reserved;
-	/* Number of seq_nums in the acknowledged range */
-	uint16_t count;
-	/* comm_id on the sender side (so the sender can look up the comm) */
-	uint16_t comm_id;
-	/* Last (highest) sequence number in the acknowledged range */
-	uint16_t ack_seq_num;
-};
-
-static_assert(sizeof(gin_ack_msg_t) == 8, "gin_ack_msg_t must be exactly 8 bytes for inline send");
-static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, msg_type) == 0,
-	      "msg_type must be at offset 0 for type-based dispatch");
-static_assert(offsetof(gin_ack_msg_t, msg_type) == 0,
-	      "msg_type must be at offset 0 for type-based dispatch");
 
 /**
  * Constants
@@ -124,15 +76,67 @@ static_assert(offsetof(gin_ack_msg_t, msg_type) == 0,
 	(((ack_req) << GIN_IMM_ACK_REQ_SHIFT) | ((nseg) << GIN_IMM_SEG_CNT_SHIFT) |               \
 	 ((seq) << GIN_IMM_SEQ_SHIFT) | ((comm_id) << GIN_IMM_COMM_SHIFT))
 
-/* ACK count field width — used by the coalescing logic in deliver_all
-   to cap the range span per ACK. */
-#define GIN_ACK_COUNT_BITS 10
-#define GIN_ACK_COUNT_MASK ((1 << GIN_ACK_COUNT_BITS) - 1)
+/* Packed sequence number + segment count (16 bits). */
+struct nccl_net_ofi_gin_metadata_seq_t {
+	uint16_t seq_num:GIN_IMM_SEQ_BITS;
+	uint16_t num_segments:GIN_IMM_SEG_CNT_BITS;
+};
+
+/* Bundled ack payload (32 bits). ack_count == 0 means no ack. */
+#define GIN_ACK_COUNT_BITS    10
+#define GIN_ACK_COUNT_MASK    ((1 << GIN_ACK_COUNT_BITS) - 1)
+struct nccl_net_ofi_gin_ack_t {
+	uint32_t ack_seq_num:GIN_IMM_SEQ_BITS;
+	uint32_t comm_id:GIN_IMM_COMM_BITS;
+	uint32_t ack_count:GIN_ACK_COUNT_BITS;
+};
+
+struct nccl_net_ofi_gin_signal_metadata_msg_t {
+	/* Message type identifier — must be GIN_MSG_TYPE_METADATA */
+	gin_msg_type_t msg_type;
+
+	/* Comm identifier on the receiver side */
+	uint8_t remote_comm_id;
+
+	/* Message sequence number and segment count */
+	nccl_net_ofi_gin_metadata_seq_t seq;
+
+	/* Bundled ack (ack_count == 0 when absent) */
+	nccl_net_ofi_gin_ack_t ack;
+
+	/* Signal information (if applicable) */
+	uint64_t signal_base_address;
+	uint64_t signal_offset;
+	uint64_t signal_value;
+};
+
+static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
+	     "nccl_net_ofi_gin_signal_metadata_msg_t must be exactly 32 bytes for inline send");
+
+/**
+ * ACK message sent via fi_send from receiver to sender.
+ */
+struct gin_ack_msg_t {
+	/* Message type identifier — must be set explicitly (freelist memory) */
+	gin_msg_type_t msg_type;
+	uint8_t reserved;
+	/* Ack payload — same format as bundled ack in metadata */
+	nccl_net_ofi_gin_ack_t ack;
+};
+
+static_assert(sizeof(gin_ack_msg_t) == 8, "gin_ack_msg_t must be exactly 8 bytes for inline send");
+static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, msg_type) == 0,
+	     "msg_type must be at offset 0 for type-based dispatch");
+static_assert(offsetof(gin_ack_msg_t, msg_type) == 0,
+	     "msg_type must be at offset 0 for type-based dispatch");
 
 /* ACK interval for PUT-only messages. Send an ACK every N consecutive PUTs
    to prevent sequence number wraparound. */
 #define GIN_ACK_INTERVAL 64
 static_assert(GIN_ACK_INTERVAL <= (1 << (GIN_IMM_SEQ_BITS - 1)),
 	      "GIN_ACK_INTERVAL must not exceed half the sequence number space");
+
+/* Max progress calls a bundled ack can wait before being flushed. */
+#define GIN_ACK_MAX_AGE 50
 
 #endif

--- a/include/nccl_ofi_dlist.h
+++ b/include/nccl_ofi_dlist.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_DLIST_H
+#define NCCL_OFI_DLIST_H
+
+#include <cstddef>
+#include "nccl_ofi_config_bottom.h"
+
+/**
+ * Intrusive doubly-linked list.
+ *
+ * Embed a nccl_ofi_dlist_node in your struct, and use nccl_ofi_dlist
+ * as the list head.  All operations are O(1).
+ *
+ * Usage:
+ *   struct my_item {
+ *       int data;
+ *       nccl_ofi_dlist_node link;
+ *   };
+ *
+ *   nccl_ofi_dlist list;
+ *
+ *   my_item item;
+ *   list.push_back(&item.link);
+ *
+ *   // Iterate (safe to remove current node):
+ *   nccl_ofi_dlist_node *pos;
+ *   nccl_ofi_dlist_for_each_safe(&list, pos) {
+ *       my_item *p = nccl_ofi_dlist_entry(pos, &my_item::link);
+ *   }
+ */
+
+struct nccl_ofi_dlist_node {
+	nccl_ofi_dlist_node *prev = nullptr;
+	nccl_ofi_dlist_node *next = nullptr;
+
+	/* True if this node is currently linked into a list. */
+	bool on_list() const { return next != nullptr; }
+
+	void remove()
+	{
+		prev->next = next;
+		next->prev = prev;
+		prev = nullptr;
+		next = nullptr;
+	}
+};
+
+struct nccl_ofi_dlist {
+	nccl_ofi_dlist_node head = {&head, &head};
+
+	bool empty() const { return head.next == &head; }
+
+	void push_back(nccl_ofi_dlist_node *node)
+	{
+		node->prev = head.prev;
+		node->next = &head;
+		head.prev->next = node;
+		head.prev = node;
+	}
+
+	/* Return the first node, or nullptr if empty. */
+	nccl_ofi_dlist_node *front() { return empty() ? nullptr : head.next; }
+
+	/* Remove and return the first node, or nullptr if empty. */
+	nccl_ofi_dlist_node *pop_front()
+	{
+		if (empty())
+			return nullptr;
+		nccl_ofi_dlist_node *node = head.next;
+		node->remove();
+		return node;
+	}
+
+	/* Remove and return the first node if pred returns true,
+	   or nullptr if empty or pred returns false. */
+	nccl_ofi_dlist_node *pop_front_if(bool (*pred)(nccl_ofi_dlist_node *))
+	{
+		if (empty() || !pred(head.next))
+			return nullptr;
+		return pop_front();
+	}
+};
+
+/* Recover the containing struct from a node pointer.
+   Uses cpp_container_of for safety with non-POD types. */
+template <class Parent>
+Parent *nccl_ofi_dlist_entry(nccl_ofi_dlist_node *ptr, nccl_ofi_dlist_node Parent::*member)
+{
+	return cpp_container_of(ptr, member);
+}
+
+/**
+ * Safe iteration: allows removal of the current node during the loop.
+ * @list:  nccl_ofi_dlist * list
+ * @pos:   nccl_ofi_dlist_node * loop cursor
+ */
+#define nccl_ofi_dlist_for_each_safe(list, pos) \
+	for (nccl_ofi_dlist_node *pos##_next_ = \
+		((pos) = (list)->head.next, (pos)->next); \
+	     (pos) != &(list)->head; \
+	     (pos) = pos##_next_, pos##_next_ = (pos)->next)
+
+#endif

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -228,9 +228,9 @@ int nccl_ofi_gin_comm::send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
 	auto *ack_msg = static_cast<gin_ack_msg_t *>(ack_elem->ptr);
 	ack_msg->msg_type = GIN_MSG_TYPE_ACK;
 	ack_msg->reserved = 0;
-	ack_msg->comm_id = static_cast<uint16_t>(peer_comm_id);
-	ack_msg->ack_seq_num = static_cast<uint16_t>(ack_seq_num);
-	ack_msg->count = static_cast<uint16_t>(count);
+	ack_msg->ack.comm_id = static_cast<uint16_t>(peer_comm_id);
+	ack_msg->ack.ack_seq_num = static_cast<uint16_t>(ack_seq_num);
+	ack_msg->ack.ack_count = static_cast<uint16_t>(count);
 
 	auto *ofi_ep = ep.get_rail(rail_id).ofi_ep.get();
 
@@ -372,6 +372,21 @@ int nccl_ofi_gin_comm::await_pending_requests()
 	int ret = 0;
 
 	NCCL_OFI_TRACE(NCCL_NET, "GIN communicator: awaiting pending acks");
+
+	/* Flush any deferred bundled acks so remote senders can
+	  complete their outstanding requests. */
+	nccl_ofi_dlist_node *pos;
+	nccl_ofi_dlist_for_each_safe(&pending_ack_list, pos) {
+		auto *pa = nccl_ofi_dlist_entry(pos, &nccl_ofi_gin_pending_ack_info::node);
+		if (pa->ack_count > 0) {
+			ret = send_ack(*this, pa->peer_rank,
+				pa->seq_num, pa->ack_count);
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+		}
+		pos->remove();
+	}
 
 	while (outstanding_ack_counter > 0) {
 		ret = resources.progress();
@@ -515,8 +530,8 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 		auto *metadata_send =
 			static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(metadata_elem->ptr);
 
-		metadata_send->msg_seq_num = msg_seq_num;
-		metadata_send->num_segments = nseg;
+		metadata_send->seq.seq_num = msg_seq_num;
+		metadata_send->seq.num_segments = nseg;
 		metadata_send->remote_comm_id = remote_comm_id;
 		metadata_send->msg_type = GIN_MSG_TYPE_METADATA;
 		metadata_send->signal_base_address =
@@ -528,6 +543,17 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 			metadata_send->signal_value = signalValue;
 		} else {
 			metadata_send->signal_value = 0;
+		}
+
+		/* Bundle pending ack for this peer */
+		if (rank_comm.pending_ack.ack_count > 0) {
+			metadata_send->ack.ack_seq_num = rank_comm.pending_ack.seq_num;
+			/* comm_id is only used for standalone ACKs, setting it here for struct completeness */
+			metadata_send->ack.comm_id = rank_comm.comm_id;
+			metadata_send->ack.ack_count = rank_comm.pending_ack.ack_count;
+			rank_comm.pending_ack.ack_count = 0;
+		} else {
+			metadata_send->ack.ack_count = 0;
 		}
 
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
@@ -638,14 +664,14 @@ int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint6
 	int ret = 0;
 
 	NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on target",
-		       req->metadata.msg_seq_num);
+		       req->metadata.seq.seq_num);
 
 	if (req->metadata_received) {
 		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
-							 req->metadata.msg_seq_num, req);
+							 req->metadata.seq.seq_num, req);
 		ret = do_gin_signal(req->metadata);
 		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
-						       req->metadata.msg_seq_num, req);
+						       req->metadata.seq.seq_num, req);
 	}
 
 	if (ret != 0) {
@@ -659,41 +685,81 @@ int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint6
 	return ret;
 }
 
+/* Extend the pending bundled ack to include seq_num. If the merged
+   range would overflow the bitfield, flush the old range first. */
+int nccl_ofi_gin_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num)
+{
+	auto &rank_comm = this->rank_comms[peer_rank];
+
+	if (rank_comm.pending_ack.node.on_list()) {
+		if (rank_comm.pending_ack.ack_count > 0) {
+			/* Callers must add ranges in-order (ascending seq_num).
+			   delta must be in (0, half_seq_space] to confirm forward progress. */
+			assert(((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) > 0 &&
+			       ((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) <= (GIN_IMM_SEQ_MASK >> 1));
+
+			uint32_t prev_start = (rank_comm.pending_ack.seq_num
+						- rank_comm.pending_ack.ack_count + 1) & GIN_IMM_SEQ_MASK;
+			uint32_t merged_count = ((seq_num - prev_start + 1) & GIN_IMM_SEQ_MASK);
+
+			if (merged_count > GIN_ACK_INTERVAL) {
+				int ret = send_ack(*this, peer_rank,
+							rank_comm.pending_ack.seq_num,
+							rank_comm.pending_ack.ack_count);
+				if (OFI_UNLIKELY(ret != 0)) {
+					return ret;
+				}
+				merged_count = 1;
+			}
+			rank_comm.pending_ack.ack_count = merged_count;
+		} else {
+			/* Was consumed by iputSignal piggyback; reuse slot */
+			rank_comm.pending_ack.ack_count = 1;
+		}
+	} else {
+		rank_comm.pending_ack.ack_count = 1;
+		rank_comm.pending_ack.peer_rank = peer_rank;
+		pending_ack_list.push_back(&rank_comm.pending_ack.node);
+	}
+
+	rank_comm.pending_ack.seq_num = seq_num;
+	rank_comm.pending_ack.start = progress_counter;
+	return 0;
+}
+
+/* Flush pending bundled acks that have aged past the threshold
+   for peers with no recent completions. Called from progress. */
+int nccl_ofi_gin_comm::flush_stale_acks()
+{
+	++progress_counter;
+	nccl_ofi_dlist_node *pos;
+	nccl_ofi_dlist_for_each_safe(&pending_ack_list, pos) {
+		auto *pa = nccl_ofi_dlist_entry(pos, &nccl_ofi_gin_pending_ack_info::node);
+		if (pa->ack_count == 0 ||
+		    progress_counter - pa->start > GIN_ACK_MAX_AGE) {
+			if (pa->ack_count > 0) {
+				int ret = send_ack(*this, pa->peer_rank,
+						pa->seq_num, pa->ack_count);
+				if (OFI_UNLIKELY(ret != 0)) {
+					return ret;
+				}
+			}
+			pos->remove();
+		}
+	}
+	return 0;
+}
+
 int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 {
 	int ret = 0;
 
-	/* Process undelivered signals in order */
-	uint16_t highest_acked_seq_num = 0;
-	uint16_t first_acked_seq_num = 0;
-	bool any_ack_requested = false;
-
-	/* Coalesce ACKs: instead of one ACK per signal, accumulate a range
-	   of ack-requested seq_nums (first_acked..highest_acked) and send
-	   a single range ACK. Seq_nums in between that did not request an
-	   ACK are harmlessly skipped on the sender side (they never set
-	   ack_outstanding). If the range would overflow the ack_count
-	   field, flush the ACK mid-loop and start a new range. */
+	/* Process undelivered signals in order.  ACK coalescing is
+	   handled entirely by stash_pending_ack(), which merges
+	   ranges and flushes when they exceed GIN_ACK_INTERVAL. */
 	while (true) {
 		auto &rank_comm = this->rank_comms[peer_rank];
 		uint16_t next_seq_num = rank_comm.next_delivered_signal_seq_num;
-
-		/* Flush if adding this seq_num would overflow the 10-bit
-		   ack_count field. range_span uses GIN_IMM_SEQ_MASK for
-		   correct wraparound in the 11-bit sequence space.
-		   ack_count uses GIN_ACK_COUNT_MASK to match the
-		   10-bit field it is encoded into. */
-		if (any_ack_requested) {
-			uint32_t range_span = ((next_seq_num - first_acked_seq_num + 1) & GIN_IMM_SEQ_MASK);
-			if (range_span > GIN_ACK_COUNT_MASK) {
-				uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_ACK_COUNT_MASK);
-				ret = send_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
-				if (OFI_UNLIKELY(ret != 0)) {
-					return ret;
-				}
-				any_ack_requested = false;
-			}
-		}
 
 		uint64_t map_key = get_req_map_key(peer_rank, next_seq_num);
 		auto it = this->outstanding_iput_signal_recv_reqs.find(map_key);
@@ -702,11 +768,10 @@ int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 
 			if (req->num_seg_completions == req->total_segments) {
 				if (req->is_ack_requested) {
-					if (!any_ack_requested) {
-						first_acked_seq_num = next_seq_num;
+					ret = stash_pending_ack(peer_rank, next_seq_num);
+					if (OFI_UNLIKELY(ret != 0)) {
+						return ret;
 					}
-					any_ack_requested = true;
-					highest_acked_seq_num = next_seq_num;
 				}
 				rank_comm.next_delivered_signal_seq_num =
 					(rank_comm.next_delivered_signal_seq_num + 1) &
@@ -729,14 +794,6 @@ int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 		}
 	}
 
-	/* Flush any remaining accumulated range ACK. ack_count uses
-	   GIN_ACK_COUNT_MASK to match the 10-bit field; the
-	   mid-loop overflow guard ensures the value always fits. */
-	if (any_ack_requested) {
-		uint32_t ack_count = ((highest_acked_seq_num - first_acked_seq_num + 1) & GIN_ACK_COUNT_MASK);
-		ret = send_ack(*this, peer_rank, highest_acked_seq_num, ack_count);
-	}
-
 	return ret;
 }
 
@@ -746,9 +803,18 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 {
 	int ret = 0;
 
-	uint16_t msg_seq_num = metadata_msg->msg_seq_num;
+	uint16_t msg_seq_num = metadata_msg->seq.seq_num;
+	uint16_t num_segments = metadata_msg->seq.num_segments;
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
+
+	/* Process bundled ack if present */
+	if (metadata_msg->ack.ack_count > 0) {
+		clear_ack_range(peer_rank,
+				metadata_msg->ack.ack_seq_num,
+				metadata_msg->ack.ack_count);
+	}
+
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 
 	auto it = outstanding_iput_signal_recv_reqs.find(map_key);
@@ -757,7 +823,7 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 		req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_recv_req>();
 
 		req->num_seg_completions = 1;
-		req->total_segments = metadata_msg->num_segments;
+		req->total_segments = num_segments;
 		req->metadata = *metadata_msg;
 		req->metadata_received = true;
 		req->is_ack_requested = true;  // Metadata always requests ACK
@@ -779,8 +845,8 @@ int nccl_ofi_gin_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_i
 					     const gin_ack_msg_t *ack_msg)
 {
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
-	uint16_t ack_seq_num = ack_msg->ack_seq_num;
-	uint16_t count = ack_msg->count;
+	uint16_t ack_seq_num = ack_msg->ack.ack_seq_num;
+	uint16_t count = ack_msg->ack.ack_count;
 	assert(count > 0);
 
 	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
@@ -792,16 +858,7 @@ int nccl_ofi_gin_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_i
 	   ordering — ACKs from different deliver_all calls can arrive
 	   in any order. A single ack_seq_num would require cumulative
 	   state that breaks under reordering. */
-	uint16_t start_seq = (ack_seq_num - count + 1) & GIN_IMM_SEQ_MASK;
-
-	uint16_t seq = start_seq;
-	while (true) {
-		clear_ack_outstanding(peer_rank, seq);
-		if (seq == ack_seq_num) {
-			break;
-		}
-		seq = (seq + 1) & GIN_IMM_SEQ_MASK;
-	}
+	clear_ack_range(peer_rank, ack_seq_num, count);
 	return 0;
 }
 
@@ -833,8 +890,8 @@ int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16
 
 	if (req->num_seg_completions == req->total_segments) {
 		/* Fill in the fields related to metadata */
-		req->metadata.msg_seq_num = msg_seq_num;
-		req->metadata.num_segments = req->total_segments;
+		req->metadata.seq.seq_num = msg_seq_num;
+		req->metadata.seq.num_segments = req->total_segments;
 		req->metadata.msg_type = GIN_MSG_TYPE_METADATA;
 	}
 

--- a/src/gin/nccl_ofi_gin_api.cpp
+++ b/src/gin/nccl_ofi_gin_api.cpp
@@ -237,7 +237,11 @@ static ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_gin_comm *>(collComm);
 	int ret = gin_comm->get_resources().progress();
+	if (OFI_UNLIKELY(ret != 0)) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
 
+	ret = gin_comm->flush_stale_acks();
 	return nccl_net_ofi_retval_translate(ret);
 }
 

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -103,7 +103,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 			auto *ack_msg =
 				static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr);
 
-			auto &gin_comm = resources.get_comm(ack_msg->comm_id);
+			auto &gin_comm = resources.get_comm(ack_msg->ack.comm_id);
 
 			ret = gin_comm.handle_ack_completion(src_addr, rail_id_arg,
 							     ack_msg);

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -15,6 +15,7 @@ noinst_HEADERS = unit_test.h
 
 noinst_PROGRAMS = \
 	assert \
+	dlist \
 	environ \
 	freelist \
 	msgbuff \
@@ -49,6 +50,7 @@ endif
 endif
 
 assert_SOURCES = $(base_sources) assert.cpp
+dlist_SOURCES = $(base_sources) dlist.cpp
 environ_SOURCES = $(base_sources) environ.cpp
 idpool_SOURCES = $(base_sources) idpool.cpp
 freelist_SOURCES = $(base_sources) freelist.cpp

--- a/tests/unit/dlist.cpp
+++ b/tests/unit/dlist.cpp
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <cstdio>
+
+#include "unit_test.h"
+#include "nccl_ofi_assert.h"
+#include "nccl_ofi_dlist.h"
+
+struct entry {
+	uint32_t id;
+	nccl_ofi_dlist_node node;
+};
+
+static entry *to_entry(nccl_ofi_dlist_node *n)
+{
+	return nccl_ofi_dlist_entry(n, &entry::node);
+}
+
+static entry *pop_entry(nccl_ofi_dlist *list)
+{
+	nccl_ofi_dlist_node *n = list->pop_front();
+	assert_always(n != nullptr);
+	return to_entry(n);
+}
+
+static void test_empty_list()
+{
+	nccl_ofi_dlist list;
+	assert_always(list.empty());
+	assert_always(list.front() == nullptr);
+	assert_always(list.pop_front() == nullptr);
+}
+
+static void test_on_list()
+{
+	entry e = {1, {}};
+	assert_always(!e.node.on_list());
+
+	nccl_ofi_dlist list;
+	list.push_back(&e.node);
+	assert_always(e.node.on_list());
+
+	e.node.remove();
+	assert_always(!e.node.on_list());
+}
+
+static void test_push_back_front()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	assert_always(to_entry(list.front())->id == 1);
+
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+	assert_always(to_entry(list.front())->id == 1);
+}
+
+static void test_pop_front_order()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	assert_always(pop_entry(&list)->id == 1);
+	assert_always(pop_entry(&list)->id == 2);
+	assert_always(pop_entry(&list)->id == 3);
+	assert_always(list.empty());
+}
+
+static void test_remove_head()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	a.node.remove();
+	assert_always(pop_entry(&list)->id == 2);
+	assert_always(pop_entry(&list)->id == 3);
+	assert_always(list.empty());
+}
+
+static void test_remove_middle()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	b.node.remove();
+	assert_always(pop_entry(&list)->id == 1);
+	assert_always(pop_entry(&list)->id == 3);
+	assert_always(list.empty());
+}
+
+static void test_remove_tail()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	c.node.remove();
+	assert_always(pop_entry(&list)->id == 1);
+	assert_always(pop_entry(&list)->id == 2);
+	assert_always(list.empty());
+}
+
+static void test_remove_only()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}};
+	list.push_back(&a.node);
+	a.node.remove();
+	assert_always(list.empty());
+}
+
+static void test_reinsert_after_remove()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}};
+	list.push_back(&a.node);
+	a.node.remove();
+	assert_always(list.empty());
+
+	a.id = 2;
+	list.push_back(&a.node);
+	assert_always(to_entry(list.front())->id == 2);
+}
+
+static void test_pop_front_if_match()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {42, {}};
+	list.push_back(&a.node);
+
+	auto *r = list.pop_front_if([](nccl_ofi_dlist_node *n) {
+		return to_entry(n)->id == 42;
+	});
+	assert_always(r == &a.node);
+	assert_always(list.empty());
+}
+
+static void test_pop_front_if_no_match()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {42, {}};
+	list.push_back(&a.node);
+
+	auto *r = list.pop_front_if([](nccl_ofi_dlist_node *n) {
+		return to_entry(n)->id == 99;
+	});
+	assert_always(r == nullptr);
+	assert_always(!list.empty());
+}
+
+static void test_pop_front_if_empty()
+{
+	nccl_ofi_dlist list;
+
+	auto *r = list.pop_front_if([](nccl_ofi_dlist_node *) { return true; });
+	assert_always(r == nullptr);
+}
+
+static void test_for_each_safe()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	/* Remove even-id entries during iteration */
+	nccl_ofi_dlist_node *pos;
+	nccl_ofi_dlist_for_each_safe(&list, pos) {
+		if (to_entry(pos)->id == 2)
+			pos->remove();
+	}
+
+	assert_always(pop_entry(&list)->id == 1);
+	assert_always(pop_entry(&list)->id == 3);
+	assert_always(list.empty());
+}
+
+static void test_for_each_safe_remove_all()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.push_back(&c.node);
+
+	nccl_ofi_dlist_node *pos;
+	nccl_ofi_dlist_for_each_safe(&list, pos) {
+		pos->remove();
+	}
+
+	assert_always(list.empty());
+}
+
+static void test_interleaved()
+{
+	nccl_ofi_dlist list;
+
+	entry a = {1, {}}, b = {2, {}}, c = {3, {}}, d = {4, {}};
+	list.push_back(&a.node);
+	list.push_back(&b.node);
+	list.pop_front();		/* removes a, list: [b] */
+	list.push_back(&c.node);	/* list: [b, c] */
+	b.node.remove();		/* list: [c] */
+	list.push_back(&d.node);	/* list: [c, d] */
+
+	assert_always(pop_entry(&list)->id == 3);
+	assert_always(pop_entry(&list)->id == 4);
+	assert_always(list.empty());
+}
+
+int main(int argc, char *argv[])
+{
+	unit_test_init();
+
+	test_empty_list();
+	test_on_list();
+	test_push_back_front();
+	test_pop_front_order();
+	test_remove_head();
+	test_remove_middle();
+	test_remove_tail();
+	test_remove_only();
+	test_reinsert_after_remove();
+	test_pop_front_if_match();
+	test_pop_front_if_no_match();
+	test_pop_front_if_empty();
+	test_for_each_safe();
+	test_for_each_safe_remove_all();
+	test_interleaved();
+
+	printf("Test completed successfully!\n");
+
+	return 0;
+}


### PR DESCRIPTION
Currently, GIN ACKs are sent as standalone messages. However, when metadata messages are already flowing to the same peer, this can be optimized by bundling the ACK into the next outgoing metadata message. If no metadata is sent within GIN_ACK_MAX_AGE progress calls, or the accumulated ACK range exceeds GIN_ACK_INTERVAL, fall back to a standalone ACK.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
