### PR TITLE
Replace manual ref counting with shared_ptr/weak_ptr

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -6,6 +6,7 @@
 #define NCCL_OFI_H_
 
 #include <unordered_map>
+#include <memory>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -285,8 +286,6 @@ public:
 			      int device_index,
 			      struct fi_info *info);
 
-	virtual int release_device() = 0;
-
 	virtual int get_properties(nccl_ofi_properties_t *props) = 0;
 
 	/**
@@ -313,7 +312,7 @@ public:
 	 * of performance tradeoffs (be sure to read the domain
 	 * description below).
 	 */
-	nccl_net_ofi_domain_t *get_domain(unsigned int domain_key = 0);
+	std::shared_ptr<nccl_net_ofi_domain_t> get_domain(unsigned int domain_key = 0);
 
 	/* Retrieve an endpoint associated with this device under the requested
 	 * domain scope.
@@ -322,16 +321,7 @@ public:
 	 * @param endpoint_key Key for endpoint caching within the domain.
 	 *                     Caller must provide an explicit key (e.g., TID or comm_id).
 	 */
-	nccl_net_ofi_ep_t *get_ep(unsigned int domain_key, long endpoint_key);
-
-	/**
-	 * implementation of retreiving a domain from a device.  This code
-	 * assumes the device lock is already held, because in the case of
-	 * get_domain() we only need to worry about the device lock, but in
-	 * the device->get_ep call, hold the lock while we're also creating
-	 * the ep.
-	 */
-	nccl_net_ofi_domain_t *nccl_net_ofi_device_get_domain_impl(unsigned int domain_key = 0);
+	std::shared_ptr<nccl_net_ofi_ep_t> get_ep(unsigned int domain_key, long endpoint_key);
 
 	/**
 	 * @brief	Erase all domain_table elements matching the provided domain
@@ -366,7 +356,6 @@ public:
 	 * multiple entities. */
 	std::mutex device_lock;
 
-protected:
 	/**
 	 * @brief	Base device destructor
 	 * 
@@ -374,16 +363,7 @@ protected:
 	 */
 	virtual ~nccl_net_ofi_device_t();
 
-	/**
-	 * @brief	Cleanup device resources.
-	 * 
-	 * Virtual function to clean up and release each transport type's device resources.
-	 * Set called_cleanup_resources to true at the start of the function to make sure
-	 * it is only called once per device instance.
-	 * 
-	 * @return	0 if successfully, negative error code on failure.
-	 */
-	virtual int cleanup_resources() = 0;
+protected:
 
 	/*
 	 * create a new domain.  This funcion is a private pure
@@ -401,17 +381,15 @@ protected:
 	int release_all_domain_and_ep();
 
 	/**
-	 * hash table indexed by thread id of active domains.
+	 * Non-owning cache of domains, indexed by domain key.
+	 * Uses weak_ptr so the table does not keep domains alive.
+	 * Comms own endpoints (shared_ptr), endpoints own domains
+	 * (shared_ptr). When the last comm releases its endpoint,
+	 * the domain is destroyed and the weak_ptr expires. Stale
+	 * entries are purged lazily on the next get_domain() miss.
 	 */
-	std::unordered_map<unsigned int, nccl_net_ofi_domain_t *> domain_table;
+	std::unordered_map<unsigned int, std::weak_ptr<nccl_net_ofi_domain_t>> domain_table;
 
-	/** 
-	 * Track whether the cleanup_resources function was already called to avoid calling
-	 * multiple time on the same device instance. It being set to true does not 
-	 * indicate that the device resources were successfully released since this is set
-	 * to true regardless of whether cleanup_resources finished successfully or not.
-	 */
-	bool called_cleanup_resources = false;
 };
 
 
@@ -424,7 +402,7 @@ protected:
  * generally it is expected that calls into resources that share the
  * same domain will share the same lock.
  */
-class nccl_net_ofi_domain_t {
+class nccl_net_ofi_domain_t : public std::enable_shared_from_this<nccl_net_ofi_domain_t> {
 public:
 	/**
 	 * @brief	Default constructor.
@@ -463,7 +441,7 @@ public:
 	 *
 	 * Pure virtual function to allocate a new endpoint structure
 	 */
-	virtual nccl_net_ofi_ep_t *create_endpoint() = 0;
+	virtual std::shared_ptr<nccl_net_ofi_ep_t> create_endpoint() = 0;
 
 	/**
 	 * @brief	Returns the base domain's device back-pointer.
@@ -471,24 +449,6 @@ public:
 	inline nccl_net_ofi_device_t *get_device()
 	{
 		return device;
-	}
-
-	/**
-	 * @brief	Increments the base domain reference count.
-	 *		This needs to be protected with device_lock as
-	 *		domain life cycle is managed at device level
-	 */
-	inline void increment_ref_cnt() {
-		ref_cnt++;
-	}
-
-	/**
-	 * @brief	Decrements the base domain reference count.
-	 *		This needs to be protected with device_lock as
-	 *		domain life cycle is managed at device level
-	 */
-	inline void decrement_ref_cnt() {
-		ref_cnt--;
 	}
 
 	/*
@@ -499,22 +459,7 @@ public:
 	 * @param endpoint_key Key for endpoint caching.
 	 * Caller must provide an explicit key (e.g., TID or comm_id).
 	 */
-	nccl_net_ofi_ep_t *get_ep(long endpoint_key);
-
-	/**
-	 * @brief 	Release resources associated with the domain
-	 * 
-	 * @param 	skip_device_lock
-	 * 		false, taking device lock by default.
-	 * 		ture, not taking device lock when caller takes it.
-	 * @param	force_cleanup
-	 * 		false, not release when endpoint exists.
-	 * 		true, release no matter endpoint exists nor not.
-	 *
-	 * TODO: Disable thread safety analysis until conditional locking is
-	 * removed.
-	 */
-	int release_domain(bool skip_device_lock, bool force_cleanup) NO_THREAD_SAFETY_ANALYSIS;
+	std::shared_ptr<nccl_net_ofi_ep_t> get_ep(long endpoint_key);
 
 	/*
 	 * Protocol-agnostic MR cache for this device.
@@ -532,39 +477,13 @@ public:
 	void remove_ep_from_map(nccl_net_ofi_ep_t *ep);
 
 	/**
-	 * @brief       Increment base domain's unreleased_inactive_ep_counter
-	 */
-	inline void inc_unreleased_inactive_ep_counter()
-	{
-		++unreleased_inactive_ep_counter;
-	}
-
-	/**
-	 * @brief       Decrement base domain's unreleased_inactive_ep_counter
-	 */
-	inline void dec_unreleased_inactive_ep_counter()
-	{
-		--unreleased_inactive_ep_counter;
-	}
-
-protected:
-	/**
 	 * @brief	Destructor.
 	 * 
 	 * Cleans up base domain resources.
 	 */
 	virtual ~nccl_net_ofi_domain_t();
 
-	/**
-	 * @brief	Cleanup domain resources.
-	 * 
-	 * Virtual function to clean up and release each transport type's domain resources.
-	 * Set called_cleanup_resources to true at the start of the function to make sure
-	 * it is only called once per domain instance.
-	 * 
-	 * @return	0 if successfully, negative error code on failure.
-	 */
-	virtual int cleanup_resources() = 0;
+protected:
 
 	/* Backpointer to the device associated with this domain. */
 	nccl_net_ofi_device_t *const device = nullptr;
@@ -572,42 +491,21 @@ protected:
 	/* The Domain index or a key in the device domain table */
 	const unsigned int domain_key;
 
-	/* Domain reference counter for resource management.
-	 *
-	 * In some modes (right now, endpoint_per_communicator), we create
-	 * multiple endpoints per domain. This counter tracks the number
-	 * of endpoints created on this domain. When it reaches 0, the
-	 * domain can be destroyed. */
-	size_t ref_cnt;
-
 	/**
-	 * release all endpoints. This function is a private
-	 * function, which is called only during cleanup_resources() to free allocated
-	 * endpoints.
+	 * Release all endpoints by clearing the ep_table.
 	 */
 	int release_all_ep();
 
 	/**
-	 * hash table indexed by thread id of active endpoints.
+	 * Non-owning cache of endpoints, indexed by endpoint key
+	 * (thread ID or comm_id for GIN). Uses weak_ptr so the
+	 * table does not keep endpoints alive. Comms own endpoints
+	 * via shared_ptr (ep). When the last comm releases
+	 * its endpoint, the ep is destroyed and the weak_ptr
+	 * expires. Stale entries are purged lazily on the next
+	 * get_ep() miss.
 	 */
-	std::unordered_map<long, nccl_net_ofi_ep_t *> ep_table;
-
-	/**
-	 * Number of endpoints that have been deactivated but not freed
-	 *
-	 * This counter is used for a diagnostic when the domain is closed,
-	 * to track inactive ednpoint (which aren't in the ep table) which
-	 * were never closed
-	 */
-	size_t unreleased_inactive_ep_counter = 0;
-
-	/** 
-	 * Track whether the cleanup_resources function was already called to avoid calling
-	 * multiple time on the same domain instance. It being set to true does not 
-	 * indicate that the domain resources were successfully released since this is set
-	 * to true regardless of whether cleanup_resources finished successfully or not.
-	 */
-	bool called_cleanup_resources = false;
+	std::unordered_map<long, std::weak_ptr<nccl_net_ofi_ep_t>> ep_table;
 };
 
 
@@ -626,7 +524,7 @@ protected:
  * call to get_ep() or during initialization is left to the
  * implementation.
  */
-class nccl_net_ofi_ep_t {
+class nccl_net_ofi_ep_t : public std::enable_shared_from_this<nccl_net_ofi_ep_t> {
 public:
 	/**
 	 * @brief	Default constructor.
@@ -635,7 +533,7 @@ public:
 	 * Expectation is that this will be called by a transport's endpoint
 	 * constructor 
 	 */
-	nccl_net_ofi_ep_t(nccl_net_ofi_domain_t *domain);
+	nccl_net_ofi_ep_t(std::shared_ptr<nccl_net_ofi_domain_t> domain);
 
 	/* Create a receiving object and provide a handle to it.
 	 *
@@ -677,43 +575,6 @@ public:
 	 */
 	virtual ofi_cq_ptr &get_ofi_cq_for_cm() = 0;
 
-	/**
-	 * @brief	Release nccl_ofi_ep.
-	 *
-	 * Decrease reference counter. Release resources and free
-	 * endpoint if reference counter becomes zero. Must be
-	 * protected by lock stored in base_dev.
-	 *
-	 * @param 	skip_lock
-	 * 		false, taking domain lock by default.
-	 * 		ture, not taking domain lock when caller takes it.
-	 * @param	force_cleanup
-	 * 		false, not release when endpoint has ref count.
-	 * 		true, release no matter endpoint has ref count or not.
-	 *
-	 * TODO: Disable thread safety analysis until conditional locking is
-	 * removed.
-	 */
-	virtual int release_ep(bool skip_lock, bool force_cleanup) NO_THREAD_SAFETY_ANALYSIS;
-
-	/**
-	 * @brief	Increments the base endpoint reference count.
-	 * 		This needs to be protected with domain_lock as
-	 * 		endpoint life cycle is managed at domain level
-	 */
-	inline void increment_ref_cnt() {
-		ref_cnt++;
-	}
-
-	/**
-	 * @brief	Decrements the base endpoint reference count.
-	 *		This needs to be protected with domain_lock as
-	 *		endpoint life cycle is managed at domain level
-	 */
-	inline void decrement_ref_cnt() {
-		ref_cnt--;
-	}
-
 	nccl_ofi_spinlock ep_lock;
 
 	/*
@@ -745,46 +606,16 @@ public:
 		return *domain;
 	}
 
-protected:
 	/**
 	 * @brief	Virtual destructor.
-	 * Virtual function called when resources associated with
-	 * the ep should be destroyed. Device lock will be held when
-	 * this function is called.
 	 */
 	virtual ~nccl_net_ofi_ep_t() = default;
 
-	/**
-	 * @brief	Cleanup endpoint resources.
-	 * 
-	 * Virtual function to clean up and release each transport type's endpoint resources.
-	 * Set called_cleanup_resources to true at the start of the function to make sure it
-	 * is only called once per endpoint instance.
-	 * 
-	 * @return	0 if successfully, negative error code on failure.
-	 */
-	virtual int cleanup_resources() = 0;
-
-	/* Backpointer to the domain associated with this ep. */
-	nccl_net_ofi_domain_t *domain = nullptr;
-
-	/** 
-	 * Track whether the cleanup_resources function was already called to avoid calling
-	 * multiple time on the same endpoint instance. It being set to true does not 
-	 * indicate that the endpoint resources were successfully released since this is set
-	 * to true regardless of whether cleanup_resources finished successfully or not.
-	 */ 
-	bool called_cleanup_resources = false;
-
-	/* Endpoint reference counter for resource management.
-	 * sendrecv_get_ep()/sendrecv_release_ep() must be called in
-	 * pair when an object is acquired to use and
-	 * released. sendrecv_get_ep() allocates a new object when it
-	 * is called for the first time. sendrecv_get_ep() creates the
-	 * endpoint libfabric resources if the reference counter was
-	 * zero. sendrecv_release_ep() releases the resources if the
-	 * reference counter is decreased down to zero. */
-	int ref_cnt;
+protected:
+	/* Backpointer to the domain associated with this ep.
+	 * Holds a shared_ptr to keep the domain alive as long as
+	 * this endpoint exists. */
+	std::shared_ptr<nccl_net_ofi_domain_t> domain;
 };
 
 enum nccl_net_ofi_comm_type_t {
@@ -807,7 +638,9 @@ public:
 	virtual ~nccl_net_ofi_comm() = default;
 
 	enum nccl_net_ofi_comm_type_t type;
-	nccl_net_ofi_ep_t *ep;
+	/* Shared ownership of the endpoint. Keeps ep alive as long
+	 * as this comm exists. */
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	int dev_id;
 };
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -799,7 +799,7 @@ public:
 	}
 
 	/* Caller must hold the device lock */
-	nccl_net_ofi_ep_t *create_endpoint() override;
+	std::shared_ptr<nccl_net_ofi_ep_t> create_endpoint() override;
 
 	/**
 	 * @brief	Register memory region on RDMA domain
@@ -898,14 +898,10 @@ public:
 protected:
 	/**
 	 * @brief	RDMA domain destructor.
-	 * 
-	 * Overrides base domain class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up RDMA domain resources before the destructor
-	 * was called.
+	 *
+	 * Cleans up RDMA domain resources (flush buffers, ep_table).
 	 */		
 	~nccl_net_ofi_rdma_domain_t() override;
-
-	int cleanup_resources() override;
 
 	/**
 	 * @brief	Allocated and registers buffer to flush RDMA operations. On
@@ -1040,25 +1036,16 @@ public:
 	 * ep_per_rComm feature where every rComm creates its own endpoint but shares
 	 * CQ from lComm.
 	 */
-	nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domain);
+	nccl_net_ofi_rdma_ep_t(std::shared_ptr<nccl_net_ofi_rdma_domain_t> domain);
 
 	/**
 	 * @brief	Destructor.
 	 * 
 	 * Overrides base endpoint class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up RDMA endpoint resources before the destructor
-	 * was called.
-	 * 
-	 * TODO: Make protected once no longer needed to be directly called in 
-	 * nccl_net_ofi_rdma_domain_t::create_endpoint.
+	 * Cleans up RDMA endpoint resources (OFI resources, rx buffers,
+	 * freelists, mutexes).
 	 */
 	~nccl_net_ofi_rdma_ep_t() override;
-
-	/**
-	 * TODO: Make protected once no longer needed to be directly called in 
-	 * nccl_net_ofi_rdma_domain_t::create_endpoint.
-	 */
-	int cleanup_resources() override;
 
 	int listen(nccl_net_ofi_conn_handle_t *handle,
 		   nccl_net_ofi_listen_comm **listen_comm) override;
@@ -1078,9 +1065,12 @@ public:
 		    nccl_net_ofi_send_comm **send_comm,
 		    int trafficClass) override;
 
+	/* Returns a raw pointer for downcasting to the transport-specific
+	 * domain type. Safe because the ep holds shared_ptr<domain>,
+	 * so the domain is alive as long as the ep exists. */
 	inline nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain()
 	{
-		return static_cast<nccl_net_ofi_rdma_domain_t *>(domain);
+		return static_cast<nccl_net_ofi_rdma_domain_t *>(domain.get());
 	}
 
 	inline nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device()
@@ -1234,8 +1224,8 @@ public:
 	 *    resources, such as completion queue
 	 *
 	 * After this function returns, the endpoint will still have non-OFI resources
-	 * allocated (freelists, rx requests, etc.), but will not be usable except to
-	 * release it (release_ep).
+	 * allocated (freelists, rx requests, etc.), but will not be usable. The
+	 * endpoint is destroyed when the last shared_ptr to it is dropped.
 	 */
 	void rdma_endpoint_abort();
 
@@ -1427,8 +1417,6 @@ public:
 				   struct fi_info *info_list,
 				   nccl_ofi_topo_t *topo);
 
-	int release_device() override;
-
 	int get_properties(nccl_ofi_properties_t *props) override;
 
 	inline struct fi_info *get_ofi_info_for_cm() override
@@ -1529,14 +1517,10 @@ public:
 protected:
 	/**
 	 * @brief	RDMA device destructor.
-	 * 
-	 * Overrides base device class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up RDMA domain resources before the destructor
-	 * was called.
+	 *
+	 * Cleans up RDMA device resources (domains, NVTX, OFI resources).
 	 */	
 	~nccl_net_ofi_rdma_device_t() override;
-
-	int cleanup_resources() override;
 
 	nccl_net_ofi_domain_t *create_domain(unsigned int domain_key = 0) override;
 

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -198,7 +198,7 @@ public:
 	}
 
 	/* Caller must hold the device lock */
-	nccl_net_ofi_ep_t *create_endpoint() override;
+	std::shared_ptr<nccl_net_ofi_ep_t> create_endpoint() override;
 
 	/* Access Domain handle */
 	ofi_domain_ptr domain;
@@ -206,14 +206,10 @@ public:
 protected:
 	/**
 	 * @brief	SENDRECV domain destructor.
-	 * 
-	 * Overrides base domain class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up SENDRECV domain resources before the
-	 * destructor was called.
+	 *
+	 * Cleans up SENDRECV domain resources (ep_table).
 	 */	
 	~nccl_net_ofi_sendrecv_domain_t();
-
-	int cleanup_resources() override;
 };
 
 
@@ -231,7 +227,7 @@ public:
 	 * 
 	 * Calls base endpoint class constructor, sets up freelist and endpoint resources.   
 	 */
-	nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_domain_t *domain_arg);
+	nccl_net_ofi_sendrecv_ep_t(std::shared_ptr<nccl_net_ofi_sendrecv_domain_t> domain_arg);
 
 	int listen(nccl_net_ofi_conn_handle_t *handle,
 		   nccl_net_ofi_listen_comm **listen_comm) override;
@@ -240,9 +236,12 @@ public:
 		    nccl_net_ofi_send_comm **send_comm,
 		    int trafficClass) override;
 
+	/* Returns a raw pointer for downcasting to the transport-specific
+	 * domain type. Safe because the ep holds shared_ptr<domain>,
+	 * so the domain is alive as long as the ep exists. */
 	inline nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain()
 	{
-		return static_cast<nccl_net_ofi_sendrecv_domain_t *>(domain);
+		return static_cast<nccl_net_ofi_sendrecv_domain_t *>(domain.get());
 	}
 
 	inline nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device()
@@ -277,8 +276,8 @@ public:
 	 *    resources, such as completion queue
 	 *
 	 * After this function returns, the endpoint will still have non-OFI resources
-	 * allocated (freelists, rx requests, etc.), but will not be usable except to
-	 * release it (release_ep).
+	 * allocated (freelists, rx requests, etc.), but will not be usable. The
+	 * endpoint is destroyed when the last shared_ptr to it is dropped.
 	 */
 	void sendrecv_endpoint_abort();
 
@@ -309,17 +308,13 @@ public:
 	 * nccl_ofi_connection_manager doesn't have a default constructor.
 	 */
 	nccl_ofi_connection_manager *cm = nullptr;
-protected:
+
 	/**
 	 * @brief	Destructor.
 	 * 
-	 * Overrides base endpoint class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up SENDRECV endpoint resources before the
-	 * destructor was called.
+	 * Cleans up SENDRECV endpoint resources (OFI endpoint, AV, CM).
 	 */
 	~nccl_net_ofi_sendrecv_ep_t() override;
-
-	int cleanup_resources() override;
 };
 
 
@@ -370,8 +365,6 @@ public:
 				       int device_id,
 				       struct fi_info *info_arg);
 
-	int release_device() override;
-
 	int get_properties(nccl_ofi_properties_t *props) override;
 
 	inline struct fi_info *get_ofi_info_for_cm() override
@@ -409,14 +402,10 @@ public:
 protected:
 	/**
 	 * @brief	SENDRECV device destructor.
-	 * 
-	 * Overrides base device class virtual destructor, asserts that "cleanup_resources"
-	 * had already been called to clean up SENDRECV device resources before the
-	 * destructor was called.
+	 *
+	 * Cleans up SENDRECV device resources (domains, fi_info).
 	 */
 	~nccl_net_ofi_sendrecv_device_t() override;
-
-	int cleanup_resources() override;
 
 	nccl_net_ofi_domain_t *create_domain(unsigned int domain_key = 0) override;
 

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -29,11 +29,11 @@ inline nccl_ofi_device_copy &get_device_copy()
  */
 class nccl_ofi_rdma_gin_listen_comm : public nccl_ofi_gin_listen_comm_t {
 private:
-	nccl_net_ofi_ep_t *ep;
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	nccl_net_ofi_listen_comm *l_comm;
 
 public:
-	nccl_ofi_rdma_gin_listen_comm(int dev_arg, nccl_net_ofi_ep_t *ep_arg,
+	nccl_ofi_rdma_gin_listen_comm(int dev_arg, const std::shared_ptr<nccl_net_ofi_ep_t> &ep_arg,
 				 nccl_net_ofi_listen_comm *l_comm_arg)
 	    : ep(ep_arg), l_comm(l_comm_arg)
 	{

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -182,17 +182,16 @@ private:
  * refactoring the base nccl_net_ofi_ep_t class, so deferring that.
  */
 struct nccl_ofi_gin_ep_holder {
-	nccl_net_ofi_ep_t &ep;
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 
-	nccl_ofi_gin_ep_holder(nccl_net_ofi_ep_t &ep_arg) : ep(ep_arg)
+	nccl_ofi_gin_ep_holder(const std::shared_ptr<nccl_net_ofi_ep_t> &ep_arg)
+		: ep(ep_arg)
 	{
-		ep.increment_ref_cnt();
 	}
 
 	~nccl_ofi_gin_ep_holder()
 	{
-		static_cast<nccl_net_ofi_rdma_ep_t &>(ep).set_gin_resources(nullptr);
-		ep.release_ep(false, false);
+		static_cast<nccl_net_ofi_rdma_ep_t &>(*ep).set_gin_resources(nullptr);
 	}
 };
 

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -75,7 +75,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
+		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_eager", 0x0000FF); \
 	} \
 } while (0)
@@ -87,7 +87,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
+		handle = (static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device())->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 } while(0)
@@ -99,7 +99,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(s_comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(s_comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Send_ctrl_recv", 0x00ffff); \
 	} \
 } while (0)
@@ -111,7 +111,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_recv_data(req)->write_ctrl_trace_id = nvtx_start_domain(true, handle, "Write_ctrl_start", 0x00ffff); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_recv_data(req)->write_ctrl_trace_id = nvtx_start_domain(true, handle, "Write_ctrl_start", 0x00ffff); \
 	} \
 } while (0)
@@ -123,7 +123,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_recv_data(req)->write_ctrl_trace_id); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_recv_data(req)->write_ctrl_trace_id);\
 	} \
 } while (0)
@@ -135,7 +135,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		get_send_data(request)->seg_trace_id[rail_id] = nvtx_start_domain(true, handle, "Send_write_seg", 0xff0000); \
 	} \
 } while(0)
@@ -147,7 +147,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_end_domain(handle, get_send_data(request)->seg_trace_id[rail_id]); \
 	} \
 } while(0)
@@ -187,7 +187,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 } while(0)

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -152,7 +152,7 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 {
 	int ret = 0;
 	nccl_net_ofi_device_t *device = nullptr;
-	nccl_net_ofi_ep_t *ep = nullptr;
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	nccl_net_ofi_listen_comm **listen_comm =
 		reinterpret_cast<nccl_net_ofi_listen_comm **>(lComm);
 
@@ -181,15 +181,15 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 		}
 
 		ret = ep->listen(static_cast<nccl_net_ofi_conn_handle_t *>(handle), listen_comm);
+		if (ret == 0 && *listen_comm != nullptr) {
+			(*listen_comm)->ep = ep;
+		}
 	}
 	catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in plugin listen: %s", e.what());
 		ret = -EINVAL;
 	}
 
-	if (ret != 0 && ep != nullptr) {
-		ep->release_ep(false, false);
-	}
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -204,11 +204,10 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
  * function with the same handle assume that the endpoint in question
  * is stored in the communicator which itself is referable from the
  * communicator state's struct of the handle.  Also, the callee
- * invokes connect() on the endpoint. If this endpoint connect()
- * function returns a value different from ncclSuccess, the callee
- * releases the handle via release_ep(). When connect() succeeds, the
- * function nccl_net_ofi_closeSend() is responsible for releasing the
- * endpoint handle by invoking release_ep().
+ * invokes connect() on the endpoint. On error, the shared_ptr<ep>
+ * drops automatically on scope exit. On success, the comm holds
+ * a shared_ptr to the endpoint (ep) which keeps it alive
+ * until the comm is closed.
  *
  * @param	Network Device ID
  * 		Connection Handle (transferred OOB by NCCL)
@@ -236,8 +235,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
 	}
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_ep_t *ep = nullptr;
-	bool created_ep = false;
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	int ret = 0;
 	try {
 		if (ofi_handle->state.comm == nullptr) {
@@ -251,8 +249,8 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
 			if (OFI_UNLIKELY(ep == nullptr)) {
 				return check_return(ncclInternalError);
 			}
-			created_ep = true;
 		} else {
+			/* Reuse existing ep from the handle's comm */
 			ep = ofi_handle->state.comm->ep;
 			if (OFI_UNLIKELY(ep == nullptr)) {
 				NCCL_OFI_WARN("Error accessing endpoint. Endpoint has not been initialized.");
@@ -272,15 +270,7 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
 		ret = -EINVAL;
 	}
 
-	if (created_ep) {
-		/**
-		 * Release the ep if we acquired one before calling
-		 * ep->connect(). The protocol should have acquired its own
-		 * endpoint when creating the communictor.
-		 */
-		ep->release_ep(false, false);
-	}
-
+	/* ep shared_ptr drops on scope exit. No manual release needed */
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -291,7 +281,8 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
  * 		rComm != nullptr
  *
  * If accept fails by returning a result other than ncclSuccess,
- * release_ep() is invoked on the listen communicator's endpoint.
+ * the listen communicator's ep shared_ptr keeps the endpoint
+ * alive until the listen comm is closed.
  *
  * @param	Listen Communicator object
  *
@@ -327,18 +318,10 @@ ncclResult_t nccl_net_ofi_accept(void *lComm, void **rComm)
 		ret = -EINVAL;
 	}
 
-	/* Invoke release_ep() on listen comm's endpoint since accept failed */
-	if (ret != 0) {
-		/* Validate endpoint */
-		if (OFI_UNLIKELY(listen_comm->ep == nullptr)) {
-			NCCL_OFI_WARN("Invalid endpoint provided");
-			ret = -EINVAL;
-			goto error;
-		}
-		listen_comm->ep->release_ep(false, false);
-	}
+	/* On failure, the listen comm's ep shared_ptr will be
+	 * released when the listen comm is destroyed. No manual
+	 * release needed. */
 
-error:
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -378,14 +361,14 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 
 #if HAVE_DECL_FI_MR_DMABUF
 	const nccl_ofi_mr_ckey_t cache_key = (fd == -1)
-		? nccl_ofi_mr_ckey_mk_vec(data, size, base_comm->ep)
-		: nccl_ofi_mr_ckey_mk_dmabuf(fd, offset, size, data, base_comm->ep);
+		? nccl_ofi_mr_ckey_mk_vec(data, size, base_comm->ep.get())
+		: nccl_ofi_mr_ckey_mk_dmabuf(fd, offset, size, data, base_comm->ep.get());
 #else
 	if (fd != -1) {
 		NCCL_OFI_WARN("Passed fd handle, but not compiled with DMA-BUF support.");
 		return nccl_net_ofi_retval_translate_impl(-EINVAL);
 	}
-	const nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size, base_comm->ep);
+	const nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size, base_comm->ep.get());
 #endif
 
 	nccl_net_ofi_send_comm *send_comm = NULL;

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -39,6 +39,26 @@
 
 extern char **environ;
 
+namespace {
+
+/*
+ * Purge expired weak_ptr entries from an unordered_map.
+ * Called on cache miss to prevent unbounded table growth.
+ */
+template <typename K, typename V>
+void purge_expired_weak_ptrs(std::unordered_map<K, std::weak_ptr<V>> &table)
+{
+	for (auto it = table.begin(); it != table.end();) {
+		if (it->second.expired()) {
+			it = table.erase(it);
+		} else {
+			++it;
+		}
+	}
+}
+
+} /* anonymous namespace */
+
 /* Indicates if GPUDirect is supported by libfabric provider */
 enum gdr_support_level_t support_gdr = GDR_UNKNOWN;
 
@@ -134,7 +154,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	int ret = 0;
 	const char *provider_filter = NULL;
 	nccl_net_ofi_plugin_t *plugin;
-	nccl_net_ofi_ep_t *ep = NULL;
+	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	nccl_net_ofi_device_t *device = NULL;
 	nccl_ofi_properties_t properties;
 	nccl_ofi_topo_t *topo = nullptr;
@@ -329,10 +349,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		      (properties.regIsGlobal == 0) ? "false" : "true");
 	NCCL_OFI_INFO(NCCL_NET | NCCL_INIT, "Support for DMA-BUF registrations: %s",
 		      (properties.dmabuf_support == 0) ? "false" : "true");
-	ret = ep->release_ep(false, false);
-	if (ret != 0) {
-		goto exit;
-	}
+	/* Drop the endpoint. shared_ptr handles cleanup */
+	ep.reset();
 
 	assert(support_gdr != GDR_UNKNOWN);
 
@@ -641,90 +659,78 @@ int nccl_net_ofi_query_provider_capabilities(const struct fi_info *selected_prov
 nccl_net_ofi_plugin_t::~nccl_net_ofi_plugin_t()
 {
 	for (size_t i = 0 ; i < this->get_num_devices() ; i++) {
-		if (this->p_devs[i] != nullptr) {
-			this->p_devs[i]->release_device();
-		}
+		delete this->p_devs[i];
 	}
 }
 
 
 void nccl_net_ofi_device_t::remove_domain_from_map(nccl_net_ofi_domain_t *domain)
 {
-	size_t n_removed = 0;
-
-	assert(!this->domain_table.empty());
 	for (auto it = this->domain_table.begin(); it != this->domain_table.end();) {
-		if (it->second == domain) {
+		auto domain_ptr = it->second.lock();
+		/* Erase if this is the target domain, or if the
+		 * weak_ptr has expired (opportunistic cleanup). */
+		if (domain_ptr.get() == domain || domain_ptr == nullptr) {
 			it = this->domain_table.erase(it);
-			++n_removed;
 		} else {
 			++it;
 		}
 	}
-
-	assert_always(n_removed == 1);
 }
 
 
-nccl_net_ofi_domain_t *nccl_net_ofi_device_t::nccl_net_ofi_device_get_domain_impl(unsigned int domain_key)
+std::shared_ptr<nccl_net_ofi_domain_t> nccl_net_ofi_device_t::get_domain(unsigned int domain_key)
 {
-	nccl_net_ofi_domain_t *domain = nullptr;
+	std::lock_guard scoped_device_lock(this->device_lock);
 
 	assert(this->plugin != nullptr);
 
 	auto domain_iter = this->domain_table.find(domain_key);
 
 	if (domain_iter != this->domain_table.end()) {
-		domain = domain_iter->second;
-	} else {
-		domain = this->create_domain();
-		if (domain == nullptr) {
-			NCCL_OFI_WARN("Initializing a new domain for device %s failed",
-				      this->name);
-			return nullptr;
+		/* Try to promote weak_ptr to shared_ptr */
+		auto domain_ptr = domain_iter->second.lock();
+		if (domain_ptr) {
+			return domain_ptr;
 		}
-
-		this->domain_table.insert(std::pair(domain_key, domain));
-
-		NCCL_OFI_TRACE(NCCL_NET, "Domain %p for device #%d (%s) is created",
-			       domain,
-			       this->dev_id,
-			       this->name);
+		/* Expired entry, erase stale entry and fall through to create */
+		this->domain_table.erase(domain_iter);
 	}
 
-	return domain;
+	/* Cache miss. Purge expired weak_ptr entries before creating
+	 * a new domain to prevent unbounded table growth. */
+	purge_expired_weak_ptrs(this->domain_table);
+
+	/* Create new domain and insert weak_ptr into table */
+	auto *raw_domain = this->create_domain();
+	if (raw_domain == nullptr) {
+		NCCL_OFI_WARN("Initializing a new domain for device %s failed",
+			      this->name);
+		return nullptr;
+	}
+
+	std::shared_ptr<nccl_net_ofi_domain_t> domain_ptr(raw_domain);
+	this->domain_table.insert(std::make_pair(domain_key, domain_ptr));
+
+	NCCL_OFI_TRACE(NCCL_NET, "Domain %p for device #%d (%s) is created",
+		       raw_domain, this->dev_id, this->name);
+
+	return domain_ptr;
 }
 
 
-nccl_net_ofi_domain_t *nccl_net_ofi_device_t::get_domain(unsigned int domain_key)
+std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_device_t::get_ep(unsigned int domain_key, long endpoint_key)
 {
-	nccl_net_ofi_domain_t *domain = nullptr;
-
-	std::lock_guard scoped_device_lock(this->device_lock);
-	domain = this->nccl_net_ofi_device_get_domain_impl(domain_key);
-
-	return domain;
-}
-
-
-nccl_net_ofi_ep_t *nccl_net_ofi_device_t::get_ep(unsigned int domain_key, long endpoint_key)
-{
-	nccl_net_ofi_domain_t *domain = nullptr;
-	nccl_net_ofi_ep_t *ep = nullptr;
-
-	std::lock_guard scoped_device_lock(this->device_lock);
-
-	domain = this->nccl_net_ofi_device_get_domain_impl(domain_key);
+	/* get_domain() acquires and releases device_lock internally.
+	 * By the time we call domain->get_ep() (which takes
+	 * domain_lock), device_lock is already released. The
+	 * shared_ptr keeps the domain alive without the lock. */
+	auto domain = this->get_domain(domain_key);
 	if (domain == nullptr) {
 		return nullptr;
 	}
 
-	ep = domain->get_ep(endpoint_key);
-	if (ep == nullptr) {
-		return nullptr;
-	}
-
-	return ep;
+	return domain->get_ep(endpoint_key);
 }
 
 
@@ -767,131 +773,75 @@ nccl_net_ofi_device_t::~nccl_net_ofi_device_t()
 
 int nccl_net_ofi_device_t::release_all_domain_and_ep()
 {
-	int ret, first_error = 0;
-
 	std::lock_guard scoped_device_lock(this->device_lock);
 
-	assert(!this->domain_table.empty());
-	for (auto domain_iter = this->domain_table.begin() ;
-	     domain_iter != this->domain_table.end();) {
-		nccl_net_ofi_domain_t *domain = domain_iter->second;
-		/* For each domain, clean up its endpoints. */
+	/* Clear the tables. The weak_ptrs expire. If any comms still
+	 * hold shared_ptrs to endpoints/domains, those objects stay
+	 * alive until the comms are destroyed. */
+	this->domain_table.clear();
 
-		/* TODO: actually release EPs */
-
-
-		/* The call to domain->release() below will remove this domain
-		   from the table, invalidating domain_iter. So increment it
-		   here first. */
-		++domain_iter;
-
-		/* domain->release takes the domain lock, and removes itself
-		 * from domain_table. Skipping device lock here.*/
-		ret = domain->release_domain(true, true);
-		if (ret != 0 && first_error != 0) {
-			first_error = ret;
-		}
-
-	}
-
-	if (OFI_UNLIKELY(!this->domain_table.empty())) {
-		NCCL_OFI_WARN("%zu domains still active after cleanup",
-			      this->domain_table.size());
-		if (first_error != 0) {
-			first_error = -FI_EBUSY; // Anything else than above
-		}
-	}
-
-	return first_error;
+	return 0;
 }
 
 
 void nccl_net_ofi_domain_t::remove_ep_from_map(nccl_net_ofi_ep_t *ep)
 {
-	size_t n_removed = 0;
-
-	assert(!this->ep_table.empty());
 	for (auto it = this->ep_table.begin(); it != this->ep_table.end();) {
-		if (it->second == ep) {
+		auto ep_ptr = it->second.lock();
+		/* Erase if this is the target ep, or if the
+		 * weak_ptr has expired (opportunistic cleanup). */
+		if (ep_ptr.get() == ep || ep_ptr == nullptr) {
 			it = this->ep_table.erase(it);
-			++n_removed;
 		} else {
 			++it;
 		}
 	}
-
-	assert_always(n_removed == 1);
 }
 
 
-nccl_net_ofi_ep_t *nccl_net_ofi_domain_t::get_ep(long endpoint_key)
+std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_domain_t::get_ep(long endpoint_key)
 {
-	nccl_net_ofi_ep_t *ep = nullptr;
-
 	std::lock_guard scoped_domain_lock(this->domain_lock);
 
 	auto ep_iter = this->ep_table.find(endpoint_key);
 
 	if (ep_iter != this->ep_table.end()) {
-		ep = ep_iter->second;
-	} else {
-		ep = this->create_endpoint();
-		if (ep == nullptr) {
-			NCCL_OFI_WARN("Creating new endpoint for domain %p failed",
-				      this);
-			return nullptr;
+		/* Try to promote weak_ptr to shared_ptr */
+		auto ep_ptr = ep_iter->second.lock();
+		if (ep_ptr) {
+			return ep_ptr;
 		}
-
-		this->ep_table.insert(std::pair(endpoint_key, ep));
-		this->increment_ref_cnt();
-
-		NCCL_OFI_TRACE(NCCL_NET, "Endpoint %p for domain %p is created with endpoint_key=%ld",
-			       ep, this, endpoint_key);
+		/* Expired entry, erase stale entry and fall through to create */
+		this->ep_table.erase(ep_iter);
 	}
 
-	ep->increment_ref_cnt();
-	return ep;
-}
+	/* Cache miss. Purge expired weak_ptr entries before creating
+	 * a new endpoint to prevent unbounded table growth. The
+	 * normal NCCL path keys by thread ID (fixed set), but the
+	 * GIN path keys by comm_id which can grow if communicators
+	 * are repeatedly created and destroyed. */
+	purge_expired_weak_ptrs(this->ep_table);
 
-
-int nccl_net_ofi_domain_t::release_domain(bool skip_device_lock, bool force_cleanup)
-{
-	int ret = 0;
-	nccl_net_ofi_device_t *device_ptr = this->device;
-
-	// The caller takes device_lock when force_cleanup.
-	if (!skip_device_lock) {
-		device_ptr->device_lock.lock();
+	/* Create new endpoint and insert weak_ptr into table */
+	auto ep_ptr = this->create_endpoint();
+	if (ep_ptr == nullptr) {
+		NCCL_OFI_WARN("Creating new endpoint for domain %p failed", this);
+		return nullptr;
 	}
 
-	this->decrement_ref_cnt();
+	this->ep_table.insert(std::make_pair(endpoint_key, ep_ptr));
 
-	if (this->ref_cnt == 0 || force_cleanup) {
+	NCCL_OFI_TRACE(NCCL_NET, "Endpoint %p for domain %p is created with endpoint_key=%ld",
+		       ep_ptr.get(), this, endpoint_key);
 
-		/* Remove this domain from the domain table */
-		device_ptr->remove_domain_from_map(this);
-
-		ret = this->cleanup_resources();
-		delete this;
-
-		if (ret != 0) {
-			NCCL_OFI_WARN("Freeing domain failed: %d", ret);
-		}
-	}
-
-	if (!skip_device_lock) {
-		device_ptr->device_lock.unlock();
-	}
-
-	return ret;
+	return ep_ptr;
 }
 
 
 nccl_net_ofi_domain_t::nccl_net_ofi_domain_t(nccl_net_ofi_device_t *device_arg,
 					     unsigned int domain_key_arg)
 	: device(device_arg),
-	  domain_key(domain_key_arg),
-	  ref_cnt(0)
+	  domain_key(domain_key_arg)
 {
 	assert(this->device != nullptr);
 
@@ -928,47 +878,14 @@ nccl_net_ofi_domain_t::nccl_net_ofi_domain_t(nccl_net_ofi_device_t *device_arg,
 
 int nccl_net_ofi_domain_t::release_all_ep()
 {
-	int ret, first_error = 0;
-
 	std::lock_guard scoped_domain_lock(this->domain_lock);
 
-	assert(!this->ep_table.empty());
-	for (auto ep_iter = this->ep_table.begin() ;
-	     ep_iter != this->ep_table.end();) {
-		nccl_net_ofi_ep_t *ep = ep_iter->second;
+	/* Clear the table. The weak_ptrs expire. If any comms still
+	 * hold shared_ptrs to endpoints, those objects stay alive
+	 * until the comms are destroyed. */
+	this->ep_table.clear();
 
-		/* The call to ep->release() below will remove this ep
-		 * from the table, invalidating ep_iter. So increment it
-		 * here first.
-		 */
-		++ep_iter;
-
-		/* ep->release takes the domain lock, and removes itself
-		 * from ep_table. Skipping device lock here.
-		 */
-		ret = ep->release_ep(true, true);
-		if (ret != 0 && first_error != 0) {
-			first_error = ret;
-		}
-	}
-
-	if (this->unreleased_inactive_ep_counter > 0) {
-		NCCL_OFI_WARN("%zu inactive endpoint are still open after cleanup",
-			       this->unreleased_inactive_ep_counter);
-
-		if (first_error != 0) {
-			first_error = -FI_EBUSY; // Anything else than above
-		}
-	}
-
-	if (OFI_UNLIKELY(!this->ep_table.empty())) {
-		NCCL_OFI_WARN("%zu endpoint still active after cleanup",
-			       this->ep_table.size());
-		if (first_error != 0) {
-			first_error = -FI_EBUSY; // Anything else than above
-		}
-	}
-	return first_error;
+	return 0;
 }
 
 
@@ -995,69 +912,15 @@ void nccl_net_ofi_ep_t::invalidate()
 		/* Remove this endpoint from the thread->domain table so that it
 		   is not used for future communicators */
 		this->domain->remove_ep_from_map(this);
-
-		this->domain->inc_unreleased_inactive_ep_counter();
 	}
 }
 
 
-int nccl_net_ofi_ep_t::release_ep(bool skip_lock, bool force_cleanup)
-{
-	int ret = 0;
-	nccl_net_ofi_domain_t *domain_ptr = this->domain;
-
-	if (!skip_lock) {
-		domain_ptr->domain_lock.lock();
-	}
-
-	this->decrement_ref_cnt();
-
-	/* Store ref_cnt in local variable in case the endpoint gets deleted */
-	int local_ref_cnt = this->ref_cnt;
-	
-	if (local_ref_cnt == 0 || force_cleanup) {
-		/* If this was the endpoint we stored in domain for connection
-		   management, remove that reference as well */
-		if (force_cleanup && local_ref_cnt != 0) {
-			NCCL_OFI_INFO(NCCL_NET, "Endpoint %p still have ref count %d when released",
-				      this, local_ref_cnt);
-		}
-
-		/* Remove this ep from the ep table if it was active.
-		   If not, it was already removed in ep_invalidate. */
-		if (this->ep_active) {
-			domain_ptr->remove_ep_from_map(this);
-		} else {
-			domain_ptr->dec_unreleased_inactive_ep_counter();
-		}
-
-		ret = this->cleanup_resources();
-		delete this;
-	}
-
-	if (!skip_lock) {
-		domain_ptr->domain_lock.unlock();
-	}
-
-	/* If we freed the endpoint (local_ref_cnt == 0), also release the domain
-	 * (decrement its ref_cnt)
-	 *
-	 * Skip domain->release when handled by device->release_all_domain_and_ep()
-	 * to avoid domain lock issue after the domain freed */
-	if (!force_cleanup && ret == 0 && local_ref_cnt == 0) {
-		ret = domain_ptr->release_domain(skip_lock, false);
-	}
-
-	return ret;
-}
-
-
-nccl_net_ofi_ep_t::nccl_net_ofi_ep_t(nccl_net_ofi_domain_t *domain_arg)
+nccl_net_ofi_ep_t::nccl_net_ofi_ep_t(std::shared_ptr<nccl_net_ofi_domain_t> domain_arg)
 	: ep_active(true),
-	  domain(domain_arg),
-	  ref_cnt(0)
+	  domain(std::move(domain_arg))
 {
-	assert(domain_arg != nullptr);
+	assert(domain != nullptr);
 }
 
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -176,7 +176,7 @@ static nccl_net_ofi_rdma_close_msg_t *rdma_send_close_get_msg
 
 nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_send_comm::get_ep()
 {
-	return (nccl_net_ofi_rdma_ep_t *)this->ep;
+	return (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 }
 
 /*
@@ -190,7 +190,7 @@ nccl_net_ofi_rdma_recv_comm_rail_t *nccl_net_ofi_rdma_recv_comm::get_control_rai
 
 nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_recv_comm::get_ep()
 {
-	return (nccl_net_ofi_rdma_ep_t *)this->ep;
+	return (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 }
 
 /*
@@ -709,7 +709,7 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
 static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_comm,
 				 nccl_net_ofi_rdma_req *req)
 {
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	assert(ep != NULL);
 
 	nccl_net_ofi_rdma_device_t *device = ep->rdma_endpoint_get_device();
@@ -844,7 +844,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 					     nccl_net_ofi_rdma_req *rx_buff_req)
 {
 	int ret;
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 
 	/* Decrease rx buffer count. It will be incremented again when reposting */
 	ret = ep->decrease_rx_buff_cnt(get_rx_buff_data(rx_buff_req)->rail);
@@ -1520,7 +1520,7 @@ static int receive_progress(nccl_net_ofi_rdma_req *req, bool add_to_pending)
 	if (rc == -FI_EAGAIN && add_to_pending) {
 		nccl_net_ofi_rdma_recv_comm *r_comm = (nccl_net_ofi_rdma_recv_comm *)req->comm;
 		/* Extract ep */
-		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 		/* Place in pending requests queue for next try */
 		nccl_net_ofi_mutex_lock(&ep->pending_reqs_lock);
 		ep->pending_reqs_queue.push_back(req);
@@ -1810,7 +1810,7 @@ static inline int free_send_req(nccl_net_ofi_rdma_req *req,
 	}
 
 	if (send_data->schedule) {
-		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 		assert(ep != NULL);
 		nccl_net_ofi_release_schedule(ep->scheduler, send_data->schedule);
 		send_data->schedule = NULL;
@@ -1880,7 +1880,7 @@ static inline int free_send_close_req(nccl_net_ofi_rdma_req *req,
 	rdma_req_send_close_data_t *send_close_data = req_get_send_close_data(req);
 
 	if (send_close_data->ctrl_schedule) {
-		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+		nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 		assert(ep != NULL);
 		nccl_net_ofi_release_schedule(ep->scheduler, send_close_data->ctrl_schedule);
 		send_close_data->ctrl_schedule = NULL;
@@ -2202,7 +2202,7 @@ static int finish_connect(nccl_net_ofi_rdma_send_comm *s_comm)
 	nccl_net_ofi_rdma_device_t *device = NULL;
 
 	/* Validate endpoint */
-	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	if (OFI_UNLIKELY(ep == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -2264,7 +2264,7 @@ static inline bool has_flush_completed(nccl_net_ofi_rdma_req *req)
 {
 	rdma_req_flush_data_t *flush_data = get_flush_data(req);
 	nccl_net_ofi_comm *base_comm = req->comm;
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_comm->ep.get();
 
 	/* Check if the flush bufffer is populated across ep rails */
 	for (uint16_t rail_id = 0; rail_id < ep->num_rails; rail_id++) {
@@ -2348,7 +2348,7 @@ int nccl_net_ofi_rdma_req::test(int *done, int *size_p)
 	assert(base_comm != NULL);
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)base_comm->ep.get();
 	assert(ep != NULL);
 
 	std::lock_guard eplock(ep->ep_lock);
@@ -2698,7 +2698,7 @@ int nccl_net_ofi_rdma_domain_t::reg_internal_mr_dma_buf(void *data,
 int nccl_net_ofi_rdma_send_comm::regMr(nccl_ofi_mr_ckey_ref ckey,
                                        int type_param, void **mhandle)
 {
-	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
     nccl_net_ofi_rdma_domain_t *domain = endpoint->rdma_endpoint_get_domain();
 	assert(domain != NULL);
 
@@ -2712,7 +2712,7 @@ int nccl_net_ofi_rdma_send_comm::regMr(nccl_ofi_mr_ckey_ref ckey,
 int nccl_net_ofi_rdma_recv_comm::regMr(nccl_ofi_mr_ckey_ref ckey,
 								       int type_param, void **mhandle)
 {
-	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	nccl_net_ofi_rdma_domain_t *domain = endpoint->rdma_endpoint_get_domain();
 	assert(domain != NULL);
 
@@ -2785,7 +2785,7 @@ static int freelist_deregmr_host_fn(void *handle)
 int nccl_net_ofi_rdma_recv_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 {
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	assert(endpoint != NULL);
 
 	nccl_net_ofi_rdma_domain_t *domain = endpoint->rdma_endpoint_get_domain();
@@ -3033,7 +3033,7 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 
 	device_id = this->dev_id;
 
-	endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	assert(endpoint != NULL);
 
 	domain = endpoint->rdma_endpoint_get_domain();
@@ -3419,8 +3419,6 @@ static int recv_comm_destroy(nccl_net_ofi_rdma_recv_comm *r_comm)
 
 	delete r_comm;
 
-	ret = ep->release_ep(false, false);
-
 	return ret;
 }
 
@@ -3478,7 +3476,7 @@ static inline int recv_comm_insert_send_close_req(nccl_net_ofi_rdma_recv_comm *r
 static inline int progress_closing_recv_comm(nccl_net_ofi_rdma_recv_comm *r_comm)
 {
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)
-		r_comm->ep;
+		r_comm->ep.get();
 
 	std::lock_guard eplock(ep->ep_lock);
 	if (!ep->ep_active) {
@@ -3612,7 +3610,7 @@ static int send_comm_destroy(nccl_net_ofi_rdma_send_comm *s_comm)
 	/* Release request freelist */
 	delete s_comm->nccl_ofi_reqs_fl;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *) s_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	nccl_net_ofi_rdma_device_t *device = ep->rdma_endpoint_get_device();
 	device->rdma_device_set_comm(s_comm->local_comm_id, NULL);
 
@@ -3636,8 +3634,6 @@ static int send_comm_destroy(nccl_net_ofi_rdma_send_comm *s_comm)
 
 	delete s_comm;
 
-	ret = ep->release_ep(false, false);
-
 	return ret;
 }
 
@@ -3659,7 +3655,7 @@ static inline int progress_closing_send_comm(nccl_net_ofi_rdma_send_comm *s_comm
 	}
 
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)
-		s_comm->ep;
+		s_comm->ep.get();
 
 	std::lock_guard eplock(ep->ep_lock);
 	if (!ep->ep_active) {
@@ -3829,7 +3825,7 @@ static int rdma_comm_alloc_flush_req(nccl_net_ofi_rdma_recv_comm *r_comm,
 					nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle,
 					nccl_net_ofi_rdma_req **ret_req)
 {
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 	int dev_id = r_comm->dev_id;
 	rdma_req_flush_data_t *flush_data = NULL;
 	*ret_req = NULL;
@@ -4107,7 +4103,7 @@ int nccl_net_ofi_rdma_recv_comm::read(void* dest, size_t size, void* mhandle,
 		return ret;
 	}
 
-	endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	assert(endpoint != NULL);
 
 	std::lock_guard eplock(endpoint->ep_lock);
@@ -4288,9 +4284,9 @@ static nccl_net_ofi_rdma_recv_comm *prepare_recv_comm(nccl_net_ofi_rdma_domain_t
 	/* Initialize next_msg_seq_num to NCCL_OFI_RDMA_MSG_SEQ_NUM_START */
 	r_comm->next_msg_seq_num = NCCL_OFI_RDMA_MSG_SEQ_NUM_START;
 
-	r_comm->ep = l_comm_ep;
+	r_comm->ep = l_comm_ep->shared_from_this();
 
-	ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 
 	/* Add ourselves to ep's lookup array */
 	device->rdma_device_set_comm(r_comm->local_comm_id, r_comm);
@@ -4491,7 +4487,7 @@ static int accept_wait_for_connection(nccl_net_ofi_rdma_domain_t *domain,
 	int dev_id = l_comm->dev_id;
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_rdma_ep_t *l_comm_ep = (nccl_net_ofi_rdma_ep_t *)l_comm->ep;
+	nccl_net_ofi_rdma_ep_t *l_comm_ep = (nccl_net_ofi_rdma_ep_t *)l_comm->ep.get();
 	assert(l_comm_ep != NULL);
 	nccl_net_ofi_rdma_ep_t *ep = NULL;
 
@@ -4545,7 +4541,7 @@ static int accept_wait_for_connection(nccl_net_ofi_rdma_domain_t *domain,
 	receiver = nullptr;
 	l_comm->r_comm = r_comm;
 
-	ep = reinterpret_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->ep);
+	ep = reinterpret_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->ep.get());
 	assert(ep != NULL);
 
 	/*
@@ -4558,9 +4554,7 @@ static int accept_wait_for_connection(nccl_net_ofi_rdma_domain_t *domain,
 	 * called.
 	 */
 
-	domain->domain_lock.lock();
-	ep->increment_ref_cnt();
-	domain->domain_lock.unlock();
+	r_comm->ep = l_comm->ep;
 
 	/* Initialize connect response message */
 	nccl_ofi_rdma_connection_info_t conn_resp_msg;
@@ -4585,12 +4579,12 @@ int nccl_net_ofi_rdma_listen_comm::accept(nccl_net_ofi_recv_comm **recv_comm)
 	int ret = 0;
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_rdma_ep_t *l_comm_ep = (nccl_net_ofi_rdma_ep_t *)this->ep;
+	nccl_net_ofi_rdma_ep_t *l_comm_ep = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	assert(l_comm_ep != NULL);
 
 	nccl_net_ofi_rdma_ep_t *endpoint = l_comm_ep;
 	if (this->r_comm) {
-		endpoint = (nccl_net_ofi_rdma_ep_t *)this->r_comm->ep;
+		endpoint = (nccl_net_ofi_rdma_ep_t *)this->r_comm->ep.get();
 		assert(endpoint != NULL);
 	}
 
@@ -4634,7 +4628,7 @@ int nccl_net_ofi_rdma_listen_comm::accept(nccl_net_ofi_recv_comm **recv_comm)
 			return 0;
 		}
 
-		endpoint = (nccl_net_ofi_rdma_ep_t *)this->r_comm->ep;
+		endpoint = (nccl_net_ofi_rdma_ep_t *)this->r_comm->ep.get();
 		assert(endpoint != NULL);
 
 		this->stage = COMM_CONN_RESP_REQ_PENDING;
@@ -4724,9 +4718,7 @@ int nccl_net_ofi_rdma_listen_comm::close()
 	delete this->listener;
 	this->listener = nullptr;
 
-	auto *ep_ptr = this->ep;
 	delete this;
-	ret = ep_ptr->release_ep(false, false);
 
 	return ret;
 }
@@ -4766,7 +4758,7 @@ int nccl_net_ofi_rdma_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 
 	/* Initialize listen communicator */
 	l_comm->type = NCCL_NET_OFI_LISTEN_COMM;
-	l_comm->ep = this;
+	l_comm->ep = shared_from_this();
 	l_comm->dev_id = dev_id;
 
 	/* Create CM listener */
@@ -4782,7 +4774,7 @@ int nccl_net_ofi_rdma_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 int nccl_net_ofi_rdma_send_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 {
     /* Retrieve and validate endpoint */
-    nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep;
+    nccl_net_ofi_rdma_ep_t *endpoint = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 	assert(endpoint != NULL);
 
 	nccl_net_ofi_rdma_domain_t *domain = endpoint->rdma_endpoint_get_domain();
@@ -4825,7 +4817,7 @@ static int alloc_rdma_send_req(nccl_net_ofi_rdma_send_comm *s_comm,
 					bool eager,
 					nccl_net_ofi_rdma_req **ret_req)
 {
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	nccl_net_ofi_rdma_device_t *device = ep->rdma_endpoint_get_device();
 	nccl_net_ofi_scheduler *scheduler = ep->scheduler;
 	*ret_req = NULL;
@@ -5131,7 +5123,7 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req *req)
 	assert(req->type == NCCL_OFI_RDMA_RECV);
 	nccl_net_ofi_rdma_recv_comm *r_comm = (nccl_net_ofi_rdma_recv_comm *)req->comm;
 
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 
 	nccl_net_ofi_scheduler *scheduler = ep->scheduler;
 	uint16_t rail_id;
@@ -5256,7 +5248,7 @@ static int post_eager_copy(nccl_net_ofi_rdma_req *req)
 static int post_flush_req(nccl_net_ofi_rdma_req *req)
 {
  	nccl_net_ofi_rdma_recv_comm *r_comm = (nccl_net_ofi_rdma_recv_comm *)req->comm;
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 	nccl_net_ofi_rdma_domain_t *domain = ep->rdma_endpoint_get_domain();
 	rdma_req_flush_data_t *flush_data = get_flush_data(req);
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail;
@@ -5306,7 +5298,7 @@ static int post_flush_req(nccl_net_ofi_rdma_req *req)
 static int post_flush_req(nccl_net_ofi_rdma_req *req)
 {
 	nccl_net_ofi_rdma_recv_comm *r_comm = (nccl_net_ofi_rdma_recv_comm *)req->comm;
-	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep;
+	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)r_comm->ep.get();
 	nccl_net_ofi_rdma_domain_t *domain = ep->rdma_endpoint_get_domain();
 	rdma_req_flush_data_t *flush_data = get_flush_data(req);
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail;
@@ -5431,7 +5423,7 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 		return ret;
 	}
 
-	endpoint = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+	endpoint = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	assert(endpoint != NULL);
 
 	domain = endpoint->rdma_endpoint_get_domain();
@@ -5825,7 +5817,7 @@ static int rma_write_impl(nccl_net_ofi_send_comm *send_comm, void* src, size_t s
 		return ret;
 	}
 
-	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep;
+	ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
 	assert(ep != NULL);
 
 	std::lock_guard eplock(ep->ep_lock);
@@ -5941,18 +5933,13 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm **s_com
 	}
 
 	ret_s_comm->type = NCCL_NET_OFI_SEND_COMM;
-	ret_s_comm->ep = this;
 	ret_s_comm->dev_id = dev_id;
 	ret_s_comm->comm_active = true;
 	ret_s_comm->next_msg_seq_num = NCCL_OFI_RDMA_MSG_SEQ_NUM_START;
 
 	/* The connect() API function acquired the endpoint we are using via
-	   get_ep(). Increase the refcnt so the endpoint is not freed when the
-	   API releases it.*/
-
-	domain_ptr->domain_lock.lock();
-	this->increment_ref_cnt();
-	domain_ptr->domain_lock.unlock();
+	   get_ep(). Store shared_ptr in the comm to keep ep alive. */
+	ret_s_comm->ep = shared_from_this();
 
 	/* Allocate send communicator ID */
 	comm_id = device->comm_idpool.allocate_id();
@@ -6007,9 +5994,6 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm **s_com
 			device->comm_idpool.free_id(ret_s_comm->local_comm_id);
 		}
 
-		domain_ptr->domain_lock.lock();
-		this->decrement_ref_cnt();
-		domain_ptr->domain_lock.unlock();
 		delete ret_s_comm;
 	}
 
@@ -6281,14 +6265,8 @@ int nccl_net_ofi_rdma_ep_t::init_rail_ofi_resources(nccl_net_ofi_rdma_device_t *
 }
 
 
-int nccl_net_ofi_rdma_ep_t::cleanup_resources() {
-	int ret = 0;
-	int err_code = 0;
-
-	/* cleanup_resources should only be called once per endpoint instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
+nccl_net_ofi_rdma_ep_t::~nccl_net_ofi_rdma_ep_t()
+{
 	nccl_net_ofi_rdma_device_t *device = this->rdma_endpoint_get_device();
 
 	if (this->cm) {
@@ -6302,33 +6280,18 @@ int nccl_net_ofi_rdma_ep_t::cleanup_resources() {
 	}
 
 	/* Ideally we would "un-post" the rx buffers, but this
-	 * should be accomplished by closing the endpoint.
-	 */
+	 * should be accomplished by closing the endpoint. */
 	this->release_rdma_ep_resources(device->dev_id);
 
-	err_code = this->fini_rx_buffers();
+	int err_code = this->fini_rx_buffers();
 	if (err_code != 0) {
-		NCCL_OFI_WARN("rdma endpoint cleanup: tearing down freelists failed, rc %d", err_code);
-		ret = -EINVAL;
+		NCCL_OFI_WARN("rdma endpoint destructor: tearing down freelists failed, rc %d", err_code);
 	}
 
 	err_code = nccl_net_ofi_mutex_destroy(&this->pending_reqs_lock);
 	if (err_code != 0) {
 		NCCL_OFI_WARN("rdma endpoint destructor: destroying pending_reqs_lock mutex failed, rc %d", err_code);
-		ret = -EINVAL;
 	}
-
-	assert(ret == 0);
-
-	return ret;
-}
-
-
-nccl_net_ofi_rdma_ep_t::~nccl_net_ofi_rdma_ep_t()
-{
-	/* cleanup_resources should always be called to clean-up endpoint resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
 }
 
 static inline int init_max_write_inline_size_if_not_initialized(nccl_net_ofi_rdma_device_t *device,
@@ -6354,16 +6317,18 @@ static inline int init_max_write_inline_size_if_not_initialized(nccl_net_ofi_rdm
 }
 
 
-nccl_net_ofi_ep_t *nccl_net_ofi_rdma_domain_t::create_endpoint()
+std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_rdma_domain_t::create_endpoint()
 {
 	int ret = 0;
 	nccl_net_ofi_rdma_device_t *device_ptr = this->rdma_domain_get_device();
 	assert(device_ptr != nullptr);
 
-	/* Allocate endpoint */
-	auto *ep = new nccl_net_ofi_rdma_ep_t(this);
+	/* Allocate endpoint. Pass shared_from_this() so the ep
+	 * holds a shared_ptr to this domain */
+	auto ep = std::make_shared<nccl_net_ofi_rdma_ep_t>(
+		std::static_pointer_cast<nccl_net_ofi_rdma_domain_t>(shared_from_this()));
 
-	NCCL_OFI_TRACE(NCCL_NET, "RDMA endpoint %p for dev #%d is created", ep, 
+	NCCL_OFI_TRACE(NCCL_NET, "RDMA endpoint %p for dev #%d is created", ep.get(), 
 		       device_ptr->dev_id);
 
 	/* During plugin initialization, this function is invoked the
@@ -6372,18 +6337,16 @@ nccl_net_ofi_ep_t *nccl_net_ofi_rdma_domain_t::create_endpoint()
 	 * path the first time, avoiding data race on
 	 * `max_write_inline_size` when `get_properties()` function
 	 * reads the maximum write inline size variable. */
-	ret = init_max_write_inline_size_if_not_initialized(device_ptr, ep);
+	ret = init_max_write_inline_size_if_not_initialized(device_ptr, ep.get());
 	if (ret != 0) {
-		ep->cleanup_resources();
-		delete ep;
-		ep = nullptr;
+		return nullptr;
 	}
 
 	return ep;
 }
 
 
-nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domain_arg)
+nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(std::shared_ptr<nccl_net_ofi_rdma_domain_t> domain_arg)
 	: nccl_net_ofi_ep_t(domain_arg)
 {
 	int ret = 0;
@@ -6427,7 +6390,7 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 	this->eager_rx_buff_size = (this->eager_send_size == 0) ?
 		EAGER_RX_BUFFER_ALIGNMENT : this->eager_send_size;
 
-	ret = this->init_rail_ofi_resources(device, domain_arg);
+	ret = this->init_rail_ofi_resources(device, domain_arg.get());
 	if (ret != 0) {
 		throw std::runtime_error("rdma endpoint constructor: initializing rails failed");
 	}
@@ -6447,43 +6410,25 @@ nccl_net_ofi_rdma_ep_t::nccl_net_ofi_rdma_ep_t(nccl_net_ofi_rdma_domain_t *domai
 }
 
 
-int nccl_net_ofi_rdma_domain_t::cleanup_resources()
-{
-	int ret = 0;
-	int err_code = 0;
-
-	/* cleanup_resources should only be called once per domain instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
-	err_code = this->dealloc_and_dereg_flush_buff();
-	if (err_code != 0) {
-		NCCL_OFI_WARN("Failed to deregister flush buffer pool");
-		ret = -EINVAL;
-	}
-
-	if (!this->ep_table.empty()) {
-		NCCL_OFI_INFO(NCCL_NET, "%zu RDMA endpoints still active at domain cleanup",
-					 this->ep_table.size());
-		err_code = this->release_all_ep();
-		if (err_code != 0) {
-			NCCL_OFI_WARN("Cleanup of RDMA domain failed. RC: %d, ERROR: %s",
-				       err_code, fi_strerror(-err_code));
-			ret = -EINVAL;
-		}
-	}
-
-	assert(ret == 0);
-
-	return ret;
-}
-
-
 nccl_net_ofi_rdma_domain_t::~nccl_net_ofi_rdma_domain_t()
 {
-	/* cleanup_resources should always be called to clean-up domain resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
+	int err_code = this->dealloc_and_dereg_flush_buff();
+	if (err_code != 0) {
+		NCCL_OFI_WARN("Failed to deregister flush buffer pool");
+	}
+
+	/* Check for leaked endpoints. With weak_ptr entries, expired
+	 * entries are harmless (stale cache). But a live weak_ptr
+	 * means a comm still holds a shared_ptr to an ep, which
+	 * indicates a leak. */
+	for (auto &entry : this->ep_table) {
+		if (!entry.second.expired()) {
+			NCCL_OFI_INFO(NCCL_NET,
+				       "Endpoint for key %ld is still alive at RDMA domain cleanup",
+				       entry.first);
+		}
+	}
+	this->release_all_ep();
 }
 
 
@@ -6605,40 +6550,19 @@ error:
 }
 
 
-int nccl_net_ofi_rdma_device_t::release_device()
+nccl_net_ofi_rdma_device_t::~nccl_net_ofi_rdma_device_t()
 {
-	int ret = 0;
-	ret = this->cleanup_resources();
-	delete this;
-
-	return ret;
-}
-
-
-/**
- * Destroy an rdma device object
- */
-int nccl_net_ofi_rdma_device_t::cleanup_resources()
-{
-	int ret = 0;
-	int err_code = 0;
-
-	/* cleanup_resources should only be called once per device instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
-	if (!this->domain_table.empty()) {
-		NCCL_OFI_INFO(NCCL_NET, "%zu RDMA domains still active at close",
-			      this->domain_table.size());
-		err_code = this->release_all_domain_and_ep();
-		if (err_code != 0) {
-			NCCL_OFI_WARN("Cleanup of RDMA domain failed. RC: %d, ERROR: %s",
-				      err_code, fi_strerror(-err_code));
-			ret = -EINVAL;
+	/* Check for leaked domains. Expired weak_ptrs are harmless
+	 * stale cache entries. Live ones indicate a leak. */
+	for (auto &entry : this->domain_table) {
+		if (!entry.second.expired()) {
+			NCCL_OFI_INFO(NCCL_NET,
+				       "Domain for key %u is still alive at RDMA device cleanup",
+				       entry.first);
 		}
 	}
+	this->release_all_domain_and_ep();
 
-	/* Destroy domain */
 #if HAVE_NVTX_TRACING
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) {
 		for (int i = 0; i < this->num_rails; ++i) {
@@ -6648,18 +6572,6 @@ int nccl_net_ofi_rdma_device_t::cleanup_resources()
 #endif
 
 	this->release_device_ofi_resources();
-
-	assert(ret == 0);
-
-	return ret;
-}
-
-
-nccl_net_ofi_rdma_device_t::~nccl_net_ofi_rdma_device_t()
-{
-	/* cleanup_resources should always be called to clean-up device resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
 }
 
 

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -452,7 +452,7 @@ int nccl_net_ofi_sendrecv_req::test(int *done, int *size_p)
 	}
 
 	/* Retrieve and validate endpoint */
-	ep = (nccl_net_ofi_sendrecv_ep_t *)base_comm->ep;
+	ep = (nccl_net_ofi_sendrecv_ep_t *)base_comm->ep.get();
 	if (OFI_UNLIKELY(ep == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -751,7 +751,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 {
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *ep =
-		(nccl_net_ofi_sendrecv_ep_t *)base_comm->ep;
+		(nccl_net_ofi_sendrecv_ep_t *)base_comm->ep.get();
 	nccl_ofi_idpool_t *key_pool = NULL;
 	if (OFI_UNLIKELY(ep == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -836,7 +836,7 @@ int nccl_net_ofi_sendrecv_recv_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 {
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *ep_local =
-		(nccl_net_ofi_sendrecv_ep_t *)this->ep;
+		(nccl_net_ofi_sendrecv_ep_t *)this->ep.get();
 	if (OFI_UNLIKELY(ep_local == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -900,7 +900,7 @@ int nccl_net_ofi_sendrecv_recv_comm::recv(int n, void **buffers,
 	auto **mr_handles = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t **>(mhandles);
 
 	/* Retrieve and validate endpoint */
-	endpoint = (nccl_net_ofi_sendrecv_ep_t *)this->ep;
+	endpoint = (nccl_net_ofi_sendrecv_ep_t *)this->ep.get();
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -1010,7 +1010,7 @@ int nccl_net_ofi_sendrecv_recv_comm::close()
 	nccl_net_ofi_sendrecv_mr_handle_t *mr_handle = nullptr;
 
 	/* Retrieve and validate endpoint */
-	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep);
+	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep.get());
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -1051,7 +1051,6 @@ int nccl_net_ofi_sendrecv_recv_comm::close()
 
 	delete this;
 
-	ret = endpoint->release_ep(false, false);
  exit:
 	return ret;
 }
@@ -1070,7 +1069,7 @@ int nccl_net_ofi_sendrecv_recv_comm::flush(int n, void **buffers,
 	int flush_n = -1;
 	auto **mr_handles = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t **>(mhandles);
 
-	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep);
+	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep.get());
 
 	std::lock_guard eplock(endpoint->ep_lock);
 
@@ -1325,7 +1324,7 @@ nccl_net_ofi_sendrecv_recv_comm *nccl_net_ofi_sendrecv_recv_comm::create(nccl_ne
 		return NULL;
 	}
 
-	r_comm->ep = ep_arg;
+	r_comm->ep = ep_arg->shared_from_this();
 	r_comm->dev_id = dev_id;
 
 	/* Increase tag ID */
@@ -1405,7 +1404,7 @@ int nccl_net_ofi_sendrecv_listen_comm::accept(nccl_net_ofi_recv_comm **recv_comm
 
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *endpoint =
-		(nccl_net_ofi_sendrecv_ep_t *)this->ep;
+		(nccl_net_ofi_sendrecv_ep_t *)this->ep.get();
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -1485,9 +1484,7 @@ int nccl_net_ofi_sendrecv_listen_comm::accept(nccl_net_ofi_recv_comm **recv_comm
 		 * refcnt and free it up when nccl_net_ofi_closeRecv is
 		 * called.
 		 */
-		domain->domain_lock.lock();
-		ep->increment_ref_cnt();
-		domain->domain_lock.unlock();
+		r_comm->ep = this->ep;
 
 		comm_state->comm = r_comm;
 
@@ -1556,14 +1553,13 @@ int nccl_net_ofi_sendrecv_listen_comm::close()
 	}
 
 	/* Retrieve and validate endpoint */
-	nccl_net_ofi_ep_t *endpoint = this->ep;
+	nccl_net_ofi_ep_t *endpoint = this->ep.get();
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		goto exit;
 	}
 
-	ret = endpoint->release_ep(false, false);
 	delete this;
  exit:
 	return ret;
@@ -1650,7 +1646,7 @@ int nccl_net_ofi_sendrecv_ep_t::listen(nccl_net_ofi_conn_handle_t *handle,
 
 	/* Initialize listen communicator */
 	l_comm->type = NCCL_NET_OFI_LISTEN_COMM;
-	l_comm->ep = this;
+	l_comm->ep = shared_from_this();
 	l_comm->dev_id = dev_id;
 	l_comm->local_ep = this->ofi_ep.get();
 	l_comm->local_ep_addr = local_ep_addr;
@@ -1668,7 +1664,7 @@ int nccl_net_ofi_sendrecv_send_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 {
 	/* Retrieve and validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *endpoint =
-		(nccl_net_ofi_sendrecv_ep_t *)this->ep;
+		(nccl_net_ofi_sendrecv_ep_t *)this->ep.get();
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -1701,7 +1697,7 @@ int nccl_net_ofi_sendrecv_send_comm::send(void *data, size_t size, int tag_param
 
 	/* Validate endpoint */
 	nccl_net_ofi_sendrecv_ep_t *endpoint =
-		(nccl_net_ofi_sendrecv_ep_t *)this->ep;
+		(nccl_net_ofi_sendrecv_ep_t *)this->ep.get();
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		NCCL_OFI_WARN("Invalid endpoint provided");
 		return -EINVAL;
@@ -1784,7 +1780,7 @@ int nccl_net_ofi_sendrecv_send_comm::close()
 	int ret = 0;
 
 	/* Retrieve and validate endpoint */
-	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep);
+	auto *endpoint = reinterpret_cast<nccl_net_ofi_sendrecv_ep_t *>(this->ep.get());
 	if (OFI_UNLIKELY(endpoint == NULL)) {
 		ret = -EINVAL;
 		NCCL_OFI_WARN("Invalid endpoint provided");
@@ -1808,8 +1804,6 @@ int nccl_net_ofi_sendrecv_send_comm::close()
 	}
 
 	delete this;
-
-	ret = endpoint->release_ep(false, false);
 
 	return ret;
 }
@@ -1852,9 +1846,6 @@ int nccl_net_ofi_sendrecv_send_comm::create(nccl_net_ofi_conn_handle_t *handle,
 		return -EINVAL;
 	}
 
-	nccl_net_ofi_sendrecv_domain_t *domain_ptr = ep_arg->sendrecv_endpoint_get_domain();
-	assert(domain_ptr != NULL);
-
 	/* Allocate and initialize send_comm */
 	ret_s_comm = new nccl_net_ofi_sendrecv_send_comm();
 	if (OFI_UNLIKELY(ret_s_comm == NULL)) {
@@ -1862,22 +1853,13 @@ int nccl_net_ofi_sendrecv_send_comm::create(nccl_net_ofi_conn_handle_t *handle,
 		return -ENOMEM;
 	}
 
-	ret_s_comm->ep = ep_arg;
+	ret_s_comm->ep = ep_arg->shared_from_this();
 	ret_s_comm->dev_id = device->dev_id;
 	ret_s_comm->tag = 0; /* Populate later from connect response */
 	ret_s_comm->local_ep = ep_arg->ofi_ep.get();
 
 	ret_s_comm->remote_ep = 0; /* Populate later from connect response */
 	ret_s_comm->connector = nullptr;
-
-	/* The connect() API function acquired the endpoint we are using via
-	   get_ep(). Increase the refcnt so the endpoint is not freed when the
-	   API releases it.
-	   Caller assumed to hold the domain lock. */
-
-	domain_ptr->domain_lock.lock();
-	ep_arg->increment_ref_cnt();
-	domain_ptr->domain_lock.unlock();
 
 	conn_info->ep_namelen = sizeof(conn_info->ep_name);
 
@@ -1903,11 +1885,6 @@ int nccl_net_ofi_sendrecv_send_comm::create(nccl_net_ofi_conn_handle_t *handle,
 	*s_comm = ret_s_comm;
 out:
 	if (ret) {
-		/* Above code incremented the ep ref counter, so decrement it on
-		   failure */
-		domain_ptr->domain_lock.lock();
-		ep_arg->decrement_ref_cnt();
-		domain_ptr->domain_lock.unlock();
 		delete ret_s_comm;
 	}
 
@@ -2027,14 +2004,8 @@ int nccl_net_ofi_sendrecv_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 }
 
 
-int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
+nccl_net_ofi_sendrecv_ep_t::~nccl_net_ofi_sendrecv_ep_t()
 {
-	int ret = 0;
-
-	/* cleanup_resources should only be called once per endpoint instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
 	if (this->cm) {
 		delete this->cm;
 		this->cm = nullptr;
@@ -2042,30 +2013,20 @@ int nccl_net_ofi_sendrecv_ep_t::cleanup_resources()
 
 	int dev_id = this->domain->get_device()->dev_id;
 	nccl_ofi_ofiutils_ep_release(this->ofi_ep, this->av, dev_id);
-
-	assert(ret == 0);
-
-	return ret;
 }
 
 
-nccl_net_ofi_sendrecv_ep_t::~nccl_net_ofi_sendrecv_ep_t()
+std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_sendrecv_domain_t::create_endpoint()
 {
-	/* cleanup_resources should always be called to clean-up endpoint resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
+	/* Allocate endpoint. Pass shared_from_this() so the ep
+	 * holds a shared_ptr to this domain */
+	return std::make_shared<nccl_net_ofi_sendrecv_ep_t>(
+		std::static_pointer_cast<nccl_net_ofi_sendrecv_domain_t>(shared_from_this()));
 }
 
 
-nccl_net_ofi_ep_t *nccl_net_ofi_sendrecv_domain_t::create_endpoint()
-{
-	/* Allocate endpoint */
-	auto ep = new nccl_net_ofi_sendrecv_ep_t(this);
-	return ep;
-}
-
-
-nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_domain_t *domain_arg)
+nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(
+	std::shared_ptr<nccl_net_ofi_sendrecv_domain_t> domain_arg)
 	: nccl_net_ofi_ep_t(domain_arg)
 {
 	nccl_net_ofi_sendrecv_device_t *device = nullptr;
@@ -2109,37 +2070,20 @@ nccl_net_ofi_sendrecv_ep_t::nccl_net_ofi_sendrecv_ep_t(nccl_net_ofi_sendrecv_dom
 }
 
 
-int nccl_net_ofi_sendrecv_domain_t::cleanup_resources()
-{
-	int ret = 0;
-	int err_code = 0;
-
-	/* cleanup_resources should only be called once per domain instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
-	if (!this->ep_table.empty()) {
-		NCCL_OFI_INFO(NCCL_NET, "%zu SENDRECV endpoints still active at close",
-			      this->ep_table.size());
-		err_code = this->release_all_ep();
-		if (err_code != 0) {
-			NCCL_OFI_WARN("Cleanup of SENDRECV domain failed. RC: %d, ERROR: %s",
-				      err_code, fi_strerror(-err_code));
-			ret = -EINVAL;
-		}
-	}
-
-	assert(ret == 0);
-
-	return ret;
-}
-
-
 nccl_net_ofi_sendrecv_domain_t::~nccl_net_ofi_sendrecv_domain_t()
 {
-	/* cleanup_resources should always be called to clean-up domain resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
+	/* Check for leaked endpoints. With weak_ptr entries, expired
+	 * entries are harmless (stale cache). But a live weak_ptr
+	 * means a comm still holds a shared_ptr to an ep, which
+	 * indicates a leak. */
+	for (auto &entry : this->ep_table) {
+		if (!entry.second.expired()) {
+			NCCL_OFI_INFO(NCCL_NET,
+				       "Endpoint for key %ld is still alive at SENDRECV domain cleanup",
+				       entry.first);
+		}
+	}
+	this->release_all_ep();
 }
 
 
@@ -2193,53 +2137,22 @@ int nccl_net_ofi_sendrecv_device_t::sendrecv_device_prepare_for_connection()
 }
 
 
-int nccl_net_ofi_sendrecv_device_t::release_device()
+nccl_net_ofi_sendrecv_device_t::~nccl_net_ofi_sendrecv_device_t()
 {
-	int ret = 0;
-	ret = this->cleanup_resources();
-	delete this;
-
-	return ret;
-}
-
-
-/**
- * Destroy an rdma device object
- */
-int nccl_net_ofi_sendrecv_device_t::cleanup_resources()
-{
-	int ret = 0;
-	int err_code = 0;
-
-	/* cleanup_resources should only be called once per device instance */
-	assert(!this->called_cleanup_resources);
-	this->called_cleanup_resources = true;
-
-	if (!this->domain_table.empty()) {
-		NCCL_OFI_INFO(NCCL_NET, "%zu SENDRECV domains still active at close",
-			      this->domain_table.size());
-		err_code = this->release_all_domain_and_ep();
-		if (err_code != 0) {
-			NCCL_OFI_WARN("Cleanup of SENDRECV domain failed. RC: %d, ERROR: %s",
-				      err_code, fi_strerror(-err_code));
-			ret = -EINVAL;
+	/* Check for leaked domains. Expired weak_ptrs are harmless
+	 * stale cache entries. Live ones indicate a leak. */
+	for (auto &entry : this->domain_table) {
+		if (!entry.second.expired()) {
+			NCCL_OFI_INFO(NCCL_NET,
+				       "Domain for key %u is still alive at SENDRECV device cleanup",
+				       entry.first);
 		}
 	}
+	this->release_all_domain_and_ep();
 
 	if (this->info != NULL) {
 		fi_freeinfo(this->info);
 	}
-
-	assert(ret == 0);
-
-	return ret;
-}
-
-nccl_net_ofi_sendrecv_device_t::~nccl_net_ofi_sendrecv_device_t()
-{
-	/* cleanup_resources should always be called to clean-up device resources before
-	   the destructor is called */
-	assert(this->called_cleanup_resources);
 }
 
 /**

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -146,7 +146,7 @@ int nccl_ofi_rdma_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[]
 	}
 
 	/* Create a GIN resources object on the endpoint if it does not exist */
-	auto *rdma_ep = static_cast<nccl_net_ofi_rdma_ep_t *>(ep);
+	auto *rdma_ep = static_cast<nccl_net_ofi_rdma_ep_t *>(ep.get());
 	auto *resources = rdma_ep->get_gin_resources();
 	if (resources == nullptr) {
 		resources = new nccl_ofi_gin_resources(*ep);

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -147,7 +147,7 @@ static ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void *
 		domain_key=0 uses the default domain, endpoint_key=comm_id caches endpoints
 		by communicator ID instead of thread ID. */
 
-		nccl_net_ofi_ep_t *ep = device->get_ep(0, static_cast<long>(comm_id));
+		auto ep = device->get_ep(0, static_cast<long>(comm_id));
 
 		nccl_net_ofi_listen_comm *l_comm = nullptr;
 		int ret = ep->listen(static_cast<nccl_net_ofi_conn_handle_t *>(handle), &l_comm);
@@ -155,6 +155,14 @@ static ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void *
 			NCCL_OFI_WARN("GIN: error listening on device %i.", dev);
 			return nccl_net_ofi_retval_translate(ret);
 		}
+
+		/* TODO: ep->listen() creates the listen_comm but does
+		 * not set l_comm->ep. The API listen() path sets it
+		 * after ep->listen() returns. GIN calls ep->listen()
+		 * directly, so it must also set l_comm->ep here.
+		 * Both callers need this for accept() to propagate
+		 * the ep to the recv_comm. */
+		l_comm->ep = ep;
 
 		*listenComm = new nccl_ofi_rdma_gin_listen_comm(dev, ep, l_comm);
 	} catch (const std::exception &e) {

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -425,7 +425,7 @@ void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail,
 }
 
 nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
-    : ep_holder(ep_arg), gin_comms(), comm_id_pool(GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
+    : ep_holder(ep_arg.shared_from_this()), gin_comms(), comm_id_pool(GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
       req_fl(nullptr, &freelist_deleter),
       rx_buff_fl(nullptr, &freelist_deleter),
       ack_send_fl(nullptr, &freelist_deleter)


### PR DESCRIPTION
*Description of changes:*

Replace manual reference counting between domain, endpoint, and communicator with shared_ptr/weak_ptr. Tables hold weak_ptr as non-owning caches, comms hold shared_ptr<ep>, endpoints hold shared_ptr<domain>. Destruction cascades automatically via the shared_ptr destructor chain without requiring locks.

This eliminates release_ep(), release_domain(), the skip_lock and force_cleanup parameters, and the domain/device lock interlock during destruction. Destructors now call cleanup_resources() directly instead of relying on the manual release path.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
