### PR TITLE
rocm: Include nccl_ofi_rocm.h in release tarball

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -43,6 +43,7 @@ noinst_HEADERS = \
 	nccl_ofi_platform.h \
 	nccl_ofi_pthread.h \
 	nccl_ofi_rdma.h \
+	nccl_ofi_rocm.h \
 	nccl_ofi_scheduler.h \
 	nccl_ofi_sendrecv.h \
 	nccl_ofi_spinlock.h \


### PR DESCRIPTION
nccl_ofi_rocm.h was missing from the noinst_HEADERS list in include/Makefile.am, causing it to be excluded from release tarballs. 
Building from an extracted tarball would fail with:
  fatal error: nccl_ofi_rocm.h: No such file or directory

Add nccl_ofi_rocm.h to noinst_HEADERS so it is included in future release tarballs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
