### PR TITLE
Separating files for GIN refactor

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -9,11 +9,11 @@ noinst_HEADERS = \
 	cm/nccl_ofi_cm_resources.h \
 	cm/nccl_ofi_cm_types.h \
 	cm/nccl_ofi_cm.h \
-	gin/nccl_ofi_gin.h \
-	gin/nccl_ofi_gin_allgather.h \
-	gin/nccl_ofi_gin_reqs.h \
-	gin/nccl_ofi_gin_resources.h \
-	gin/nccl_ofi_gin_types.h \
+	rdma/gin/nccl_ofi_gin.h \
+	rdma/gin/nccl_ofi_gin_allgather.h \
+	rdma/gin/nccl_ofi_gin_reqs.h \
+	rdma/gin/nccl_ofi_gin_resources.h \
+	rdma/gin/nccl_ofi_gin_types.h \
 	nccl_ofi_gin_base.h \
 	nccl_ofi.h \
 	nccl_ofi_api.h \

--- a/include/nccl_ofi_gin_base.h
+++ b/include/nccl_ofi_gin_base.h
@@ -6,6 +6,17 @@
 #define NCCL_OFI_GIN_BASE_H_
 
 #include <cassert>
+#include <cstddef>
+#include <cstdint>
+
+struct nccl_ofi_mr_ckey;
+typedef struct nccl_ofi_mr_ckey const *const nccl_ofi_mr_ckey_ref;
+struct nccl_net_ofi_conn_handle;
+typedef struct nccl_net_ofi_conn_handle nccl_net_ofi_conn_handle_t;
+
+class nccl_ofi_gin_put_comm_t;
+class nccl_ofi_gin_symm_mr_handle_t;
+class nccl_ofi_gin_req_t;
 
 /**
  * Abstract GIN endpoint base class.
@@ -38,19 +49,43 @@ public:
 };
 
 /**
- * Abstract GIN listen communicator.
+ * Abstract GIN listen communicator. Created during connection setup,
+ * produces a put_comm via connect().
  */
 class nccl_ofi_gin_listen_comm_t {
 public:
 	virtual ~nccl_ofi_gin_listen_comm_t() = default;
+
+	virtual int connect(nccl_net_ofi_conn_handle_t *handles[],
+			    int nranks, int rank,
+			    nccl_ofi_gin_put_comm_t **put_comm_out) = 0;
 };
 
 /**
- * Abstract GIN put communicator.
+ * Abstract GIN put communicator. Provides data transfer
+ * and MR operations.
  */
 class nccl_ofi_gin_put_comm_t {
 public:
 	virtual ~nccl_ofi_gin_put_comm_t() = default;
+
+	virtual int regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey,
+				   void *data_ptr, size_t size,
+				   int type, uint64_t mrFlags,
+				   nccl_ofi_gin_symm_mr_handle_t **mr_handle_out) = 0;
+
+	virtual int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) = 0;
+
+	virtual int iputSignal(uint64_t srcOff,
+			       nccl_ofi_gin_symm_mr_handle_t *srcMhandle,
+			       size_t size, uint64_t dstOff,
+			       nccl_ofi_gin_symm_mr_handle_t *dstMhandle,
+			       uint32_t rank, uint64_t signalOff,
+			       nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
+			       uint64_t signalValue, uint32_t signalOp,
+			       nccl_ofi_gin_req_t **request) = 0;
+
+	virtual int await_pending_requests() = 0;
 };
 
 #endif /* NCCL_OFI_GIN_BASE_H_ */

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -27,19 +27,19 @@ inline nccl_ofi_device_copy &get_device_copy()
  * The listen communicator which implements GIN API's nccl_ofi_gin_listen() and
  * nccl_ofi_gin_connect() functionality
  */
-class nccl_ofi_gin_listen_comm : public nccl_ofi_gin_listen_comm_t {
+class nccl_ofi_rdma_gin_listen_comm : public nccl_ofi_gin_listen_comm_t {
 private:
 	nccl_net_ofi_ep_t *ep;
 	nccl_net_ofi_listen_comm *l_comm;
 
 public:
-	nccl_ofi_gin_listen_comm(int dev_arg, nccl_net_ofi_ep_t *ep_arg,
+	nccl_ofi_rdma_gin_listen_comm(int dev_arg, nccl_net_ofi_ep_t *ep_arg,
 				 nccl_net_ofi_listen_comm *l_comm_arg)
 	    : ep(ep_arg), l_comm(l_comm_arg)
 	{
 	}
 
-	~nccl_ofi_gin_listen_comm()
+	~nccl_ofi_rdma_gin_listen_comm()
 	{
 		int ret = l_comm->close();
 		if (ret != 0) {
@@ -48,7 +48,7 @@ public:
 	}
 
 	int connect(nccl_net_ofi_conn_handle_t *handles[], int nranks, int rank,
-		    nccl_ofi_gin_comm **gin_comm_out);
+		    nccl_ofi_rdma_gin_put_comm **gin_comm_out);
 };
 
 /**
@@ -142,7 +142,7 @@ struct gin_remote_mr {
  * A symmetric memory registration handle. This is the result of GIN API's
  * regMrSym() family of functions.
  */
-struct gin_sym_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
+struct nccl_ofi_rdma_gin_symm_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 	/* Address provided by NCCL to regMrSym. This is the base for the offset
 	   provided by NCCL */
 	void *input_address;
@@ -162,12 +162,12 @@ struct gin_sym_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 /**
  * This represents the main GIN communicator
  */
-class nccl_ofi_gin_comm : public nccl_ofi_gin_put_comm_t {
+class nccl_ofi_rdma_gin_put_comm : public nccl_ofi_gin_put_comm_t {
 public:
-	nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
+	nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
 			  nccl_net_ofi_send_comm *s_comm_, nccl_net_ofi_recv_comm *r_comm_);
 
-	~nccl_ofi_gin_comm();
+	~nccl_ofi_rdma_gin_put_comm();
 
 	nccl_ofi_gin_resources &get_resources()
 	{
@@ -198,9 +198,9 @@ public:
 	 * @return: 0 on success, non-zero on failure
 	 */
 	int regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
-			   uint64_t mrFlags, gin_sym_mr_handle **mr_handle_out);
+			   uint64_t mrFlags, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out);
 
-	int deregMrSym(gin_sym_mr_handle *mr_handle);
+	int deregMrSym(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle);
 
 	void increment_outstanding_ack_counter()
 	{
@@ -259,10 +259,10 @@ public:
 	 *
 	 * @return: 0 on success, non-zero on failure
 	 */
-	int iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle, size_t size, uint64_t dstOff,
-		       gin_sym_mr_handle *dstMhandle, uint32_t rank, uint64_t signalOff,
-		       gin_sym_mr_handle *signalMhandle, uint64_t signalValue, uint32_t signalOp,
-		       nccl_net_ofi_gin_iputsignal_req_t **request);
+	int iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_symm_mr_handle *srcMhandle, size_t size, uint64_t dstOff,
+		       nccl_ofi_rdma_gin_symm_mr_handle *dstMhandle, uint32_t rank, uint64_t signalOff,
+		       nccl_ofi_rdma_gin_symm_mr_handle *signalMhandle, uint64_t signalValue, uint32_t signalOp,
+		       nccl_ofi_rdma_gin_iputsignal_req **request);
 
 	/**
 	 * Callback for metadata completion.
@@ -333,7 +333,7 @@ private:
 
 	   TODO: we could also just pass this in the handle to avoid a map
 	   lookup. Not sure yet if that is the right thing to do. */
-	std::unordered_map<void *, gin_sym_mr_handle *> mr_handle_map;
+	std::unordered_map<void *, nccl_ofi_rdma_gin_symm_mr_handle *> mr_handle_map;
 
 	/* Number of outstanding RDMA writes for signal delivery acknowledgement
 	   Used to wait for remaining acknowledgements on communicator close. */
@@ -352,7 +352,7 @@ private:
 	 * @param ack_seq_num last (highest) sequence number in the acknowledged range
 	 * @param count number of seq_nums in the acknowledged range
 	 */
-	int send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
+	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
 		     uint32_t ack_seq_num, uint32_t count);
 
 	/**
@@ -370,7 +370,7 @@ private:
 	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num);
 	int iput_signal_deliver_all(uint32_t peer_rank);
 
-	friend class nccl_ofi_gin_listen_comm;
+	friend class nccl_ofi_rdma_gin_listen_comm;
 
 public:
 	/* NVTX tracing support - public for macro access (parallel to RDMA struct pattern) */

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -2,12 +2,12 @@
  * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef NCCL_OFI_GIN_H
-#define NCCL_OFI_GIN_H
+#ifndef NCCL_OFI_RDMA_GIN_H
+#define NCCL_OFI_RDMA_GIN_H
 
-#include "gin/nccl_ofi_gin_allgather.h"
-#include "gin/nccl_ofi_gin_resources.h"
-#include "gin/nccl_ofi_gin_types.h"
+#include "rdma/gin/nccl_ofi_gin_allgather.h"
+#include "rdma/gin/nccl_ofi_gin_resources.h"
+#include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi_dlist.h"
 
 #include "nccl_ofi.h"

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -48,7 +48,7 @@ public:
 	}
 
 	int connect(nccl_net_ofi_conn_handle_t *handles[], int nranks, int rank,
-		    nccl_ofi_rdma_gin_put_comm **gin_comm_out);
+		    nccl_ofi_gin_put_comm_t **gin_comm_out) override;
 };
 
 /**
@@ -198,9 +198,9 @@ public:
 	 * @return: 0 on success, non-zero on failure
 	 */
 	int regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
-			   uint64_t mrFlags, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out);
+			   uint64_t mrFlags, nccl_ofi_gin_symm_mr_handle_t **mr_handle_out) override;
 
-	int deregMrSym(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle);
+	int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) override;
 
 	void increment_outstanding_ack_counter()
 	{
@@ -233,7 +233,7 @@ public:
 
 	/* Wait for any outstanding requests as necessary. Should be called before
 	   the GIN comm is destructed. */
-	int await_pending_requests();
+	int await_pending_requests() override;
 
 	/* Flush bundled acks that were not sent with metadata. Called from progress. */
 	int flush_stale_acks();
@@ -259,10 +259,10 @@ public:
 	 *
 	 * @return: 0 on success, non-zero on failure
 	 */
-	int iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_symm_mr_handle *srcMhandle, size_t size, uint64_t dstOff,
-		       nccl_ofi_rdma_gin_symm_mr_handle *dstMhandle, uint32_t rank, uint64_t signalOff,
-		       nccl_ofi_rdma_gin_symm_mr_handle *signalMhandle, uint64_t signalValue, uint32_t signalOp,
-		       nccl_ofi_rdma_gin_iputsignal_req **request);
+	int iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size, uint64_t dstOff,
+		       nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t rank, uint64_t signalOff,
+		       nccl_ofi_gin_symm_mr_handle_t *signalMhandle, uint64_t signalValue, uint32_t signalOp,
+		       nccl_ofi_gin_req_t **request) override;
 
 	/**
 	 * Callback for metadata completion.

--- a/include/rdma/gin/nccl_ofi_gin_allgather.h
+++ b/include/rdma/gin/nccl_ofi_gin_allgather.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef NCCL_OFI_GIN_ALLGATHER_H
-#define NCCL_OFI_GIN_ALLGATHER_H
+#ifndef NCCL_OFI_RDMA_GIN_ALLGATHER_H
+#define NCCL_OFI_RDMA_GIN_ALLGATHER_H
 
 #include "nccl_ofi.h"
 
@@ -38,4 +38,4 @@ public:
 	int all_gather(void *data, size_t size);
 };
 
-#endif /* NCCL_OFI_GIN_ALLGATHER_H */
+#endif /* NCCL_OFI_RDMA_GIN_ALLGATHER_H */

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -159,7 +159,7 @@ public:
 	int handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/, fi_addr_t /*src_addr*/,
 			    uint16_t /*rail_id*/) override;
 
-	nccl_net_ofi_gin_sendack_req_t(nccl_ofi_gin_comm &gin_comm_arg, fid_ep *ep_arg,
+	nccl_net_ofi_gin_sendack_req_t(nccl_ofi_rdma_gin_put_comm &gin_comm_arg, fid_ep *ep_arg,
 					int rail_id_arg,
 					nccl_ofi_freelist::fl_entry *ack_elem_arg,
 					fi_addr_t remote_addr_arg,
@@ -175,7 +175,7 @@ public:
 	virtual ~nccl_net_ofi_gin_sendack_req_t() override;
 
 private:
-	nccl_ofi_gin_comm &gin_comm;
+	nccl_ofi_rdma_gin_put_comm &gin_comm;
 	struct fid_ep *ep;
 	int rail_id;
 	nccl_ofi_freelist::fl_entry *ack_elem;
@@ -189,10 +189,10 @@ class nccl_net_ofi_gin_metadata_send_req_t;
 /**
  * Represents an in-progress iputSignal operation on the initiator side
  */
-class nccl_net_ofi_gin_iputsignal_req_t : public nccl_net_ofi_gin_base_req {
+class nccl_ofi_rdma_gin_iputsignal_req : public nccl_net_ofi_gin_base_req {
 public:
-	nccl_net_ofi_gin_iputsignal_req_t(
-		nccl_ofi_gin_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg,
+	nccl_ofi_rdma_gin_iputsignal_req(
+		nccl_ofi_rdma_gin_put_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg,
 		std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs_arg,
 		nccl_net_ofi_gin_metadata_send_req_t *send_req_arg,
 		bool is_ack_requested_arg)
@@ -216,7 +216,7 @@ public:
 
 private:
 	/* Associated Comm object */
-	nccl_ofi_gin_comm &gin_comm;
+	nccl_ofi_rdma_gin_put_comm &gin_comm;
 
 	uint32_t peer_rank;
 	/* Message sequence number */
@@ -232,7 +232,7 @@ private:
  * Freed when the signal is delivered.
  *
  * All members are private, because this class is only used by
- * nccl_ofi_gin_comm. That class is added as a friend.
+ * nccl_ofi_rdma_gin_put_comm. That class is added as a friend.
  */
 class nccl_net_ofi_gin_iputsignal_recv_req : public nccl_net_ofi_gin_base_req {
 	/* NVTX tracing support - public for macro access */
@@ -272,7 +272,7 @@ private:
 	/* This request structure doesn't have any use outside of gin_comm.
 	   So, instead of adding a bunch of getters/setters, just add a
 	   friend class. */
-	friend class nccl_ofi_gin_comm;
+	friend class nccl_ofi_rdma_gin_put_comm;
 };
 
 /**
@@ -392,7 +392,7 @@ private:
 	nccl_net_ofi_gin_base_req base_req;
 	nccl_net_ofi_gin_recv_req_t recv_req;
 	nccl_net_ofi_gin_sendack_req_t sendack_req;
-	nccl_net_ofi_gin_iputsignal_req_t iputsignal_req;
+	nccl_ofi_rdma_gin_iputsignal_req iputsignal_req;
 	nccl_net_ofi_gin_iputsignal_recv_req iputsignal_recv_req;
 	nccl_net_ofi_gin_write_req_t write_req;
 	nccl_net_ofi_gin_metadata_send_req_t metadata_send_req;

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -2,10 +2,10 @@
  * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef NCCL_OFI_GIN_REQS_H
-#define NCCL_OFI_GIN_REQS_H
+#ifndef NCCL_OFI_RDMA_GIN_REQS_H
+#define NCCL_OFI_RDMA_GIN_REQS_H
 
-#include "gin/nccl_ofi_gin_types.h"
+#include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi.h"
 #include "nccl_ofi_gin_base.h"
 #include "nccl_ofi_freelist.h"

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef NCCL_OFI_GIN_RESOURCES_H
-#define NCCL_OFI_GIN_RESOURCES_H
+#ifndef NCCL_OFI_RDMA_GIN_RESOURCES_H
+#define NCCL_OFI_RDMA_GIN_RESOURCES_H
 
 #include "rdma/fabric.h"
 
@@ -12,8 +12,8 @@
 #include <vector>
 #include <unordered_map>
 
-#include "gin/nccl_ofi_gin_reqs.h"
-#include "gin/nccl_ofi_gin_types.h"
+#include "rdma/gin/nccl_ofi_gin_reqs.h"
+#include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi_gin_base.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_rdma.h"

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -219,7 +219,7 @@ public:
 	 * Get GIN communicator with given comm_id from map. Throw exception if
 	 * not found.
 	 */
-	nccl_ofi_gin_comm &get_comm(uint32_t comm_id)
+	nccl_ofi_rdma_gin_put_comm &get_comm(uint32_t comm_id)
 	{
 		auto it = gin_comms.find(comm_id);
 		if (it == gin_comms.end()) {
@@ -234,7 +234,7 @@ public:
 	 * Set a GIN communicator with given comm_id in map. Throw exception if
 	 * comm_id already exists.
 	 */
-	void set_comm(uint32_t comm_id, nccl_ofi_gin_comm &comm)
+	void set_comm(uint32_t comm_id, nccl_ofi_rdma_gin_put_comm &comm)
 	{
 		auto it = gin_comms.insert({ comm_id, &comm });
 		if (!it.second) {
@@ -344,7 +344,7 @@ public:
 private:
 	nccl_ofi_gin_ep_holder ep_holder;
 
-	std::unordered_map<uint32_t, nccl_ofi_gin_comm *> gin_comms;
+	std::unordered_map<uint32_t, nccl_ofi_rdma_gin_put_comm *> gin_comms;
 
 	nccl_ofi_idpool_t comm_id_pool;
 

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -12,7 +12,7 @@
  * Forward-declarations of GIN types
  */
 class nccl_ofi_gin_mr_handle_t;
-class nccl_ofi_gin_comm;
+class nccl_ofi_rdma_gin_put_comm;
 class nccl_ofi_gin_resources;
 struct nccl_ofi_gin_ep_rail_t;
 

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -2,8 +2,8 @@
  * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
  */
 
-#ifndef NCCL_OFI_GIN_TYPES_H
-#define NCCL_OFI_GIN_TYPES_H
+#ifndef NCCL_OFI_RDMA_GIN_TYPES_H
+#define NCCL_OFI_RDMA_GIN_TYPES_H
 
 #include <stddef.h>
 #include <stdint.h>

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -52,11 +52,11 @@ endif
 if HAVE_CUDA
 sources += nccl_ofi_cuda.cpp nccl_ofi_interface_nvidia.cpp
 sources += \
-	gin/nccl_ofi_gin.cpp \
-	gin/nccl_ofi_gin_allgather.cpp \
-	gin/nccl_ofi_gin_api.cpp \
-	gin/nccl_ofi_gin_reqs.cpp \
-	gin/nccl_ofi_gin_resources.cpp
+	rdma/gin/nccl_ofi_gin.cpp \
+	rdma/gin/nccl_ofi_gin_allgather.cpp \
+	rdma/gin/nccl_ofi_gin_api.cpp \
+	rdma/gin/nccl_ofi_gin_reqs.cpp \
+	rdma/gin/nccl_ofi_gin_resources.cpp
 endif
 
 # add the tuner sources into the library

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -4,7 +4,7 @@
 
 #include "config.h"
 
-#include "gin/nccl_ofi_gin.h"
+#include "rdma/gin/nccl_ofi_gin.h"
 
 #include "nccl_ofi_assert.h"
 #include "nccl_ofi_gdrcopy.h"

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -108,7 +108,7 @@ static inline int rail_addr_insert(nccl_ofi_gin_ep_rail_t &rail, const nccl_ofi_
 }
 
 int nccl_ofi_rdma_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int nranks, int rank,
-				      nccl_ofi_rdma_gin_put_comm **gin_comm_out)
+				      nccl_ofi_gin_put_comm_t **gin_comm_out)
 {
 	int ret = 0;
 
@@ -260,7 +260,7 @@ int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, u
 }
 
 int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
-				      int type, uint64_t mrFlags, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
+				      int type, uint64_t mrFlags, nccl_ofi_gin_symm_mr_handle_t **mr_handle_out)
 {
 	auto &gin_ep = resources.get_ep();
 
@@ -345,8 +345,9 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 	return 0;
 }
 
-int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle)
+int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle_base)
 {
+	auto *mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mr_handle_base);
 	NCCL_OFI_TRACE(NCCL_NET, "deregMrSym handle %p", mr_handle);
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		int ret = get_device_copy().deregister_region(mr_handle->gdr_handle);
@@ -400,12 +401,16 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 	return ret;
 }
 
-int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_symm_mr_handle *srcMhandle, size_t size,
-				  uint64_t dstOff, nccl_ofi_rdma_gin_symm_mr_handle *dstMhandle, uint32_t dst_rank,
-				  uint64_t signalOff, nccl_ofi_rdma_gin_symm_mr_handle *signalMhandle,
+int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size,
+				  uint64_t dstOff, nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t dst_rank,
+				  uint64_t signalOff, nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
 				  uint64_t signalValue, uint32_t signalOp,
-				  nccl_ofi_rdma_gin_iputsignal_req **request)
+				  nccl_ofi_gin_req_t **request)
 {
+	auto *src_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(srcMhandle);
+	auto *dst_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(dstMhandle);
+	auto *sig_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(signalMhandle);
+
 	if (signalOp != 0 && signalOp != NCCL_NET_SIGNAL_OP_INC &&
 	    signalOp != NCCL_NET_SIGNAL_OP_ADD) {
 		NCCL_OFI_WARN("Only support signal add/increment");
@@ -470,8 +475,8 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_sy
 
 	if (size > 0) {
 		/* Post write-immediate request with user data */
-		void *src = static_cast<uint8_t *>(srcMhandle->input_address) + srcOff;
-		auto *src_mhandle = srcMhandle->local_handle;
+		void *src = static_cast<uint8_t *>(src_mr->input_address) + srcOff;
+		auto *src_mhandle = src_mr->local_handle;
 
 		const auto schedule =
 			scheduler->get_schedule(size, gin_ep.get_num_rails());
@@ -482,7 +487,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_sy
 
 		uint64_t data = GIN_IMM_SEG_DATA(remote_comm_id, msg_seq_num, nseg, is_ack_requested);
 
-		auto &dest_remote_mr = dstMhandle->remote_mr[dst_rank];
+		auto &dest_remote_mr = dst_mr->remote_mr[dst_rank];
 		uint64_t dest = dest_remote_mr.address_offset + dstOff;
 		int wr_it = 0;
 
@@ -537,7 +542,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_sy
 		metadata_send->remote_comm_id = remote_comm_id;
 		metadata_send->msg_type = GIN_MSG_TYPE_METADATA;
 		metadata_send->signal_base_address =
-			(signalMhandle ? signalMhandle->remote_mr[dst_rank].address : 0);
+			(sig_mr ? sig_mr->remote_mr[dst_rank].address : 0);
 		metadata_send->signal_offset = signalOff;
 		if (signalOp == NCCL_NET_SIGNAL_OP_INC) {
 			metadata_send->signal_value = 1;

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -25,7 +25,7 @@ struct gin_connect_handle {
 	nccl_ofi_addr ep_names[MAX_NUM_RAILS];
 };
 
-nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
+nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
 				     nccl_net_ofi_send_comm *s_comm_,
 				     nccl_net_ofi_recv_comm *r_comm_)
     : resources(resources_arg), resource_releaser { resources }, rank(rank_), nranks(nranks_),
@@ -64,7 +64,7 @@ nccl_ofi_gin_comm::nccl_ofi_gin_comm(nccl_ofi_gin_resources &resources_arg, int 
 	resources.increment_ref_cnt();
 }
 
-nccl_ofi_gin_comm::~nccl_ofi_gin_comm()
+nccl_ofi_rdma_gin_put_comm::~nccl_ofi_rdma_gin_put_comm()
 {
 #if HAVE_NVTX_TRACING
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) {
@@ -107,8 +107,8 @@ static inline int rail_addr_insert(nccl_ofi_gin_ep_rail_t &rail, const nccl_ofi_
 	return 0;
 }
 
-int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int nranks, int rank,
-				      nccl_ofi_gin_comm **gin_comm_out)
+int nccl_ofi_rdma_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int nranks, int rank,
+				      nccl_ofi_rdma_gin_put_comm **gin_comm_out)
 {
 	int ret = 0;
 
@@ -153,8 +153,8 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 		rdma_ep->set_gin_resources(resources);
 	}
 
-	nccl_ofi_gin_comm *gin_comm =
-		new nccl_ofi_gin_comm(*resources, rank, nranks, s_comm, r_comm);
+	nccl_ofi_rdma_gin_put_comm *gin_comm =
+		new nccl_ofi_rdma_gin_put_comm(*resources, rank, nranks, s_comm, r_comm);
 
 	std::vector<gin_connect_handle> all_handles(nranks, gin_connect_handle {});
 	gin_connect_handle &my_gin_handle = all_handles[rank];
@@ -206,7 +206,7 @@ int nccl_ofi_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[], int
 	return 0;
 }
 
-int nccl_ofi_gin_comm::send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
+int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
 			       uint32_t ack_seq_num, uint32_t count)
 {
 	assert(count <= GIN_ACK_COUNT_MASK);
@@ -259,12 +259,12 @@ int nccl_ofi_gin_comm::send_ack(nccl_ofi_gin_comm &gin_comm, uint32_t peer_rank,
 	return ret;
 }
 
-int nccl_ofi_gin_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
-				      int type, uint64_t mrFlags, gin_sym_mr_handle **mr_handle_out)
+int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
+				      int type, uint64_t mrFlags, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
 {
 	auto &gin_ep = resources.get_ep();
 
-	auto *mr_handle = new gin_sym_mr_handle {};
+	auto *mr_handle = new nccl_ofi_rdma_gin_symm_mr_handle {};
 
 	NCCL_OFI_TRACE(NCCL_NET, "regMrSymDmaBuf ptr %p size %zu type %d flags %lu handle %p",
 		       data_ptr, size, type, mrFlags, mr_handle);
@@ -345,7 +345,7 @@ int nccl_ofi_gin_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr,
 	return 0;
 }
 
-int nccl_ofi_gin_comm::deregMrSym(gin_sym_mr_handle *mr_handle)
+int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle)
 {
 	NCCL_OFI_TRACE(NCCL_NET, "deregMrSym handle %p", mr_handle);
 	if (mr_handle->type == NCCL_PTR_CUDA) {
@@ -369,7 +369,7 @@ int nccl_ofi_gin_comm::deregMrSym(gin_sym_mr_handle *mr_handle)
 	return 0;
 }
 
-int nccl_ofi_gin_comm::await_pending_requests()
+int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 {
 	int ret = 0;
 
@@ -400,11 +400,11 @@ int nccl_ofi_gin_comm::await_pending_requests()
 	return ret;
 }
 
-int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle, size_t size,
-				  uint64_t dstOff, gin_sym_mr_handle *dstMhandle, uint32_t dst_rank,
-				  uint64_t signalOff, gin_sym_mr_handle *signalMhandle,
+int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_rdma_gin_symm_mr_handle *srcMhandle, size_t size,
+				  uint64_t dstOff, nccl_ofi_rdma_gin_symm_mr_handle *dstMhandle, uint32_t dst_rank,
+				  uint64_t signalOff, nccl_ofi_rdma_gin_symm_mr_handle *signalMhandle,
 				  uint64_t signalValue, uint32_t signalOp,
-				  nccl_net_ofi_gin_iputsignal_req_t **request)
+				  nccl_ofi_rdma_gin_iputsignal_req **request)
 {
 	if (signalOp != 0 && signalOp != NCCL_NET_SIGNAL_OP_INC &&
 	    signalOp != NCCL_NET_SIGNAL_OP_ADD) {
@@ -463,7 +463,7 @@ int nccl_ofi_gin_comm::iputSignal(uint64_t srcOff, gin_sym_mr_handle *srcMhandle
 	nccl_net_ofi_gin_metadata_send_req_t *send_req = nullptr;
 
 	/* Create umbrella request first for tracing */
-	auto *req = resources.get_req_from_pool<nccl_net_ofi_gin_iputsignal_req_t>(
+	auto *req = resources.get_req_from_pool<nccl_ofi_rdma_gin_iputsignal_req>(
 		*this, dst_rank, msg_seq_num, write_reqs, nullptr, is_ack_requested);
 
 	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
@@ -603,7 +603,7 @@ static inline uint64_t get_req_map_key(uint32_t peer_rank, uint16_t msg_seq_num)
 	return (static_cast<uint64_t>(peer_rank) << 16) | static_cast<uint64_t>(msg_seq_num);
 }
 
-int nccl_ofi_gin_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata)
+int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata)
 {
 	void *signal_base = reinterpret_cast<void *>(metadata.signal_base_address);
 
@@ -616,7 +616,7 @@ int nccl_ofi_gin_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_
 		NCCL_OFI_WARN("Signal base address %p not found in MR handle map", signal_base);
 		return -EINVAL;
 	}
-	gin_sym_mr_handle *mr_handle = it->second;
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = it->second;
 
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		uint64_t old_value;
@@ -660,7 +660,7 @@ int nccl_ofi_gin_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_
 	return 0;
 }
 
-int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
+int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 						       nccl_net_ofi_gin_iputsignal_recv_req *req)
 {
 	int ret = 0;
@@ -689,7 +689,7 @@ int nccl_ofi_gin_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint6
 
 /* Extend the pending bundled ack to include seq_num. If the merged
    range would overflow the bitfield, flush the old range first. */
-int nccl_ofi_gin_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num)
+int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num)
 {
 	auto &rank_comm = this->rank_comms[peer_rank];
 
@@ -731,7 +731,7 @@ int nccl_ofi_gin_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num)
 
 /* Flush pending bundled acks that have aged past the threshold
    for peers with no recent completions. Called from progress. */
-int nccl_ofi_gin_comm::flush_stale_acks()
+int nccl_ofi_rdma_gin_put_comm::flush_stale_acks()
 {
 	++progress_counter;
 	nccl_ofi_dlist_node *pos;
@@ -752,7 +752,7 @@ int nccl_ofi_gin_comm::flush_stale_acks()
 	return 0;
 }
 
-int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
+int nccl_ofi_rdma_gin_put_comm::iput_signal_deliver_all(uint32_t peer_rank)
 {
 	int ret = 0;
 
@@ -799,7 +799,7 @@ int nccl_ofi_gin_comm::iput_signal_deliver_all(uint32_t peer_rank)
 	return ret;
 }
 
-int nccl_ofi_gin_comm::handle_signal_metadata_completion(
+int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	fi_addr_t src_addr, uint16_t rail_id,
 	const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg)
 {
@@ -843,7 +843,7 @@ int nccl_ofi_gin_comm::handle_signal_metadata_completion(
 	return ret;
 }
 
-int nccl_ofi_gin_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
+int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
 					     const gin_ack_msg_t *ack_msg)
 {
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
@@ -864,7 +864,7 @@ int nccl_ofi_gin_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_i
 	return 0;
 }
 
-int nccl_ofi_gin_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
+int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
 						      uint16_t msg_seq_num, uint64_t total_segms,
 						      size_t len, bool is_ack_requested)
 {

--- a/src/rdma/gin/nccl_ofi_gin_allgather.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_allgather.cpp
@@ -4,7 +4,7 @@
 
 #include "config.h"
 
-#include "gin/nccl_ofi_gin_allgather.h"
+#include "rdma/gin/nccl_ofi_gin_allgather.h"
 
 #include "nccl_ofi_api.h"
 

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -4,8 +4,8 @@
 
 #include "config.h"
 
-#include "gin/nccl_ofi_gin.h"
-#include "gin/nccl_ofi_gin_types.h"
+#include "rdma/gin/nccl_ofi_gin.h"
+#include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 #include "nccl_ofi_param.h"

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -156,7 +156,7 @@ static ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void *
 			return nccl_net_ofi_retval_translate(ret);
 		}
 
-		*listenComm = new nccl_ofi_gin_listen_comm(dev, ep, l_comm);
+		*listenComm = new nccl_ofi_rdma_gin_listen_comm(dev, ep, l_comm);
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in GIN listen: %s", e.what());
 		return ncclSystemError;
@@ -169,13 +169,13 @@ static ncclResult_t nccl_ofi_gin_connect(void *ctx, void *handles[], int nranks,
 					 void *listenComm, void **collComm)
 {
 	auto *gin_handles = reinterpret_cast<nccl_net_ofi_conn_handle_t **>(handles);
-	auto *gin_l_comm = static_cast<nccl_ofi_gin_listen_comm *>(listenComm);
+	auto *gin_l_comm = static_cast<nccl_ofi_rdma_gin_listen_comm *>(listenComm);
 
 	int ret = 0;
 
 	try {
 		ret = gin_l_comm->connect(gin_handles, nranks, rank,
-					  reinterpret_cast<nccl_ofi_gin_comm **>(collComm));
+					  reinterpret_cast<nccl_ofi_rdma_gin_put_comm **>(collComm));
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in GIN connect: %s", e.what());
 		ret = -EINVAL;
@@ -188,8 +188,8 @@ static ncclResult_t nccl_ofi_gin_regMrSymDmaBuf(void *collComm, void *data, size
 						uint64_t offset, int fd, uint64_t mrFlags,
 						void **mhandle, void **ginHandle)
 {
-	auto *comm = static_cast<nccl_ofi_gin_comm *>(collComm);
-	gin_sym_mr_handle *mr_handle = nullptr;
+	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = nullptr;
 
 #if HAVE_DECL_FI_MR_DMABUF
 	const nccl_ofi_mr_ckey_t cache_key =
@@ -222,8 +222,8 @@ static ncclResult_t nccl_ofi_gin_regMrSym(void *collComm, void *data, size_t siz
 
 static ncclResult_t nccl_ofi_gin_deregMrSym(void *collComm, void *mhandle)
 {
-	auto *comm = static_cast<nccl_ofi_gin_comm *>(collComm);
-	auto *mr_handle = static_cast<gin_sym_mr_handle *>(mhandle);
+	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	auto *mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mhandle);
 
 	int ret = comm->deregMrSym(mr_handle);
 	if (ret != 0) {
@@ -235,7 +235,7 @@ static ncclResult_t nccl_ofi_gin_deregMrSym(void *collComm, void *mhandle)
 
 static ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 {
-	auto *gin_comm = static_cast<nccl_ofi_gin_comm *>(collComm);
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	int ret = gin_comm->get_resources().progress();
 	if (OFI_UNLIKELY(ret != 0)) {
 		return nccl_net_ofi_retval_translate(ret);
@@ -247,7 +247,7 @@ static ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 
 static ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 {
-	auto *gin_comm = static_cast<nccl_ofi_gin_comm *>(collComm);
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 
 	int ret = gin_comm->await_pending_requests();
 
@@ -258,13 +258,13 @@ static ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 
 static ncclResult_t nccl_ofi_gin_closeListen(void *listenComm)
 {
-	delete static_cast<nccl_ofi_gin_listen_comm *>(listenComm);
+	delete static_cast<nccl_ofi_rdma_gin_listen_comm *>(listenComm);
 	return ncclSuccess;
 }
 
 static ncclResult_t nccl_ofi_gin_test(void *collComm, void *request, int *done)
 {
-	auto *req = static_cast<nccl_net_ofi_gin_iputsignal_req_t *>(request);
+	auto *req = static_cast<nccl_ofi_rdma_gin_iputsignal_req *>(request);
 	int ret = req->test(done);
 	return nccl_net_ofi_retval_translate(ret);
 }
@@ -274,12 +274,12 @@ static ncclResult_t nccl_ofi_gin_iputSignal(void *collComm, uint64_t srcOff, voi
 					    uint32_t rank, uint64_t signalOff, void *signalMhandle,
 					    uint64_t signalValue, uint32_t signalOp, void **request)
 {
-	auto *gin_comm = static_cast<nccl_ofi_gin_comm *>(collComm);
-	auto *src_mr_handle = static_cast<gin_sym_mr_handle *>(srcMhandle);
-	auto *dst_mr_handle = static_cast<gin_sym_mr_handle *>(dstMhandle);
-	auto *signal_mr_handle = static_cast<gin_sym_mr_handle *>(signalMhandle);
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	auto *src_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(srcMhandle);
+	auto *dst_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(dstMhandle);
+	auto *signal_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(signalMhandle);
 
-	nccl_net_ofi_gin_iputsignal_req_t *req = nullptr;
+	nccl_ofi_rdma_gin_iputsignal_req *req = nullptr;
 	int ret = gin_comm->iputSignal(srcOff, src_mr_handle, size, dstOff, dst_mr_handle, rank,
 				       signalOff, signal_mr_handle, signalValue, signalOp, &req);
 	if (ret != 0) {

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -175,7 +175,7 @@ static ncclResult_t nccl_ofi_gin_connect(void *ctx, void *handles[], int nranks,
 
 	try {
 		ret = gin_l_comm->connect(gin_handles, nranks, rank,
-					  reinterpret_cast<nccl_ofi_rdma_gin_put_comm **>(collComm));
+					  reinterpret_cast<nccl_ofi_gin_put_comm_t **>(collComm));
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in GIN connect: %s", e.what());
 		ret = -EINVAL;
@@ -189,7 +189,7 @@ static ncclResult_t nccl_ofi_gin_regMrSymDmaBuf(void *collComm, void *data, size
 						void **mhandle, void **ginHandle)
 {
 	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = nullptr;
+	nccl_ofi_gin_symm_mr_handle_t *mr_handle = nullptr;
 
 #if HAVE_DECL_FI_MR_DMABUF
 	const nccl_ofi_mr_ckey_t cache_key =
@@ -223,7 +223,7 @@ static ncclResult_t nccl_ofi_gin_regMrSym(void *collComm, void *data, size_t siz
 static ncclResult_t nccl_ofi_gin_deregMrSym(void *collComm, void *mhandle)
 {
 	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	auto *mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mhandle);
+	auto *mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(mhandle);
 
 	int ret = comm->deregMrSym(mr_handle);
 	if (ret != 0) {
@@ -275,11 +275,11 @@ static ncclResult_t nccl_ofi_gin_iputSignal(void *collComm, uint64_t srcOff, voi
 					    uint64_t signalValue, uint32_t signalOp, void **request)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	auto *src_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(srcMhandle);
-	auto *dst_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(dstMhandle);
-	auto *signal_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(signalMhandle);
+	auto *src_mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(srcMhandle);
+	auto *dst_mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(dstMhandle);
+	auto *signal_mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(signalMhandle);
 
-	nccl_ofi_rdma_gin_iputsignal_req *req = nullptr;
+	nccl_ofi_gin_req_t *req = nullptr;
 	int ret = gin_comm->iputSignal(srcOff, src_mr_handle, size, dstOff, dst_mr_handle, rank,
 				       signalOff, signal_mr_handle, signalValue, signalOp, &req);
 	if (ret != 0) {

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -194,7 +194,7 @@ nccl_net_ofi_gin_sendack_req_t::~nccl_net_ofi_gin_sendack_req_t()
 	ack_fl->entry_free(ack_elem);
 }
 
-int nccl_net_ofi_gin_iputsignal_req_t::test(int *done)
+int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 {
 	*done = 0;
 

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -4,9 +4,9 @@
 
 #include "config.h"
 
-#include "gin/nccl_ofi_gin.h"
-#include "gin/nccl_ofi_gin_reqs.h"
-#include "gin/nccl_ofi_gin_resources.h"
+#include "rdma/gin/nccl_ofi_gin.h"
+#include "rdma/gin/nccl_ofi_gin_reqs.h"
+#include "rdma/gin/nccl_ofi_gin_resources.h"
 #include "nccl_ofi_tracepoint.h"
 
 int nccl_net_ofi_gin_op_req_t::op_req_ctx::handle_cq_entry(struct fi_cq_entry *cq_entry_base,

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -4,8 +4,8 @@
 
 #include "config.h"
 
-#include "gin/nccl_ofi_gin_resources.h"
-#include "gin/nccl_ofi_gin_reqs.h"
+#include "rdma/gin/nccl_ofi_gin_resources.h"
+#include "rdma/gin/nccl_ofi_gin_reqs.h"
 
 #include "nccl_ofi_assert.h"
 #include "nccl_ofi_cuda.h"

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -1,5 +1,6 @@
 assert
 aws_platform_mapper
+dlist
 environ
 ep_addr_list
 freelist


### PR DESCRIPTION
*Description of changes:*
- Move GIN files from src/gin/ and include/gin/ to src/rdma_gin/ and include/rdma_gin/ to reflect that GIN is RDMA-transport-specific. Update all include paths, header guards, and Makefile references.
- Rename concrete GIN classes to nccl_ofi_rdma_gin_* prefix: nccl_ofi_gin_comm → nccl_ofi_rdma_gin_put_comm, nccl_ofi_gin_listen_comm → nccl_ofi_rdma_gin_listen_comm, gin_sym_mr_handle → nccl_ofi_rdma_gin_symm_mr_handle, nccl_net_ofi_gin_iputsignal_req_t → nccl_ofi_rdma_gin_iputsignal_req.
- Add pure virtual methods to abstract base classes in nccl_ofi_gin_base.h. Concrete implementations use abstract parameter types with internal downcasts and override on all overriding methods. API layer updated to use abstract types.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
