### PR TITLE
Convert MR cache from C struct to C++ class

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -519,7 +519,7 @@ public:
 	/*
 	 * Protocol-agnostic MR cache for this device.
 	 */
-	nccl_ofi_mr_cache_t *mr_cache = nullptr;
+	nccl_ofi_mr_cache *mr_cache = nullptr;
 
 	/* Memory registration key pool */
 	nccl_ofi_idpool_t *mr_rkey_pool = nullptr;

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -12,6 +12,7 @@
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/uio.h>
+#include <vector>
 
 #include <rdma/fi_domain.h>
 #include "nccl_ofi_math.h"
@@ -194,57 +195,72 @@ typedef struct nccl_ofi_reg_entry {
 /**
  * Device-specific memory registration cache.
  */
-typedef struct nccl_ofi_mr_cache {
-	nccl_ofi_reg_entry_t **slots;
-	size_t system_page_size;
-	size_t size;
-	size_t used;
-	uint32_t hit_count;
-	uint32_t miss_count;
+class nccl_ofi_mr_cache {
+public:
+	/**
+	 * Create a new mr cache. Both the initial number of entries and the
+	 * system page size must be greater than zero.
+	 *
+	 * @param init_num_entries Initial capacity (used for vector::reserve)
+	 * @param mr_cache_page_size Page size for address alignment
+	 * @throws std::runtime_error on invalid arguments
+	 */
+	nccl_ofi_mr_cache(size_t init_num_entries, size_t mr_cache_page_size);
+
+	/**
+	 * Destructor. Logs hit/miss stats and destroys the mutex.
+	 */
+	~nccl_ofi_mr_cache();
+
+	/* Not copyable or movable */
+	nccl_ofi_mr_cache(const nccl_ofi_mr_cache &) = delete;
+	nccl_ofi_mr_cache &operator=(const nccl_ofi_mr_cache &) = delete;
+
+	/**
+	 * Lookup a cache entry matching the given address and size.
+	 * Input addr and size are rounded up to enclosing page boundaries.
+	 * If entry is found, refcnt is increased.
+	 *
+	 * @return mr handle if found, or NULL if not found
+	 */
+	void *lookup_entry(nccl_ofi_mr_ckey_ref ckey, bool is_endpoint_mr);
+
+	/**
+	 * Insert a new cache entry with the given address and size.
+	 * Input addr and size are rounded up to enclosing page boundaries.
+	 *
+	 * @return 0, on success
+	 *	   -ENOMEM, on allocation failure
+	 *	   -EEXIST, if matching entry already exists in cache
+	 */
+	int insert_entry(nccl_ofi_mr_ckey_ref ckey, bool is_endpoint_mr, void *handle);
+
+	/**
+	 * Decrement refcnt of entry with given handle. If refcnt was reduced
+	 * to 0, delete entry from cache. Return value indicates whether entry
+	 * was deleted from cache (in which case, caller should deregister the
+	 * handle).
+	 *
+	 * @return 0, on success, and reg was not deleted (refcnt not zero)
+	 *	   1, on success, and reg was deleted (refcnt was zero)
+	 *	   -ENOENT, if no matching entry was found
+	 */
+	int del_entry(void *handle);
+
 	pthread_mutex_t lock;
-} nccl_ofi_mr_cache_t;
 
-/**
- * Create a new mr cache. Both then initial number of entries and the system
- * page size must be greater than zero.
- * @return a new mr cache, or NULL if an allocation error occurred
- */
-nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
-					    size_t mr_cache_page_size);
+private:
+	std::vector<nccl_ofi_reg_entry_t *> slots;
+	size_t system_page_size;
+	uint32_t hit_count = 0;
+	uint32_t miss_count = 0;
 
-/**
- * Finalize mr cache
- */
-void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache);
-
-/**
- * Lookup a cache entry matching the given address and size
- * Input addr and size are rounded up to enclosing page boundaries.
- * If entry is found, refcnt is increased
- * @return mr handle if found, or NULL if not found
- */
-void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache, nccl_ofi_mr_ckey_ref ckey,
-				     bool is_endpoint_mr);
-
-/**
- * Insert a new cache entry with the given address and size
- * Input addr and size are rounded up to enclosing page boundaries.
- * @return 0, on success
- *	   -ENOMEM, on allocation failure
- *	   -EEXIST, if matching entry already exists in cache
- */
-int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache, nccl_ofi_mr_ckey_ref ckey,
-				   bool is_endpoint_mr, void *handle);
-
-/**
- * Decrement refcnt of entry with given handle. If refcnt was reduced to 0,
- * delete entry from cache. Return value indicates whether entry was deleted
- * from cache (in which case, caller should deregister the handle).
- *
- * @return 0, on success, and reg was not deleted (refcnt not zero)
- *	   1, on success, and reg was deleted (refcnt was zero)
- *	   -ENOENT, if no matching entry was found
- */
-int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle);
+	/**
+	 * Compute page-aligned address and number of pages for a given
+	 * address and size, using this cache's system_page_size.
+	 */
+	void compute_page_address(uintptr_t addr, size_t size,
+				  uintptr_t *page_addr, size_t *pages) const;
+};
 
 #endif  // End NCCL_OFI_MR_H_

--- a/src/nccl_ofi_mr.cpp
+++ b/src/nccl_ofi_mr.cpp
@@ -5,196 +5,123 @@
 #include "config.h"
 
 #include <errno.h>
+#include <stdexcept>
 #include <stdlib.h>
+#include <cstring>
 
 #include "nccl_ofi_mr.h"
 #include "nccl_ofi_pthread.h"
 
-nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
-					    size_t mr_cache_page_size)
+void nccl_ofi_mr_cache::compute_page_address(uintptr_t addr,
+					     size_t size,
+					     uintptr_t *page_addr,
+					     size_t *pages) const
 {
-	nccl_ofi_mr_cache_t *ret_cache = NULL;
+	*page_addr = addr & -(uintptr_t)this->system_page_size; /* start of page of data */
+	*pages = (addr + size - (*page_addr) + this->system_page_size - 1) / this->system_page_size; /* Number of pages in buffer */
+}
 
+nccl_ofi_mr_cache::nccl_ofi_mr_cache(size_t init_num_entries,
+				     size_t mr_cache_page_size)
+{
 	if (init_num_entries == 0) {
 		NCCL_OFI_WARN("MR cache: initial number of entries must be positive");
-		goto error;
+		throw std::runtime_error("MR cache: initial number of entries must be positive");
 	}
 
 	if (mr_cache_page_size == 0) {
 		NCCL_OFI_WARN("MR cache: system page size must be positive");
-		goto error;
+		throw std::runtime_error("MR cache: system page size must be positive");
 	}
 
-	ret_cache = (nccl_ofi_mr_cache_t *)calloc(1, sizeof(*ret_cache));
-	if (!ret_cache) {
-		NCCL_OFI_WARN("Could not allocate memory for cache");
-		goto error;
+	if (nccl_net_ofi_mutex_init(&this->lock, NULL)) {
+		throw std::runtime_error("MR cache: mutex init failed");
 	}
 
-	ret_cache->slots = (nccl_ofi_reg_entry_t **)calloc(init_num_entries, sizeof(*ret_cache->slots));
-	if (!ret_cache->slots) {
-		NCCL_OFI_WARN("Could not allocate memory for cache slots");
-		goto error;
-	}
-
-	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
-		goto error;
-	}
 	/*
 	 * System page size isn't reflective of the GDR mappings. We're not trying to map a
 	 * whole page, but just to find an interval that makes an array-based cache manageable.
 	 */
-	ret_cache->system_page_size = mr_cache_page_size;
-	ret_cache->size = init_num_entries;
-	ret_cache->used = 0;
-	ret_cache->hit_count = 0;
-	ret_cache->miss_count = 0;
-
-	return ret_cache;
-
-error:
-	if (ret_cache) {
-		if (ret_cache->slots) {
-			free(ret_cache->slots);
-		}
-		free(ret_cache);
-	}
-	return NULL;
+	this->system_page_size = mr_cache_page_size;
+	this->slots.reserve(init_num_entries);
 }
 
-void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache)
+nccl_ofi_mr_cache::~nccl_ofi_mr_cache()
 {
-	assert(cache);
-
 	NCCL_OFI_INFO(NCCL_NET,
 		      "MR cache %d hits %d misses",
-		      cache->hit_count,
-		      cache->miss_count);
+		      this->hit_count,
+		      this->miss_count);
 
-	nccl_net_ofi_mutex_destroy(&cache->lock);
-
-	free(cache->slots);
-
-	free(cache);
+	nccl_net_ofi_mutex_destroy(&this->lock);
 }
 
-/**
- * Grow cache to 2x its current size
- */
-static int nccl_ofi_mr_cache_grow(nccl_ofi_mr_cache_t *cache)
-{
-	void *ptr;
-	int ret = 0;
-	cache->size *= 2;
-	NCCL_OFI_TRACE(NCCL_NET, "Growing cache to size %zu", cache->size);
-	ptr = realloc(cache->slots, cache->size * sizeof(*cache->slots));
-	if (!ptr) {
-		NCCL_OFI_WARN("Unable to grow cache");
-		ret = -ENOMEM;
-		goto out;
-	}
-	cache->slots = (nccl_ofi_reg_entry_t **)ptr;
-
-out:
-	return ret;
-}
-
-static inline void compute_page_address(uintptr_t addr,
-					size_t size,
-					uintptr_t system_page_size,
-					uintptr_t *page_addr,
-					size_t *pages)
-{
-	*page_addr = addr & -system_page_size; /* start of page of data */
-	*pages = (addr + size - (*page_addr) + system_page_size - 1) / system_page_size; /* Number of pages in buffer */
-}
-
-void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache,
-				     nccl_ofi_mr_ckey_ref ckey,
-				     bool is_endpoint_mr)
+void *nccl_ofi_mr_cache::lookup_entry(nccl_ofi_mr_ckey_ref ckey,
+				      bool is_endpoint_mr)
 {
 	uintptr_t page_addr;
 	size_t pages;
 
-	compute_page_address(nccl_ofi_mr_ckey_baseaddr(ckey),
+	this->compute_page_address(nccl_ofi_mr_ckey_baseaddr(ckey),
 			     nccl_ofi_mr_ckey_len(ckey),
-			     (uintptr_t)cache->system_page_size,
 			     &page_addr,
 			     &pages);
 
 	for (size_t slot = 0;; slot++) {
-		assert(slot <= cache->used && slot <= cache->size);
+		assert(slot <= this->slots.size());
 
-		if (slot == cache->used ||
-		    page_addr < cache->slots[slot]->addr) {
+		if (slot == this->slots.size() ||
+		    page_addr < this->slots[slot]->addr) {
 			/* cache missed */
-			cache->miss_count++;
+			this->miss_count++;
 			return NULL;
-		} else if (is_endpoint_mr && (ckey->ep != cache->slots[slot]->ep)) {
+		} else if (is_endpoint_mr && (ckey->ep != this->slots[slot]->ep)) {
                         continue;
-		} else if ((page_addr >= cache->slots[slot]->addr) &&
-			   ((page_addr - cache->slots[slot]->addr) /
-				    cache->system_page_size +
-			    pages) <= cache->slots[slot]->pages) {
+		} else if ((page_addr >= this->slots[slot]->addr) &&
+			   ((page_addr - this->slots[slot]->addr) /
+				    this->system_page_size +
+			    pages) <= this->slots[slot]->pages) {
 			/* cache hit */
-			cache->hit_count++;
+			this->hit_count++;
 			NCCL_OFI_TRACE(NCCL_NET,
 			               "Found MR handle %p for %ld(%s) in cache slot %zu",
-			               cache->slots[slot]->handle,
+			               this->slots[slot]->handle,
 			               nccl_ofi_mr_ckey_baseaddr(ckey),
 			               nccl_ofi_mr_ckey_type_str(ckey),
 			               slot);
-			cache->slots[slot]->refcnt++;
-			return cache->slots[slot]->handle;
+			this->slots[slot]->refcnt++;
+			return this->slots[slot]->handle;
 		}
 	}
 }
 
-int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
-				   nccl_ofi_mr_ckey_ref ckey,
-				   bool is_endpoint_mr,
-				   void *handle)
+int nccl_ofi_mr_cache::insert_entry(nccl_ofi_mr_ckey_ref ckey,
+				    bool is_endpoint_mr,
+				    void *handle)
 {
 	uintptr_t page_addr;
 	size_t pages;
 	int ret = 0;
 
-	compute_page_address((uintptr_t)nccl_ofi_mr_ckey_baseaddr(ckey),
+	this->compute_page_address((uintptr_t)nccl_ofi_mr_ckey_baseaddr(ckey),
 	                     nccl_ofi_mr_ckey_len(ckey),
-	                     (uintptr_t)cache->system_page_size,
 	                     &page_addr,
 	                     &pages);
 
 	for (size_t slot = 0;; slot++) {
-		assert(slot <= cache->used && slot <= cache->size);
+		assert(slot <= this->slots.size());
 
-		if (slot == cache->used ||
-		    page_addr < cache->slots[slot]->addr) {
-			/* cache missed */
+		if (slot == this->slots.size() ||
+		    page_addr < this->slots[slot]->addr) {
+			/* cache missed — insert here */
 
-			/* grow the cache if needed */
-			if (cache->used == cache->size) {
-				ret = nccl_ofi_mr_cache_grow(cache);
-				if (ret != 0) {
-					goto out;
-				}
-			}
-
-			assert(cache->slots);
-			memmove(cache->slots + slot + 1,
-				cache->slots + slot,
-				(cache->used - slot) *
-					sizeof(nccl_ofi_reg_entry_t *));
-			cache->slots[slot] = (nccl_ofi_reg_entry_t *)calloc(
-				1,
-				sizeof(nccl_ofi_reg_entry_t));
-			if (!cache->slots[slot]) {
+			nccl_ofi_reg_entry_t *entry = (nccl_ofi_reg_entry_t *)calloc(
+				1, sizeof(nccl_ofi_reg_entry_t));
+			if (!entry) {
 				NCCL_OFI_WARN("Failed to allocate new slot");
 				ret = -ENOMEM;
 				goto out;
 			}
-
-			nccl_ofi_reg_entry_t *entry = cache->slots[slot];
 
 			entry->addr = page_addr;
 			entry->pages = pages;
@@ -202,7 +129,8 @@ int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
 			entry->handle = handle;
 			entry->ep = ckey->ep;
 
-			cache->used++;
+			this->slots.insert(this->slots.begin() + slot, entry);
+
 			NCCL_OFI_TRACE(NCCL_NET,
 			               "Inserted MR handle %p for %ld(%s) in cache slot %zu",
 			               handle,
@@ -210,11 +138,11 @@ int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
 			               nccl_ofi_mr_ckey_type_str(ckey),
 			               slot);
 			goto out;
-		} else if ((!(is_endpoint_mr && (cache->slots[slot]->ep != ckey->ep))) &&
-			   (page_addr >= cache->slots[slot]->addr) &&
-			   ((page_addr - cache->slots[slot]->addr) /
-				    cache->system_page_size +
-			    pages) <= cache->slots[slot]->pages) {
+		} else if ((!(is_endpoint_mr && (this->slots[slot]->ep != ckey->ep))) &&
+			   (page_addr >= this->slots[slot]->addr) &&
+			   ((page_addr - this->slots[slot]->addr) /
+				    this->system_page_size +
+			    pages) <= this->slots[slot]->pages) {
 			/* cache hit */
 			NCCL_OFI_WARN("Entry already exists for input (%s) base %lu size %zu",
 			              nccl_ofi_mr_ckey_type_str(ckey),
@@ -229,23 +157,19 @@ out:
 	return ret;
 }
 
-static int nccl_ofi_mr_cache_lookup_handle(nccl_ofi_mr_cache_t *cache,
-					   void *handle)
+int nccl_ofi_mr_cache::del_entry(void *handle)
 {
-	for (size_t i = 0; i < cache->used; i++) {
-		if (handle == cache->slots[i]->handle) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
-{
-	int slot = -1;
 	int ret = 0;
 
-	slot = nccl_ofi_mr_cache_lookup_handle(cache, handle);
+	/* Find slot by handle */
+	int slot = -1;
+	for (size_t i = 0; i < this->slots.size(); i++) {
+		if (handle == this->slots[i]->handle) {
+			slot = (int)i;
+			break;
+		}
+	}
+
 	if (slot < 0) {
 		NCCL_OFI_WARN("Did not find entry to delete");
 		ret = -ENOENT;
@@ -253,7 +177,7 @@ int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
 	}
 
 	/* Keep entry alive for other users */
-	if (--cache->slots[slot]->refcnt) {
+	if (--this->slots[slot]->refcnt) {
 		NCCL_OFI_TRACE(
 			NCCL_NET,
 			"Decremented refcnt for MR handle %p in cache slot %d",
@@ -262,12 +186,9 @@ int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
 		goto out;
 	}
 
-	/* Free this entry and defrag cache */
-	free(cache->slots[slot]);
-	memmove(cache->slots + slot,
-		cache->slots + slot + 1,
-		(cache->used - slot - 1) * sizeof(nccl_ofi_reg_entry_t *));
-	--cache->used;
+	/* Free this entry and remove from vector */
+	free(this->slots[slot]);
+	this->slots.erase(this->slots.begin() + slot);
 
 	NCCL_OFI_TRACE(NCCL_NET,
 		       "Removed MR handle %p in cache slot %d",

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -897,12 +897,8 @@ nccl_net_ofi_domain_t::nccl_net_ofi_domain_t(nccl_net_ofi_device_t *device_arg,
 
 	if (!ofi_nccl_mr_cache_disable()) {
 		this->mr_cache =
-			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
-					       system_page_size);
-		if (!this->mr_cache) {
-			NCCL_OFI_WARN("Unable to initialize domain mr cache");
-			throw std::runtime_error("base domain constructor: mr cache init failed");
-		}
+			new nccl_ofi_mr_cache(NCCL_OFI_MR_CACHE_INIT_SIZE,
+					      system_page_size);
 	}
 
 	if (this->device->need_mr_rkey_pool) {
@@ -975,7 +971,8 @@ int nccl_net_ofi_domain_t::release_all_ep()
 nccl_net_ofi_domain_t::~nccl_net_ofi_domain_t()
 {
 	if (mr_cache != nullptr) {
-		nccl_ofi_mr_cache_finalize(mr_cache);
+		delete mr_cache;
+		mr_cache = nullptr;
 	}
 
 	if (mr_rkey_pool != nullptr) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2510,7 +2510,7 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handl
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = nccl_ofi_mr_cache_del_entry(this->mr_cache, mr_handle);
+		int ret = this->mr_cache->del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -2535,7 +2535,7 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr_no_lock(nccl_net_ofi_rdma_mr_handle_t *
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = nccl_ofi_mr_cache_del_entry(this->mr_cache, mr_handle);
+		int ret = this->mr_cache->del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -2627,7 +2627,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 		pthread_wrapper mr_cache_lock(&this->mr_cache->lock);
 
 		ret_handle = static_cast<nccl_net_ofi_rdma_mr_handle_t *>(
-			nccl_ofi_mr_cache_lookup_entry(this->mr_cache, ckey, endpoint_mr));
+			this->mr_cache->lookup_entry(ckey, endpoint_mr));
 		if (ret_handle) {
 			/* Cache hit */
 			*mhandle = ret_handle;
@@ -2640,8 +2640,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 			return ret;
 		}
 
-		ret = nccl_ofi_mr_cache_insert_entry(this->mr_cache,
-						     ckey,
+		ret = this->mr_cache->insert_entry(ckey,
 						     endpoint_mr,
 						     ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -70,7 +70,7 @@ int nccl_net_ofi_sendrecv_mr_handle_t::get_mr_key(uint64_t *mr_key_ptr)
 
 static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_handle,
 					nccl_ofi_idpool_t *key_pool,
-					nccl_ofi_mr_cache_t *mr_cache);
+					nccl_ofi_mr_cache *mr_cache);
 
 
 int nccl_net_ofi_sendrecv_device_t::get_properties(nccl_ofi_properties_t *props)
@@ -710,7 +710,7 @@ static int sendrecv_mr_base_register(nccl_net_ofi_sendrecv_domain_t *domain, fid
 
 static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_handle,
 				       nccl_ofi_idpool_t *key_pool,
-				       nccl_ofi_mr_cache_t *mr_cache)
+				       nccl_ofi_mr_cache *mr_cache)
 {
 	int ret = 0;
 
@@ -726,7 +726,7 @@ static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_ha
 		 * refcnt, or delete the entry for this handle.
 		 */
 		nccl_net_ofi_mutex_lock(&mr_cache->lock);
-		ret = nccl_ofi_mr_cache_del_entry(mr_cache, (void *)mr_handle);
+		ret = mr_cache->del_entry((void *)mr_handle);
 		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
@@ -774,7 +774,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 	int dev_id = device->dev_id;
 
 	int ret = 0;
-	nccl_ofi_mr_cache_t *mr_cache = domain->mr_cache;
+	nccl_ofi_mr_cache *mr_cache = domain->mr_cache;
 	nccl_net_ofi_sendrecv_mr_handle_t *ret_handle = nullptr;
 
 	if (mr_cache) {
@@ -784,7 +784,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 		 */
 		nccl_net_ofi_mutex_lock(&mr_cache->lock);
 		ret_handle = static_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(
-			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey, endpoint_mr));
+			mr_cache->lookup_entry(ckey, endpoint_mr));
 
 		if (ret_handle) {
 			/* Cache hit */
@@ -802,7 +802,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 	}
 
 	if (mr_cache) {
-		ret = nccl_ofi_mr_cache_insert_entry(mr_cache, ckey, endpoint_mr, ret_handle);
+		ret = mr_cache->insert_entry(ckey, endpoint_mr, ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			/* MR cache insert failed. Deregister memory region without
 			 * trying to delete MR cache entry.

--- a/tests/unit/mr.cpp
+++ b/tests/unit/mr.cpp
@@ -10,7 +10,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_mr.h"
 
-static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+static inline bool test_lookup_impl(nccl_ofi_mr_cache *cache, void *addr, size_t size,
 		 void *expected_val)
 {
 	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
@@ -18,9 +18,9 @@ static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 	 * passing nullptr
 	 */
 	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);;
-	void *result = nccl_ofi_mr_cache_lookup_entry(cache, &ckey, false);
+	void *result = cache->lookup_entry(&ckey, false);
 	if (result != expected_val) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_lookup_entry returned unexpected result. Expected: %p. Actual: %p",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::lookup_entry returned unexpected result. Expected: %p. Actual: %p",
 			expected_val, result);
 		return false;
 	}
@@ -32,7 +32,7 @@ static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 		exit(1);                                          \
 	}
 
-static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+static inline bool test_insert_impl(nccl_ofi_mr_cache *cache, void *addr, size_t size,
 		 void *handle, int expected_ret)
 {
 	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
@@ -40,9 +40,9 @@ static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 	 * passing nullptr
 	 */
 	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);
-	int ret = nccl_ofi_mr_cache_insert_entry(cache, &ckey, false, handle);
+	int ret = cache->insert_entry(&ckey, false, handle);
 	if (ret != expected_ret) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_insert_entry returned unexpected result. Expected: %d. Actual: %d",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::insert_entry returned unexpected result. Expected: %d. Actual: %d",
 			expected_ret, ret);
 		return false;
 	}
@@ -54,11 +54,11 @@ static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 		exit(1);                                                  \
 	}
 
-static inline bool test_delete_impl(nccl_ofi_mr_cache_t *cache, void *handle, int expected_ret)
+static inline bool test_delete_impl(nccl_ofi_mr_cache *cache, void *handle, int expected_ret)
 {
-	int ret = nccl_ofi_mr_cache_del_entry(cache, handle);
+	int ret = cache->del_entry(handle);
 	if (ret != expected_ret) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_del_entry returned unexpected result. Expected: %d. Actual: %d",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::del_entry returned unexpected result. Expected: %d. Actual: %d",
 			expected_ret, ret);
 		return false;
 	}
@@ -103,9 +103,9 @@ int main(int argc, char *argv[])
 
 	unit_test_init();
 
-	nccl_ofi_mr_cache_t *cache = nccl_ofi_mr_cache_init(cache_init_size, fake_page_size);
+	nccl_ofi_mr_cache *cache = new nccl_ofi_mr_cache(cache_init_size, fake_page_size);
 	if (!cache) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_init failed");
+		NCCL_OFI_WARN("nccl_ofi_mr_cache constructor failed");
 		exit(1);
 	}
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 	test_make_aligned_key(fake_page_size - 16, 17, 0, fake_page_size * 2);
 #endif
 
-	nccl_ofi_mr_cache_finalize(cache);
+	delete cache;
 
 	printf("Test completed successfully!\n");
 }


### PR DESCRIPTION
The MR cache used manual malloc/realloc/memmove for a sorted array of registration entries, which was error-prone and required explicit init/finalize lifecycle management. Converting to a C++ class with std::vector and constructor/destructor simplifies the code and eliminates the manual memory management, while keeping the same algorithmic behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
