### PR TITLE
Convert message buffer from C-style struct to C++ class

### DIFF
--- a/include/nccl_ofi_msgbuff.h
+++ b/include/nccl_ofi_msgbuff.h
@@ -5,8 +5,9 @@
 #ifndef NCCL_OFI_MSGBUFF_H_
 #define NCCL_OFI_MSGBUFF_H_
 
-#include <pthread.h>
-#include <stdint.h>
+#include <cstdint>
+#include <mutex>
+#include <vector>
 
 /**
  * A "modified circular buffer" used to track in-flight (or INPROGRESS) messages.
@@ -77,105 +78,92 @@ typedef struct {
 	void *elem;
 } nccl_ofi_msgbuff_elem_t;
 
-typedef struct {
-	// Element storage buffer. Allocated in msgbuff_init
-	nccl_ofi_msgbuff_elem_t *buff;
-	/* Max number of INPROGRESS elements. These are the only
-	 * ones backed by the storage buffer, so this is also the
-	 * size of the storage buffer */
+class nccl_ofi_msgbuff {
+public:
+	/**
+	 * Construct a message buffer.
+	 * @param max_inprogress max number of INPROGRESS elements
+	 * @param bit_width bit width of the sequence numbers
+	 * @param start_seq start of sequence numbers
+	 *
+	 * @throws std::invalid_argument if parameters are invalid
+	 * @throws std::bad_alloc on allocation failure
+	 */
+	nccl_ofi_msgbuff(uint16_t max_inprogress, uint16_t bit_width, uint16_t start_seq);
+
+	~nccl_ofi_msgbuff() = default;
+
+	/* Not copyable or movable */
+	nccl_ofi_msgbuff(const nccl_ofi_msgbuff &) = delete;
+	nccl_ofi_msgbuff &operator=(const nccl_ofi_msgbuff &) = delete;
+
+	/**
+	 * Insert a new message element
+	 *
+	 * @param msg_index sequence number of the message
+	 * @param elem pointer to store at msg_index
+	 * @param type type of element
+	 * @param msg_idx_status output: message status, if return value is INVALID_IDX
+	 *
+	 * @return NCCL_OFI_MSGBUFF_SUCCESS, NCCL_OFI_MSGBUFF_INVALID_IDX, or NCCL_OFI_MSGBUFF_ERROR
+	 */
+	nccl_ofi_msgbuff_result_t insert(uint16_t msg_index, void *elem,
+					 nccl_ofi_msgbuff_elemtype_t type,
+					 nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+	/**
+	 * Replace an existing message element
+	 *
+	 * @param msg_index sequence number of the message
+	 * @param elem pointer to store at msg_index
+	 * @param type type of element
+	 * @param msg_idx_status output: message status, if return value is INVALID_IDX
+	 *
+	 * @return NCCL_OFI_MSGBUFF_SUCCESS, NCCL_OFI_MSGBUFF_INVALID_IDX, or NCCL_OFI_MSGBUFF_ERROR
+	 */
+	nccl_ofi_msgbuff_result_t replace(uint16_t msg_index, void *elem,
+					  nccl_ofi_msgbuff_elemtype_t type,
+					  nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+	/**
+	 * Retrieve message with given index
+	 *
+	 * @param msg_index sequence number of the message
+	 * @param elem output: pointer to element at msg_index
+	 * @param type output: type of element
+	 * @param msg_idx_status output: message status, if return value is INVALID_IDX
+	 *
+	 * @return NCCL_OFI_MSGBUFF_SUCCESS, NCCL_OFI_MSGBUFF_INVALID_IDX, or NCCL_OFI_MSGBUFF_ERROR
+	 */
+	nccl_ofi_msgbuff_result_t retrieve(uint16_t msg_index, void **elem,
+					   nccl_ofi_msgbuff_elemtype_t *type,
+					   nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+	/**
+	 * Mark message with given index as complete
+	 *
+	 * @param msg_index sequence number of the message
+	 * @param msg_idx_status output: message status, if return value is INVALID_IDX
+	 *
+	 * @return NCCL_OFI_MSGBUFF_SUCCESS, NCCL_OFI_MSGBUFF_INVALID_IDX, or NCCL_OFI_MSGBUFF_ERROR
+	 */
+	nccl_ofi_msgbuff_result_t complete(uint16_t msg_index,
+					   nccl_ofi_msgbuff_status_t *msg_idx_status);
+
+private:
+	uint16_t distance(uint16_t front, uint16_t back) const;
+	uint16_t num_inflight() const;
+	nccl_ofi_msgbuff_elem_t &buff_idx(uint16_t idx);
+	const nccl_ofi_msgbuff_elem_t &buff_idx(uint16_t idx) const;
+	nccl_ofi_msgbuff_status_t get_idx_status(uint16_t msg_index) const;
+
+	std::vector<nccl_ofi_msgbuff_elem_t> buff;
 	uint16_t max_inprogress;
-
-	/* Size of the range of all possible sequence numbers,
-	 * which depends on how many bits are used for them. */
 	uint16_t field_size;
-	/* Bit mask for the sequence numbers */
 	uint16_t field_mask;
-	// Points to the not-finished message with the lowest sequence number
 	uint16_t msg_last_incomplete;
-	// Points to the message after the inserted message with highest sequence number.
 	uint16_t msg_next;
-	// Mutex for this msg buffer -- locks all non-init operations
-	pthread_mutex_t lock;
-} nccl_ofi_msgbuff_t;
-
-/**
- * Allocates and initializes a new message buffer.
- * @param max_inprogress max number of INPROGRESS elements, which are backed by
- *                       the storage buffer
- * @param bit_width bit_width of the sequence numbers, which provides the range
- *                  of elements tracked by this msgbuff
- * @param start_seq start of sequence numbers
- *
- * @return a new msgbuff, or NULL if initialization failed
- */
-nccl_ofi_msgbuff_t *nccl_ofi_msgbuff_init(uint16_t max_inprogress, uint16_t bit_width, uint16_t start_seq);
-
-/**
- * Destroy a message buffer (free memory used by buffer).
- *
- * @return true if success, false if failed
- */
-bool nccl_ofi_msgbuff_destroy(nccl_ofi_msgbuff_t *msgbuff);
-
-/**
- * Insert a new message element
- *
- * @param elem, pointer to store at msg_index
- *   type, type of element
- *   msg_idx_status, output: message status, if return value is INVALID_IDX
- *
- * @return
- *  NCCL_OFI_MSGBUFF_SUCCESS, success
- *  NCCL_OFI_MSGBUFF_INVALID_IDX, invalid index. See msg_idx_status.
- *  NCCL_OFI_MSGBUFF_ERROR, other error
- */
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status);
-
-/**
- * Replace an existing message element
- *
- * @param elem, pointer to store at msg_index
- *   type, type of element
- *   msg_idx_status, output: message status, if return value is INVALID_IDX
- *
- * @return
- *  NCCL_OFI_MSGBUFF_SUCCESS, success
- *  NCCL_OFI_MSGBUFF_INVALID_IDX, invalid index. See msg_idx_status.
- *  NCCL_OFI_MSGBUFF_ERROR, other error
- */
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status);
-
-/**
- * Retrieve message with given index
- *
- * @param elem, output: pointer to element at msg_index
- *   type, output: type of element
- *   msg_idx_status, output: message status, if return value is INVALID_IDX
- *
- * @return
- *  NCCL_OFI_MSGBUFF_SUCCESS, success
- *  NCCL_OFI_MSGBUFF_INVALID_IDX, invalid index. See msg_idx_status.
- *  NCCL_OFI_MSGBUFF_ERROR, other error
- */
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void **elem, nccl_ofi_msgbuff_elemtype_t *type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status);
-
-/**
- * Mark message with given index as complete
- *
- * @param msg_idx_status, output: message status, if return value is INVALID_IDX
- *
- * @return
- *  NCCL_OFI_MSGBUFF_SUCCESS, success
- *  NCCL_OFI_MSGBUFF_INVALID_IDX, invalid index. See msg_idx_status.
- *  NCCL_OFI_MSGBUFF_ERROR, other error
- */
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, nccl_ofi_msgbuff_status_t *msg_idx_status);
+	std::mutex lock;
+};
 
 #endif // End NCCL_OFI_MSGBUFF_H_

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -680,7 +680,7 @@ public:
 
 	uint16_t next_msg_seq_num;
 
-	nccl_ofi_msgbuff_t *msgbuff;
+	nccl_ofi_msgbuff *msgbuff;
 
 	/* Free list to track control buffers, for sending RDMA control messages */
 	nccl_ofi_freelist *ctrl_buff_fl;

--- a/src/nccl_ofi_msgbuff.cpp
+++ b/src/nccl_ofi_msgbuff.cpp
@@ -4,126 +4,66 @@
 
 #include "config.h"
 
-#include <assert.h>
-#include <errno.h>
-#include <stdlib.h>
-#include <inttypes.h>
+#include <cassert>
+#include <cstdint>
+#include <stdexcept>
 
 #include "nccl_ofi_msgbuff.h"
 #include "nccl_ofi_log.h"
-#include "nccl_ofi_pthread.h"
 
-nccl_ofi_msgbuff_t *nccl_ofi_msgbuff_init(uint16_t max_inprogress, uint16_t bit_width, uint16_t start_seq)
+nccl_ofi_msgbuff::nccl_ofi_msgbuff(uint16_t max_inprogress_arg, uint16_t bit_width, uint16_t start_seq)
+	: buff(max_inprogress_arg),
+	  max_inprogress(max_inprogress_arg),
+	  field_size((uint16_t)(1 << bit_width)),
+	  field_mask((uint16_t)(1 << bit_width) - 1),
+	  msg_last_incomplete(start_seq),
+	  msg_next(start_seq)
 {
-	int ret;
-	nccl_ofi_msgbuff_t *msgbuff = NULL;
-
-	if (max_inprogress == 0 || (uint16_t)(1 << bit_width) <= 2 * max_inprogress) {
-		NCCL_OFI_WARN("Wrong parameters for msgbuff_init max_inprogress %" PRIu16 " bit_width %" PRIu16 "",
-			      max_inprogress, bit_width);
-		goto error;
+	if (this->max_inprogress == 0 || this->field_size <= 2 * this->max_inprogress) {
+		throw std::invalid_argument("Invalid msgbuff parameters: max_inprogress="
+			+ std::to_string(this->max_inprogress) + " bit_width=" + std::to_string(bit_width));
 	}
-
-	msgbuff = (nccl_ofi_msgbuff_t *)malloc(sizeof(nccl_ofi_msgbuff_t));
-	if (!msgbuff) {
-		NCCL_OFI_WARN("Memory allocation (msgbuff) failed");
-		goto error;
-	}
-
-	msgbuff->buff =
-		(nccl_ofi_msgbuff_elem_t *)malloc(sizeof(nccl_ofi_msgbuff_elem_t) * max_inprogress);
-	if (!msgbuff->buff) {
-		NCCL_OFI_WARN("Memory allocation (msgbuff->buff) failed");
-		goto error;
-	}
-
-	msgbuff->msg_last_incomplete = start_seq;
-	msgbuff->msg_next = start_seq;
-	msgbuff->field_size = (uint16_t)(1 << bit_width);
-	msgbuff->field_mask = (uint16_t)(1 << bit_width) - 1;
-	msgbuff->max_inprogress = max_inprogress;
-
-	ret = nccl_net_ofi_mutex_init(&msgbuff->lock, NULL);
-	if (ret != 0) {
-		NCCL_OFI_WARN("Mutex initialization failed: %s", strerror(ret));
-		goto error;
-	}
-
-	return msgbuff;
-
-error:
-	if (msgbuff) {
-		if (msgbuff->buff) {
-			free(msgbuff->buff);
-		}
-		free(msgbuff);
-	}
-	return NULL;
 }
 
-static inline uint16_t distance(const nccl_ofi_msgbuff_t *msgbuff, const uint16_t front, const uint16_t back)
+uint16_t nccl_ofi_msgbuff::distance(uint16_t front, uint16_t back) const
 {
-	return (front < back ? msgbuff->field_size : 0) + front - back;
+	return (front < back ? this->field_size : 0) + front - back;
 }
 
-bool nccl_ofi_msgbuff_destroy(nccl_ofi_msgbuff_t *msgbuff)
+uint16_t nccl_ofi_msgbuff::num_inflight() const
 {
-	if (!msgbuff) {
-		NCCL_OFI_WARN("msgbuff is NULL");
-		return false;
-	}
-	if (!msgbuff->buff) {
-		NCCL_OFI_WARN("msgbuff->buff is NULL");
-		return false;
-	}
-	free(msgbuff->buff);
-	nccl_net_ofi_mutex_destroy(&msgbuff->lock);
-	free(msgbuff);
-	return true;
+	return this->distance(this->msg_next, this->msg_last_incomplete);
 }
 
-static uint16_t nccl_ofi_msgbuff_num_inflight(const nccl_ofi_msgbuff_t *msgbuff) {
-	/**
-	 * Computes the "distance" between msg_last_incomplete and msg_next. This works
-	 * correctly even if msg_next is wrapped around and msg_last_incomplete has not.
-	 */
-	return distance(msgbuff, msgbuff->msg_next, msgbuff->msg_last_incomplete);
-}
-
-static inline nccl_ofi_msgbuff_elem_t *buff_idx(const nccl_ofi_msgbuff_t *msgbuff,
-                                                uint16_t idx)
+nccl_ofi_msgbuff_elem_t &nccl_ofi_msgbuff::buff_idx(uint16_t idx)
 {
-	return &msgbuff->buff[idx % msgbuff->max_inprogress];
+	return this->buff[idx % this->max_inprogress];
 }
 
-/**
- * Given a msg buffer and an index, returns message status
- * @return
- *  NCCL_OFI_MSGBUFF_COMPLETED
- *  NCCL_OFI_MSGBUFF_INPROGRESS
- *  NCCL_OFI_MSGBUFF_NOTSTARTED
- *  NCCL_OFI_MSGBUFF_UNAVAILABLE
- */
-static nccl_ofi_msgbuff_status_t nccl_ofi_msgbuff_get_idx_status
-		(const nccl_ofi_msgbuff_t *msgbuff, uint16_t msg_index)
+const nccl_ofi_msgbuff_elem_t &nccl_ofi_msgbuff::buff_idx(uint16_t idx) const
+{
+	return this->buff[idx % this->max_inprogress];
+}
+
+nccl_ofi_msgbuff_status_t nccl_ofi_msgbuff::get_idx_status(uint16_t msg_index) const
 {
 	/* Test for INPROGRESS: index is between msg_last_incomplete (inclusive) and msg_next
 	 * (exclusive) */
-	if (distance(msgbuff, msg_index, msgbuff->msg_last_incomplete) <
-	    distance(msgbuff, msgbuff->msg_next, msgbuff->msg_last_incomplete)) {
-		return buff_idx(msgbuff,msg_index)->stat;
+	if (this->distance(msg_index, this->msg_last_incomplete) <
+	    this->distance(this->msg_next, this->msg_last_incomplete)) {
+		return this->buff_idx(msg_index).stat;
 	}
 
 	/* Test for COMPLETED: index is within max_inprogress below msg_last_incomplete, including
 	 * wraparound */
-	if (msg_index != msgbuff->msg_last_incomplete &&
-	    distance(msgbuff, msgbuff->msg_last_incomplete, msg_index) <= msgbuff->max_inprogress) {
+	if (msg_index != this->msg_last_incomplete &&
+	    this->distance(this->msg_last_incomplete, msg_index) <= this->max_inprogress) {
 		return NCCL_OFI_MSGBUFF_COMPLETED;
 	}
 
 	/* Test for NOTSTARTED: index is >= msg_next and there is room in the buffer */
-	if (distance(msgbuff, msg_index, msgbuff->msg_next) <
-	    distance(msgbuff, msgbuff->max_inprogress, nccl_ofi_msgbuff_num_inflight(msgbuff))) {
+	if (this->distance(msg_index, this->msg_next) <
+	    this->distance(this->max_inprogress, this->num_inflight())) {
 		return NCCL_OFI_MSGBUFF_NOTSTARTED;
 	}
 
@@ -131,119 +71,96 @@ static nccl_ofi_msgbuff_status_t nccl_ofi_msgbuff_get_idx_status
 	return NCCL_OFI_MSGBUFF_UNAVAILABLE;
 }
 
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_insert(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status)
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff::insert(uint16_t msg_index, void *elem,
+						    nccl_ofi_msgbuff_elemtype_t type,
+						    nccl_ofi_msgbuff_status_t *msg_idx_status)
 {
-	assert(msgbuff);
+	std::lock_guard<std::mutex> guard(this->lock);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
-
-	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
-	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
+	*msg_idx_status = this->get_idx_status(msg_index);
 
 	if (*msg_idx_status == NCCL_OFI_MSGBUFF_NOTSTARTED) {
-		buff_idx(msgbuff, msg_index)->stat = NCCL_OFI_MSGBUFF_INPROGRESS;
-		buff_idx(msgbuff, msg_index)->elem = elem;
-		buff_idx(msgbuff, msg_index)->type = type;
+		this->buff_idx(msg_index).stat = NCCL_OFI_MSGBUFF_INPROGRESS;
+		this->buff_idx(msg_index).elem = elem;
+		this->buff_idx(msg_index).type = type;
 		/* Update msg_next ptr */
-		while (distance(msgbuff, msg_index, msgbuff->msg_next) <= msgbuff->max_inprogress) {
-			if (msgbuff->msg_next != msg_index) {
-				buff_idx(msgbuff, msgbuff->msg_next)->stat = NCCL_OFI_MSGBUFF_NOTSTARTED;
-				buff_idx(msgbuff, msgbuff->msg_next)->elem = NULL;
+		while (this->distance(msg_index, this->msg_next) <= this->max_inprogress) {
+			if (this->msg_next != msg_index) {
+				this->buff_idx(this->msg_next).stat = NCCL_OFI_MSGBUFF_NOTSTARTED;
+				this->buff_idx(this->msg_next).elem = NULL;
 			}
-			msgbuff->msg_next = (msgbuff->msg_next + 1) & msgbuff->field_mask;
+			this->msg_next = (this->msg_next + 1) & this->field_mask;
 		}
-		ret = NCCL_OFI_MSGBUFF_SUCCESS;
-	} else {
-		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
+		return NCCL_OFI_MSGBUFF_SUCCESS;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
-	return ret;
+	return NCCL_OFI_MSGBUFF_INVALID_IDX;
 }
 
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_replace(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void *elem, nccl_ofi_msgbuff_elemtype_t type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status)
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff::replace(uint16_t msg_index, void *elem,
+						     nccl_ofi_msgbuff_elemtype_t type,
+						     nccl_ofi_msgbuff_status_t *msg_idx_status)
 {
-	assert(msgbuff);
+	std::lock_guard<std::mutex> guard(this->lock);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
-
-	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
-	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
+	*msg_idx_status = this->get_idx_status(msg_index);
 
 	if (*msg_idx_status == NCCL_OFI_MSGBUFF_INPROGRESS) {
-		buff_idx(msgbuff, msg_index)->elem = elem;
-		buff_idx(msgbuff, msg_index)->type = type;
-		ret = NCCL_OFI_MSGBUFF_SUCCESS;
-	} else {
-		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
+		this->buff_idx(msg_index).elem = elem;
+		this->buff_idx(msg_index).type = type;
+		return NCCL_OFI_MSGBUFF_SUCCESS;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
-	return ret;
+	return NCCL_OFI_MSGBUFF_INVALID_IDX;
 }
 
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_retrieve(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, void **elem, nccl_ofi_msgbuff_elemtype_t *type,
-		nccl_ofi_msgbuff_status_t *msg_idx_status)
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff::retrieve(uint16_t msg_index, void **elem,
+						      nccl_ofi_msgbuff_elemtype_t *type,
+						      nccl_ofi_msgbuff_status_t *msg_idx_status)
 {
-	assert(msgbuff);
-
 	if (OFI_UNLIKELY(!elem)) {
 		NCCL_OFI_WARN("elem is NULL");
 		return NCCL_OFI_MSGBUFF_ERROR;
 	}
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
 
-	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
-	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
+	std::lock_guard<std::mutex> guard(this->lock);
+
+	*msg_idx_status = this->get_idx_status(msg_index);
 
 	if (*msg_idx_status == NCCL_OFI_MSGBUFF_INPROGRESS) {
-		*elem = buff_idx(msgbuff, msg_index)->elem;
-		*type = buff_idx(msgbuff, msg_index)->type;
-		ret = NCCL_OFI_MSGBUFF_SUCCESS;
-	} else  {
-		if (*msg_idx_status == NCCL_OFI_MSGBUFF_UNAVAILABLE) {
-			// UNAVAILABLE really only applies to insert, so return NOTSTARTED here
-			*msg_idx_status = NCCL_OFI_MSGBUFF_NOTSTARTED;
-		}
-		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
+		*elem = this->buff_idx(msg_index).elem;
+		*type = this->buff_idx(msg_index).type;
+		return NCCL_OFI_MSGBUFF_SUCCESS;
 	}
 
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
-	return ret;
+	if (*msg_idx_status == NCCL_OFI_MSGBUFF_UNAVAILABLE) {
+		/* UNAVAILABLE really only applies to insert, so return NOTSTARTED here */
+		*msg_idx_status = NCCL_OFI_MSGBUFF_NOTSTARTED;
+	}
+	return NCCL_OFI_MSGBUFF_INVALID_IDX;
 }
 
-nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff_complete(nccl_ofi_msgbuff_t *msgbuff,
-		uint16_t msg_index, nccl_ofi_msgbuff_status_t *msg_idx_status)
+nccl_ofi_msgbuff_result_t nccl_ofi_msgbuff::complete(uint16_t msg_index,
+						     nccl_ofi_msgbuff_status_t *msg_idx_status)
 {
-	assert(msgbuff);
+	std::lock_guard<std::mutex> guard(this->lock);
 
-	nccl_net_ofi_mutex_lock(&msgbuff->lock);
-
-	*msg_idx_status = nccl_ofi_msgbuff_get_idx_status(msgbuff, msg_index);
-	nccl_ofi_msgbuff_result_t ret = NCCL_OFI_MSGBUFF_ERROR;
+	*msg_idx_status = this->get_idx_status(msg_index);
 
 	if (*msg_idx_status == NCCL_OFI_MSGBUFF_INPROGRESS) {
-		buff_idx(msgbuff, msg_index)->stat = NCCL_OFI_MSGBUFF_COMPLETED;
-		buff_idx(msgbuff, msg_index)->elem = NULL;
+		this->buff_idx(msg_index).stat = NCCL_OFI_MSGBUFF_COMPLETED;
+		this->buff_idx(msg_index).elem = NULL;
 		/* Move up tail msg_last_incomplete ptr */
-		while (msgbuff->msg_last_incomplete != msgbuff->msg_next &&
-				buff_idx(msgbuff, msgbuff->msg_last_incomplete)->stat == NCCL_OFI_MSGBUFF_COMPLETED)
-		{
-			msgbuff->msg_last_incomplete = (msgbuff->msg_last_incomplete + 1) & msgbuff->field_mask;
+		while (this->msg_last_incomplete != this->msg_next &&
+		       this->buff_idx(this->msg_last_incomplete).stat == NCCL_OFI_MSGBUFF_COMPLETED) {
+			this->msg_last_incomplete = (this->msg_last_incomplete + 1) & this->field_mask;
 		}
-		ret = NCCL_OFI_MSGBUFF_SUCCESS;
-	} else {
-		if (*msg_idx_status == NCCL_OFI_MSGBUFF_UNAVAILABLE) {
-			// UNAVAILABLE really only applies to insert, so return NOTSTARTED here
-			*msg_idx_status = NCCL_OFI_MSGBUFF_NOTSTARTED;
-		}
-		ret = NCCL_OFI_MSGBUFF_INVALID_IDX;
+		return NCCL_OFI_MSGBUFF_SUCCESS;
 	}
-	nccl_net_ofi_mutex_unlock(&msgbuff->lock);
-	return ret;
+
+	if (*msg_idx_status == NCCL_OFI_MSGBUFF_UNAVAILABLE) {
+		/* UNAVAILABLE really only applies to insert, so return NOTSTARTED here */
+		*msg_idx_status = NCCL_OFI_MSGBUFF_NOTSTARTED;
+	}
+	return NCCL_OFI_MSGBUFF_INVALID_IDX;
 }

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -853,7 +853,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 	}
 
 	nccl_ofi_msgbuff_status_t stat;
-	nccl_ofi_msgbuff_result_t mb_res = nccl_ofi_msgbuff_insert(r_comm->msgbuff, msg_seq_num,
+	nccl_ofi_msgbuff_result_t mb_res = r_comm->msgbuff->insert(msg_seq_num,
 		rx_buff_req, NCCL_OFI_MSGBUFF_BUFF, &stat);
 
 	if (mb_res == NCCL_OFI_MSGBUFF_SUCCESS) {
@@ -874,7 +874,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 	// In this case, there is already a req entry here. Initiate eager copy.
 	void *elem;
 	nccl_ofi_msgbuff_elemtype_t type;
-	mb_res = nccl_ofi_msgbuff_retrieve(r_comm->msgbuff, msg_seq_num, &elem, &type, &stat);
+	mb_res = r_comm->msgbuff->retrieve( msg_seq_num, &elem, &type, &stat);
 	if (OFI_UNLIKELY(mb_res != NCCL_OFI_MSGBUFF_SUCCESS || type != NCCL_OFI_MSGBUFF_REQ)) {
 		NCCL_OFI_WARN("Invalid message retrieval result for msg %hu", msg_seq_num);
 		return -EINVAL;
@@ -1047,7 +1047,7 @@ static inline nccl_net_ofi_rdma_req *get_req_from_imm_data
 	nccl_ofi_msgbuff_elemtype_t type;
 	nccl_ofi_msgbuff_status_t stat;
 
-	nccl_ofi_msgbuff_result_t mb_res = nccl_ofi_msgbuff_retrieve(r_comm->msgbuff,
+	nccl_ofi_msgbuff_result_t mb_res = r_comm->msgbuff->retrieve(
 		msg_seq_num, &elem, &type, &stat);
 	if (OFI_UNLIKELY(mb_res != NCCL_OFI_MSGBUFF_SUCCESS)) {
 		/* Unexpected: we don't have a msgbuff entry corresponding to this message*/
@@ -2424,10 +2424,10 @@ int nccl_net_ofi_rdma_req::test(int *done, int *size_p)
 
 		if (this->type == NCCL_OFI_RDMA_RECV) {
 			/* Mark as complete in message buffer */
-			nccl_ofi_msgbuff_t *msgbuff = ((nccl_net_ofi_rdma_recv_comm *)base_comm)->msgbuff;
+			nccl_ofi_msgbuff *msgbuff = ((nccl_net_ofi_rdma_recv_comm *)base_comm)->msgbuff;
 
 			nccl_ofi_msgbuff_status_t stat;
-			nccl_ofi_msgbuff_result_t mb_res = nccl_ofi_msgbuff_complete(msgbuff, this->msg_seq_num, &stat);
+			nccl_ofi_msgbuff_result_t mb_res = msgbuff->complete(this->msg_seq_num, &stat);
 			if (OFI_UNLIKELY(mb_res != NCCL_OFI_MSGBUFF_SUCCESS)) {
 				NCCL_OFI_WARN("Invalid result of msgbuff_complete for msg %hu", this->msg_seq_num);
 				ret = -EINVAL;
@@ -2940,7 +2940,7 @@ static inline int insert_rdma_recv_req_into_msgbuff(nccl_net_ofi_rdma_recv_comm 
 		 * There is already a buffer entry in the message buffer, so
 		 * replace it with a request.
 		 */
-		mb_res = nccl_ofi_msgbuff_replace(r_comm->msgbuff,
+		mb_res = r_comm->msgbuff->replace(
 					req->msg_seq_num, req,
 					NCCL_OFI_MSGBUFF_REQ,
 					&msg_stat);
@@ -2951,7 +2951,7 @@ static inline int insert_rdma_recv_req_into_msgbuff(nccl_net_ofi_rdma_recv_comm 
 		}
 	} else {
 		/* Try inserting the new request */
-		mb_res = nccl_ofi_msgbuff_insert(r_comm->msgbuff, req->msg_seq_num, req,
+		mb_res = r_comm->msgbuff->insert( req->msg_seq_num, req,
 						 NCCL_OFI_MSGBUFF_REQ, &msg_stat);
 
 		if (OFI_UNLIKELY((mb_res == NCCL_OFI_MSGBUFF_INVALID_IDX) &&
@@ -3065,7 +3065,7 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 	nccl_ofi_msgbuff_status_t msg_stat;
 	nccl_ofi_msgbuff_result_t mb_res;
 
-	mb_res = nccl_ofi_msgbuff_retrieve(this->msgbuff, msg_seq_num, &elem,
+	mb_res = this->msgbuff->retrieve( msg_seq_num, &elem,
 					   &elem_type, &msg_stat);
 	if (mb_res == NCCL_OFI_MSGBUFF_SUCCESS) {
 
@@ -3400,11 +3400,7 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm *r_comm)
 	delete r_comm->flush_buff_fl;
 	delete r_comm->nccl_ofi_reqs_fl;
 
-	if (!nccl_ofi_msgbuff_destroy(r_comm->msgbuff)) {
-		NCCL_OFI_WARN("Failed to destroy msgbuff (r_comm)");
-		ret = -EINVAL;
-		return ret;
-	}
+	delete r_comm->msgbuff;
 
 	/* Destroy domain */
 #if HAVE_NVTX_TRACING
@@ -4371,10 +4367,11 @@ static nccl_net_ofi_rdma_recv_comm *prepare_recv_comm(nccl_net_ofi_rdma_domain_t
 							 true);
 
 	/* Allocate message buffer with initial sequence number NCCL_OFI_RDMA_MSG_SEQ_NUM_START */
-	r_comm->msgbuff = nccl_ofi_msgbuff_init(NCCL_OFI_RDMA_MSGBUFF_SIZE, NCCL_OFI_RDMA_SEQ_BITS,
-						NCCL_OFI_RDMA_MSG_SEQ_NUM_START);
-	if (!r_comm->msgbuff) {
-		NCCL_OFI_WARN("Failed to allocate and initialize message buffer");
+	try {
+		r_comm->msgbuff = new nccl_ofi_msgbuff(NCCL_OFI_RDMA_MSGBUFF_SIZE, NCCL_OFI_RDMA_SEQ_BITS,
+						       NCCL_OFI_RDMA_MSG_SEQ_NUM_START);
+	} catch (const std::exception &e) {
+		NCCL_OFI_WARN("Failed to allocate and initialize message buffer: %s", e.what());
 		delete r_comm;
 		return NULL;
 	}
@@ -4416,7 +4413,7 @@ static nccl_net_ofi_rdma_recv_comm *prepare_recv_comm(nccl_net_ofi_rdma_domain_t
 		if (r_comm->nccl_ofi_reqs_fl)
 			delete r_comm->nccl_ofi_reqs_fl;
 		if (r_comm->msgbuff)
-			nccl_ofi_msgbuff_destroy(r_comm->msgbuff);
+			delete r_comm->msgbuff;
 		if (COMM_ID_INVALID != r_comm->local_comm_id) {
 			device->comm_idpool.free_id(r_comm->local_comm_id);
 		}

--- a/tests/unit/msgbuff.cpp
+++ b/tests/unit/msgbuff.cpp
@@ -31,9 +31,11 @@ int main(int argc, char *argv[])
 		buff_store[i] = i;
 	}
 
-	nccl_ofi_msgbuff_t *msgbuff;
-	if (!(msgbuff = nccl_ofi_msgbuff_init(max_inprogress, num_msg_seq_num_bits, 0))) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_init failed");
+	nccl_ofi_msgbuff *msgbuff;
+	try {
+		msgbuff = new nccl_ofi_msgbuff(max_inprogress, num_msg_seq_num_bits, 0);
+	} catch (const std::exception &e) {
+		NCCL_OFI_WARN("nccl_ofi_msgbuff construction failed: %s", e.what());
 		return 1;
 	}
 
@@ -45,73 +47,73 @@ int main(int argc, char *argv[])
 	for (int rounds = 0; rounds < 4; rounds++) {
 		/** Test insert new **/
 		for (uint16_t i = 0; i < max_inprogress; ++i) {
-			if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + i) % field_size, &buff_store[i], type,
-						    &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
-				NCCL_OFI_WARN("nccl_ofi_msgbuff_insert failed when non-full");
+			if (msgbuff->insert((msg_seq_num + i) % field_size, &buff_store[i], type,
+					    &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+				NCCL_OFI_WARN("msgbuff->insert failed when non-full");
 				return 1;
 			}
 		}
 
-		if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + max_inprogress) % field_size, NULL, type, &stat) !=
+		if (msgbuff->insert((msg_seq_num + max_inprogress) % field_size, NULL, type, &stat) !=
 			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_UNAVAILABLE) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return unavailable when full");
+			NCCL_OFI_WARN("msgbuff->insert did not return unavailable when full");
 			return 1;
 		}
 
-		if (nccl_ofi_msgbuff_insert(msgbuff, (msg_seq_num + max_inprogress - 1) % field_size, NULL, type,
-					    &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		if (msgbuff->insert((msg_seq_num + max_inprogress - 1) % field_size, NULL, type,
+				    &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_INPROGRESS) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_insert did not return inprogress on duplicate insert");
+			NCCL_OFI_WARN("msgbuff->insert did not return inprogress on duplicate insert");
 			return 1;
 		}
 
 		/** Test retrieve **/
 		for (uint16_t i = 0; i < max_inprogress; ++i) {
-			if (nccl_ofi_msgbuff_retrieve(msgbuff, (msg_seq_num + i) % field_size, (void **)&result, &type,
-						      &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
-				NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve failed on valid index");
+			if (msgbuff->retrieve((msg_seq_num + i) % field_size, (void **)&result, &type,
+					      &stat) != NCCL_OFI_MSGBUFF_SUCCESS) {
+				NCCL_OFI_WARN("msgbuff->retrieve failed on valid index");
 				return 1;
 			}
 			if (*result != buff_store[i]) {
-				NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve returned incorrect value");
+				NCCL_OFI_WARN("msgbuff->retrieve returned incorrect value");
 				return 1;
 			}
 		}
 
-		if (nccl_ofi_msgbuff_retrieve(msgbuff, (msg_seq_num + max_inprogress) % field_size, (void **)&result,
-					      &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		if (msgbuff->retrieve((msg_seq_num + max_inprogress) % field_size, (void **)&result,
+				      &type, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return notstarted");
+			NCCL_OFI_WARN("msgbuff->retrieve did not return notstarted");
 			return 1;
 		}
 
-		if (nccl_ofi_msgbuff_retrieve(msgbuff, last_completed, (void **)&result, &type, &stat) !=
+		if (msgbuff->retrieve(last_completed, (void **)&result, &type, &stat) !=
 			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_COMPLETED) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_retrieve did not return completed");
+			NCCL_OFI_WARN("msgbuff->retrieve did not return completed");
 			return 1;
 		}
 
 		/** Test complete **/
 		for (uint16_t i = 0; i < max_inprogress; ++i) {
-			if (nccl_ofi_msgbuff_complete(msgbuff, (msg_seq_num + i) % field_size, &stat) !=
+			if (msgbuff->complete((msg_seq_num + i) % field_size, &stat) !=
 			    NCCL_OFI_MSGBUFF_SUCCESS) {
-				NCCL_OFI_WARN("nccl_ofi_msgbuff_complete failed");
+				NCCL_OFI_WARN("msgbuff->complete failed");
 				return 1;
 			}
 		}
 
-		if (nccl_ofi_msgbuff_complete(msgbuff, (msg_seq_num + max_inprogress) % field_size, &stat) !=
+		if (msgbuff->complete((msg_seq_num + max_inprogress) % field_size, &stat) !=
 			    NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_NOTSTARTED) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return notstarted");
+			NCCL_OFI_WARN("msgbuff->complete did not return notstarted");
 			return 1;
 		}
 
-		if (nccl_ofi_msgbuff_complete(msgbuff, msg_seq_num, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
+		if (msgbuff->complete(msg_seq_num, &stat) != NCCL_OFI_MSGBUFF_INVALID_IDX ||
 		    stat != NCCL_OFI_MSGBUFF_COMPLETED) {
-			NCCL_OFI_WARN("nccl_ofi_msgbuff_complete did not return completed");
+			NCCL_OFI_WARN("msgbuff->complete did not return completed");
 			return 1;
 		}
 
@@ -119,10 +121,7 @@ int main(int argc, char *argv[])
 		msg_seq_num = (msg_seq_num + max_inprogress) % field_size;
 	}
 
-	if (!nccl_ofi_msgbuff_destroy(msgbuff)) {
-		NCCL_OFI_WARN("nccl_ofi_msgbuff_destroy failed");
-		return 1;
-	}
+	delete msgbuff;
 
 	free(buff_store);
 


### PR DESCRIPTION
*Description of changes:*

Convert nccl_ofi_msgbuff_t from a typedef struct with free functions to a proper C++ class nccl_ofi_msgbuff.

- Constructor replaces nccl_ofi_msgbuff_init(), throws on invalid parameters instead of returning NULL
- Default destructor replaces nccl_ofi_msgbuff_destroy(), vector member handles buffer deallocation automatically
- Four free functions converted to public methods: insert(), replace(), retrieve(), complete()
- Four static helpers converted to private methods: distance(), num_inflight(), buff_idx(), get_idx_status()
- Internal buffer changed from malloc'd array to std::vector
- pthread_mutex_t replaced with std::mutex and std::lock_guard
- Simplified control flow with early returns instead of goto-unlock
- Updated all call sites in nccl_ofi_rdma.cpp and unit test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
