### PR TITLE
Decouple GIN from core base classes with abstract interfaces

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -14,6 +14,7 @@ noinst_HEADERS = \
 	gin/nccl_ofi_gin_reqs.h \
 	gin/nccl_ofi_gin_resources.h \
 	gin/nccl_ofi_gin_types.h \
+	nccl_ofi_gin_base.h \
 	nccl_ofi.h \
 	nccl_ofi_api.h \
 	nccl_ofi_assert.h \

--- a/include/gin/nccl_ofi_gin.h
+++ b/include/gin/nccl_ofi_gin.h
@@ -27,7 +27,7 @@ inline nccl_ofi_device_copy &get_device_copy()
  * The listen communicator which implements GIN API's nccl_ofi_gin_listen() and
  * nccl_ofi_gin_connect() functionality
  */
-class nccl_ofi_gin_listen_comm {
+class nccl_ofi_gin_listen_comm : public nccl_ofi_gin_listen_comm_t {
 private:
 	nccl_net_ofi_ep_t *ep;
 	nccl_net_ofi_listen_comm *l_comm;
@@ -142,7 +142,7 @@ struct gin_remote_mr {
  * A symmetric memory registration handle. This is the result of GIN API's
  * regMrSym() family of functions.
  */
-struct gin_sym_mr_handle {
+struct gin_sym_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 	/* Address provided by NCCL to regMrSym. This is the base for the offset
 	   provided by NCCL */
 	void *input_address;
@@ -162,7 +162,7 @@ struct gin_sym_mr_handle {
 /**
  * This represents the main GIN communicator
  */
-class nccl_ofi_gin_comm {
+class nccl_ofi_gin_comm : public nccl_ofi_gin_put_comm_t {
 public:
 	nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
 			  nccl_net_ofi_send_comm *s_comm_, nccl_net_ofi_recv_comm *r_comm_);

--- a/include/gin/nccl_ofi_gin_reqs.h
+++ b/include/gin/nccl_ofi_gin_reqs.h
@@ -5,7 +5,9 @@
 #ifndef NCCL_OFI_GIN_REQS_H
 #define NCCL_OFI_GIN_REQS_H
 
+#include "gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi.h"
+#include "nccl_ofi_gin_base.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_tracepoint.h"
 #include <array>
@@ -52,7 +54,7 @@ public:
 /**
  * GIN base request type.
  */
-class nccl_net_ofi_gin_base_req {
+class nccl_net_ofi_gin_base_req : public nccl_ofi_gin_req_t {
 public:
 	void set_fl_entry(nccl_ofi_freelist::fl_entry *entry)
 	{
@@ -305,9 +307,9 @@ public:
 		return 0;
 	}
 
-	int test(bool &done_arg)
+	int test(int *done_out) override
 	{
-		done_arg = this->done;
+		*done_out = this->done ? 1 : 0;
 		return 0;
 	}
 
@@ -361,9 +363,9 @@ public:
 		return 0;
 	}
 
-	int test(bool &done_arg)
+	int test(int *done_out) override
 	{
-		done_arg = this->done;
+		*done_out = this->done ? 1 : 0;
 		return 0;
 	}
 

--- a/include/gin/nccl_ofi_gin_resources.h
+++ b/include/gin/nccl_ofi_gin_resources.h
@@ -17,6 +17,9 @@
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_scheduler.h"
 
+#include "nccl_ofi_gin_base.h"
+#include "nccl_ofi_rdma.h"
+
 static inline void freelist_deleter(nccl_ofi_freelist *fl)
 {
 	delete fl;
@@ -185,7 +188,7 @@ struct nccl_ofi_gin_ep_holder {
 
 	~nccl_ofi_gin_ep_holder()
 	{
-		ep.set_gin_resources(nullptr);
+		static_cast<nccl_net_ofi_rdma_ep_t &>(ep).set_gin_resources(nullptr);
 		ep.release_ep(false, false);
 	}
 };

--- a/include/gin/nccl_ofi_gin_resources.h
+++ b/include/gin/nccl_ofi_gin_resources.h
@@ -14,11 +14,10 @@
 
 #include "gin/nccl_ofi_gin_reqs.h"
 #include "gin/nccl_ofi_gin_types.h"
-#include "nccl_ofi_freelist.h"
-#include "nccl_ofi_scheduler.h"
-
 #include "nccl_ofi_gin_base.h"
+#include "nccl_ofi_freelist.h"
 #include "nccl_ofi_rdma.h"
+#include "nccl_ofi_scheduler.h"
 
 static inline void freelist_deleter(nccl_ofi_freelist *fl)
 {
@@ -49,18 +48,19 @@ struct nccl_ofi_gin_ep_rail_t {
 /**
  * The GIN endpoint type
  */
-class nccl_ofi_gin_ep_t {
+class nccl_ofi_rdma_gin_ep_t : public nccl_ofi_gin_ep_t {
 public:
 	/**
 	 * Create a GIN EP using the provided domain object
 	 *
 	 * @param domain_arg: Domain object from net transport
 	 */
-	nccl_ofi_gin_ep_t(nccl_net_ofi_domain_t &domain_arg);
+	nccl_ofi_rdma_gin_ep_t(nccl_net_ofi_domain_t &domain_arg);
 
-	nccl_ofi_gin_ep_t(const nccl_ofi_gin_ep_t &) = delete;
+	nccl_ofi_rdma_gin_ep_t(const nccl_ofi_rdma_gin_ep_t &) = delete;
+	nccl_ofi_rdma_gin_ep_t &operator=(const nccl_ofi_rdma_gin_ep_t &) = delete;
 
-	~nccl_ofi_gin_ep_t();
+	~nccl_ofi_rdma_gin_ep_t() override;
 
 	uint16_t get_num_rails() const
 	{
@@ -114,6 +114,9 @@ private:
 	std::vector<nccl_ofi_gin_ep_rail_t> rails;
 
 	nccl_net_ofi_scheduler *scheduler;
+
+	/* Cached from param at construction; avoids mutex in CQ loop */
+	size_t cq_process_max_iter;
 	/**
 	 * Handler for list of CQ entries
 	 */
@@ -240,7 +243,7 @@ public:
 		}
 	}
 
-	nccl_ofi_gin_ep_t &get_ep()
+	nccl_ofi_rdma_gin_ep_t &get_ep()
 	{
 		return gin_ep;
 	}
@@ -345,7 +348,7 @@ private:
 
 	nccl_ofi_idpool_t comm_id_pool;
 
-	nccl_ofi_gin_ep_t gin_ep;
+	nccl_ofi_rdma_gin_ep_t gin_ep;
 
 	/**
 	 * Queue of pending Libfabric requests to be retried

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -752,20 +752,6 @@ public:
 		return *domain;
 	}
 
-	/**
-	 * Get pointer to the gin resources associated with this endpoint, or
-	 * nullptr if there are no associated GIN resources.
-	 */
-	inline nccl_ofi_gin_resources *get_gin_resources()
-	{
-		return gin_resources;
-	}
-
-	inline void set_gin_resources(nccl_ofi_gin_resources *gin_resources_arg)
-	{
-		this->gin_resources = gin_resources_arg;
-	}
-
 protected:
 	/**
 	 * @brief	Virtual destructor.
@@ -806,11 +792,6 @@ protected:
 	 * zero. sendrecv_release_ep() releases the resources if the
 	 * reference counter is decreased down to zero. */
 	int ref_cnt;
-
-	/**
-	 * Associated GIN resources object
-	 */
-	nccl_ofi_gin_resources *gin_resources = nullptr;
 };
 
 enum nccl_net_ofi_comm_type_t {

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -15,7 +15,6 @@
 #include <rdma/fi_rma.h>
 #include <nccl/net.h>
 
-#include "gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_idpool.h"
@@ -92,12 +91,6 @@ extern bool cuda_flush;
    const), but will not change during execution.  Therefore, it may be
    read in the polling loop without protection of a lock. */
 extern size_t cq_read_count;
-
-/* Maximum number of iterations for GIN CQ processing loop.
-   This variable will be updated during init (hence, can not be
-   const), but will not change during execution.  Therefore, it may be
-   read in the polling loop without protection of a lock. */
-extern size_t gin_cq_process_max_iter;
 
 /* Indicates if endpoint memory registration is required */
 extern bool endpoint_mr;

--- a/include/nccl_ofi_gin_base.h
+++ b/include/nccl_ofi_gin_base.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_GIN_BASE_H_
+#define NCCL_OFI_GIN_BASE_H_
+
+#include <cassert>
+
+/**
+ * Abstract GIN endpoint base class.
+ */
+class nccl_ofi_gin_ep_t {
+public:
+	virtual ~nccl_ofi_gin_ep_t() = default;
+};
+
+/**
+ * Abstract GIN symmetric MR handle.
+ */
+class nccl_ofi_gin_symm_mr_handle_t {
+public:
+	virtual ~nccl_ofi_gin_symm_mr_handle_t() = default;
+};
+
+/**
+ * Abstract GIN request. Returned by iputSignal, polled via test().
+ */
+class nccl_ofi_gin_req_t {
+public:
+	virtual ~nccl_ofi_gin_req_t() = default;
+	virtual int test(int *done)
+	{
+		(void)done;
+		assert(false && "test() called on non-testable request");
+		return -1;
+	}
+};
+
+/**
+ * Abstract GIN listen communicator.
+ */
+class nccl_ofi_gin_listen_comm_t {
+public:
+	virtual ~nccl_ofi_gin_listen_comm_t() = default;
+};
+
+/**
+ * Abstract GIN put communicator.
+ */
+class nccl_ofi_gin_put_comm_t {
+public:
+	virtual ~nccl_ofi_gin_put_comm_t() = default;
+};
+
+#endif /* NCCL_OFI_GIN_BASE_H_ */

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -247,6 +247,7 @@ typedef struct nccl_net_ofi_flush_data {
 class nccl_net_ofi_rdma_device_t;
 class nccl_net_ofi_rdma_domain_t;
 class nccl_net_ofi_rdma_ep_t;
+class nccl_ofi_gin_resources;
 
 class nccl_net_ofi_rdma_device_rail_t;
 class nccl_net_ofi_rdma_domain_rail_t;
@@ -1088,6 +1089,20 @@ public:
 	}
 
 	/**
+	 * Get pointer to the gin resources associated with this endpoint, or
+	 * nullptr if there are no associated GIN resources.
+	 */
+	inline nccl_ofi_gin_resources *get_gin_resources()
+	{
+		return gin_resources;
+	}
+
+	inline void set_gin_resources(nccl_ofi_gin_resources *gin_resources_arg)
+	{
+		this->gin_resources = gin_resources_arg;
+	}
+
+	/**
 	 * @brief Return endpoint rail with index `rail_id`
 	 */
 	inline nccl_net_ofi_rdma_ep_rail_t *rdma_endpoint_get_rail(uint16_t rail_id)
@@ -1335,6 +1350,10 @@ protected:
 				nccl_net_ofi_rdma_cq_rail_t *cq_rail,
 				uint32_t tclass);
 
+	/**
+	 * Associated GIN resources object
+	 */
+	nccl_ofi_gin_resources *gin_resources = nullptr;
 };
 
 /*

--- a/src/gin/nccl_ofi_gin.cpp
+++ b/src/gin/nccl_ofi_gin.cpp
@@ -8,6 +8,7 @@
 
 #include "nccl_ofi_assert.h"
 #include "nccl_ofi_gdrcopy.h"
+#include "nccl_ofi_rdma.h"
 #include "nccl_ofi_tracepoint.h"
 
 struct gin_connect_handle {
@@ -145,10 +146,11 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 	}
 
 	/* Create a GIN resources object on the endpoint if it does not exist */
-	auto *resources = ep->get_gin_resources();
+	auto *rdma_ep = static_cast<nccl_net_ofi_rdma_ep_t *>(ep);
+	auto *resources = rdma_ep->get_gin_resources();
 	if (resources == nullptr) {
 		resources = new nccl_ofi_gin_resources(*ep);
-		ep->set_gin_resources(resources);
+		rdma_ep->set_gin_resources(resources);
 	}
 
 	nccl_ofi_gin_comm *gin_comm =

--- a/src/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/gin/nccl_ofi_gin_reqs.cpp
@@ -204,8 +204,8 @@ int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)
 	bool all_writes_done = true;
 	for (auto &write_req : write_reqs) {
 		if (write_req) {
-			bool write_done = false;
-			int ret = write_req->test(write_done);
+			int write_done = 0;
+			int ret = write_req->test(&write_done);
 			if (ret != 0)
 				return ret;
 			if (write_done) {
@@ -219,8 +219,8 @@ int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)
 	}
 
 	if (send_req) {
-		bool send_done = false;
-		int ret = send_req->test(send_done);
+		int send_done = 0;
+		int ret = send_req->test(&send_done);
 		if (ret != 0)
 			return ret;
 		if (send_done) {

--- a/src/gin/nccl_ofi_gin_resources.cpp
+++ b/src/gin/nccl_ofi_gin_resources.cpp
@@ -15,9 +15,10 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
 
-nccl_ofi_gin_ep_t::nccl_ofi_gin_ep_t(nccl_net_ofi_domain_t &domain_arg) : domain(domain_arg)
+nccl_ofi_rdma_gin_ep_t::nccl_ofi_rdma_gin_ep_t(nccl_net_ofi_domain_t &domain_arg) : domain(domain_arg)
 {
 	this->num_rails = domain.get_ofi_num_rails();
+	this->cq_process_max_iter = ofi_nccl_gin_cq_process_max_iter();
 	rails.reserve(this->num_rails);
 
 	// Create rails
@@ -27,7 +28,7 @@ nccl_ofi_gin_ep_t::nccl_ofi_gin_ep_t(nccl_net_ofi_domain_t &domain_arg) : domain
 	this->scheduler = new nccl_net_ofi_threshold_scheduler(this->num_rails);
 }
 
-nccl_ofi_gin_ep_t::~nccl_ofi_gin_ep_t()
+nccl_ofi_rdma_gin_ep_t::~nccl_ofi_rdma_gin_ep_t()
 {
 	if (scheduler) {
 		delete scheduler;
@@ -35,7 +36,7 @@ nccl_ofi_gin_ep_t::~nccl_ofi_gin_ep_t()
 	}
 }
 
-int nccl_ofi_gin_ep_t::gin_process_completions(struct fi_cq_data_entry *cq_entry,
+int nccl_ofi_rdma_gin_ep_t::gin_process_completions(struct fi_cq_data_entry *cq_entry,
 					       fi_addr_t *src_addrs, uint64_t num_cqes,
 					       uint16_t rail_id)
 {
@@ -65,7 +66,7 @@ int nccl_ofi_gin_ep_t::gin_process_completions(struct fi_cq_data_entry *cq_entry
 	return 0;
 }
 
-int nccl_ofi_gin_ep_t::gin_process_error_entry(struct fi_cq_err_entry *err_entry, struct fid_cq *cq,
+int nccl_ofi_rdma_gin_ep_t::gin_process_error_entry(struct fi_cq_err_entry *err_entry, struct fid_cq *cq,
 					       uint16_t rail_id)
 {
 	void *op_ctx = err_entry->op_context;
@@ -80,7 +81,7 @@ int nccl_ofi_gin_ep_t::gin_process_error_entry(struct fi_cq_err_entry *err_entry
 	return ctx->handle_error_entry(cq, err_entry, rail_id);
 }
 
-int nccl_ofi_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
+int nccl_ofi_rdma_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
 {
 	assert(rail_id < num_rails);
 
@@ -137,13 +138,13 @@ int nccl_ofi_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
 			ret = -EINVAL;
 			goto exit;
 		}
-	} while (iter < gin_cq_process_max_iter);
+	} while (iter < cq_process_max_iter);
 
 exit:
 	return ret;
 }
 
-int nccl_ofi_gin_ep_t::process_cq()
+int nccl_ofi_rdma_gin_ep_t::process_cq()
 {
 	int ret = 0;
 
@@ -159,7 +160,7 @@ int nccl_ofi_gin_ep_t::process_cq()
 	return ret;
 }
 
-void nccl_ofi_gin_ep_t::close_ofi_eps()
+void nccl_ofi_rdma_gin_ep_t::close_ofi_eps()
 {
 	rails.clear();
 }
@@ -205,7 +206,7 @@ static int set_mr_req_attr(uint64_t mr_key, nccl_ofi_mr_ckey_ref ckey, uint64_t 
 	return ret;
 }
 
-int nccl_ofi_gin_ep_t::reg_mr(nccl_ofi_mr_ckey_ref ckey, int type,
+int nccl_ofi_rdma_gin_ep_t::reg_mr(nccl_ofi_mr_ckey_ref ckey, int type,
 			      nccl_ofi_gin_mr_handle_t **mhandle)
 {
 	int ret = 0;
@@ -257,7 +258,7 @@ int nccl_ofi_gin_ep_t::reg_mr(nccl_ofi_mr_ckey_ref ckey, int type,
 	return 0;
 }
 
-void nccl_ofi_gin_ep_t::dereg_mr(nccl_ofi_gin_mr_handle_t *handle_ptr)
+void nccl_ofi_rdma_gin_ep_t::dereg_mr(nccl_ofi_gin_mr_handle_t *handle_ptr)
 {
 	if (OFI_UNLIKELY(handle_ptr == NULL)) {
 		NCCL_OFI_WARN("Attempted to deregister NULL memory region handle");
@@ -267,16 +268,16 @@ void nccl_ofi_gin_ep_t::dereg_mr(nccl_ofi_gin_mr_handle_t *handle_ptr)
 	delete handle_ptr;
 }
 
-int nccl_ofi_gin_ep_t::freelist_regmr_fn(void *ep_ptr, void *data, size_t size, void **mhandle)
+int nccl_ofi_rdma_gin_ep_t::freelist_regmr_fn(void *ep_ptr, void *data, size_t size, void **mhandle)
 {
-	auto ep = static_cast<nccl_ofi_gin_ep_t *>(ep_ptr);
+	auto ep = static_cast<nccl_ofi_rdma_gin_ep_t *>(ep_ptr);
 	/* Setting ep to nullptr for the cache key -- we don't use the MR cache for GIN */
 	auto ckey = nccl_ofi_mr_ckey_mk_vec(data, size, nullptr);
 	return ep->reg_mr(&ckey, NCCL_PTR_HOST,
 			  reinterpret_cast<nccl_ofi_gin_mr_handle_t **>(mhandle));
 }
 
-int nccl_ofi_gin_ep_t::freelist_deregmr_fn(void *handle)
+int nccl_ofi_rdma_gin_ep_t::freelist_deregmr_fn(void *handle)
 {
 	auto mr_handle = static_cast<nccl_ofi_gin_mr_handle_t *>(handle);
 

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -53,12 +53,6 @@ bool cuda_flush = false;
    read in the polling loop without protection of a lock. */
 size_t cq_read_count = 1;
 
-/* Maximum number of iterations for GIN CQ processing loop.
-   This variable will be updated during init (hence, can not be
-   const), but will not change during execution.  Therefore, it may be
-   read in the polling loop without protection of a lock. */
-size_t gin_cq_process_max_iter = 0;
-
 /* Indicates if endpoint memory registration is required */
 bool endpoint_mr = false;
 
@@ -179,7 +173,6 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 
 	/* configuration parameters */
 	cq_read_count = ofi_nccl_cq_read_count();
-	gin_cq_process_max_iter = ofi_nccl_gin_cq_process_max_iter();
 
 	topo = nccl_ofi_topo_create();
 	if (!topo) {


### PR DESCRIPTION
*Description of changes:*
- Add `nccl_ofi_gin_base.h` with abstract base classes: `nccl_ofi_gin_ep_t`, `nccl_ofi_gin_listen_comm_t`, `nccl_ofi_gin_put_comm_t`, `nccl_ofi_gin_symm_mr_handle_t`, `nccl_ofi_gin_req_t`
- Rename concrete GIN EP to `nccl_ofi_rdma_gin_ep_t`, inheriting from abstract base
- Concrete `listen_comm`, `put_comm`, `symm_mr_handle`, and `base_req` inherit from their respective abstract bases
- Move `gin_resources` pointer and accessors from base `nccl_net_ofi_ep_t` to RDMA-specific `nccl_net_ofi_rdma_ep_t`
- Remove from `nccl_ofi.h`: `gin/nccl_ofi_gin_types.h` include, `gin_cq_process_max_iter` global variable
- Cache `gin_cq_process_max_iter` on GIN EP at construction time


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
