### PR TITLE
Adding Net v12 / GIN v13 API Header

### DIFF
--- a/3rd-party/nccl/cuda/include/nccl/gin_v13.h
+++ b/3rd-party/nccl/cuda/include/nccl/gin_v13.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2017-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef GIN_V13_H_
+#define GIN_V13_H_
+
+#include "net_v12.h"
+
+typedef struct {
+  int nSignals;
+  int nCounters;
+  int nContexts;
+  int queueDepth;
+  int trafficClass;
+} ncclGinConfig_v13_t;
+
+typedef struct {
+  // Name of the GIN support (mainly for logs)
+  const char* name;
+  // Initialize the GIN support.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  // Return the number of adapters capable of doing GIN operations.
+  // If ndev returns 0, all other functions might be set to NULL.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create connections.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Create a group for GIN operations. handles have been created
+  // using listen() above. rank indicates caller's rank in the collective network.
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank,
+                          void* listenComm, void** collComm);
+  // Create device-side GIN context. devHandle will be passed to device code.
+  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle);
+  // Collective memory registration
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
+  // Close and free collective comm objects
+  ncclResult_t (*destroyContext)(void* ginCtx);
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Put operations
+  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+      uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
+  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
+      size_t size, uint64_t dstOff, void* dstMhandle,
+      uint32_t rank, uint64_t signalOff, void *signalMhandle,
+      uint64_t signalValue, uint32_t signalOp, void** request);
+  ncclResult_t (*iget)(void* ginCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+      uint64_t localOff, void* localMhandle, uint32_t rank, void** request);
+
+  ncclResult_t (*iflush)(void* ginCtx, int context, void* mhandle, uint32_t rank, void** request);
+
+  // Test whether a request is complete.
+  ncclResult_t (*test)(void* collComm, void* request, int* done);
+
+  // Progress function. Will be called if non-NULL in GIN_PROXY mode, or if devHandle.needsProxyProgress=1.
+  ncclResult_t (*ginProgress)(void* ginCtx);
+
+  // Query the last error for the GIN support. Particularly important when ginProgress is not used, to report errors.
+  ncclResult_t (*queryLastError)(void* ginCtx, bool *hasError);
+
+  // Finalize the GIN support
+  ncclResult_t (*finalize)(void* ctx);
+} ncclGin_v13_t;
+#endif // end include guard

--- a/3rd-party/nccl/cuda/include/nccl/net.h
+++ b/3rd-party/nccl/cuda/include/nccl/net.h
@@ -38,6 +38,7 @@ typedef enum {NCCL_INIT=1, NCCL_COLL=2, NCCL_P2P=4, NCCL_SHM=8, NCCL_NET=16, NCC
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* phandle, int64_t pluginId, void* extData);
 
+#include "net_v12.h"
 #include "net_v11.h"
 #include "net_v10.h"
 #include "net_v9.h"

--- a/3rd-party/nccl/cuda/include/nccl/net.h
+++ b/3rd-party/nccl/cuda/include/nccl/net.h
@@ -38,6 +38,7 @@ typedef enum {NCCL_INIT=1, NCCL_COLL=2, NCCL_P2P=4, NCCL_SHM=8, NCCL_NET=16, NCC
 typedef void (*ncclDebugLogger_t)(ncclDebugLogLevel level, unsigned long flags, const char *file, int line, const char *fmt, ...);
 typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* phandle, int64_t pluginId, void* extData);
 
+#include "net_v12.h"
 #include "net_v11.h"
 #include "net_v10.h"
 #include "net_v9.h"
@@ -48,5 +49,7 @@ typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* p
 #include "net_v4.h"
 #include "net_v3.h"
 #include "net_v2.h"
+
+#include "gin_v13.h"
 
 #endif // end include guard

--- a/3rd-party/nccl/cuda/include/nccl/net_device.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_device.h
@@ -33,6 +33,7 @@ typedef ncclNetDeviceHandle_v7_t ncclNetDeviceHandle_v8_t;
 typedef ncclNetDeviceHandle_v8_t ncclNetDeviceHandle_v9_t;
 typedef ncclNetDeviceHandle_v9_t ncclNetDeviceHandle_v10_t;
 typedef ncclNetDeviceHandle_v10_t ncclNetDeviceHandle_v11_t;
-typedef ncclNetDeviceHandle_v11_t ncclNetDeviceHandle_t;
+typedef ncclNetDeviceHandle_v11_t ncclNetDeviceHandle_v12_t;
+typedef ncclNetDeviceHandle_v12_t ncclNetDeviceHandle_t;
 
 #endif

--- a/3rd-party/nccl/cuda/include/nccl/net_v12.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_v12.h
@@ -1,0 +1,259 @@
+/*
+ * Copyright (c) 2017-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_V12_H_
+#define NET_V12_H_
+
+#include <stdbool.h>
+
+#include "types.h"
+#include "net_device.h"
+
+#define NCCL_NET_MAX_DEVS_PER_NIC_V12 8
+
+typedef struct {
+  int ndevs;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V12];
+} ncclNetVDeviceProps_v12_t;
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v12_t;
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int forceFlush;                  // Force a flush on receives
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  ncclNetVDeviceProps_v12_t vProps;
+  size_t maxP2pBytes;              // Max transfer size for point-to-point operations
+  size_t maxCollBytes;             // Max transfer size for collective operations
+  int maxMultiRequestSize;         // Maximum number of requests supported in a single multi-request.
+  int16_t railId;                  // rail ID associated with the netdev
+  int16_t planeId;                 // plane ID associated with the netdev
+} ncclNetProperties_v12_t;
+
+#define NCCL_NET_ATTR_UNDEF -1
+
+#define NCCL_NET_ID_UNDEF -1
+
+#define NCCL_NET_ATTR_INIT { \
+  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* sendCommAttr */ \
+  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* recvCommAttr */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
+}
+
+typedef struct {
+  int32_t maxConcurrentPeers;
+  int32_t minConcurrentPeers;
+  int32_t maxFlowsPerPeer;
+  int32_t minFlowsPerPeer;
+} ncclNetCommAttr_v12_t;
+
+typedef struct {
+  ncclNetCommAttr_v12_t sendCommAttr;
+  ncclNetCommAttr_v12_t recvCommAttr;
+  uint32_t op;
+  uint32_t algo;
+  uint32_t proto;
+} ncclNetAttr_v12_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*connect)(void* ctx, int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v12_t** sendDevComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v12_t** recvDevComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Copy the given mhandle to a dptr in a format usable by this plugin's device code
+  ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+
+  // Notify the plugin that a recv has completed by the device
+  ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+
+  // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
+  // what index this new vNIC exists at
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v12_t* props);
+  // Finalize the network.
+  ncclResult_t (*finalize)(void* ctx);
+
+  ncclResult_t (*setNetAttr)(void* ctx, ncclNetAttr_v12_t* netAttr);
+} ncclNet_v12_t;
+
+typedef struct {
+  void* mhandle;
+  void* address;
+  size_t size;
+} ncclNetSGE_v12_t;
+
+typedef struct {
+  // Name of the collective network (mainly for logs)
+  const char* name;
+  // Initialize the collective network.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  // Return the number of adapters capable of doing collective operations.
+  // If ndev returns 0, all other functions might be set to NULL.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create connections.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Create a group for collective operations. handles have been created
+  // using listen() above. rank indicates caller's rank in the collective network.
+  ncclResult_t (*connect)(void* handles[], int nranks, int rank, void* listenComm, void** collComm);
+  // Returns whether a reduction operation on a data type is supported.
+  // 1 for supported, 0 otherwise.
+  ncclResult_t (*reduceSupport)(ncclDataType_t dataType, ncclRedOp_t redOp, int* supported);
+  // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* collComm, void* mhandle);
+  // Performs an asynchronous allreduce operation on the collective group.
+  // May return request == NULL if the call cannot be performed (or would block).
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
+      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v12_t* recvParts,
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                             void* sendMhandle, void** request);
+  ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v12_t* sendParts, void* recvData,
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                 ncclDataType_t dataType, ncclRedOp_t redOp,
+                                 void* recvMhandle, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* size);
+  // Close and free collective comm objects
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Create a virtual NIC given the specified properties, which can be accessed at device index d
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v12_t* props);
+  // Finalize the collective network.
+  ncclResult_t (*finalize)(void* ctx);
+} ncclCollNet_v12_t;
+
+typedef struct {
+  int nSignals;
+  int nCounters;
+  int nContexts;
+  int queueDepth;
+  int trafficClass;
+} ncclGinConfig_v13_t;
+
+typedef struct {
+  // Name of the GIN support (mainly for logs)
+  const char* name;
+  // Initialize the GIN support.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  // Return the number of adapters capable of doing GIN operations.
+  // If ndev returns 0, all other functions might be set to NULL.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create connections.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Create a group for GIN operations. handles have been created
+  // using listen() above. rank indicates caller's rank in the collective network.
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank,
+                          void* listenComm, void** collComm);
+  // Create device-side GIN context. devHandle will be passed to device code.
+  ncclResult_t (*createContext)(void* collComm, ncclGinConfig_v13_t* config, void** ginCtx, ncclNetDeviceHandle_v11_t** devHandle);
+  // Collective memory registration
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, uint64_t mrFlags, void** mhandle, void **ginHandle);
+  ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
+  // Close and free collective comm objects
+  ncclResult_t (*destroyContext)(void* ginCtx);
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Put operations
+  ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
+      uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
+  ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
+      size_t size, uint64_t dstOff, void* dstMhandle,
+      uint32_t rank, uint64_t signalOff, void *signalMhandle,
+      uint64_t signalValue, uint32_t signalOp, void** request);
+  ncclResult_t (*iget)(void* ginCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+      uint64_t localOff, void* localMhandle, uint32_t rank, void** request);
+
+  ncclResult_t (*iflush)(void* ginCtx, int context, void* mhandle, uint32_t rank, void** request);
+
+  // Test whether a request is complete.
+  ncclResult_t (*test)(void* collComm, void* request, int* done);
+
+  // Progress function. Will be called if non-NULL in GIN_PROXY mode, or if devHandle.needsProxyProgress=1.
+  ncclResult_t (*ginProgress)(void* ginCtx);
+
+  // Query the last error for the GIN support. Particularly important when ginProgress is not used, to report errors.
+  ncclResult_t (*queryLastError)(void* ginCtx, bool *hasError);
+
+  // Finalize the GIN support
+  ncclResult_t (*finalize)(void* ctx);
+} ncclGin_v13_t;
+#endif // end include guard

--- a/3rd-party/nccl/cuda/include/nccl/net_v12.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_v12.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright (c) 2017-2026, NVIDIA CORPORATION. All rights reserved.
+ */
+
+#ifndef NET_V12_H_
+#define NET_V12_H_
+
+#include <stdbool.h>
+
+#include "types.h"
+#include "net_device.h"
+
+#define NCCL_NET_MAX_DEVS_PER_NIC_V12 8
+
+typedef struct {
+  int ndevs;
+  int devs[NCCL_NET_MAX_DEVS_PER_NIC_V12];
+} ncclNetVDeviceProps_v12_t;
+
+#define NCCL_NET_TRAFFIC_CLASS_UNDEF -1
+
+typedef struct {
+  // Plugin-specific TC value
+  int trafficClass;
+} ncclNetCommConfig_v12_t;
+
+typedef struct {
+  char* name;                      // Used mostly for logging.
+  char* pciPath;                   // Path to the PCI device in /sys.
+  uint64_t guid;                   // Unique identifier for the NIC chip. Important for
+                                   // cards with multiple PCI functions (Physical or virtual).
+  int ptrSupport;                  // [NCCL_PTR_HOST|NCCL_PTR_CUDA|NCCL_PTR_DMABUF]
+  int regIsGlobal;                 // regMr is not tied to a particular comm
+  int forceFlush;                  // Force a flush on receives
+  int speed;                       // Port speed in Mbps.
+  int port;                        // Port number.
+  float latency;                   // Network latency
+  int maxComms;                    // Maximum number of comms we can create
+  int maxRecvs;                    // Maximum number of grouped receives.
+  ncclNetDeviceType netDeviceType; // Network offload type
+  int netDeviceVersion;            // Version number for network offload
+  ncclNetVDeviceProps_v12_t vProps;
+  size_t maxP2pBytes;              // Max transfer size for point-to-point operations
+  size_t maxCollBytes;             // Max transfer size for collective operations
+  int maxMultiRequestSize;         // Maximum number of requests supported in a single multi-request.
+  int16_t railId;                  // rail ID associated with the netdev
+  int16_t planeId;                 // plane ID associated with the netdev
+} ncclNetProperties_v12_t;
+
+#define NCCL_NET_ATTR_UNDEF -1
+
+#define NCCL_NET_ID_UNDEF -1
+
+#define NCCL_NET_ATTR_INIT { \
+  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* sendCommAttr */ \
+  { NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF, NCCL_NET_ATTR_UNDEF }, /* recvCommAttr */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* op */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* algo */ \
+  (uint32_t)NCCL_NET_ATTR_UNDEF, /* proto */ \
+}
+
+typedef struct {
+  int32_t maxConcurrentPeers;
+  int32_t minConcurrentPeers;
+  int32_t maxFlowsPerPeer;
+  int32_t minFlowsPerPeer;
+} ncclNetCommAttr_v12_t;
+
+typedef struct {
+  ncclNetCommAttr_v12_t sendCommAttr;
+  ncclNetCommAttr_v12_t recvCommAttr;
+  uint32_t op;
+  uint32_t algo;
+  uint32_t proto;
+} ncclNetAttr_v12_t;
+
+typedef struct {
+  // Name of the network (mainly for logs)
+  const char* name;
+  // Initialize the network.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclNetCommConfig_v12_t* config, ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction);
+  // Return the number of adapters.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create a connection.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Connect to a handle and return a sending comm object for that peer.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with sendComm == NULL with the expectation that
+  // it will be called again until sendComm != NULL.
+  // If *sendDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*connect)(void* ctx, int dev, void* handle, void** sendComm, ncclNetDeviceHandle_v12_t** sendDevComm);
+  // Finalize connection establishment after remote peer has called connect.
+  // This call must not block for the connection to be established, and instead
+  // should return successfully with recvComm == NULL with the expectation that
+  // it will be called again until recvComm != NULL.
+  // If *recvDevComm points to a valid object, then NCCL is requesting device offload for this connection
+  ncclResult_t (*accept)(void* listenComm, void** recvComm, ncclNetDeviceHandle_v12_t** recvDevComm);
+  // Register/Deregister memory. Comm can be either a sendComm or a recvComm.
+  // Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* comm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* comm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* comm, void* mhandle);
+  // Asynchronous send to a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*isend)(void* sendComm, void* data, size_t size, int tag, void* mhandle, void* phandle, void** request);
+  // Asynchronous recv from a peer.
+  // May return request == NULL if the call cannot be performed (or would block)
+  ncclResult_t (*irecv)(void* recvComm, int n, void** data, size_t* sizes, int* tags, void** mhandles, void** phandles, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* recvComm, int n, void** data, int* sizes, void** mhandles, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* sizes);
+  // Close and free send/recv comm objects
+  ncclResult_t (*closeSend)(void* sendComm);
+  ncclResult_t (*closeRecv)(void* recvComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Copy the given mhandle to a dptr in a format usable by this plugin's device code
+  ncclResult_t (*getDeviceMr)(void* comm, void* mhandle, void** dptr_mhandle);
+
+  // Notify the plugin that a recv has completed by the device
+  ncclResult_t (*irecvConsumed)(void* recvComm, int n, void* request);
+
+  // Virtual NIC APIs. makeVDevice will create a virtual NIC given the specified properties, and tell the caller
+  // what index this new vNIC exists at
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v12_t* props);
+  // Finalize the network.
+  ncclResult_t (*finalize)(void* ctx);
+
+  ncclResult_t (*setNetAttr)(void* ctx, ncclNetAttr_v12_t* netAttr);
+} ncclNet_v12_t;
+
+typedef struct {
+  void* mhandle;
+  void* address;
+  size_t size;
+} ncclNetSGE_v12_t;
+
+typedef struct {
+  // Name of the collective network (mainly for logs)
+  const char* name;
+  // Initialize the collective network.
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  // Return the number of adapters capable of doing collective operations.
+  // If ndev returns 0, all other functions might be set to NULL.
+  ncclResult_t (*devices)(int* ndev);
+  // Get various device properties.
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  // Create a receiving object and provide a handle to connect to it. The
+  // handle can be up to NCCL_NET_HANDLE_MAXSIZE bytes and will be exchanged
+  // between ranks to create connections.
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  // Create a group for collective operations. handles have been created
+  // using listen() above. rank indicates caller's rank in the collective network.
+  ncclResult_t (*connect)(void* handles[], int nranks, int rank, void* listenComm, void** collComm);
+  // Returns whether a reduction operation on a data type is supported.
+  // 1 for supported, 0 otherwise.
+  ncclResult_t (*reduceSupport)(ncclDataType_t dataType, ncclRedOp_t redOp, int* supported);
+  // Register/Deregister memory. Type is either NCCL_PTR_HOST or NCCL_PTR_CUDA.
+  ncclResult_t (*regMr)(void* collComm, void* data, size_t size, int type, void** mhandle);
+  /* DMA-BUF support */
+  ncclResult_t (*regMrDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd, void** mhandle);
+  ncclResult_t (*deregMr)(void* collComm, void* mhandle);
+  // Performs an asynchronous allreduce operation on the collective group.
+  // May return request == NULL if the call cannot be performed (or would block).
+  ncclResult_t (*iallreduce)(void* collComm, void* sendData, void* recvData, size_t count,
+      ncclDataType_t dataType, ncclRedOp_t redOp, void* sendMhandle, void* recvMhandle, void** request);
+  ncclResult_t (*iallgather)(void* collComm, void* sendData, int nRecvParts, ncclNetSGE_v12_t* recvParts,
+                             size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                             void* sendMhandle, void** request);
+  ncclResult_t (*ireducescatter)(void* collComm, int nSendParts, ncclNetSGE_v12_t* sendParts, void* recvData,
+                                 size_t bytesPerRank, size_t windowOffset, size_t windowBytes,
+                                 ncclDataType_t dataType, ncclRedOp_t redOp,
+                                 void* recvMhandle, void** request);
+  // Perform a flush/fence to make sure all data received with NCCL_PTR_CUDA is
+  // visible to the GPU
+  ncclResult_t (*iflush)(void* collComm, void* data, int size, void* mhandle, void** request);
+  // Test whether a request is complete. If size is not NULL, it returns the
+  // number of bytes sent/received.
+  ncclResult_t (*test)(void* request, int* done, int* size);
+  // Close and free collective comm objects
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // Create a virtual NIC given the specified properties, which can be accessed at device index d
+  ncclResult_t (*makeVDevice)(int* d, ncclNetVDeviceProps_v12_t* props);
+  // Finalize the collective network.
+  ncclResult_t (*finalize)(void* ctx);
+} ncclCollNet_v12_t;
+#endif // end include guard

--- a/src/nccl_ofi_interface_nvidia.cpp
+++ b/src/nccl_ofi_interface_nvidia.cpp
@@ -589,6 +589,68 @@ static ncclResult_t finalize_v11(void *ctx)
 }
 
 
+static ncclResult_t init_v12(void **ctx, uint64_t commId, ncclNetCommConfig_v12_t *config,
+			     ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction)
+{
+	std::lock_guard lock(netMutex);
+	ncclNetCommConfig_v12_t *net_config = (ncclNetCommConfig_v12_t *)malloc(sizeof(ncclNetCommConfig_v12_t));
+	if (net_config == NULL) return ncclSystemError;
+	net_config->trafficClass = config->trafficClass;
+	*ctx = net_config;
+
+	if (netRefCount++ > 0) return ncclSuccess;
+	return nccl_net_ofi_init(logFunction);
+}
+
+
+static ncclResult_t getProperties_v12(int dev_id, ncclNetProperties_v12_t *props)
+{
+	nccl_ofi_properties_t ofi_properties;
+	ncclResult_t ret = nccl_net_ofi_get_properties(dev_id, &ofi_properties);
+	if (ret != ncclSuccess) {
+		return ret;
+	}
+
+	props->name = ofi_properties.name;
+	props->pciPath = ofi_properties.pci_path;
+	props->guid = ofi_properties.guid;
+	props->ptrSupport = NCCL_PTR_HOST;
+	if (ofi_properties.hmem_support) {
+		props->ptrSupport |= NCCL_PTR_CUDA;
+	}
+	if (ofi_properties.dmabuf_support) {
+		props->ptrSupport |= NCCL_PTR_DMABUF;
+	}
+
+	props->regIsGlobal = ofi_properties.regIsGlobal;
+	props->forceFlush = 0;
+	props->speed = ofi_properties.port_speed;
+	props->port = ofi_properties.port_number;
+	props->latency = ofi_properties.latency;
+	props->maxComms = ofi_properties.max_communicators;
+	props->maxRecvs = ofi_properties.max_group_receives;
+	props->netDeviceType = NCCL_NET_DEVICE_HOST;
+	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+	props->vProps.ndevs = 1;
+	props->vProps.devs[0] = dev_id;
+	props->maxP2pBytes = ofi_properties.max_p2p_bytes;
+	props->maxCollBytes = ofi_properties.max_coll_bytes;
+	props->maxMultiRequestSize = 1;
+	props->railId = -1;
+	props->planeId = -1;
+
+	return ncclSuccess;
+}
+
+
+static ncclResult_t connect_v12(void *ctx, int dev, void *handle,
+				void **sendComm, ncclNetDeviceHandle_v12_t **sendDevComm)
+{
+	ncclNetCommConfig_v12_t *config = (ncclNetCommConfig_v12_t *)ctx;
+	return nccl_net_ofi_connect(dev, handle, sendComm, config->trafficClass, 0, 0);
+}
+
+
 extern "C" {
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v6_t ncclNetPlugin_v6 = {
@@ -726,6 +788,31 @@ NCCL_OFI_EXPORT_SYMBOL ncclNet_v11_t ncclNetPlugin_v11 = {
         .setNetAttr = NULL,
 };
 
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v12_t ncclNetPlugin_v12 = {
+        .name = "Libfabric",
+        .init = init_v12,
+        .devices = devices_v2,
+        .getProperties = getProperties_v12,
+        .listen = listen_v11,
+        .connect = connect_v12,
+        .accept = accept_v9,
+        .regMr = regMr_v8,
+        .regMrDmaBuf = regMrDmaBuf_v6,
+        .deregMr = deregMr_v2,
+        .isend = isend_v10,
+        .irecv = irecv_v10,
+        .iflush = iflush_v5,
+        .test = test_v2,
+        .closeSend = closeSend_v2,
+        .closeRecv = closeRecv_v2,
+        .closeListen = closeListen_v2,
+        .getDeviceMr = NULL,
+        .irecvConsumed = NULL,
+        .makeVDevice = NULL,
+        .finalize = finalize_v11,
+        .setNetAttr = NULL,
+};
+
 } /* extern "C" */
 
 
@@ -747,6 +834,7 @@ __attribute__((constructor)) static void nvidia_plugin_name_fixup(void)
 		ncclNetPlugin_v9.name = "AWS Libfabric";
 		ncclNetPlugin_v10.name = "AWS Libfabric";
 		ncclNetPlugin_v11.name = "AWS Libfabric";
+		ncclNetPlugin_v12.name = "AWS Libfabric";
 	} else if (net_env != NULL && 0 == strcasecmp(net_env, "OFI")) {
 		ncclNetPlugin_v6.name = "OFI";
 		ncclNetPlugin_v7.name = "OFI";
@@ -754,5 +842,6 @@ __attribute__((constructor)) static void nvidia_plugin_name_fixup(void)
 		ncclNetPlugin_v9.name = "OFI";
 		ncclNetPlugin_v10.name = "OFI";
 		ncclNetPlugin_v11.name = "OFI";
+		ncclNetPlugin_v12.name = "OFI";
 	}
 }

--- a/src/nccl_ofi_interface_nvidia.cpp
+++ b/src/nccl_ofi_interface_nvidia.cpp
@@ -589,6 +589,68 @@ static ncclResult_t finalize_v11(void *ctx)
 }
 
 
+static ncclResult_t init_v12(void **ctx, uint64_t commId, ncclNetCommConfig_v12_t *config,
+			     ncclDebugLogger_t logFunction, ncclProfilerCallback_t profFunction)
+{
+	std::lock_guard lock(netMutex);
+	ncclNetCommConfig_v12_t *net_config = (ncclNetCommConfig_v12_t *)malloc(sizeof(ncclNetCommConfig_v12_t));
+	if (net_config == NULL) return ncclSystemError;
+	net_config->trafficClass = config->trafficClass;
+	*ctx = net_config;
+
+	if (netRefCount++ > 0) return ncclSuccess;
+	return nccl_net_ofi_init(logFunction);
+}
+
+
+static ncclResult_t getProperties_v12(int dev_id, ncclNetProperties_v12_t *props)
+{
+	nccl_ofi_properties_t ofi_properties;
+	ncclResult_t ret = nccl_net_ofi_get_properties(dev_id, &ofi_properties);
+	if (ret != ncclSuccess) {
+		return ret;
+	}
+
+	props->name = ofi_properties.name;
+	props->pciPath = ofi_properties.pci_path;
+	props->guid = ofi_properties.guid;
+	props->ptrSupport = NCCL_PTR_HOST;
+	if (ofi_properties.hmem_support) {
+		props->ptrSupport |= NCCL_PTR_CUDA;
+	}
+	if (ofi_properties.dmabuf_support) {
+		props->ptrSupport |= NCCL_PTR_DMABUF;
+	}
+
+	props->regIsGlobal = ofi_properties.regIsGlobal;
+	props->forceFlush = 0;
+	props->speed = ofi_properties.port_speed;
+	props->port = ofi_properties.port_number;
+	props->latency = ofi_properties.latency;
+	props->maxComms = ofi_properties.max_communicators;
+	props->maxRecvs = ofi_properties.max_group_receives;
+	props->netDeviceType = NCCL_NET_DEVICE_HOST;
+	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+	props->vProps.ndevs = 1;
+	props->vProps.devs[0] = dev_id;
+	props->maxP2pBytes = ofi_properties.max_p2p_bytes;
+	props->maxCollBytes = ofi_properties.max_coll_bytes;
+	props->maxMultiRequestSize = 1;
+	props->railId = -1;
+	props->planeId = -1;
+
+	return ncclSuccess;
+}
+
+
+static ncclResult_t connect_v12(void *ctx, int dev, void *handle,
+				void **sendComm, ncclNetDeviceHandle_v12_t **sendDevComm)
+{
+	ncclNetCommConfig_v12_t *config = (ncclNetCommConfig_v12_t *)ctx;
+	return nccl_net_ofi_connect(dev, handle, sendComm, config->trafficClass, 0, 0);
+}
+
+
 extern "C" {
 
 NCCL_OFI_EXPORT_SYMBOL ncclNet_v6_t ncclNetPlugin_v6 = {
@@ -726,6 +788,37 @@ NCCL_OFI_EXPORT_SYMBOL ncclNet_v11_t ncclNetPlugin_v11 = {
         .setNetAttr = NULL,
 };
 
+/* Net v12 was introduced in NCCL v2.30.
+ * Each function uses the earliest version whose signature is compatible
+ * with v12.  New v12 wrappers are only needed where the NCCL type names
+ * changed (init, getProperties, connect), even though the underlying
+ * layouts are identical to v11.
+ */
+NCCL_OFI_EXPORT_SYMBOL ncclNet_v12_t ncclNetPlugin_v12 = {
+        .name = "Libfabric",
+        .init = init_v12,
+        .devices = devices_v2,
+        .getProperties = getProperties_v12,
+        .listen = listen_v11,
+        .connect = connect_v12,
+        .accept = accept_v9,
+        .regMr = regMr_v8,
+        .regMrDmaBuf = regMrDmaBuf_v6,
+        .deregMr = deregMr_v2,
+        .isend = isend_v10,
+        .irecv = irecv_v10,
+        .iflush = iflush_v5,
+        .test = test_v2,
+        .closeSend = closeSend_v2,
+        .closeRecv = closeRecv_v2,
+        .closeListen = closeListen_v2,
+        .getDeviceMr = NULL,
+        .irecvConsumed = NULL,
+        .makeVDevice = NULL,
+        .finalize = finalize_v11,
+        .setNetAttr = NULL,
+};
+
 } /* extern "C" */
 
 
@@ -747,6 +840,7 @@ __attribute__((constructor)) static void nvidia_plugin_name_fixup(void)
 		ncclNetPlugin_v9.name = "AWS Libfabric";
 		ncclNetPlugin_v10.name = "AWS Libfabric";
 		ncclNetPlugin_v11.name = "AWS Libfabric";
+		ncclNetPlugin_v12.name = "AWS Libfabric";
 	} else if (net_env != NULL && 0 == strcasecmp(net_env, "OFI")) {
 		ncclNetPlugin_v6.name = "OFI";
 		ncclNetPlugin_v7.name = "OFI";
@@ -754,5 +848,6 @@ __attribute__((constructor)) static void nvidia_plugin_name_fixup(void)
 		ncclNetPlugin_v9.name = "OFI";
 		ncclNetPlugin_v10.name = "OFI";
 		ncclNetPlugin_v11.name = "OFI";
+		ncclNetPlugin_v12.name = "OFI";
 	}
 }

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -318,6 +318,100 @@ static ncclResult_t nccl_ofi_gin_finalize(void *ctx)
 	return ncclSuccess;
 }
 
+/**
+ * v13 proxy context. Created by createContext, wraps the collComm pointer
+ * so that v13 functions receiving ginCtx can recover the underlying comm.
+ */
+struct nccl_ofi_gin_proxy_ctx {
+	void *collComm;
+};
+
+static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v12_t *props)
+{
+	nccl_ofi_properties_t ofi_properties;
+	ncclResult_t ret = nccl_net_ofi_get_properties(dev, &ofi_properties);
+	if (ret != ncclSuccess) {
+		return ret;
+	}
+
+	props->name = ofi_properties.name;
+	props->pciPath = ofi_properties.pci_path;
+	props->guid = ofi_properties.guid;
+	props->ptrSupport = NCCL_PTR_HOST;
+	if (ofi_properties.hmem_support) {
+		props->ptrSupport |= NCCL_PTR_CUDA;
+	}
+	if (ofi_properties.dmabuf_support) {
+		props->ptrSupport |= NCCL_PTR_DMABUF;
+	}
+
+	props->regIsGlobal = ofi_properties.regIsGlobal;
+	props->forceFlush = 0;
+	props->speed = ofi_properties.port_speed;
+	props->port = ofi_properties.port_number;
+	props->latency = ofi_properties.latency;
+	props->maxComms = ofi_properties.max_communicators;
+	props->maxRecvs = ofi_properties.max_group_receives;
+	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
+	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+	props->vProps.ndevs = 1;
+	props->vProps.devs[0] = dev;
+	props->maxP2pBytes = ofi_properties.max_p2p_bytes;
+	props->maxCollBytes = ofi_properties.max_coll_bytes;
+	props->maxMultiRequestSize = 1;
+	props->railId = -1;
+	props->planeId = -1;
+
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_createContext_v13(void *collComm, ncclGinConfig_v13_t *config,
+						   void **ginCtx, ncclNetDeviceHandle_v11_t **devHandle)
+{
+	auto *proxy_ctx = new (std::nothrow) nccl_ofi_gin_proxy_ctx{collComm};
+	if (proxy_ctx == nullptr) {
+		return ncclSystemError;
+	}
+	*ginCtx = proxy_ctx;
+	if (devHandle != nullptr) {
+		*devHandle = nullptr;
+	}
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_destroyContext_v13(void *ginCtx)
+{
+	delete static_cast<nccl_ofi_gin_proxy_ctx *>(ginCtx);
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_iput_v13(void *ginCtx, int context, uint64_t srcOff,
+					  void *srcMhandle, size_t size, uint64_t dstOff,
+					  void *dstMhandle, uint32_t rank, void **request)
+{
+	auto *proxy_ctx = static_cast<nccl_ofi_gin_proxy_ctx *>(ginCtx);
+	return nccl_ofi_gin_iput(proxy_ctx->collComm, srcOff, srcMhandle, size,
+				 dstOff, dstMhandle, rank, request);
+}
+
+static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint64_t srcOff,
+						void *srcMhandle, size_t size, uint64_t dstOff,
+						void *dstMhandle, uint32_t rank, uint64_t signalOff,
+						void *signalMhandle, uint64_t signalValue,
+						uint32_t signalOp, void **request)
+{
+	auto *proxy_ctx = static_cast<nccl_ofi_gin_proxy_ctx *>(ginCtx);
+	return nccl_ofi_gin_iputSignal(proxy_ctx->collComm, srcOff, srcMhandle, size,
+				       dstOff, dstMhandle, rank, signalOff, signalMhandle,
+				       signalValue, signalOp, request);
+}
+
+static ncclResult_t nccl_ofi_gin_ginProgress_v13(void *ginCtx)
+{
+	auto *proxy_ctx = static_cast<nccl_ofi_gin_proxy_ctx *>(ginCtx);
+	return nccl_ofi_gin_ginProgress(proxy_ctx->collComm);
+}
+
 NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	/* Since there is no equivalent of NCCL_NET for GIN, currently we don't
 	   have name fixup depending on env var like nvidia_plugin_name_fixup().
@@ -342,6 +436,30 @@ NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	.test = nccl_ofi_gin_test,
 	.ginProgress = nccl_ofi_gin_ginProgress,
 	/* Not used by NCCL in proxy mode */
+	.queryLastError = nullptr,
+	.finalize = nccl_ofi_gin_finalize
+};
+
+NCCL_OFI_EXPORT_SYMBOL ncclGin_v13_t ncclGinPlugin_v13 = {
+	.name = "Libfabric",
+	.init = nccl_ofi_gin_init,
+	.devices = nccl_ofi_gin_devices,
+	.getProperties = nccl_ofi_gin_getProperties_v13,
+	.listen = nccl_ofi_gin_listen,
+	.connect = nccl_ofi_gin_connect,
+	.createContext = nccl_ofi_gin_createContext_v13,
+	.regMrSym = nccl_ofi_gin_regMrSym,
+	.regMrSymDmaBuf = nccl_ofi_gin_regMrSymDmaBuf,
+	.deregMrSym = nccl_ofi_gin_deregMrSym,
+	.destroyContext = nccl_ofi_gin_destroyContext_v13,
+	.closeColl = nccl_ofi_gin_closeColl,
+	.closeListen = nccl_ofi_gin_closeListen,
+	.iput = nccl_ofi_gin_iput_v13,
+	.iputSignal = nccl_ofi_gin_iputSignal_v13,
+	.iget = nullptr,
+	.iflush = nullptr,
+	.test = nccl_ofi_gin_test,
+	.ginProgress = nccl_ofi_gin_ginProgress_v13,
 	.queryLastError = nullptr,
 	.finalize = nccl_ofi_gin_finalize
 };

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -318,6 +318,78 @@ static ncclResult_t nccl_ofi_gin_finalize(void *ctx)
 	return ncclSuccess;
 }
 
+static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v12_t *props)
+{
+	nccl_ofi_properties_t ofi_properties;
+	ncclResult_t ret = nccl_net_ofi_get_properties(dev, &ofi_properties);
+	if (ret != ncclSuccess) {
+		return ret;
+	}
+
+	props->name = ofi_properties.name;
+	props->pciPath = ofi_properties.pci_path;
+	props->guid = ofi_properties.guid;
+	props->ptrSupport = NCCL_PTR_HOST;
+	if (ofi_properties.hmem_support) {
+		props->ptrSupport |= NCCL_PTR_CUDA;
+	}
+	if (ofi_properties.dmabuf_support) {
+		props->ptrSupport |= NCCL_PTR_DMABUF;
+	}
+
+	props->regIsGlobal = ofi_properties.regIsGlobal;
+	props->forceFlush = 0;
+	props->speed = ofi_properties.port_speed;
+	props->port = ofi_properties.port_number;
+	props->latency = ofi_properties.latency;
+	props->maxComms = ofi_properties.max_communicators;
+	props->maxRecvs = ofi_properties.max_group_receives;
+	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
+	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
+	props->vProps.ndevs = 1;
+	props->vProps.devs[0] = dev;
+	props->maxP2pBytes = ofi_properties.max_p2p_bytes;
+	props->maxCollBytes = ofi_properties.max_coll_bytes;
+	props->maxMultiRequestSize = 1;
+	props->railId = -1;
+	props->planeId = -1;
+
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_createContext_v13(void *collComm, ncclGinConfig_v13_t *config,
+						   void **ginCtx, ncclNetDeviceHandle_v11_t **devHandle)
+{
+	*ginCtx = collComm;
+	if (devHandle != nullptr)
+		*devHandle = nullptr;
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_destroyContext_v13(void *ginCtx)
+{
+	return ncclSuccess;
+}
+
+static ncclResult_t nccl_ofi_gin_iput_v13(void *ginCtx, int context, uint64_t srcOff,
+					  void *srcMhandle, size_t size, uint64_t dstOff,
+					  void *dstMhandle, uint32_t rank, void **request)
+{
+	return nccl_ofi_gin_iput(ginCtx, srcOff, srcMhandle, size,
+				 dstOff, dstMhandle, rank, request);
+}
+
+static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint64_t srcOff,
+						void *srcMhandle, size_t size, uint64_t dstOff,
+						void *dstMhandle, uint32_t rank, uint64_t signalOff,
+						void *signalMhandle, uint64_t signalValue,
+						uint32_t signalOp, void **request)
+{
+	return nccl_ofi_gin_iputSignal(ginCtx, srcOff, srcMhandle, size,
+				       dstOff, dstMhandle, rank, signalOff, signalMhandle,
+				       signalValue, signalOp, request);
+}
+
 NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	/* Since there is no equivalent of NCCL_NET for GIN, currently we don't
 	   have name fixup depending on env var like nvidia_plugin_name_fixup().
@@ -342,6 +414,31 @@ NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	.test = nccl_ofi_gin_test,
 	.ginProgress = nccl_ofi_gin_ginProgress,
 	/* Not used by NCCL in proxy mode */
+	.queryLastError = nullptr,
+	.finalize = nccl_ofi_gin_finalize
+};
+
+/* GIN v13 was introduced in NCCL v2.30 */
+NCCL_OFI_EXPORT_SYMBOL ncclGin_v13_t ncclGinPlugin_v13 = {
+	.name = "Libfabric",
+	.init = nccl_ofi_gin_init,
+	.devices = nccl_ofi_gin_devices,
+	.getProperties = nccl_ofi_gin_getProperties_v13,
+	.listen = nccl_ofi_gin_listen,
+	.connect = nccl_ofi_gin_connect,
+	.createContext = nccl_ofi_gin_createContext_v13,
+	.regMrSym = nccl_ofi_gin_regMrSym,
+	.regMrSymDmaBuf = nccl_ofi_gin_regMrSymDmaBuf,
+	.deregMrSym = nccl_ofi_gin_deregMrSym,
+	.destroyContext = nccl_ofi_gin_destroyContext_v13,
+	.closeColl = nccl_ofi_gin_closeColl,
+	.closeListen = nccl_ofi_gin_closeListen,
+	.iput = nccl_ofi_gin_iput_v13,
+	.iputSignal = nccl_ofi_gin_iputSignal_v13,
+	.iget = nullptr,
+	.iflush = nullptr,
+	.test = nccl_ofi_gin_test,
+	.ginProgress = nccl_ofi_gin_ginProgress,
 	.queryLastError = nullptr,
 	.finalize = nccl_ofi_gin_finalize
 };

--- a/tests/functional/functional_test.h
+++ b/tests/functional/functional_test.h
@@ -83,10 +83,10 @@
 
 // Can be changed when porting new versions to the plugin
 #define NCCL_PLUGIN_SYMBOL ncclNetPlugin_v11
-#define NCCL_GIN_PLUGIN_SYMBOL ncclGinPlugin_v11
+#define NCCL_GIN_PLUGIN_SYMBOL ncclGinPlugin_v13
 
 typedef ncclNet_v11_t test_nccl_net_t;
-typedef ncclGin_v11_t test_nccl_gin_t;
+typedef ncclGin_v13_t test_nccl_gin_t;
 typedef ncclNetProperties_v11_t test_nccl_properties_t;
 typedef ncclNetDeviceHandle_v11_t test_nccl_net_device_handle_t;
 typedef ncclNetCommConfig_v11_t test_nccl_net_config_t;

--- a/tests/functional/gin.cpp
+++ b/tests/functional/gin.cpp
@@ -11,7 +11,8 @@
 #include <vector>
 
 static inline ncclResult_t
-poll_request_completion(ncclGin_v11_t *extGin, std::deque<void *> &request_deque, void *collComm)
+poll_request_completion(ncclGin_v13_t *extGin, std::deque<void *> &request_deque, void *collComm,
+		       void *ginCtx)
 {
 	/* Wait for outstanding requests */
 	int done = 0;
@@ -19,18 +20,12 @@ poll_request_completion(ncclGin_v11_t *extGin, std::deque<void *> &request_deque
 	if (done) {
 		request_deque.pop_front();
 	} else {
-		/**
-		 * Note: The NCCL GIN proxy thread will call ginProgress repeatedly
-		 * until the communicator is closed. We emulate that throughout this
-		 * test by ensuring each rank calls `ginProgress` until the barrier
-		 * before verification is reached.
-		 */
-		OFINCCLCHECK(extGin->ginProgress(collComm));
+		OFINCCLCHECK(extGin->ginProgress(ginCtx));
 	}
 	return ncclSuccess;
 }
 
-static inline ncclResult_t alloc_and_reg_buff(ncclGin_v11_t *extGin, void *collComm, size_t size,
+static inline ncclResult_t alloc_and_reg_buff(ncclGin_v13_t *extGin, void *collComm, size_t size,
 					      int buffer_type, int value, void **buff,
 					      void **mr_handle)
 {
@@ -151,7 +146,7 @@ int main(int argc, char *argv[])
 
 	/* Get Properties for the device */
 	for (dev = 0; dev < ndev; dev++) {
-		ncclNetProperties_v11_t props = {};
+		ncclNetProperties_v12_t props = {};
 		OFINCCLCHECK(extGin->getProperties(dev, &props));
 
 		/* Set CUDA support */
@@ -191,6 +186,18 @@ int main(int argc, char *argv[])
 		extGin->connect(ginCtx, handles_ptrs.data(), nranks, rank, listenComm, &collComm));
 	assert(collComm != nullptr);
 
+	/* v13: create a GIN context from the collComm */
+	ncclGinConfig_v13_t ginConfig = {};
+	ginConfig.nSignals = 64;
+	ginConfig.nContexts = 1;
+	ginConfig.queueDepth = 64;
+	ginConfig.trafficClass = -1;
+
+	void *proxyCtx = nullptr;
+	ncclNetDeviceHandle_v11_t *devHandle = nullptr;
+	OFINCCLCHECK(extGin->createContext(collComm, &ginConfig, &proxyCtx, &devHandle));
+	assert(proxyCtx != nullptr);
+
 	/* Allocate, register, and initialize all buffers to zero. */
 	void *put_buff = nullptr;
 	void *put_mhandle = nullptr;
@@ -224,7 +231,7 @@ int main(int argc, char *argv[])
 			/* iput API */
 			for (int i = 0; i < NUM_REQS_PER_PEER; ++i) {
 				void *request = nullptr;
-				OFINCCLCHECK(extGin->iput(collComm, 0, put_mhandle, SEND_SIZE, 0,
+				OFINCCLCHECK(extGin->iput(proxyCtx, 0, 0, put_mhandle, SEND_SIZE, 0,
 							  put_mhandle, dst_rank, &request));
 				assert(request != nullptr);
 				request_deque.push_back(request);
@@ -235,8 +242,9 @@ int main(int argc, char *argv[])
 				/* TODO: Expand the test to cover other signal types, such as
 				 * NCCL_NET_SIGNAL_OP_ADD */
 				void *request = nullptr;
-				OFINCCLCHECK(extGin->iputSignal(collComm, 0, put_signal_mhandle,
-								SEND_SIZE, 0, put_signal_mhandle,
+				OFINCCLCHECK(extGin->iputSignal(proxyCtx, 0, 0,
+								put_signal_mhandle, SEND_SIZE,
+								0, put_signal_mhandle,
 								dst_rank, 0, signal_mhandle, 1,
 								NCCL_NET_SIGNAL_OP_INC, &request));
 				assert(request != nullptr);
@@ -246,13 +254,13 @@ int main(int argc, char *argv[])
 
 		/* Wait for remaining requests */
 		while (!request_deque.empty()) {
-			OFINCCLCHECK(poll_request_completion(extGin, request_deque, collComm));
+			OFINCCLCHECK(poll_request_completion(extGin, request_deque, collComm, proxyCtx));
 		}
 	} else {
 		/* Validate that the signal_buff reaches the designated signal value */
 		uint64_t signal_h = 0;
 		while (signal_h != NUM_REQS_PER_PEER) {
-			OFINCCLCHECK(extGin->ginProgress(collComm));
+			OFINCCLCHECK(extGin->ginProgress(proxyCtx));
 			CUDACHECK(cudaMemcpy(&signal_h, signal_buf, sizeof(uint64_t),
 					     cudaMemcpyDefault));
 		}
@@ -263,7 +271,7 @@ int main(int argc, char *argv[])
 	int barrier_done = 0;
 	while (!barrier_done) {
 		/* Make progress on comm until all ranks reach the barrier */
-		OFINCCLCHECK(extGin->ginProgress(collComm));
+		OFINCCLCHECK(extGin->ginProgress(proxyCtx));
 		MPI_Test(&barrier_req, &barrier_done, MPI_STATUS_IGNORE);
 	}
 
@@ -279,6 +287,9 @@ int main(int argc, char *argv[])
 	put_signal_mhandle = nullptr;
 	OFINCCLCHECK(extGin->deregMrSym(collComm, put_mhandle));
 	put_mhandle = nullptr;
+
+	OFINCCLCHECK(extGin->destroyContext(proxyCtx));
+	proxyCtx = nullptr;
 
 	OFINCCLCHECK(extGin->closeColl(collComm));
 	collComm = nullptr;


### PR DESCRIPTION
*Description of changes:*
- Adds new net_v12 header from NCCL v2.30.3-1.
- Updates net interface with new v12 API
- Updates gin interface with new v13 API
- Updates functional test to use new v13 API

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
