### PR TITLE
Fix flush buffer MR handle leak in SendRecv recv comm close

### DIFF
--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1030,7 +1030,8 @@ int nccl_net_ofi_sendrecv_recv_comm::close()
 		/* Deregister Flush buffer memory region */
 		mr_handle = this->flush_buff.mr_handle;
 		if (mr_handle) {
-			mr_handle->mr.reset();
+			delete mr_handle;
+			this->flush_buff.mr_handle = nullptr;
 		}
 		ret = nccl_net_ofi_dealloc_mr_buffer(this->flush_buff.host_buffer,
 						    system_page_size);


### PR DESCRIPTION
*Description of changes:*

The recv comm close path resets the flush buffer MR via mr_handle->mr.reset() but never deletes the mr_handle object itself. This leaks one nccl_net_ofi_sendrecv_mr_handle_t on every recv comm close.

Delete the mr_handle after resetting the MR.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
