### PR TITLE
rocm: fix DMA-BUF fd retrieval guard and enum for ROCm 7.x

### DIFF
--- a/m4/check_pkg_rocm.m4
+++ b/m4/check_pkg_rocm.m4
@@ -40,6 +40,14 @@ AC_DEFUN([CHECK_PKG_ROCM], [
                                         [], [])],
                           [], [AC_INCLUDES_DEFAULT])])
 
+  dnl Check for hipMemRangeHandleTypeDmaBufFd enum (needed for DMA-BUF fd retrieval)
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [AC_CHECK_DECLS([hipMemRangeHandleTypeDmaBufFd],
+                       [],
+                       [],
+                       [[#define __HIP_PLATFORM_AMD__
+#include <hip/hip_runtime_api.h>]])])
+
   AS_IF([test "${check_pkg_found}" = "yes"],
         [check_pkg_define="yes"],
         [check_pkg_define="no"

--- a/src/nccl_ofi_rocm.cpp
+++ b/src/nccl_ofi_rocm.cpp
@@ -128,9 +128,9 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 
 int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
 {
-#if defined(HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD)
-	hipError_t ret = hipMemGetHandleForAddressRange(fd, (uintptr_t)aligned_ptr, aligned_size,
-						      HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0);
+#if HAVE_DECL_HIPMEMRANGEHANDLETYPEDMABUFFD
+	hipError_t ret = hipMemGetHandleForAddressRange(fd, (hipDeviceptr_t)aligned_ptr, aligned_size,
+						      hipMemRangeHandleTypeDmaBufFd, 0);
 	*offset = 0;
 	return ret == hipSuccess ? 0 : -EINVAL;
 #else


### PR DESCRIPTION
HIP does not define HIP_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD as a preprocessor macro; it is an enum value (hipMemRangeHandleTypeDmaBufFd). The old #if defined(...) guard therefore always evaluated to false, so nccl_net_ofi_gpu_get_dma_buf_fd() always returned -ENOTSUP even when the ROCm runtime supports DMA-BUF fd export.  On MI300A with HSA runtime support this caused nccl_ofi_dmabuf_viable_and_supported() to return true while the fd retrieval immediately failed, breaking domain initialisation.

Add an AC_CHECK_DECLS([hipMemRangeHandleTypeDmaBufFd]) probe in m4/check_pkg_rocm.m4 so the build system writes
HAVE_DECL_HIPMEMRANGEHANDLETYPEDMABUFFD to config.h.  Switch the guard in nccl_ofi_rocm.cpp to use this macro and also fix the pointer cast from uintptr_t to hipDeviceptr_t as required by hipMemGetHandleForAddressRange.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
