### PR TITLE
Fix memory leak of pci_path and name in getProperties

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -363,6 +363,22 @@ public:
 	 */
 	char *name = nullptr;
 
+	/*
+	 * Cached PCI path for this device (e.g., /sys/devices/pci...).
+	 * Populated on first get_properties() call via realpath() and
+	 * returned on subsequent calls. Freed in the destructor.
+	 */
+	char *pci_path = nullptr;
+
+	/*
+	 * Cached device name returned in properties (domain or NIC
+	 * device name from libfabric). Distinct from the 'name' field
+	 * above which holds the provider name. Populated on first
+	 * get_properties() call via strdup() and returned on subsequent
+	 * calls. Freed in the destructor.
+	 */
+	char *props_name = nullptr;
+
 	/* do we need to use an mr rkey pool?  This is a
 	 * provider-specific behavior determined when providers are
 	 * selected.

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -434,7 +434,7 @@ static int get_device_pci_path(struct fid_nic *nic_info, char** path)
 static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 				 nccl_ofi_properties_t *props)
 {
-	props->name = strdup(nic_prov->domain_attr->name);
+	props->name = nic_prov->domain_attr->name;
 
 	/*
 	 * Currently, libfabric providers provide multiple `fi_info`
@@ -535,19 +535,36 @@ int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
 			      "No NIC info for dev %d. Supplying default values for NIC properties.",
 			      dev_id);
+		if (OFI_UNLIKELY(device->props_name == nullptr)) {
+			std::lock_guard<std::mutex> lock(device->device_lock);
+			if (device->props_name == nullptr) {
+				device->props_name = strdup(nic_prov->domain_attr->name);
+				assert(device->props_name != nullptr);
+			}
+		}
+		props->name = device->props_name;
 		ret = 0;
 		goto exit;
 	}
 
-	/* name is NULL if device is a part of multirail config */
-	/* overriding default name only if value is available from provider */
-	if (nic_info->device_attr->name) {
-		if (props->name) {
-			free(props->name);
+	/*
+	 * Cache props_name and pci_path on the device. These are
+	 * allocated once and returned on all subsequent calls.
+	 * Double-checked locking avoids the mutex on the common path.
+	 */
+	if (OFI_UNLIKELY(device->props_name == nullptr)) {
+		std::lock_guard<std::mutex> lock(device->device_lock);
+		if (device->props_name == nullptr) {
+			/* Prefer NIC device name; fall back to domain name */
+			if (nic_info->device_attr->name) {
+				device->props_name = strdup(nic_info->device_attr->name);
+			} else {
+				device->props_name = strdup(nic_prov->domain_attr->name);
+			}
+			assert(device->props_name != nullptr);
 		}
-		props->name = strdup(nic_info->device_attr->name);
-		assert(props->name != nullptr);
 	}
+	props->name = device->props_name;
 
 	/* Speed reported in Mbps */
 	props->port_speed = nic_info->link_attr->speed / (1e6);
@@ -569,20 +586,21 @@ int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov
 		props->port_speed = 200 * (1e3);
 	}
 
-	ret = get_device_pci_path(nic_info, &props->pci_path);
-	if (ret != 0) {
-		ret = 0;
-		props->pci_path = NULL;
+	if (OFI_UNLIKELY(device->pci_path == nullptr)) {
+		std::lock_guard<std::mutex> lock(device->device_lock);
+		if (device->pci_path == nullptr) {
+			ret = get_device_pci_path(nic_info, &device->pci_path);
+			if (ret != 0) {
+				ret = 0;
+				device->pci_path = nullptr;
+			}
+		}
 	}
+	props->pci_path = device->pci_path;
 
 	goto exit;
 error:
-	if (props->pci_path) {
-		free(props->pci_path);
-	}
-	if (props->name) {
-		free(props->name);
-	}
+	/* pci_path and name are owned by the device, not freed here */
 
 exit:
 	return ret;
@@ -768,6 +786,12 @@ nccl_net_ofi_device_t::~nccl_net_ofi_device_t()
 {
 	if (this->name != nullptr) {
 		free(this->name);
+	}
+	if (this->pci_path != nullptr) {
+		free(this->pci_path);
+	}
+	if (this->props_name != nullptr) {
+		free(this->props_name);
 	}
 }
 


### PR DESCRIPTION
*Description of changes:*

realpath() and strdup() allocate new strings on every getProperties
call. The callers store these pointers in stack-allocated
nccl_ofi_properties_t structs that go out of scope without freeing
them, leaking memory on every call.

Cache both pci_path and the properties name on the device object,
which persists for the process lifetime. getProperties now returns
pointers to the device's cached copies instead of freshly allocated
strings. The device destructor frees them.

Use double-checked locking with the device mutex to ensure thread
safety, since NCCL calls getProperties concurrently from multiple
proxy threads for the same device. The outer check avoids acquiring
the mutex on the common path after the first call.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
