### PR TITLE
Size active_put_signal to full sequence number space

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -14,6 +14,8 @@
 #include "nccl_ofi_gdrcopy.h"
 #include "nccl_ofi_tracepoint.h"
 
+#include <bitset>
+
 /**
  * Get singleton instance of the device copy context shared across all GIN communicators.
  */
@@ -103,13 +105,18 @@ struct nccl_ofi_gin_peer_rank_info {
 	uint16_t next_delivered_signal_seq_num = 0;
 
 	/* Flag, stored at initiator, indicating the given sequence number (mod
-	   max_requests) is in use at initiator side. This allows initiator to
-	   track in-use sequence numbers to avoid overflow and only mark
+	   the sequence space) is in use at initiator side. This allows initiator
+	   to track in-use sequence numbers to avoid overflow and only mark
 	   iputSignal complete when it has received the ack from the target,
 	   which has delivered the signal atomic.
-	   */
-	bool active_put_signal[NCCL_OFI_MAX_REQUESTS];
 	
+	   Sized to the full sequence number space so that every in-flight
+	   seq number maps to a unique slot, regardless of how many contexts
+	   are active. */
+	std::bitset<GIN_IMM_SEQ_MASK + 1> active_put_signal;
+	static_assert(GIN_IMM_SEQ_MASK + 1 <= UINT16_MAX,
+		      "active_put_signal must fit within the 16-bit seq_num range");
+
 	/* Counter for consecutive PUT-only messages without ACK.
 	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
 	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
@@ -213,12 +220,12 @@ public:
 
 	bool query_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num) const
 	{
-		return rank_comms[peer_rank].active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS];
+		return rank_comms[peer_rank].active_put_signal.test(msg_seq_num & GIN_IMM_SEQ_MASK);
 	}
 
 	void clear_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num)
 	{
-		rank_comms[peer_rank].active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = false;
+		rank_comms[peer_rank].active_put_signal.reset(msg_seq_num & GIN_IMM_SEQ_MASK);
 	}
 
 	void clear_ack_range(uint32_t peer_rank, uint16_t ack_seq_num, uint16_t ack_count)

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -424,7 +424,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	uint16_t rail_id = resources.get_next_rail();
 	auto scheduler = gin_ep.get_scheduler();
 
-	if (OFI_UNLIKELY(rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS])) {
+	if (OFI_UNLIKELY(rank_comm.active_put_signal.test(msg_seq_num & GIN_IMM_SEQ_MASK))) {
 		NCCL_OFI_WARN("Next sequence number is in use");
 		assert(false);
 		return -EBUSY;
@@ -585,7 +585,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	/* Update umbrella request with send_req */
 	req->send_req = send_req;
 
-	rank_comm.active_put_signal[msg_seq_num % NCCL_OFI_MAX_REQUESTS] = is_ack_requested;
+	rank_comm.active_put_signal.set(msg_seq_num & GIN_IMM_SEQ_MASK, is_ack_requested);
 	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
 
 	*request = req;

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -368,6 +368,16 @@ static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v1
 static ncclResult_t nccl_ofi_gin_createContext_v13(void *collComm, ncclGinConfig_v13_t *config,
 						   void **ginCtx, ncclNetDeviceHandle_v11_t **devHandle)
 {
+	int max_contexts = (GIN_IMM_SEQ_MASK + 1) / NCCL_NET_MAX_REQUESTS;
+	if (config->nContexts > max_contexts) {
+		NCCL_OFI_INFO(NCCL_INIT, "GIN: requested %d contexts exceeds max %d "
+			      "(seq space %d / max_requests %d)",
+			      config->nContexts,
+			      max_contexts,
+			      GIN_IMM_SEQ_MASK + 1,
+			      NCCL_NET_MAX_REQUESTS);
+	}
+
 	*ginCtx = collComm;
 	if (devHandle != nullptr)
 		*devHandle = nullptr;


### PR DESCRIPTION
The active_put_signal array was sized to NCCL_OFI_MAX_REQUESTS (128) but indexed by sequence numbers that wrap at GIN_IMM_SEQ_MASK (2047). This caused aliasing: sequence numbers 128 apart mapped to the same slot, which could either spuriously return -EBUSY or silently lose ACK tracking for an earlier sequence number.

Size the array to the full 11-bit sequence space (2048 entries) so every in-flight sequence number maps to a unique slot. Use bitwise AND instead of modulo for indexing, matching the masking used elsewhere for sequence number arithmetic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
