### PR TITLE
Convert MR cache to C++ and move lock to domain

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -7,6 +7,7 @@
 
 #include <unordered_map>
 #include <memory>
+#include <optional>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -464,7 +465,10 @@ public:
 	/*
 	 * Protocol-agnostic MR cache for this device.
 	 */
-	nccl_ofi_mr_cache_t *mr_cache = nullptr;
+	std::optional<nccl_ofi_mr_cache> mr_cache;
+
+	/* Lock protecting mr_cache operations */
+	std::mutex mr_cache_lock;
 
 	/* Memory registration key pool */
 	nccl_ofi_idpool_t *mr_rkey_pool = nullptr;

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -8,10 +8,10 @@
 #include "config.h"
 
 #include <assert.h>
-#include <pthread.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <sys/uio.h>
+#include <vector>
 
 #include <rdma/fi_domain.h>
 #include "nccl_ofi_math.h"
@@ -183,68 +183,85 @@ static inline void nccl_ofi_mr_ckey_fill_mr_attrs(nccl_ofi_mr_ckey_ref ckey, str
 /**
  * A memory registration cache entry
  */
-typedef struct nccl_ofi_reg_entry {
+struct nccl_ofi_reg_entry {
 	uintptr_t addr;
 	size_t pages;
 	int refcnt;
 	void *handle;
 	nccl_net_ofi_ep_t *ep;
-} nccl_ofi_reg_entry_t;
+
+	nccl_ofi_reg_entry(uintptr_t addr_arg, size_t pages_arg, void *handle_arg, nccl_net_ofi_ep_t *ep_arg)
+		: addr(addr_arg), pages(pages_arg), refcnt(1), handle(handle_arg), ep(ep_arg) {}
+};
+typedef struct nccl_ofi_reg_entry nccl_ofi_reg_entry_t;
 
 /**
  * Device-specific memory registration cache.
  */
-typedef struct nccl_ofi_mr_cache {
-	nccl_ofi_reg_entry_t **slots;
-	size_t system_page_size;
-	size_t size;
-	size_t used;
-	uint32_t hit_count;
-	uint32_t miss_count;
-	pthread_mutex_t lock;
-} nccl_ofi_mr_cache_t;
+class nccl_ofi_mr_cache {
+public:
+	/**
+	 * Create a new mr cache. Both the initial number of entries and the
+	 * page size must be greater than zero.
+	 *
+	 * @param init_num_entries Initial capacity (used for vector::reserve)
+	 * @param page_size Page size for address alignment
+	 * @throws std::runtime_error on invalid arguments
+	 */
+	nccl_ofi_mr_cache(size_t init_num_entries, size_t page_size_arg);
 
-/**
- * Create a new mr cache. Both then initial number of entries and the system
- * page size must be greater than zero.
- * @return a new mr cache, or NULL if an allocation error occurred
- */
-nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
-					    size_t mr_cache_page_size);
+	/**
+	 * Destructor. Logs hit/miss stats.
+	 */
+	~nccl_ofi_mr_cache();
 
-/**
- * Finalize mr cache
- */
-void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache);
+	/* Not copyable or movable */
+	nccl_ofi_mr_cache(const nccl_ofi_mr_cache &) = delete;
+	nccl_ofi_mr_cache &operator=(const nccl_ofi_mr_cache &) = delete;
 
-/**
- * Lookup a cache entry matching the given address and size
- * Input addr and size are rounded up to enclosing page boundaries.
- * If entry is found, refcnt is increased
- * @return mr handle if found, or NULL if not found
- */
-void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache, nccl_ofi_mr_ckey_ref ckey,
-				     bool is_endpoint_mr);
+	/**
+	 * Lookup a cache entry matching the given address and size.
+	 * Input addr and size are rounded up to enclosing page boundaries.
+	 * If entry is found, refcnt is increased.
+	 *
+	 * @return mr handle if found, or nullptr if not found
+	 */
+	void *lookup_entry(nccl_ofi_mr_ckey_ref ckey, bool is_endpoint_mr);
 
-/**
- * Insert a new cache entry with the given address and size
- * Input addr and size are rounded up to enclosing page boundaries.
- * @return 0, on success
- *	   -ENOMEM, on allocation failure
- *	   -EEXIST, if matching entry already exists in cache
- */
-int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache, nccl_ofi_mr_ckey_ref ckey,
-				   bool is_endpoint_mr, void *handle);
+	/**
+	 * Insert a new cache entry with the given address and size.
+	 * Input addr and size are rounded up to enclosing page boundaries.
+	 *
+	 * @return 0, on success
+	 *	   -ENOMEM, on allocation failure
+	 *	   -EEXIST, if matching entry already exists in cache
+	 */
+	int insert_entry(nccl_ofi_mr_ckey_ref ckey, bool is_endpoint_mr, void *handle);
 
-/**
- * Decrement refcnt of entry with given handle. If refcnt was reduced to 0,
- * delete entry from cache. Return value indicates whether entry was deleted
- * from cache (in which case, caller should deregister the handle).
- *
- * @return 0, on success, and reg was not deleted (refcnt not zero)
- *	   1, on success, and reg was deleted (refcnt was zero)
- *	   -ENOENT, if no matching entry was found
- */
-int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle);
+	/**
+	 * Decrement refcnt of entry with given handle. If refcnt was reduced
+	 * to 0, delete entry from cache. Return value indicates whether entry
+	 * was deleted from cache (in which case, caller should deregister the
+	 * handle).
+	 *
+	 * @return 0, on success, and reg was not deleted (refcnt not zero)
+	 *	   1, on success, and reg was deleted (refcnt was zero)
+	 *	   -ENOENT, if no matching entry was found
+	 */
+	int del_entry(void *handle);
+
+private:
+	std::vector<nccl_ofi_reg_entry_t *> slots;
+	size_t page_size;
+	uint32_t hit_count = 0;
+	uint32_t miss_count = 0;
+
+	/**
+	 * Compute page-aligned address and number of pages for a given
+	 * address and size, using this cache's page_size.
+	 */
+	void compute_page_address(uintptr_t addr, size_t size,
+				  uintptr_t &page_addr, size_t &pages) const;
+};
 
 #endif  // End NCCL_OFI_MR_H_

--- a/src/nccl_ofi_mr.cpp
+++ b/src/nccl_ofi_mr.cpp
@@ -4,270 +4,178 @@
 
 #include "config.h"
 
-#include <errno.h>
-#include <stdlib.h>
+#include <cerrno>
+#include <cstdlib>
+#include <stdexcept>
 
 #include "nccl_ofi_mr.h"
-#include "nccl_ofi_pthread.h"
 
-nccl_ofi_mr_cache_t *nccl_ofi_mr_cache_init(size_t init_num_entries,
-					    size_t mr_cache_page_size)
+nccl_ofi_mr_cache::nccl_ofi_mr_cache(size_t init_num_entries,
+				     size_t page_size_arg)
+	: page_size(page_size_arg)
 {
-	nccl_ofi_mr_cache_t *ret_cache = NULL;
-
 	if (init_num_entries == 0) {
 		NCCL_OFI_WARN("MR cache: initial number of entries must be positive");
-		goto error;
+		throw std::runtime_error("MR cache: initial number of entries must be positive");
 	}
 
-	if (mr_cache_page_size == 0) {
-		NCCL_OFI_WARN("MR cache: system page size must be positive");
-		goto error;
+	if (page_size_arg == 0) {
+		NCCL_OFI_WARN("MR cache: page size must be positive");
+		throw std::runtime_error("MR cache: page size must be positive");
 	}
 
-	ret_cache = (nccl_ofi_mr_cache_t *)calloc(1, sizeof(*ret_cache));
-	if (!ret_cache) {
-		NCCL_OFI_WARN("Could not allocate memory for cache");
-		goto error;
-	}
-
-	ret_cache->slots = (nccl_ofi_reg_entry_t **)calloc(init_num_entries, sizeof(*ret_cache->slots));
-	if (!ret_cache->slots) {
-		NCCL_OFI_WARN("Could not allocate memory for cache slots");
-		goto error;
-	}
-
-	if (nccl_net_ofi_mutex_init(&ret_cache->lock, NULL)) {
-		goto error;
-	}
 	/*
 	 * System page size isn't reflective of the GDR mappings. We're not trying to map a
 	 * whole page, but just to find an interval that makes an array-based cache manageable.
 	 */
-	ret_cache->system_page_size = mr_cache_page_size;
-	ret_cache->size = init_num_entries;
-	ret_cache->used = 0;
-	ret_cache->hit_count = 0;
-	ret_cache->miss_count = 0;
-
-	return ret_cache;
-
-error:
-	if (ret_cache) {
-		if (ret_cache->slots) {
-			free(ret_cache->slots);
-		}
-		free(ret_cache);
-	}
-	return NULL;
+	this->slots.reserve(init_num_entries);
 }
 
-void nccl_ofi_mr_cache_finalize(nccl_ofi_mr_cache_t *cache)
+nccl_ofi_mr_cache::~nccl_ofi_mr_cache()
 {
-	assert(cache);
-
 	NCCL_OFI_INFO(NCCL_NET,
 		      "MR cache %d hits %d misses",
-		      cache->hit_count,
-		      cache->miss_count);
+		      this->hit_count,
+		      this->miss_count);
 
-	nccl_net_ofi_mutex_destroy(&cache->lock);
-
-	free(cache->slots);
-
-	free(cache);
-}
-
-/**
- * Grow cache to 2x its current size
- */
-static int nccl_ofi_mr_cache_grow(nccl_ofi_mr_cache_t *cache)
-{
-	void *ptr;
-	int ret = 0;
-	cache->size *= 2;
-	NCCL_OFI_TRACE(NCCL_NET, "Growing cache to size %zu", cache->size);
-	ptr = realloc(cache->slots, cache->size * sizeof(*cache->slots));
-	if (!ptr) {
-		NCCL_OFI_WARN("Unable to grow cache");
-		ret = -ENOMEM;
-		goto out;
+	/* Free any remaining entries that were not deleted via del_entry() */
+	if (!this->slots.empty()) {
+		NCCL_OFI_WARN("MR cache destroyed while %zu memory segments still held by the application. "
+			      "Forcing release of remaining entries.",
+			      this->slots.size());
+		for (auto *entry : this->slots) {
+			delete entry;
+		}
 	}
-	cache->slots = (nccl_ofi_reg_entry_t **)ptr;
-
-out:
-	return ret;
 }
 
-static inline void compute_page_address(uintptr_t addr,
-					size_t size,
-					uintptr_t system_page_size,
-					uintptr_t *page_addr,
-					size_t *pages)
+void nccl_ofi_mr_cache::compute_page_address(uintptr_t addr,
+					     size_t size,
+					     uintptr_t &page_addr,
+					     size_t &pages) const
 {
-	*page_addr = addr & -system_page_size; /* start of page of data */
-	*pages = (addr + size - (*page_addr) + system_page_size - 1) / system_page_size; /* Number of pages in buffer */
+	page_addr = addr & -(uintptr_t)this->page_size; /* start of page of data */
+	pages = (addr + size - page_addr + this->page_size - 1) / this->page_size; /* Number of pages in buffer */
 }
 
-void *nccl_ofi_mr_cache_lookup_entry(nccl_ofi_mr_cache_t *cache,
-				     nccl_ofi_mr_ckey_ref ckey,
-				     bool is_endpoint_mr)
+void *nccl_ofi_mr_cache::lookup_entry(nccl_ofi_mr_ckey_ref ckey,
+				      bool is_endpoint_mr)
 {
 	uintptr_t page_addr;
 	size_t pages;
 
-	compute_page_address(nccl_ofi_mr_ckey_baseaddr(ckey),
+	this->compute_page_address(nccl_ofi_mr_ckey_baseaddr(ckey),
 			     nccl_ofi_mr_ckey_len(ckey),
-			     (uintptr_t)cache->system_page_size,
-			     &page_addr,
-			     &pages);
+			     page_addr,
+			     pages);
 
 	for (size_t slot = 0;; slot++) {
-		assert(slot <= cache->used && slot <= cache->size);
+		assert(slot <= this->slots.size());
 
-		if (slot == cache->used ||
-		    page_addr < cache->slots[slot]->addr) {
+		if (slot == this->slots.size() ||
+		    page_addr < this->slots[slot]->addr) {
 			/* cache missed */
-			cache->miss_count++;
-			return NULL;
-		} else if (is_endpoint_mr && (ckey->ep != cache->slots[slot]->ep)) {
+			this->miss_count++;
+			return nullptr;
+		} else if (is_endpoint_mr && (ckey->ep != this->slots[slot]->ep)) {
                         continue;
-		} else if ((page_addr >= cache->slots[slot]->addr) &&
-			   ((page_addr - cache->slots[slot]->addr) /
-				    cache->system_page_size +
-			    pages) <= cache->slots[slot]->pages) {
+		} else if ((page_addr >= this->slots[slot]->addr) &&
+			   ((page_addr - this->slots[slot]->addr) /
+				    this->page_size +
+			    pages) <= this->slots[slot]->pages) {
 			/* cache hit */
-			cache->hit_count++;
+			this->hit_count++;
 			NCCL_OFI_TRACE(NCCL_NET,
 			               "Found MR handle %p for %ld(%s) in cache slot %zu",
-			               cache->slots[slot]->handle,
+			               this->slots[slot]->handle,
 			               nccl_ofi_mr_ckey_baseaddr(ckey),
 			               nccl_ofi_mr_ckey_type_str(ckey),
 			               slot);
-			cache->slots[slot]->refcnt++;
-			return cache->slots[slot]->handle;
+			this->slots[slot]->refcnt++;
+			return this->slots[slot]->handle;
 		}
 	}
 }
 
-int nccl_ofi_mr_cache_insert_entry(nccl_ofi_mr_cache_t *cache,
-				   nccl_ofi_mr_ckey_ref ckey,
-				   bool is_endpoint_mr,
-				   void *handle)
+int nccl_ofi_mr_cache::insert_entry(nccl_ofi_mr_ckey_ref ckey,
+				    bool is_endpoint_mr,
+				    void *handle)
 {
 	uintptr_t page_addr;
 	size_t pages;
-	int ret = 0;
 
-	compute_page_address((uintptr_t)nccl_ofi_mr_ckey_baseaddr(ckey),
+	this->compute_page_address((uintptr_t)nccl_ofi_mr_ckey_baseaddr(ckey),
 	                     nccl_ofi_mr_ckey_len(ckey),
-	                     (uintptr_t)cache->system_page_size,
-	                     &page_addr,
-	                     &pages);
+	                     page_addr,
+	                     pages);
 
 	for (size_t slot = 0;; slot++) {
-		assert(slot <= cache->used && slot <= cache->size);
+		assert(slot <= this->slots.size());
 
-		if (slot == cache->used ||
-		    page_addr < cache->slots[slot]->addr) {
-			/* cache missed */
+		if (slot == this->slots.size() ||
+		    page_addr < this->slots[slot]->addr) {
+			/* cache missed — insert here */
 
-			/* grow the cache if needed */
-			if (cache->used == cache->size) {
-				ret = nccl_ofi_mr_cache_grow(cache);
-				if (ret != 0) {
-					goto out;
-				}
-			}
-
-			assert(cache->slots);
-			memmove(cache->slots + slot + 1,
-				cache->slots + slot,
-				(cache->used - slot) *
-					sizeof(nccl_ofi_reg_entry_t *));
-			cache->slots[slot] = (nccl_ofi_reg_entry_t *)calloc(
-				1,
-				sizeof(nccl_ofi_reg_entry_t));
-			if (!cache->slots[slot]) {
+			auto *entry = new (std::nothrow) nccl_ofi_reg_entry(
+				page_addr, pages, handle, ckey->ep);
+			if (!entry) {
 				NCCL_OFI_WARN("Failed to allocate new slot");
-				ret = -ENOMEM;
-				goto out;
+				return -ENOMEM;
 			}
 
-			nccl_ofi_reg_entry_t *entry = cache->slots[slot];
+			this->slots.insert(this->slots.begin() + slot, entry);
 
-			entry->addr = page_addr;
-			entry->pages = pages;
-			entry->refcnt = 1;
-			entry->handle = handle;
-			entry->ep = ckey->ep;
-
-			cache->used++;
 			NCCL_OFI_TRACE(NCCL_NET,
 			               "Inserted MR handle %p for %ld(%s) in cache slot %zu",
 			               handle,
 			               nccl_ofi_mr_ckey_baseaddr(ckey),
 			               nccl_ofi_mr_ckey_type_str(ckey),
 			               slot);
-			goto out;
-		} else if ((!(is_endpoint_mr && (cache->slots[slot]->ep != ckey->ep))) &&
-			   (page_addr >= cache->slots[slot]->addr) &&
-			   ((page_addr - cache->slots[slot]->addr) /
-				    cache->system_page_size +
-			    pages) <= cache->slots[slot]->pages) {
+			return 0;
+		} else if ((!(is_endpoint_mr && (this->slots[slot]->ep != ckey->ep))) &&
+			   (page_addr >= this->slots[slot]->addr) &&
+			   ((page_addr - this->slots[slot]->addr) /
+				    this->page_size +
+			    pages) <= this->slots[slot]->pages) {
 			/* cache hit */
 			NCCL_OFI_WARN("Entry already exists for input (%s) base %lu size %zu",
 			              nccl_ofi_mr_ckey_type_str(ckey),
 			              nccl_ofi_mr_ckey_baseaddr(ckey),
 			              nccl_ofi_mr_ckey_len(ckey));
-			ret = -EEXIST;
-			goto out;
+			return -EEXIST;
 		}
 	}
-
-out:
-	return ret;
 }
 
-static int nccl_ofi_mr_cache_lookup_handle(nccl_ofi_mr_cache_t *cache,
-					   void *handle)
+int nccl_ofi_mr_cache::del_entry(void *handle)
 {
-	for (size_t i = 0; i < cache->used; i++) {
-		if (handle == cache->slots[i]->handle) {
-			return i;
-		}
-	}
-	return -1;
-}
-
-int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
-{
+	/* Find slot by handle */
 	int slot = -1;
-	int ret = 0;
+	for (size_t i = 0; i < this->slots.size(); i++) {
+		if (handle == this->slots[i]->handle) {
+			slot = (int)i;
+			break;
+		}
+	}
 
-	slot = nccl_ofi_mr_cache_lookup_handle(cache, handle);
 	if (slot < 0) {
 		NCCL_OFI_WARN("Did not find entry to delete");
-		ret = -ENOENT;
-		goto out;
+		return -ENOENT;
 	}
 
 	/* Keep entry alive for other users */
-	if (--cache->slots[slot]->refcnt) {
+	if (--this->slots[slot]->refcnt) {
 		NCCL_OFI_TRACE(
 			NCCL_NET,
 			"Decremented refcnt for MR handle %p in cache slot %d",
 			handle,
 			slot);
-		goto out;
+		return 0;
 	}
 
-	/* Free this entry and defrag cache */
-	free(cache->slots[slot]);
-	memmove(cache->slots + slot,
-		cache->slots + slot + 1,
-		(cache->used - slot - 1) * sizeof(nccl_ofi_reg_entry_t *));
-	--cache->used;
+	/* Free this entry and remove from vector */
+	delete this->slots[slot];
+	this->slots.erase(this->slots.begin() + slot);
 
 	NCCL_OFI_TRACE(NCCL_NET,
 		       "Removed MR handle %p in cache slot %d",
@@ -275,8 +183,5 @@ int nccl_ofi_mr_cache_del_entry(nccl_ofi_mr_cache_t *cache, void *handle)
 		       slot);
 
 	/* Signal to caller to deregister handle */
-	ret = 1;
-
-out:
-	return ret;
+	return 1;
 }

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -846,13 +846,8 @@ nccl_net_ofi_domain_t::nccl_net_ofi_domain_t(nccl_net_ofi_device_t *device_arg,
 	assert(this->device != nullptr);
 
 	if (!ofi_nccl_mr_cache_disable()) {
-		this->mr_cache =
-			nccl_ofi_mr_cache_init(NCCL_OFI_MR_CACHE_INIT_SIZE,
-					       system_page_size);
-		if (!this->mr_cache) {
-			NCCL_OFI_WARN("Unable to initialize domain mr cache");
-			throw std::runtime_error("base domain constructor: mr cache init failed");
-		}
+		this->mr_cache.emplace(NCCL_OFI_MR_CACHE_INIT_SIZE,
+				       system_page_size);
 	}
 
 	if (this->device->need_mr_rkey_pool) {
@@ -891,10 +886,6 @@ int nccl_net_ofi_domain_t::release_all_ep()
 
 nccl_net_ofi_domain_t::~nccl_net_ofi_domain_t()
 {
-	if (mr_cache != nullptr) {
-		nccl_ofi_mr_cache_finalize(mr_cache);
-	}
-
 	if (mr_rkey_pool != nullptr) {
 		delete mr_rkey_pool;
 		mr_rkey_pool = nullptr;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2503,14 +2503,14 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handl
 	}
 
 	if (this->mr_cache) {
-		pthread_wrapper mr_cache_lock(&this->mr_cache->lock);
+		std::lock_guard cache_guard(this->mr_cache_lock);
 
 		/*
 		* Depending on the number of references on this handle and the cache
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = nccl_ofi_mr_cache_del_entry(this->mr_cache, mr_handle);
+		int ret = this->mr_cache->del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -2535,7 +2535,7 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr_no_lock(nccl_net_ofi_rdma_mr_handle_t *
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = nccl_ofi_mr_cache_del_entry(this->mr_cache, mr_handle);
+		int ret = this->mr_cache->del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -2622,12 +2622,12 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 	if (this->mr_cache) {
 		/*
 		 * MR cache is locked between lookup and insert, to be sure we
-		 * insert a missing entry
+		 * insert a missing entry.
 		 */
-		pthread_wrapper mr_cache_lock(&this->mr_cache->lock);
+		std::lock_guard cache_guard(this->mr_cache_lock);
 
 		ret_handle = static_cast<nccl_net_ofi_rdma_mr_handle_t *>(
-			nccl_ofi_mr_cache_lookup_entry(this->mr_cache, ckey, endpoint_mr));
+			this->mr_cache->lookup_entry(ckey, endpoint_mr));
 		if (ret_handle) {
 			/* Cache hit */
 			*mhandle = ret_handle;
@@ -2640,8 +2640,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 			return ret;
 		}
 
-		ret = nccl_ofi_mr_cache_insert_entry(this->mr_cache,
-						     ckey,
+		ret = this->mr_cache->insert_entry(ckey,
 						     endpoint_mr,
 						     ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -69,8 +69,8 @@ int nccl_net_ofi_sendrecv_mr_handle_t::get_mr_key(uint64_t *mr_key_ptr)
 
 
 static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_handle,
-					nccl_ofi_idpool_t *key_pool,
-					nccl_ofi_mr_cache_t *mr_cache);
+				       nccl_ofi_idpool_t *key_pool,
+				       nccl_net_ofi_domain_t *domain);
 
 
 int nccl_net_ofi_sendrecv_device_t::get_properties(nccl_ofi_properties_t *props)
@@ -710,7 +710,7 @@ static int sendrecv_mr_base_register(nccl_net_ofi_sendrecv_domain_t *domain, fid
 
 static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_handle,
 				       nccl_ofi_idpool_t *key_pool,
-				       nccl_ofi_mr_cache_t *mr_cache)
+				       nccl_net_ofi_domain_t *domain)
 {
 	int ret = 0;
 
@@ -719,15 +719,16 @@ static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_ha
 		return;
 	}
 
-	if (mr_cache) {
+	if (domain && domain->mr_cache) {
 		/*
 		 * Depending on the number of references on this handle and the
 		 * cache itself, this call would either just decrement the
 		 * refcnt, or delete the entry for this handle.
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
-		ret = nccl_ofi_mr_cache_del_entry(mr_cache, (void *)mr_handle);
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
+		{
+			std::lock_guard guard(domain->mr_cache_lock);
+			ret = domain->mr_cache->del_entry((void *)mr_handle);
+		}
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -774,48 +775,51 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 	int dev_id = device->dev_id;
 
 	int ret = 0;
-	nccl_ofi_mr_cache_t *mr_cache = domain->mr_cache;
 	nccl_net_ofi_sendrecv_mr_handle_t *ret_handle = nullptr;
+	bool has_cache = domain->mr_cache.has_value();
 
-	if (mr_cache) {
+	if (has_cache) {
 		/*
 		 * MR cache is locked between lookup and insert, to be sure we
-		 * insert a missing entry
+		 * insert a missing entry.
 		 */
-		nccl_net_ofi_mutex_lock(&mr_cache->lock);
+		std::lock_guard cache_guard(domain->mr_cache_lock);
+
 		ret_handle = static_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(
-			nccl_ofi_mr_cache_lookup_entry(mr_cache, ckey, endpoint_mr));
+			domain->mr_cache->lookup_entry(ckey, endpoint_mr));
 
 		if (ret_handle) {
 			/* Cache hit */
-			goto unlock;
+			*mr_handle = ret_handle;
+			return ret;
 		}
 		/* Cache miss */
-	}
 
-	key_pool = domain->mr_rkey_pool;
-	ret = sendrecv_mr_base_register(domain, ep->ofi_ep.get(), key_pool,
-					dev_id, ckey, type, &ret_handle);
-	if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
-		ret_handle = NULL;
-		goto unlock;
-	}
+		key_pool = domain->mr_rkey_pool;
+		ret = sendrecv_mr_base_register(domain, ep->ofi_ep.get(), key_pool,
+						dev_id, ckey, type, &ret_handle);
+		if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
+			*mr_handle = nullptr;
+			return ret;
+		}
 
-	if (mr_cache) {
-		ret = nccl_ofi_mr_cache_insert_entry(mr_cache, ckey, endpoint_mr, ret_handle);
+		ret = domain->mr_cache->insert_entry(ckey, endpoint_mr, ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			/* MR cache insert failed. Deregister memory region without
 			 * trying to delete MR cache entry.
 			 */
-			sendrecv_comm_mr_base_dereg(ret_handle, key_pool, NULL);
-			ret_handle = NULL;
-			goto unlock;
+			sendrecv_comm_mr_base_dereg(ret_handle, key_pool, nullptr);
+			*mr_handle = nullptr;
+			return ret;
 		}
-	}
-
-unlock:
-	if (mr_cache) {
-		nccl_net_ofi_mutex_unlock(&mr_cache->lock);
+	} else {
+		key_pool = domain->mr_rkey_pool;
+		ret = sendrecv_mr_base_register(domain, ep->ofi_ep.get(), key_pool,
+						dev_id, ckey, type, &ret_handle);
+		if (OFI_UNLIKELY(ret_handle == NULL || ret != 0)) {
+			*mr_handle = nullptr;
+			return ret;
+		}
 	}
 
 	*mr_handle = ret_handle;
@@ -853,7 +857,7 @@ int nccl_net_ofi_sendrecv_recv_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 	assert(domain != NULL);
 
 	auto *mr_handle = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(mhandle);
-	sendrecv_comm_mr_base_dereg(mr_handle, domain->mr_rkey_pool, domain->mr_cache);
+	sendrecv_comm_mr_base_dereg(mr_handle, domain->mr_rkey_pool, domain);
 	return 0;
 }
 
@@ -1682,7 +1686,7 @@ int nccl_net_ofi_sendrecv_send_comm::deregMr(nccl_net_ofi_mr_handle_t *mhandle)
 	assert(domain != NULL);
 
 	auto *mr_handle = reinterpret_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(mhandle);
-	sendrecv_comm_mr_base_dereg(mr_handle, domain->mr_rkey_pool, domain->mr_cache);
+	sendrecv_comm_mr_base_dereg(mr_handle, domain->mr_rkey_pool, domain);
 	return 0;
 }
 

--- a/tests/unit/mr.cpp
+++ b/tests/unit/mr.cpp
@@ -10,7 +10,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_mr.h"
 
-static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+static inline bool test_lookup_impl(nccl_ofi_mr_cache *cache, void *addr, size_t size,
 		 void *expected_val)
 {
 	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
@@ -18,9 +18,9 @@ static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 	 * passing nullptr
 	 */
 	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);;
-	void *result = nccl_ofi_mr_cache_lookup_entry(cache, &ckey, false);
+	void *result = cache->lookup_entry(&ckey, false);
 	if (result != expected_val) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_lookup_entry returned unexpected result. Expected: %p. Actual: %p",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::lookup_entry returned unexpected result. Expected: %p. Actual: %p",
 			expected_val, result);
 		return false;
 	}
@@ -32,7 +32,7 @@ static inline bool test_lookup_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 		exit(1);                                          \
 	}
 
-static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size_t size,
+static inline bool test_insert_impl(nccl_ofi_mr_cache *cache, void *addr, size_t size,
 		 void *handle, int expected_ret)
 {
 	/* TODO: To test mr_endpoint feature, pass endpoint object while creating
@@ -40,9 +40,9 @@ static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 	 * passing nullptr
 	 */
 	nccl_ofi_mr_ckey_t ckey = nccl_ofi_mr_ckey_mk_vec(addr, size, nullptr);
-	int ret = nccl_ofi_mr_cache_insert_entry(cache, &ckey, false, handle);
+	int ret = cache->insert_entry(&ckey, false, handle);
 	if (ret != expected_ret) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_insert_entry returned unexpected result. Expected: %d. Actual: %d",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::insert_entry returned unexpected result. Expected: %d. Actual: %d",
 			expected_ret, ret);
 		return false;
 	}
@@ -54,11 +54,11 @@ static inline bool test_insert_impl(nccl_ofi_mr_cache_t *cache, void *addr, size
 		exit(1);                                                  \
 	}
 
-static inline bool test_delete_impl(nccl_ofi_mr_cache_t *cache, void *handle, int expected_ret)
+static inline bool test_delete_impl(nccl_ofi_mr_cache *cache, void *handle, int expected_ret)
 {
-	int ret = nccl_ofi_mr_cache_del_entry(cache, handle);
+	int ret = cache->del_entry(handle);
 	if (ret != expected_ret) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_del_entry returned unexpected result. Expected: %d. Actual: %d",
+		NCCL_OFI_WARN("nccl_ofi_mr_cache::del_entry returned unexpected result. Expected: %d. Actual: %d",
 			expected_ret, ret);
 		return false;
 	}
@@ -103,9 +103,9 @@ int main(int argc, char *argv[])
 
 	unit_test_init();
 
-	nccl_ofi_mr_cache_t *cache = nccl_ofi_mr_cache_init(cache_init_size, fake_page_size);
+	nccl_ofi_mr_cache *cache = new nccl_ofi_mr_cache(cache_init_size, fake_page_size);
 	if (!cache) {
-		NCCL_OFI_WARN("nccl_ofi_mr_cache_init failed");
+		NCCL_OFI_WARN("nccl_ofi_mr_cache constructor failed");
 		exit(1);
 	}
 
@@ -174,7 +174,7 @@ int main(int argc, char *argv[])
 	test_make_aligned_key(fake_page_size - 16, 17, 0, fake_page_size * 2);
 #endif
 
-	nccl_ofi_mr_cache_finalize(cache);
+	delete cache;
 
 	printf("Test completed successfully!\n");
 }


### PR DESCRIPTION
**Three incremental commits to convert the MR cache to a proper C++ class:**

1. Convert MR cache from C struct to C++ class — Replaces the C-style nccl_ofi_mr_cache struct with a C++ class using std::vector, constructor/destructor, and encapsulated methods. Not the end state, but a reasonable first step.
2. Modernize mr_cache internals to C++ conventions — Clean up C idioms inside the cache: C++ headers (cerrno, cstdlib), new/delete instead of calloc/free, nullptr instead of NULL, early returns instead of goto. Add destructor cleanup for leaked entries.
3. Move mr_cache lock from cache to domain — The lock was owned by the cache object, but the cache is shared across concurrent endpoints via the domain. Move it to nccl_net_ofi_domain_t as std::mutex so synchronization scope matches sharing scope. Use std::lock_guard/std::unique_lock with CTAD.