### PR TITLE
ci: Update GitHub Actions to fix Node.js 20 deprecation warnings

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -8,12 +8,6 @@ on:
       - main
       - v*
   pull_request:
-env:
-  # note, related to issue around actions/checkout@v4, linked below. This
-  # environment variable is also now needed, as of july 2024.
-  # ref: https://github.com/actions/runner/issues/2906#issuecomment-2208546951
-  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: 'true'
-
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
@@ -56,7 +50,7 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-al2023:${{ matrix.sdk }}-efa${{ matrix.efainstaller }}
     name: al2023/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/${{ matrix.build-type }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -118,7 +112,7 @@ jobs:
     name: u2204/${{ matrix.sdk }}/${{matrix.cc}}-${{matrix.cc-variant}}-${{matrix.tracing}}/${{ matrix.build-type }}
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.cc-variant }}-${{ matrix.tracing }}-efalattest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -190,7 +184,7 @@ jobs:
     name: U2404/${{ matrix.sdk }}/${{matrix.cc}}/${{matrix.tracing}}/${{ matrix.build-type }}
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -260,7 +254,7 @@ jobs:
     name: U2404/${{ matrix.sdk }}/${{matrix.cc}}/Thread Safety Analysis
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -312,7 +306,7 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-codechecker:${{ matrix.sdk }}-latest
     name: CodeChecker - ${{ matrix.sdk }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -15,7 +15,7 @@ jobs:
       ubuntu2404: ${{ steps.set-matrix.outputs.ubuntu2404 }}
       codechecker: ${{ steps.set-matrix.outputs.codechecker }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - id: set-matrix
         run: |
           echo "amazonlinux=$(jq -c '.matrix_config.amazonlinux' .github/matrix-config.json)" >> $GITHUB_OUTPUT
@@ -32,20 +32,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build and push amazonlinux containers
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: docker/base
           file: docker/base/Dockerfile.al2023
@@ -68,20 +68,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build and push ubuntu containers
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: docker/base
           file: docker/base/Dockerfile.ubuntu
@@ -106,20 +106,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push Ubuntu 24.04 containers
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: docker/base
           file: docker/base/Dockerfile.ubuntu2404
@@ -142,20 +142,20 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           
       - name: Build and push CodeChecker containers
-        uses: docker/build-push-action@v4
+        uses: docker/build-push-action@v6
         with:
           context: docker/base
           file: docker/base/Dockerfile.codechecker


### PR DESCRIPTION
*Description of changes:*

GitHub is deprecating Node.js 20 for Actions runners starting June 2nd, 2026 ([announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/)). Both update-containers.yaml and distcheck.yaml were using older action versions that depend on Node.js 20, producing deprecation warnings on every run.

This commit bumps the following actions to Node.js 22+ compatible versions:

- actions/checkout: v3/v4 → v5
- docker/login-action: v2 → v3
- docker/build-push-action: v4 → v6

Also removes the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION environment variable workaround from distcheck.yaml, which is no longer needed.

Validated on fork: https://github.com/akkart-aws/aws-ofi-nccl/actions/runs/24772451127

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
