### PR TITLE
Retry DMA-BUF flush buffer registration with default mapping

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -58,7 +58,8 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size);
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset,
+				    bool force_default_path = false);
 
 /*
  * @brief	query CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED

--- a/include/nccl_ofi_rocm.h
+++ b/include/nccl_ofi_rocm.h
@@ -57,7 +57,8 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size);
  * @return	0 on success
  *		-1 on error
  */
-int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset,
+				    bool force_default_path = false);
 
 bool nccl_net_ofi_gpu_have_dma_buf_attr(void);
 bool nccl_net_ofi_gpu_have_gdr_support_attr(void);

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -218,7 +218,8 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset,
+				    bool force_default_path)
 {
 #if HAVE_CUDA_DMABUF_SUPPORT
 	unsigned long long flags = 0;
@@ -227,7 +228,9 @@ int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int 
 	assert(NCCL_OFI_IS_ALIGNED(aligned_size, system_page_size));
 
 # if HAVE_CUDA_DMABUF_MAPPING_TYPE_PCIE
-	flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+	if (!force_default_path) {
+		flags = CU_MEM_RANGE_FLAG_DMA_BUF_MAPPING_TYPE_PCIE;
+	}
 # endif
 
 	CUresult ret = pfn_cuMemGetHandleForAddressRange(fd, (uintptr_t)aligned_ptr, aligned_size,

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -3316,9 +3316,6 @@ int nccl_net_ofi_rdma_domain_t::alloc_and_reg_flush_buff(int dev_id)
 		size_t offset = 0;
 		int fd;
 
-		/*
-		* Retrieve the fd and offset and the aligned ptr used for dma buf
-		*/
 		ret = nccl_net_ofi_gpu_get_dma_buf_fd(this->flush_buff.buffer, system_page_size, &fd, &offset);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Unable to retrieve flush buffer fd (%d)", ret);
@@ -3330,6 +3327,28 @@ int nccl_net_ofi_rdma_domain_t::alloc_and_reg_flush_buff(int dev_id)
 		ret = this->reg_internal_mr_dma_buf(this->flush_buff.buffer, fd, offset, system_page_size,
 						NCCL_PTR_CUDA, &mr_handle);
 		close(fd);
+
+		/*
+		 * If registration failed, the DMA-BUF fd may have been
+		 * exported with FORCE_PCIE mapping which the kernel
+		 * rejected. Retry with a DEFAULT mapping fd (flags=0),
+		 * mirroring NCCL GIN fallback in gdakiRegMrDmaBuf().
+		 */
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+				      "DMA-BUF flush buffer registration failed (%d), "
+				      "retrying with default mapping", ret);
+			ret = nccl_net_ofi_gpu_get_dma_buf_fd(this->flush_buff.buffer,
+							      system_page_size, &fd, &offset, true);
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_WARN("Unable to retrieve flush buffer fd "
+					      "with default mapping (%d)", ret);
+				return ret;
+			}
+			ret = this->reg_internal_mr_dma_buf(this->flush_buff.buffer, fd, offset,
+							    system_page_size, NCCL_PTR_CUDA, &mr_handle);
+			close(fd);
+		}
 	} else {
 		ret = this->reg_internal_mr(this->flush_buff.buffer, system_page_size, NCCL_PTR_CUDA, &mr_handle);
 	}

--- a/src/nccl_ofi_rocm.cpp
+++ b/src/nccl_ofi_rocm.cpp
@@ -126,7 +126,8 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 	return ret == hipSuccess ? 0 : -EINVAL;
 }
 
-int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset)
+int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset,
+				    bool force_default_path)
 {
 #if HAVE_DECL_HIPMEMRANGEHANDLETYPEDMABUFFD
 	hipError_t ret = hipMemGetHandleForAddressRange(fd, (hipDeviceptr_t)aligned_ptr, aligned_size,


### PR DESCRIPTION
*Description of changes:*

The RDMA flush buffer DMA-BUF registration may fail on some platforms
when using FORCE_PCIE mapping. Add a fallback that retries with
DEFAULT mapping (flags=0), mirroring NCCL GIN fallback logic in
gdakiRegMrDmaBuf().

Add a force_default_path parameter to nccl_net_ofi_gpu_get_dma_buf_fd
so the retry can request a DEFAULT mapping fd.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
