### PR TITLE
Cherry pick v1.19.x 

### DIFF
--- a/contrib/python/requirements.txt
+++ b/contrib/python/requirements.txt
@@ -3,7 +3,7 @@ markdown-it-py==4.0.0
 mdurl==0.1.2
 numpy==2.4.1
 pandas==3.0.0
-Pygments==2.19.2
+Pygments==2.20.0
 python-dateutil==2.9.0.post0
 rich==14.3.1
 shellingham==1.5.4

--- a/include/nccl_ofi_freelist.h
+++ b/include/nccl_ofi_freelist.h
@@ -177,7 +177,16 @@ public:
 		nccl_net_ofi_mem_defined_unaligned(entry, sizeof(*entry));
 
 		this->entries = entry->next;
-		entry_set_undefined(entry->ptr);
+
+		if (this->entry_init_fn) {
+			/* If the user provided an entry initialization function,
+			   assume the buffer is initialized. This is necessary because
+			   the freelist cannot know which parts of the buffer were actually
+			   initialized by the user's init function. */
+			entry_set_defined(entry->ptr);
+		} else {
+			entry_set_undefined(entry->ptr);
+		}
 
 		this->num_in_use_entries++;
 
@@ -219,6 +228,19 @@ public:
 	}
 
 protected:
+	/*
+	 * Set memcheck guards of freelist entry's user data to accessible and defined
+	 */
+	void entry_set_defined(void *entry_p)
+	{
+		size_t user_entry_size = this->entry_size - MEMCHECK_REDZONE_SIZE;
+
+		/* Entry allocated by the user is accessible and
+		 * defined. Note that this allows the user to
+		 * override the fl_entry structure. */
+		nccl_net_ofi_mem_defined(entry_p, user_entry_size);
+	}
+
 	/* Internal function, which grows the freelist */
 	int add(size_t num_entries);
 

--- a/src/cm/nccl_ofi_cm_reqs.cpp
+++ b/src/cm/nccl_ofi_cm_reqs.cpp
@@ -74,6 +74,7 @@ int nccl_ofi_cm_rx_req::progress()
 {
 	auto conn_msg = static_cast<nccl_ofi_cm_conn_msg *>(rx_elem.ptr);
 	auto mr_handle = static_cast<endpoint::mr_handle_t *>(rx_elem.mr_handle);
+	memset(conn_msg, 0, resources.get_conn_msg_size());
 	return resources.ep.recv(*conn_msg, resources.get_conn_msg_size(), *mr_handle, *this);
 }
 

--- a/src/nccl_ofi_freelist.cpp
+++ b/src/nccl_ofi_freelist.cpp
@@ -152,6 +152,13 @@ nccl_ofi_freelist::~nccl_ofi_freelist()
 		if (this->entry_fini_fn != NULL) {
 			for (size_t i = 0; i < block->num_entries; ++i) {
 				nccl_ofi_freelist::fl_entry *entry = &block->entries[i];
+
+				/**
+				 * Mark the memory as defined before calling the fini function
+				 * It was initialized previously by entry_init_fn
+				 */
+				this->entry_set_defined(entry->ptr);
+
 				this->entry_fini_fn(entry->ptr);
 			}
 		}

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -1747,9 +1747,6 @@ static inline int free_base_req(uint64_t *num_inflight_reqs,
 
 	elem = req->elem;
 
-	/* Zero out buffer */
-	zero_nccl_ofi_req(req);
-
 	nccl_ofi_reqs_fl->entry_free(elem);
 
 	/* Reduce inflight commands */
@@ -2815,6 +2812,9 @@ static inline nccl_net_ofi_rdma_req *allocate_req(nccl_ofi_freelist *fl)
 	assert(req);
 
 	req->elem = elem;
+
+	/* Zero out buffer */
+	zero_nccl_ofi_req(req);
 
 	return req;
 }

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1030,7 +1030,8 @@ int nccl_net_ofi_sendrecv_recv_comm::close()
 		/* Deregister Flush buffer memory region */
 		mr_handle = this->flush_buff.mr_handle;
 		if (mr_handle) {
-			mr_handle->mr.reset();
+			delete mr_handle;
+			this->flush_buff.mr_handle = nullptr;
 		}
 		ret = nccl_net_ofi_dealloc_mr_buffer(this->flush_buff.host_buffer,
 						    system_page_size);

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -382,9 +382,6 @@ static inline int sendrecv_req_free(uint64_t *num_inflight_reqs,
 
 	elem = req->elem;
 
-	/* Zero out buffer */
-	sendrecv_req_zero(req);
-
 	assert(elem);
 	nccl_ofi_reqs_fl->entry_free(elem);
 	/* Reduce inflight commands */
@@ -883,6 +880,9 @@ static inline nccl_net_ofi_sendrecv_req *sendrecv_allocate_req(nccl_ofi_freelist
 	req = (nccl_net_ofi_sendrecv_req*) elem->ptr;
 	assert(req);
 	req->elem = elem;
+
+	/* Zero out buffer */
+	sendrecv_req_zero(req);
 
  exit:
 	return req;


### PR DESCRIPTION
*Description of changes:*

Cherry-pick 5 commits from master into the v1.19.x release branch:

- 1ba5805 build(deps): bump pygments from 2.19.2 to 2.20.0
- 7930162 Fix flush buffer MR handle leak in SendRecv recv comm close
- fc15acd freelist: Fix use-uninitialized warnings
- d1a1ebe transports: Zero requests on allocation instead of free
- e2f60b6 cm: Zero-initialize RX buffer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
