### PR TITLE
Add grouped receive (multi-recv) support to RDMA transport (when eager is disabled)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,5 @@ m4/lt~obsolete.m4
 # can automatically generate from config.status script
 # (which is called by configure script))
 Makefile
+install/
+.vscode/

--- a/doc/multi-recv.md
+++ b/doc/multi-recv.md
@@ -1,0 +1,108 @@
+# Multi-Recv Support in the RDMA Protocol
+
+## Overview
+
+The RDMA transport in aws-ofi-nccl supports **grouped receives** (`maxRecvs > 1`),
+where NCCL posts a single `irecv()` with N destination buffers, each identified by
+a tag. A single sender issues N separate `isend()` calls on the same communicator,
+each targeting a specific tag. The receiver completes when all N sub-receives have
+arrived.
+
+The primary use case is **AllToAll with PXN (Proxy Cross-Node)**: each receive
+gathers data from all ranks on a remote node, sent by a single proxy rank into
+N separate buffers (one per remote rank). With `NCCL_NET_SHARED_COMMS=1`, NCCL
+multiplexes these N sub-channels onto a single network communicator, using tags
+to distinguish them.
+
+This document describes the multi-recv design and the changes to the RDMA
+protocol to support it.
+
+**Note:** Eager message support for grouped receives is not yet implemented and
+will be added in a future change. Currently, eager sends with grouped receives
+are disabled.
+
+## Background: Single Recv Flow
+
+In the baseline RDMA protocol, a single send/recv pair works as follows:
+
+1. **Receiver** calls `recv()`, which allocates a request, populates a control
+   message (ctrl msg) in its local mailbox with the destination buffer address,
+   MR keys, and buffer length, then RDMA-writes the ctrl msg to the sender's
+   mailbox.
+
+2. **Sender** calls `send()`, finds the ctrl msg in its mailbox (keyed by
+   `msg_seq_num`), reads the destination info, and issues `fi_writedata()` to
+   RDMA-write the data directly into the receiver's buffer. The immediate data
+   carries `comm_id`, `msg_seq_num`, `recv_idx`, and `seg_count`.
+
+3. **Receiver** gets a write completion with the immediate data, identifies the
+   request, and marks it complete.
+
+## Multi-Recv Design
+
+### Control Message Format
+
+The ctrl msg is extended to a **fat control message**: an array of up to
+`NCCL_OFI_MAX_RECVS` (8) entries, each 64 bytes (cache-line aligned). Each
+entry describes one sub-receive:
+
+```
+struct nccl_net_ofi_ctrl_msg_entry {
+    uintptr_t buff_offset;          // destination buffer offset
+    uint64_t  mr_key[MAX_NUM_RAILS]; // MR keys per rail
+    uint32_t  buff_len;             // destination buffer length
+    int16_t   tag;                  // tag for matching to isend
+    uint16_t  msg_seq_num;          // sequence number (ready bit in entry[0])
+    uint16_t  flags;                // e.g. recv completion optional
+    uint16_t  num_recvs;            // N (only in entry[0])
+    uint8_t   recv_idx;             // index of this entry (0..N-1)
+    uint8_t   pad[9];
+};
+```
+
+Total ctrl msg size: `64 × NCCL_OFI_MAX_RECVS = 512 bytes`. The RDMA write to
+the sender is sized based on the number of receive buffers in the request
+(`n × 64` bytes), so a single recv only writes 64 bytes.
+
+### Immediate Data Format
+
+The 32-bit RDMA write immediate data is:
+
+```
+| 4-bit seg_count | 3-bit recv_idx | 15-bit comm_id | 10-bit msg_seq_num |
+```
+
+The `recv_idx` field (3 bits, max 8) identifies which sub-receive a write
+completion belongs to, enabling per-sub-receive size tracking.
+
+### Sender Group Tracking
+
+When the sender reads a ctrl msg with `num_recvs > 1`, it enters **group mode**:
+- `group_num_recvs` = N
+- `group_sends_remaining` = N
+- Each `send()` call matches its tag against the ctrl msg entries
+- `next_msg_seq_num` advances only after all N sub-sends complete
+- The `entry_used` flag prevents the same entry from being matched twice
+
+### Per-Sub-Receive Size Tracking
+
+Each sub-receive tracks its own `recv_size`. On RDMA write completion, the
+receiver extracts `recv_idx` from the immediate data and accumulates
+`cq_entry->len` into `recvs[recv_idx].recv_size`. The `test()` function reports
+per-sub sizes to NCCL.
+
+## Limitations
+
+- **Maximum grouped receives**: `NCCL_OFI_MAX_RECVS = 8` (limited by 3-bit
+  `recv_idx` in immediate data).
+
+- **Maximum communicators**: Reduced from 256K to 32K (15-bit `comm_id`) to
+  make room for `recv_idx` in the immediate data.
+
+- **Version gating**: Grouped receives (`maxRecvs > 1`) are only reported for
+  ncclNet v9 and later, where `irecv` uses `size_t` sizes. Earlier versions
+  and the Neuron/sendrecv protocol report `maxRecvs = 1`.
+
+- **Eager sends**: Eager message support for grouped receives is not yet
+  implemented. When multi-recv is enabled, eager sends continue to work for
+  single receives (n=1) using the existing eager path.

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -50,7 +50,7 @@
 #define MIN_TAG_BITS_FOR_RING_ID	(32 + 1)
 
 /* Maximum number of grouped receives */
-#define NCCL_OFI_MAX_RECVS	1
+#define NCCL_OFI_MAX_RECVS	8
 
 /*
  * This defines a higher value than maximum inflight requests supported by NCCL

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -398,9 +398,6 @@ typedef struct {
 } rdma_req_recv_segms_data_t;
 
 /*
- * @brief	Data of request responsible for receive operation
- */
-/*
  * @brief	Per-sub-receive metadata within a grouped receive
  */
 typedef struct rdma_req_recv_sub {
@@ -718,9 +715,9 @@ public:
     nccl_net_ofi_rdma_recv_comm_rail_t *get_data_rail(uint16_t rail_id);
     nccl_net_ofi_rdma_recv_comm_rail_t *get_control_rail(uint16_t rail_id);
     int allocate_recv_req(nccl_net_ofi_rdma_device_t *device,
-			  int dev_id_arg, uint16_t msg_seq_num, void *buff,
-			  size_t size,
-			  nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle,
+			  int dev_id_arg, uint16_t msg_seq_num, int num_recvs,
+			  void **buffs, size_t *sizes, int *tags,
+			  nccl_net_ofi_rdma_mr_handle_t **buff_mr_handles,
 			  nccl_net_ofi_rdma_req **ret_req,
 			  bool recv_completion_optional);
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -377,26 +377,54 @@ typedef struct {
 } rdma_req_eager_copy_data_t;
 
 /*
- * @brief	Data of request responsible for receiving segements
+ * @brief	Data of request responsible for receiving segments
  */
 typedef struct {
 	/* Pointer to recv parent request */
 	nccl_net_ofi_rdma_req *recv_req;
+	/* For grouped receives: running total of expected segments across all senders.
+	 * Updated dynamically as we learn each sender's segment count from immediate data. */
+	int total_expected_segms;
+	/* Number of distinct senders whose segment count we've registered */
+	int num_senders_registered;
+	int num_expected_senders;
 } rdma_req_recv_segms_data_t;
 
 /*
  * @brief	Data of request responsible for receive operation
  */
-typedef struct {
+/*
+ * @brief	Per-sub-receive metadata within a grouped receive
+ */
+typedef struct rdma_req_recv_sub {
 	/* Destination buffer */
 	void *dst_buff;
 	/* Destination length */
 	size_t dst_len;
 	/* Mr handle for destination buffer */
 	nccl_net_ofi_rdma_mr_handle_t *dest_mr_handle;
+	/* Tag for matching to corresponding isend */
+	int tag;
+	/* Completed size for this sub-receive */
+	size_t recv_size;
+	/* Number of segments completed for this sub-receive */
+	int ncompls;
+	/* Total expected segments for this sub-receive */
+	int total_segms;
+} rdma_req_recv_sub_t;
+
+/*
+ * @brief	Data of request responsible for receive operation
+ */
+typedef struct {
+	/* Number of sub-receives in this grouped receive */
+	int num_recvs;
+	/* Per-sub-receive metadata */
+	rdma_req_recv_sub_t recvs[NCCL_OFI_MAX_RECVS];
 	/* Pointer to receive segments child request */
 	nccl_net_ofi_rdma_req *recv_segms_req;
-	/* (Eager messages) pointer to eager local copy request */
+	/* (Eager messages) pointer to eager local copy request.
+	 * Only used when num_recvs == 1 */
 	nccl_net_ofi_rdma_req *eager_copy_req;
 	/* Total number of completions. Expect one send ctrl
 	 * completion and one completion that indicates that all

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -336,6 +336,8 @@ typedef struct {
 	size_t buff_len;
 	/* Memory region descriptors associated to `buff' */
 	nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle;
+	/* Tag for matching to the correct sub-entry in a grouped receive ctrl msg */
+	int tag;
 	/* Schedule used to transfer this request. We save the pointer to
 	 * reference it when transferring the request over network. */
 	nccl_net_ofi_schedule_t *schedule;
@@ -620,6 +622,13 @@ public:
 	uint32_t remote_comm_id;
 
 	uint16_t next_msg_seq_num;
+
+	/* For grouped receives: how many sends remain for the current msg_seq_num */
+	uint16_t group_sends_remaining;
+	/* Total num_recvs for the current group (0 = not in a group) */
+	uint16_t group_num_recvs;
+	/* Bitmask of tags used in the current group */
+	uint32_t group_tag_used;
 
 	/* Number of rails */
 	uint16_t num_rails;

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -160,15 +160,15 @@ public:
  */
 #define NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT (1 << 0)
 
-/*
- * @brief Control messages
- *
- * The control message contains the destination buffer address, mr keys,
- * message sequence number and padding to align it to cache line size.
- * It is used by the receiver to post the control message to the sender.
- */
-typedef struct nccl_net_ofi_ctrl_msg {
+/* Sentinel tag value indicating a ctrl msg entry has been consumed */
+#define NCCL_OFI_CTRL_MSG_TAG_INVALID ((int16_t)-1)
 
+/*
+ * @brief Control message sub-entry
+ *
+ * Each sub-entry describes one destination buffer within a grouped receive.
+ */
+typedef struct nccl_net_ofi_ctrl_msg_entry {
 	/* Destination buffer offset from base address.
 	 * For virtual address mode, base address is 0, so this is the virtual address.
 	 * For offset mode, this is the offset from the MR base address. */
@@ -182,20 +182,43 @@ typedef struct nccl_net_ofi_ctrl_msg {
 	/* Destination buffer len */
 	uint32_t buff_len;
 
-	/* Flags to indicate if recv completion is optional or not */
-	uint16_t flags;
-
-	/* Control message sequence number. The is also used as the
-	* ready bit to indicate that the control message has been posted.
-	*/
+	/* Tag for matching this sub-entry to the corresponding isend */
+	int16_t tag;
+	/* Per-entry sequence number for RDMA atomicity verification.
+	 * In entries[0], this also serves as the ctrl msg ready bit. */
 	uint16_t msg_seq_num;
+	/* The following fields are only meaningful in entries[0] and carry
+	 * metadata that applies to the entire control message. */
+	uint16_t flags;
+	uint16_t num_recvs;
+	/* Padding to 64-byte cache line boundary */
+	uint8_t pad[10];
+} nccl_net_ofi_ctrl_msg_entry_t;
+static_assert(sizeof(nccl_net_ofi_ctrl_msg_entry_t) == 64,
+		"Wrong size for RDMA Control message entry");
 
-	/* Padding to ensure we are aligned to cache line*/
-	uint8_t cache_line_padding[16];
+/*
+ * @brief Control messages
+ *
+ * The control message is a flat array of up to NCCL_OFI_MAX_RECVS entries,
+ * each describing one destination buffer in a grouped receive. Common metadata
+ * (msg_seq_num, flags, num_recvs) is stored in entries[0]'s pad area.
+ * It is used by the receiver to post the control message to the sender.
+ *
+ * Layout:
+ *   [msg_seq_num | flags | num_recvs | padding]  (header, 8 bytes)
+ *   [entry 0]                                     (48 bytes)
+ *   [entry 1]                                     (48 bytes)
+ *   ...
+ *   [entry N-1]                                   (48 bytes)
+ *   [padding to cache-line alignment]
+ */
+typedef struct nccl_net_ofi_ctrl_msg {
+	/* Flat array of entries. Common metadata (msg_seq_num used as ready
+	 * bit, flags, num_recvs) lives in entries[0].pad area. */
+	nccl_net_ofi_ctrl_msg_entry_t entries[NCCL_OFI_MAX_RECVS];
 } nccl_net_ofi_ctrl_msg_t;
-/* Assert to make sure that the control message on the wire
- * is of cache line size */
-static_assert(sizeof(nccl_net_ofi_ctrl_msg_t) == 64,
+static_assert(sizeof(nccl_net_ofi_ctrl_msg_t) == 64 * NCCL_OFI_MAX_RECVS,
                 "Wrong size for RDMA Control message");
 
 static inline size_t nccl_net_ofi_rdma_ctrl_msg_size()

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -43,7 +43,8 @@ static_assert(MAX_NUM_RAILS <= UINT16_MAX);
 /*
  * @brief      Number of bits used for the communicator ID
  */
-#define NCCL_OFI_RDMA_COMM_ID_BITS (18)
+#define NCCL_OFI_RDMA_COMM_ID_BITS (15)
+#define NCCL_OFI_RDMA_RECV_IDX_BITS (3)
 
 /* Maximum number of comms open simultaneously. Eventually this will be
    runtime-expandable */
@@ -191,8 +192,10 @@ typedef struct nccl_net_ofi_ctrl_msg_entry {
 	 * metadata that applies to the entire control message. */
 	uint16_t flags;
 	uint16_t num_recvs;
+	/* Index of this entry within the grouped receive (0..N-1) */
+	uint8_t recv_idx;
 	/* Padding to 64-byte cache line boundary */
-	uint8_t pad[10];
+	uint8_t pad[9];
 } nccl_net_ofi_ctrl_msg_entry_t;
 static_assert(sizeof(nccl_net_ofi_ctrl_msg_entry_t) == 64,
 		"Wrong size for RDMA Control message entry");
@@ -338,6 +341,8 @@ typedef struct {
 	nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle;
 	/* Tag for matching to the correct sub-entry in a grouped receive ctrl msg */
 	int tag;
+	/* Sub-receive index within a grouped receive (encoded in immediate data) */
+	uint8_t recv_idx;
 	/* Schedule used to transfer this request. We save the pointer to
 	 * reference it when transferring the request over network. */
 	nccl_net_ofi_schedule_t *schedule;

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -494,12 +494,6 @@ ncclResult_t nccl_net_ofi_irecv(void* recvComm, int n, void** data,
 		return check_return(ncclInternalError);
 	}
 
-	if (OFI_UNLIKELY(n > NCCL_OFI_MAX_RECVS)) {
-		NCCL_OFI_WARN("Request for group recv size of %d, greater than maximum of %d",
-			      n, NCCL_OFI_MAX_RECVS);
-		return check_return(ncclInternalError);
-	}
-
 	if (OFI_UNLIKELY(handles == NULL)) {
 		NCCL_OFI_WARN("Invalid memory handle provided");
 		return check_return(ncclInternalError);

--- a/src/nccl_ofi_interface_neuron.cpp
+++ b/src/nccl_ofi_interface_neuron.cpp
@@ -107,7 +107,8 @@ static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v5_t* props)
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* Neuron uses sendrecv protocol which does not support grouped receives */
+	props->maxRecvs = 1;
 
 	props->max_write_inline_size = ofi_properties.max_write_inline_size;
 	props->max_mr_key_size = ofi_properties.max_mr_key_size;

--- a/src/nccl_ofi_interface_neuron.cpp
+++ b/src/nccl_ofi_interface_neuron.cpp
@@ -107,7 +107,7 @@ static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v5_t* props)
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	/* Neuron uses sendrecv protocol which does not support grouped receives */
+	/* No support for multi-recv in Neuron as of now */
 	props->maxRecvs = 1;
 
 	props->max_write_inline_size = ofi_properties.max_write_inline_size;

--- a/src/nccl_ofi_interface_nvidia.cpp
+++ b/src/nccl_ofi_interface_nvidia.cpp
@@ -293,7 +293,8 @@ static ncclResult_t getProperties_v8(int dev_id, ncclNetProperties_v8_t* props)
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* Grouped receives (maxRecvs > 1) supported from v9 onwards */
+	props->maxRecvs = 1;
 	props->netDeviceType = NCCL_NET_DEVICE_HOST;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 
@@ -322,7 +323,8 @@ static ncclResult_t getProperties_v7(int dev_id, ncclNetProperties_v7_t *props)
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* Grouped receives (maxRecvs > 1) supported from v9 onwards */
+	props->maxRecvs = 1;
 	props->netDeviceType = NCCL_NET_DEVICE_HOST;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 
@@ -352,7 +354,10 @@ static ncclResult_t getProperties_v5(int dev_id, ncclNetProperties_v6_t *props)
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	props->maxRecvs = ofi_properties.max_group_receives;;
+	/*
+	 * Grouped receives (maxRecvs > 1) supported from v9 onwards.
+	 */
+	props->maxRecvs = 1;
 
 	return ncclSuccess;
 }

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -458,16 +458,10 @@ static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 	props->latency = ofi_nccl_net_latency.get();
 
 	/*
-	 * Maximum number of grouped receives. Currently, we set it to 1 to
-	 * maintain single send/recv semantics (similar to NCCL versions < v2.12).
-	 *
-	 * Grouped receives are useful for alltoall collectives where one
-	 * receiver is expected to receive from multiple remote GPUs using
-	 * PXN(PCIe X NVLINK) feature. Other collectives like allreduce aren't
-	 * impacted with this feature as NCCL doesn't aggregate receives from
-	 * same source.
+	 * Maximum number of grouped receives. We set it to 1 by default
+	 * Will be overwritten depending on libfabric feature
 	 */
-	props->max_group_receives = NCCL_OFI_MAX_RECVS;
+	props->max_group_receives = 1;
 
 	if (support_gdr == GDR_SUPPORTED) {
 		props->hmem_support = true;
@@ -548,6 +542,13 @@ int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov
 			      dev_id);
 		ret = 0;
 		goto exit;
+	}
+
+	/* Only support multi-recv if eager is disabled for now
+	 * Enabling it requires multiple iovs that point to both host and GPU memory
+	 */
+	if (ofi_nccl_eager_max_size() < 0) {
+		props->max_group_receives = NCCL_OFI_MAX_RECVS;
 	}
 
 	/* name is NULL if device is a part of multirail config */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -539,6 +539,8 @@ static inline void set_request_state_to_error(nccl_net_ofi_rdma_req *req)
  * @return	0, on success
  *		non-zero, on error
  */
+static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req, size_t size, int total_nsegms);
+
 static inline int inc_req_completion(nccl_net_ofi_rdma_req *req,
 				     size_t size, int total_ncompls)
 {
@@ -609,7 +611,11 @@ static inline int set_eager_copy_completed(nccl_net_ofi_rdma_req *req)
 	}
 
 	/* Add completion to parent request */
-	ret = inc_req_completion(recv_req, size, recv_data->total_num_compls);
+	if (recv_data->num_recvs > 1) {
+		ret = inc_recv_seg_completion(recv_data->recv_segms_req, size, 1);
+	} else {
+		ret = inc_req_completion(recv_req, size, recv_data->total_num_compls);
+	}
 
 	return ret;
 }
@@ -673,18 +679,30 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
 	
 	nccl_net_ofi_mutex_lock(&req->req_lock);
 
+	rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(req);
+
 	/* Sum up segment sizes */
 	req->size += size;
 	/* Sum up number of segments */
 	req->ncompls++;
 
+	/* Register this sender's total_nsegms if we haven't seen enough senders yet.
+	 * For a single recv (num_expected_senders=1), this registers once on the first completion.
+	 * For grouped receives, each fi_writedata completion represents one sender.
+	 * We use the original heuristic for non-grouped, and simple counting for grouped. */
+	if (req->ncompls > recv_segms_data->total_expected_segms) {
+		recv_segms_data->total_expected_segms += total_nsegms;
+		recv_segms_data->num_senders_registered++;
+	}
+
 	/* The arrival of the last segment is treated as a single
 	 * request completion of the parent request */
-	segms_received = req->ncompls == total_nsegms;
+	segms_received = (req->ncompls == recv_segms_data->total_expected_segms) &&
+			   (recv_segms_data->num_senders_registered == recv_segms_data->num_expected_senders);
 	
 	/* Mark receive segments request and receive request as completed */
 	if (segms_received) {
-		rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(req);
+		/* recv_segms_data already available from outer scope */
 		nccl_net_ofi_rdma_req *recv_req = recv_segms_data->recv_req;
 		rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 
@@ -914,7 +932,11 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 			NCCL_OFI_WARN("Failed call to check_post_rx_buff_req");
 			return ret;
 		}
-		ret = inc_req_completion(recv_req, 0, recv_data->total_num_compls);
+		if (recv_data->num_recvs > 1) {
+			ret = inc_recv_seg_completion(recv_data->recv_segms_req, 0, 1);
+		} else {
+			ret = inc_req_completion(recv_req, 0, recv_data->total_num_compls);
+		}
 		return ret;
 	}
 
@@ -2461,7 +2483,21 @@ int nccl_net_ofi_rdma_req::test(int *done, int *size_p)
 		nccl_net_ofi_mutex_unlock(&this->req_lock);
 
 		if (size_p) {
-			*size_p = req_size;
+			if (this->type == NCCL_OFI_RDMA_RECV) {
+				rdma_req_recv_data_t *local_recv_data = get_recv_data(this);
+				if (local_recv_data->num_recvs > 1) {
+					/* For grouped receives, distribute total received
+					 * size evenly across sub-receives. */
+					size_t per_sub = req_size / local_recv_data->num_recvs;
+					for (int i = 0; i < local_recv_data->num_recvs; i++) {
+						size_p[i] = per_sub;
+					}
+				} else {
+					*size_p = req_size;
+				}
+			} else {
+				*size_p = req_size;
+			}
 		}
 		/* Mark as done */
 		*done = 1;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -718,12 +718,35 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_co
 	rdma_req_send_data_t *send_data = get_send_data(req);
 	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 
-	send_data->remote_buff_offset = s_comm->ctrl_mailbox[slot].entries[0].buff_offset;
-	send_data->remote_len = s_comm->ctrl_mailbox[slot].entries[0].buff_len;
+	/* Find the ctrl msg entry matching this send's tag */
+	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
+	nccl_net_ofi_ctrl_msg_entry_t *entry = NULL;
+	if (ctrl->entries[0].num_recvs <= 1) {
+		entry = &ctrl->entries[0];
+	} else {
+		for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
+			if (ctrl->entries[i].tag == send_data->tag) {
+				entry = &ctrl->entries[i];
+				break;
+			}
+		}
+	}
+	if (OFI_UNLIKELY(entry == NULL)) {
+		NCCL_OFI_WARN("No ctrl msg entry found for tag %d in slot %u (num_recvs=%u)",
+			       send_data->tag, slot, ctrl->entries[0].num_recvs);
+		return -EINVAL;
+	}
+
+	send_data->remote_buff_offset = entry->buff_offset;
+	send_data->remote_len = entry->buff_len;
 
 	for (uint16_t rail_id = 0; rail_id != ep->num_rails; ++rail_id) {
-		send_data->remote_mr_key[rail_id] = s_comm->ctrl_mailbox[slot].entries[0].mr_key[rail_id];
+		send_data->remote_mr_key[rail_id] = entry->mr_key[rail_id];
 	}
+
+	/* Invalidate the entry so duplicate tags from step interleaving
+	 * won't match this already-consumed entry */
+	entry->tag = NCCL_OFI_CTRL_MSG_TAG_INVALID;
 
 	/* If recv buffer is smaller than send buffer, we reduce the size of the send req */
 	nccl_net_ofi_mutex_lock(&req->req_lock);
@@ -2284,19 +2307,40 @@ static inline bool has_flush_completed(nccl_net_ofi_rdma_req *req)
  * @brief Check the contents of the control mailbox to check if the
  * control message has arrived or not
  */
-static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t seq_num)
+static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t seq_num, int tag)
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-	return (READ_ONCE(s_comm->ctrl_mailbox[slot].msg_seq_num) == ((uint64_t)seq_num & MSG_SEQ_NUM_MASK));
+	uint16_t expected = (uint16_t)(seq_num & MSG_SEQ_NUM_MASK);
+	if (READ_ONCE(s_comm->ctrl_mailbox[slot].entries[0].msg_seq_num) != expected)
+		return false;
+	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
+	if (ctrl->entries[0].num_recvs <= 1)
+		return true;
+	/* Grouped receive: verify per-entry seq nums and find matching tag */
+	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
+		if (READ_ONCE(ctrl->entries[i].msg_seq_num) != expected)
+			return false;
+		if (ctrl->entries[i].tag == tag)
+			return true;
+	}
+	return false;
 }
 
 /*
  * @brief Get the buff len of a given msg_seq_num from the control mailbox
  */
-static inline uint32_t get_ctrl_msg_buff_len(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t seq_num)
+static inline uint32_t get_ctrl_msg_buff_len(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t seq_num, int tag)
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-	return (s_comm->ctrl_mailbox[slot].entries[0].buff_len);
+	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
+	if (ctrl->entries[0].num_recvs <= 1)
+		return ctrl->entries[0].buff_len;
+	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
+		if (ctrl->entries[i].tag == tag) {
+			return ctrl->entries[i].buff_len;
+		}
+	}
+	return 0;
 }
 
 /*
@@ -2310,9 +2354,9 @@ static inline int update_send_request(nccl_net_ofi_rdma_send_comm* s_comm, nccl_
 	rdma_req_send_data_t *send_data = get_send_data(req);
 
 	/* Only increment completion if the send has completed */
-	if (send_data->eager && has_ctrl_msg(s_comm, req->msg_seq_num) && req->ncompls > 0) {
+	if (send_data->eager && has_ctrl_msg(s_comm, req->msg_seq_num, send_data->tag) && req->ncompls > 0) {
 
-		send_data->remote_len = get_ctrl_msg_buff_len(s_comm, req->msg_seq_num);
+		send_data->remote_len = get_ctrl_msg_buff_len(s_comm, req->msg_seq_num, send_data->tag);
 		if (send_data->remote_len < send_data->buff_len) {
 			NCCL_OFI_TRACE(NCCL_NET,
 				       "Remote recv buffer (%zu) smaller than send buffer (%zu) in eager send",
@@ -4872,7 +4916,7 @@ static int alloc_rdma_send_req(nccl_net_ofi_rdma_send_comm *s_comm,
 					uint16_t msg_seq_num,
 					void *buff, size_t size,
 					nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle,
-					bool eager,
+					bool eager, int tag,
 					nccl_net_ofi_rdma_req **ret_req)
 {
 	nccl_net_ofi_rdma_ep_t *ep = (nccl_net_ofi_rdma_ep_t *)s_comm->ep.get();
@@ -4897,6 +4941,7 @@ static int alloc_rdma_send_req(nccl_net_ofi_rdma_send_comm *s_comm,
 	send_data->buff = buff;
 	send_data->buff_len = size;
 	send_data->buff_mr_handle = buff_mr_handle;
+	send_data->tag = tag;
 
 	/* If this is not an eager send, the schedule is created after knowing the
 	   remote length received in the control message.
@@ -5466,6 +5511,8 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 	uint16_t msg_seq_num = s_comm->next_msg_seq_num;
 	bool have_ctrl = false;
 	bool eager = false;
+	bool in_group = false;
+
 
 	assert(s_comm != NULL);
 
@@ -5521,10 +5568,26 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 		mr_handle = domain->flush_buff.mr_handle;
 	}
 
-	have_ctrl = has_ctrl_msg(s_comm, msg_seq_num);
+	in_group = (s_comm->group_sends_remaining > 0);
 
-	/* Determine if this should be sent eagerly. */
-	if (!have_ctrl && (ssize_t)size <= endpoint->eager_send_size && s_comm->num_inflight_writes == 0) {
+	have_ctrl = has_ctrl_msg(s_comm, msg_seq_num, tag);
+
+	/* If ctrl msg indicates a grouped recv, start tracking the group */
+	if (have_ctrl && !in_group) {
+		uint16_t slot = msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
+		uint16_t nr = s_comm->ctrl_mailbox[slot].entries[0].num_recvs;
+		if (nr > 1) {
+			s_comm->group_num_recvs = nr;
+			s_comm->group_sends_remaining = nr;
+			in_group = true;
+		}
+	}
+
+	/* Determine if this should be sent eagerly.
+	 * Disable eager entirely when maxRecvs > 1: the sender must wait for
+	 * the ctrl msg so it can detect grouped receives and reuse msg_seq_num. */
+	if (NCCL_OFI_MAX_RECVS == 1 && !have_ctrl &&
+	    (ssize_t)size <= endpoint->eager_send_size && s_comm->num_inflight_writes == 0) {
 		eager = true;
 	}
 
@@ -5535,15 +5598,14 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 			ret = 0;
 			goto error;
 		}
-	} else {
-		/* Memory synchronization point to ensure that the data in the control msg is not
-		 * read before the sequence number is checked */
+	} else if (!in_group || s_comm->group_sends_remaining == s_comm->group_num_recvs) {
+		/* Memory synchronization point - only on first send of a group or non-grouped */
 		std::atomic_thread_fence(std::memory_order_acquire);
 		s_comm->n_ctrl_received += 1;
 	}
 
 	ret = alloc_rdma_send_req(s_comm, msg_seq_num, data,
-				  size, mr_handle, eager, &req);
+				  size, mr_handle, eager, tag, &req);
 	if (OFI_UNLIKELY(ret != 0)) {
 		goto error;
 	}
@@ -5593,8 +5655,16 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 
 	/* Return request to NCCL */
 	*base_req = req;
-	/* Increment next_msg_seq_num for next call */
-	s_comm->next_msg_seq_num = (s_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
+	/* Increment next_msg_seq_num: for grouped sends, only after the last sub-send */
+	if (in_group) {
+		s_comm->group_sends_remaining--;
+		if (s_comm->group_sends_remaining == 0) {
+			s_comm->group_num_recvs = 0;
+			s_comm->next_msg_seq_num = (s_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
+		}
+	} else {
+		s_comm->next_msg_seq_num = (s_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
+	}
 
 	goto exit;
 
@@ -5997,6 +6067,9 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm **s_com
 	ret_s_comm->dev_id = dev_id;
 	ret_s_comm->comm_active = true;
 	ret_s_comm->next_msg_seq_num = NCCL_OFI_RDMA_MSG_SEQ_NUM_START;
+	ret_s_comm->group_sends_remaining = 0;
+	ret_s_comm->group_num_recvs = 0;
+	ret_s_comm->group_tag_used = 0;
 
 	/* The connect() API function acquired the endpoint we are using via
 	   get_ep(). Store shared_ptr in the comm to keep ep alive. */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -65,6 +65,11 @@
 #define MSG_NUM_SEG_MASK (((uint64_t)1 << NUM_NUM_SEG_BITS) - 1)
 
 /*
+ * @brief	Sub-receive index bitmask for immediate data
+ */
+#define MSG_RECV_IDX_MASK (((uint64_t)1 << NCCL_OFI_RDMA_RECV_IDX_BITS) - 1)
+
+/*
  * @brief	Extract communicator ID from write completion immediate data
  *
  * The immediate data bit format is documented in the definition of NCCL_OFI_RDMA_SEQ_BITS
@@ -83,7 +88,12 @@
  *
  * The immediate data bit format is documented in the definition of NCCL_OFI_RDMA_SEQ_BITS
  */
-#define GET_NUM_SEG_FROM_IMM(data) (((data) >> (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS)) & MSG_NUM_SEG_MASK)
+#define GET_NUM_SEG_FROM_IMM(data) (((data) >> (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS + NCCL_OFI_RDMA_RECV_IDX_BITS)) & MSG_NUM_SEG_MASK)
+
+/*
+ * @brief	Extract sub-receive index from write completion immediate data
+ */
+#define GET_RECV_IDX_FROM_IMM(data) (((data) >> (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS)) & MSG_RECV_IDX_MASK)
 
 /*
  * @brief	Build write completion immediate data from comm ID, message seq
@@ -91,8 +101,10 @@
  *
  * The immediate data bit format is documented in the definition of NCCL_OFI_RDMA_SEQ_BITS
  */
-#define GET_RDMA_WRITE_IMM_DATA(comm_id, seq, nseg) \
-	((seq) | ((comm_id) << NCCL_OFI_RDMA_SEQ_BITS) | ((nseg) << (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS)))
+#define GET_RDMA_WRITE_IMM_DATA(comm_id, seq, recv_idx, nseg) \
+	((seq) | ((comm_id) << NCCL_OFI_RDMA_SEQ_BITS) | \
+	 ((recv_idx) << (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS)) | \
+	 ((nseg) << (NCCL_OFI_RDMA_SEQ_BITS + NCCL_OFI_RDMA_COMM_ID_BITS + NCCL_OFI_RDMA_RECV_IDX_BITS)))
 
 /*
  * Return value from some functions indicating that the communicator is
@@ -741,10 +753,12 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_co
 	nccl_net_ofi_ctrl_msg_entry_t *entry = NULL;
 	if (ctrl->entries[0].num_recvs <= 1) {
 		entry = &ctrl->entries[0];
+		send_data->recv_idx = 0;
 	} else {
 		for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
 			if (ctrl->entries[i].tag == send_data->tag) {
 				entry = &ctrl->entries[i];
+				send_data->recv_idx = entry->recv_idx;
 				break;
 			}
 		}
@@ -785,7 +799,7 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_co
 	send_data->total_num_compls = send_data->schedule->num_xfer_infos;
 
 	send_data->wdata =
-		GET_RDMA_WRITE_IMM_DATA(s_comm->remote_comm_id, req->msg_seq_num, send_data->schedule->num_xfer_infos);
+		GET_RDMA_WRITE_IMM_DATA(s_comm->remote_comm_id, req->msg_seq_num, send_data->recv_idx, send_data->schedule->num_xfer_infos);
 
 	if (s_comm->ctrl_mailbox[slot].entries[0].flags & NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT)
 		send_data->no_target_completion = true;
@@ -1124,6 +1138,10 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 	nccl_net_ofi_rdma_req *recv_segms_req = recv_data->recv_segms_req;
 
 	uint64_t total_segms = GET_NUM_SEG_FROM_IMM(cq_entry->data);
+	uint8_t recv_idx = GET_RECV_IDX_FROM_IMM(cq_entry->data);
+
+	/* Accumulate per-sub-receive size for grouped receives */
+	recv_data->recvs[recv_idx].recv_size += cq_entry->len;
 
 	ret = inc_recv_seg_completion(recv_segms_req, cq_entry->len, total_segms);
 	if (OFI_UNLIKELY(ret != 0)) {
@@ -2486,11 +2504,8 @@ int nccl_net_ofi_rdma_req::test(int *done, int *size_p)
 			if (this->type == NCCL_OFI_RDMA_RECV) {
 				rdma_req_recv_data_t *local_recv_data = get_recv_data(this);
 				if (local_recv_data->num_recvs > 1) {
-					/* For grouped receives, distribute total received
-					 * size evenly across sub-receives. */
-					size_t per_sub = req_size / local_recv_data->num_recvs;
 					for (int i = 0; i < local_recv_data->num_recvs; i++) {
-						size_p[i] = per_sub;
+						size_p[i] = local_recv_data->recvs[i].recv_size;
 					}
 				} else {
 					*size_p = req_size;
@@ -3238,6 +3253,7 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 		this->ctrl_mailbox[slot].entries[0].num_recvs = n;
 		/* Entry 0 was already populated by allocate_recv_req, but update its tag */
 		this->ctrl_mailbox[slot].entries[0].tag = tags[0];
+		this->ctrl_mailbox[slot].entries[0].recv_idx = 0;
 		this->ctrl_mailbox[slot].entries[0].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
 
 		for (i = 1; i < n; i++) {
@@ -3246,6 +3262,7 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 			entry->buff_offset = (uintptr_t)buffers[i] - mr_h->base_addr;
 			entry->buff_len = sizes[i];
 			entry->tag = tags[i];
+			entry->recv_idx = i;
 			entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
 			for (uint16_t rail_id = 0; rail_id < this->num_rails; rail_id++) {
 				uint64_t rkey = fi_mr_key(mr_h->mr[rail_id].get());
@@ -4992,7 +5009,7 @@ static int alloc_rdma_send_req(nccl_net_ofi_rdma_send_comm *s_comm,
 		   has not arrived, so we expect one extra completion for the ctrl msg recv. */
 		send_data->total_num_compls = send_data->schedule->num_xfer_infos + 1;
 		send_data->wdata = GET_RDMA_WRITE_IMM_DATA(s_comm->remote_comm_id, req->msg_seq_num,
-							   send_data->schedule->num_xfer_infos);
+							   send_data->recv_idx, send_data->schedule->num_xfer_infos);
 	}
 
 	send_data->eager = eager;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -5598,9 +5598,11 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 	}
 
 	/* Determine if this should be sent eagerly.
-	 * Disable eager entirely when maxRecvs > 1: the sender must wait for
-	 * the ctrl msg so it can detect grouped receives and reuse msg_seq_num. */
-	if (NCCL_OFI_MAX_RECVS == 1 && !have_ctrl &&
+	 * Eager is disabled when multi-recv requires the sender to wait for
+	 * the ctrl msg to detect grouped receives. Currently multi-recv is
+	 * only supported with eager_send_size == -1, so the size check
+	 * is sufficient to disable eager for multi-recv. */
+	if (!have_ctrl &&
 	    (ssize_t)size <= endpoint->eager_send_size && s_comm->num_inflight_writes == 0) {
 		eager = true;
 	}

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -698,10 +698,13 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
 	/* Sum up number of segments */
 	req->ncompls++;
 
-	/* Register this sender's total_nsegms if we haven't seen enough senders yet.
-	 * For a single recv (num_expected_senders=1), this registers once on the first completion.
-	 * For grouped receives, each fi_writedata completion represents one sender.
-	 * We use the original heuristic for non-grouped, and simple counting for grouped. */
+	/* Detect when a completion belongs to a new sender we haven't
+	 * registered yet. Each sender's first segment pushes ncompls past
+	 * the sum of all previously registered senders' segment counts.
+	 * When that happens, we register this sender's total_nsegms.
+	 * For single recv (1 sender), this fires once on the first completion.
+	 * For grouped recv (N senders), this fires N times as each sender's
+	 * first completion crosses the running total. */
 	if (req->ncompls > recv_segms_data->total_expected_segms) {
 		recv_segms_data->total_expected_segms += total_nsegms;
 		recv_segms_data->num_senders_registered++;
@@ -2351,17 +2354,21 @@ static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t se
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 	uint16_t expected = (uint16_t)(seq_num & MSG_SEQ_NUM_MASK);
-	if (READ_ONCE(s_comm->ctrl_mailbox[slot].entries[0].msg_seq_num) != expected)
+	if (READ_ONCE(s_comm->ctrl_mailbox[slot].entries[0].msg_seq_num) != expected) {
 		return false;
+	}
 	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
-	if (ctrl->entries[0].num_recvs <= 1)
+	if (ctrl->entries[0].num_recvs <= 1) {
 		return true;
+	}
 	/* Grouped receive: verify per-entry seq nums and find matching tag */
 	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
-		if (READ_ONCE(ctrl->entries[i].msg_seq_num) != expected)
+		if (READ_ONCE(ctrl->entries[i].msg_seq_num) != expected) {
 			return false;
-		if (ctrl->entries[i].tag == tag)
+		}
+		if (ctrl->entries[i].tag == tag) {
 			return true;
+		}
 	}
 	return false;
 }
@@ -2373,8 +2380,9 @@ static inline uint32_t get_ctrl_msg_buff_len(nccl_net_ofi_rdma_send_comm* s_comm
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
-	if (ctrl->entries[0].num_recvs <= 1)
+	if (ctrl->entries[0].num_recvs <= 1) {
 		return ctrl->entries[0].buff_len;
+	}
 	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
 		if (ctrl->entries[i].tag == tag) {
 			return ctrl->entries[i].buff_len;
@@ -2919,8 +2927,7 @@ static inline nccl_net_ofi_rdma_req *allocate_req(nccl_ofi_freelist *fl)
 static inline int insert_recv_segms_req(
 				nccl_net_ofi_rdma_recv_comm *r_comm,
 				nccl_net_ofi_rdma_device_t *device,
-				int dev_id, uint16_t msg_seq_num, void *buff,
-				size_t size,
+				int dev_id, uint16_t msg_seq_num, int num_recvs,
 				nccl_net_ofi_rdma_req *recv_req)
 {
 	/* Allocate recv segms request */
@@ -2941,7 +2948,7 @@ static inline int insert_recv_segms_req(
 	recv_segms_data->recv_req = recv_req;
 	recv_segms_data->total_expected_segms = 0;
 	recv_segms_data->num_senders_registered = 0;
-	recv_segms_data->num_expected_senders = 1;
+	recv_segms_data->num_expected_senders = num_recvs;
 
 	rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 	recv_data->recv_segms_req = recv_segms_req;
@@ -2954,13 +2961,14 @@ static inline int insert_recv_segms_req(
  */
 int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 				nccl_net_ofi_rdma_device_t *device,
-				int dev_id_arg, uint16_t msg_seq_num, void *buff,
-				size_t size,
-				nccl_net_ofi_rdma_mr_handle_t *buff_mr_handle,
+				int dev_id_arg, uint16_t msg_seq_num, int num_recvs,
+				void **buffs, size_t *sizes, int *tags,
+				nccl_net_ofi_rdma_mr_handle_t **buff_mr_handles,
 				nccl_net_ofi_rdma_req **ret_req,
 				bool recv_completion_optional)
 {
 	int ret = 0;
+	int i;
 	rdma_req_recv_data_t *recv_data;
 
 	/* Allocate receive request */
@@ -2981,58 +2989,49 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 	/* In the case of early completion, only expect the completion for control msg itself */
 	recv_data->total_num_compls = recv_completion_optional ? 1 : 2;
 	recv_data->eager_copy_req = NULL;
-	recv_data->num_recvs = 1;
-	recv_data->recvs[0].dst_buff = buff;
-	recv_data->recvs[0].dst_len = size;
-	recv_data->recvs[0].dest_mr_handle = buff_mr_handle;
-	recv_data->recvs[0].tag = 0;
-	recv_data->recvs[0].recv_size = 0;
-	recv_data->recvs[0].ncompls = 0;
-	recv_data->recvs[0].total_segms = 0;
+	recv_data->num_recvs = num_recvs;
+	for (i = 0; i < num_recvs; i++) {
+		recv_data->recvs[i].dst_buff = buffs[i];
+		recv_data->recvs[i].dst_len = sizes[i];
+		recv_data->recvs[i].dest_mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)buff_mr_handles[i];
+		recv_data->recvs[i].tag = tags[i];
+		recv_data->recvs[i].recv_size = 0;
+		recv_data->recvs[i].ncompls = 0;
+		recv_data->recvs[i].total_segms = 0;
+	}
 
-	ret = insert_recv_segms_req(this, device, dev_id_arg, msg_seq_num, buff, size, req);
+	ret = insert_recv_segms_req(this, device, dev_id_arg, msg_seq_num, num_recvs, req);
 	if (ret) {
 		NCCL_OFI_WARN("Failed to insert receive segments request into recv request");
 		return ret;
 	}
 
-	/* Update receiver's control mailbox slot
-	* The receiver updates a slot in its control mailbox with the sequence number of the recv request.
-	* The contents of this slot are then written to the sender's mailbox. The sender checks the slot
-	* corresponding to the send request's sequence number to identify whether the control message
-	* for this message is available or not. Since we start with sequence number of 1(as opposed to 0),
-	* we do not run into the case where the sender mistakenly thinks that the control message has
-	* been received. Also, since the size of the mailbox is less than MSG_SEQ_NUM_MASK+1
-	* wrap around works fine too */
+	/* Update receiver's control mailbox slot */
 	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-	/* Zero the slot first, then populate. msg_seq_num is written last as the ready bit. */
 	memset(&this->ctrl_mailbox[slot], 0, sizeof(nccl_net_ofi_ctrl_msg_t));
-	this->ctrl_mailbox[slot].entries[0].num_recvs = 1;
+	this->ctrl_mailbox[slot].entries[0].num_recvs = num_recvs;
 	if (recv_completion_optional) {
 		this->ctrl_mailbox[slot].entries[0].flags |= NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT;
 	}
 
-	/* Populate entry 0 */
-	nccl_net_ofi_ctrl_msg_entry_t *entry = &this->ctrl_mailbox[slot].entries[0];
-	entry->buff_offset = (uintptr_t)buff - buff_mr_handle->base_addr;
-	entry->buff_len = size;
-	entry->tag = 0;
-	entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
-
-	uint16_t rail_id = 0;
-	for (; rail_id < this->num_rails; rail_id++) {
-		uint64_t rkey = fi_mr_key(buff_mr_handle->mr[rail_id].get());
-
-		if (rkey == FI_KEY_NOTAVAIL) {
-			NCCL_OFI_WARN("RDMA write buffers should be pre-registered");
-			return -ENOENT;
+	/* Populate all entries */
+	for (i = 0; i < num_recvs; i++) {
+		nccl_net_ofi_ctrl_msg_entry_t *entry = &this->ctrl_mailbox[slot].entries[i];
+		nccl_net_ofi_rdma_mr_handle_t *mr_h = (nccl_net_ofi_rdma_mr_handle_t *)buff_mr_handles[i];
+		entry->buff_offset = (uintptr_t)buffs[i] - mr_h->base_addr;
+		entry->buff_len = sizes[i];
+		entry->tag = tags[i];
+		entry->recv_idx = i;
+		entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
+		for (uint16_t rail_id = 0; rail_id < this->num_rails; rail_id++) {
+			uint64_t rkey = fi_mr_key(mr_h->mr[rail_id].get());
+			if (rkey == FI_KEY_NOTAVAIL) {
+				NCCL_OFI_WARN("RDMA write buffers should be pre-registered");
+				return -ENOENT;
+			}
+			entry->mr_key[rail_id] = rkey;
 		}
-
-		entry->mr_key[rail_id] = rkey;
 	}
-
-	/* Write msg_seq_num last as the ready bit */
-	this->ctrl_mailbox[slot].entries[0].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
 
 	*ret_req = req;
 
@@ -3211,7 +3210,18 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 		eager = false;
 	}
 
-	/* Handle 0-byte messages: use flush buffer for valid SGE */
+	/* NCCL versions prior to 2.24 require special handling for 0 byte
+	 * messages when using user buffer registration.  NCCL passes the base
+	 * pointer from the user buffer, but passes the registration from the
+	 * channel buffer, to avoid an MR cache lookup.  This is fine with
+	 * InfiniBand, where the spec says the SGE is not used for a 0 byte
+	 * message, but is a problem for EFA, which validates the pointer / MR
+	 * even for a 0 byte transfer.
+	 *
+	 * To handle this case, we use the flush buffer (note we still move 0
+	 * bytes of data, we just need a valid SGE) instead of the provided base
+	 * pointer and MR
+	 */
 	for (i = 0 ; i < n ; i++) {
 		if (sizes[i] == 0) {
 			buffers[i] = domain->flush_buff.buffer;
@@ -3220,61 +3230,13 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 	}
 
 	ret = this->allocate_recv_req(device, device_id, msg_seq_num,
-					buffers[0], sizes[0],
-					mr_handles[0], &req, recv_completion_optional);
+					n, buffers, sizes, tags,
+					mr_handles, &req, recv_completion_optional);
 	if (ret != 0) {
 		goto error;
 	}
 
 	recv_data = get_recv_data(req);
-
-	/* Populate per-sub-receive metadata for all n buffers */
-	recv_data->num_recvs = n;
-	/* Update recv_segms to expect n senders for grouped receives */
-	if (n > 1) {
-		rdma_req_recv_segms_data_t *segms_data = get_recv_segms_data(recv_data->recv_segms_req);
-		segms_data->num_expected_senders = n;
-	}
-	for (i = 0; i < n; i++) {
-		recv_data->recvs[i].dst_buff = buffers[i];
-		recv_data->recvs[i].dst_len = sizes[i];
-		recv_data->recvs[i].dest_mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mr_handles[i];
-		recv_data->recvs[i].tag = tags[i];
-		recv_data->recvs[i].recv_size = 0;
-		recv_data->recvs[i].ncompls = 0;
-		recv_data->recvs[i].total_segms = 0;
-	}
-
-	/* Update the ctrl mailbox slot with all n sub-entries.
-	 * allocate_recv_req already populated entries[0] and the header.
-	 * Now update num_recvs and populate entries[1..n-1]. */
-	{
-		uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-		this->ctrl_mailbox[slot].entries[0].num_recvs = n;
-		/* Entry 0 was already populated by allocate_recv_req, but update its tag */
-		this->ctrl_mailbox[slot].entries[0].tag = tags[0];
-		this->ctrl_mailbox[slot].entries[0].recv_idx = 0;
-		this->ctrl_mailbox[slot].entries[0].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
-
-		for (i = 1; i < n; i++) {
-			nccl_net_ofi_ctrl_msg_entry_t *entry = &this->ctrl_mailbox[slot].entries[i];
-			nccl_net_ofi_rdma_mr_handle_t *mr_h = (nccl_net_ofi_rdma_mr_handle_t *)mr_handles[i];
-			entry->buff_offset = (uintptr_t)buffers[i] - mr_h->base_addr;
-			entry->buff_len = sizes[i];
-			entry->tag = tags[i];
-			entry->recv_idx = i;
-			entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
-			for (uint16_t rail_id = 0; rail_id < this->num_rails; rail_id++) {
-				uint64_t rkey = fi_mr_key(mr_h->mr[rail_id].get());
-				if (rkey == FI_KEY_NOTAVAIL) {
-					NCCL_OFI_WARN("RDMA write buffers should be pre-registered");
-					ret = -ENOENT;
-					goto error;
-				}
-				entry->mr_key[rail_id] = rkey;
-			}
-		}
-	}
 
 	if (eager) {
 		nccl_net_ofi_rdma_req *rx_buff_req = (nccl_net_ofi_rdma_req *)elem;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -5528,7 +5528,6 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 	bool eager = false;
 	bool in_group = false;
 
-
 	assert(s_comm != NULL);
 
 	if (s_comm->comm_active == false) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2922,6 +2922,7 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 	entry->buff_offset = (uintptr_t)buff - buff_mr_handle->base_addr;
 	entry->buff_len = size;
 	entry->tag = 0;
+	entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
 
 	uint16_t rail_id = 0;
 	for (; rail_id < this->num_rails; rail_id++) {
@@ -3107,22 +3108,15 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 	}
 
 	/*
-	 * TODO: Use NCCL provided tags when using grouped receives aka
-	 * props->maxRecvs > 1.
+	 * Disable eager for grouped receives (n > 1).
+	 * Eager requires matching a single rx bounce buffer to a single dest,
+	 * which doesn't generalize to multiple destinations.
 	 */
+	if (n > 1) {
+		eager = false;
+	}
 
-	/* NCCL versions prior to 2.24 require special handling for 0 byte
-	 * messages when using user buffer registration.  NCCL passes the base
-	 * pointer from the user buffer, but passes the registration from the
-	 * channel buffer, to avoid an MR cache lookup.  This is fine with
-	 * InfiniBand, where the spec says the SGE is not used for a 0 byte
-	 * message, but is a problem for EFA, which validates the pointer / MR
-	 * even for a 0 byte transfer.
-	 *
-	 * To handle this case, we use the flush buffer (note we still move 0
-	 * bytes of data, we just need a valid SGE) instead of the provided base
-	 * pointer and MR
-	 */
+	/* Handle 0-byte messages: use flush buffer for valid SGE */
 	for (i = 0 ; i < n ; i++) {
 		if (sizes[i] == 0) {
 			buffers[i] = domain->flush_buff.buffer;
@@ -3138,6 +3132,52 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 	}
 
 	recv_data = get_recv_data(req);
+
+	/* Populate per-sub-receive metadata for all n buffers */
+	recv_data->num_recvs = n;
+	/* Update recv_segms to expect n senders for grouped receives */
+	if (n > 1) {
+		rdma_req_recv_segms_data_t *segms_data = get_recv_segms_data(recv_data->recv_segms_req);
+		segms_data->num_expected_senders = n;
+	}
+	for (i = 0; i < n; i++) {
+		recv_data->recvs[i].dst_buff = buffers[i];
+		recv_data->recvs[i].dst_len = sizes[i];
+		recv_data->recvs[i].dest_mr_handle = (nccl_net_ofi_rdma_mr_handle_t *)mr_handles[i];
+		recv_data->recvs[i].tag = tags[i];
+		recv_data->recvs[i].recv_size = 0;
+		recv_data->recvs[i].ncompls = 0;
+		recv_data->recvs[i].total_segms = 0;
+	}
+
+	/* Update the ctrl mailbox slot with all n sub-entries.
+	 * allocate_recv_req already populated entries[0] and the header.
+	 * Now update num_recvs and populate entries[1..n-1]. */
+	{
+		uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
+		this->ctrl_mailbox[slot].entries[0].num_recvs = n;
+		/* Entry 0 was already populated by allocate_recv_req, but update its tag */
+		this->ctrl_mailbox[slot].entries[0].tag = tags[0];
+		this->ctrl_mailbox[slot].entries[0].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
+
+		for (i = 1; i < n; i++) {
+			nccl_net_ofi_ctrl_msg_entry_t *entry = &this->ctrl_mailbox[slot].entries[i];
+			nccl_net_ofi_rdma_mr_handle_t *mr_h = (nccl_net_ofi_rdma_mr_handle_t *)mr_handles[i];
+			entry->buff_offset = (uintptr_t)buffers[i] - mr_h->base_addr;
+			entry->buff_len = sizes[i];
+			entry->tag = tags[i];
+			entry->msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
+			for (uint16_t rail_id = 0; rail_id < this->num_rails; rail_id++) {
+				uint64_t rkey = fi_mr_key(mr_h->mr[rail_id].get());
+				if (rkey == FI_KEY_NOTAVAIL) {
+					NCCL_OFI_WARN("RDMA write buffers should be pre-registered");
+					ret = -ENOENT;
+					goto error;
+				}
+				entry->mr_key[rail_id] = rkey;
+			}
+		}
+	}
 
 	if (eager) {
 		nccl_net_ofi_rdma_req *rx_buff_req = (nccl_net_ofi_rdma_req *)elem;
@@ -5145,7 +5185,10 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req *req)
 
 	nccl_net_ofi_scheduler *scheduler = ep->scheduler;
 	uint16_t rail_id;
-	size_t ctrl_msg_len = nccl_net_ofi_rdma_ctrl_msg_size();
+	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
+	/* Only send the entries that are populated (64 bytes per entry) */
+	size_t ctrl_msg_len = r_comm->ctrl_mailbox[slot].entries[0].num_recvs
+			      * sizeof(nccl_net_ofi_ctrl_msg_entry_t);
 	nccl_net_ofi_schedule_t *schedule = NULL;
 
 	if (ep->num_control_rails > 1) {
@@ -5167,7 +5210,6 @@ static int post_rdma_ctrl(nccl_net_ofi_rdma_req *req)
 		rail_id = 0;
 	}
 
-	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 	void *desc = fi_mr_desc(r_comm->ctrl_mr_handle->mr[rail_id].get());
 	nccl_net_ofi_rdma_recv_comm_rail_t *comm_rail = r_comm->get_control_rail(rail_id);
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -746,7 +746,7 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_co
 	send_data->wdata =
 		GET_RDMA_WRITE_IMM_DATA(s_comm->remote_comm_id, req->msg_seq_num, send_data->schedule->num_xfer_infos);
 
-	if (s_comm->ctrl_mailbox[slot].flags & NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT)
+	if (s_comm->ctrl_mailbox[slot].entries[0].flags & NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT)
 		send_data->no_target_completion = true;
 	return 0;
 }
@@ -2907,7 +2907,7 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 	this->ctrl_mailbox[slot].buff_offset = (uintptr_t)buff - buff_mr_handle->base_addr;
 	this->ctrl_mailbox[slot].buff_len = size;
 	if (recv_completion_optional) {
-		this->ctrl_mailbox[slot].flags |= NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT;
+		this->ctrl_mailbox[slot].entries[0].flags |= NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT;
 	}
 
 	uint16_t rail_id = 0;
@@ -4010,7 +4010,8 @@ nccl_net_ofi_rdma_recv_comm::nccl_net_ofi_rdma_recv_comm()
 	remote_mailbox_addr = 0;
 	remote_mr_key = {};
 
-	const size_t ctrl_mailbox_size = sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE;
+	const size_t ctrl_mailbox_raw_size = sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE;
+	const size_t ctrl_mailbox_size = NCCL_OFI_ROUND_UP(ctrl_mailbox_raw_size, system_page_size);
 	ctrl_mailbox = (nccl_net_ofi_ctrl_msg_t *)aligned_alloc(system_page_size, ctrl_mailbox_size);
 	if (OFI_UNLIKELY(!ctrl_mailbox)) {
 		NCCL_OFI_WARN("Unable to allocate receive communicator control mailbox");
@@ -4273,7 +4274,9 @@ static nccl_net_ofi_rdma_recv_comm *prepare_recv_comm(nccl_net_ofi_rdma_domain_t
 
 	nccl_net_ofi_rdma_mr_handle_t *mr_handle;
 
-	ret = domain->reg_internal_mr(r_comm->ctrl_mailbox, sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE, NCCL_PTR_HOST, &mr_handle);
+	ret = domain->reg_internal_mr(r_comm->ctrl_mailbox,
+		NCCL_OFI_ROUND_UP(sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE, system_page_size),
+		NCCL_PTR_HOST, &mr_handle);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Failed to register memory for the control mailbox: %d", ret);
 		goto error;
@@ -5656,7 +5659,8 @@ nccl_net_ofi_rdma_send_comm::nccl_net_ofi_rdma_send_comm()
 	ctrl_mailbox = nullptr;
 	ctrl_mr_handle = nullptr;
 
-	const size_t ctrl_mailbox_size = sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE;
+	const size_t ctrl_mailbox_raw_size = sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE;
+	const size_t ctrl_mailbox_size = NCCL_OFI_ROUND_UP(ctrl_mailbox_raw_size, system_page_size);
 	ctrl_mailbox = (nccl_net_ofi_ctrl_msg_t *)aligned_alloc(system_page_size, ctrl_mailbox_size);
 	if (OFI_UNLIKELY(!ctrl_mailbox)) {
 		NCCL_OFI_WARN("Unable to allocate send communicator control mailbox");
@@ -5964,7 +5968,8 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm **s_com
 							     true);
 
 	/* Allocate control mailbox */
-	ret = domain_ptr->reg_internal_mr(ret_s_comm->ctrl_mailbox, sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE,
+	ret = domain_ptr->reg_internal_mr(ret_s_comm->ctrl_mailbox,
+					  NCCL_OFI_ROUND_UP(sizeof(nccl_net_ofi_ctrl_msg_t) * NCCL_OFI_CTRL_MAILBOX_SIZE, system_page_size),
 						  NCCL_PTR_HOST, &ret_s_comm->ctrl_mr_handle);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Could not register memory for control mailbox for dev %d", dev_id);

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -718,11 +718,11 @@ static inline int update_send_data_from_remote(nccl_net_ofi_rdma_send_comm *s_co
 	rdma_req_send_data_t *send_data = get_send_data(req);
 	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 
-	send_data->remote_buff_offset = s_comm->ctrl_mailbox[slot].buff_offset;
-	send_data->remote_len = s_comm->ctrl_mailbox[slot].buff_len;
+	send_data->remote_buff_offset = s_comm->ctrl_mailbox[slot].entries[0].buff_offset;
+	send_data->remote_len = s_comm->ctrl_mailbox[slot].entries[0].buff_len;
 
 	for (uint16_t rail_id = 0; rail_id != ep->num_rails; ++rail_id) {
-		send_data->remote_mr_key[rail_id] = s_comm->ctrl_mailbox[slot].mr_key[rail_id];
+		send_data->remote_mr_key[rail_id] = s_comm->ctrl_mailbox[slot].entries[0].mr_key[rail_id];
 	}
 
 	/* If recv buffer is smaller than send buffer, we reduce the size of the send req */
@@ -2296,7 +2296,7 @@ static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t se
 static inline uint32_t get_ctrl_msg_buff_len(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t seq_num)
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-	return (s_comm->ctrl_mailbox[slot].buff_len);
+	return (s_comm->ctrl_mailbox[slot].entries[0].buff_len);
 }
 
 /*
@@ -2844,6 +2844,9 @@ static inline int insert_recv_segms_req(
 
 	rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(recv_segms_req);
 	recv_segms_data->recv_req = recv_req;
+	recv_segms_data->total_expected_segms = 0;
+	recv_segms_data->num_senders_registered = 0;
+	recv_segms_data->num_expected_senders = 1;
 
 	rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 	recv_data->recv_segms_req = recv_segms_req;
@@ -2883,9 +2886,14 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 	/* In the case of early completion, only expect the completion for control msg itself */
 	recv_data->total_num_compls = recv_completion_optional ? 1 : 2;
 	recv_data->eager_copy_req = NULL;
-	recv_data->dst_buff = buff;
-	recv_data->dst_len = size;
-	recv_data->dest_mr_handle = buff_mr_handle;
+	recv_data->num_recvs = 1;
+	recv_data->recvs[0].dst_buff = buff;
+	recv_data->recvs[0].dst_len = size;
+	recv_data->recvs[0].dest_mr_handle = buff_mr_handle;
+	recv_data->recvs[0].tag = 0;
+	recv_data->recvs[0].recv_size = 0;
+	recv_data->recvs[0].ncompls = 0;
+	recv_data->recvs[0].total_segms = 0;
 
 	ret = insert_recv_segms_req(this, device, dev_id_arg, msg_seq_num, buff, size, req);
 	if (ret) {
@@ -2902,13 +2910,18 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 	* been received. Also, since the size of the mailbox is less than MSG_SEQ_NUM_MASK+1
 	* wrap around works fine too */
 	uint16_t slot = req->msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
-	this->ctrl_mailbox[slot].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
-	/* Calculate offset from MR base address. For virtual address mode, base_addr is 0. */
-	this->ctrl_mailbox[slot].buff_offset = (uintptr_t)buff - buff_mr_handle->base_addr;
-	this->ctrl_mailbox[slot].buff_len = size;
+	/* Zero the slot first, then populate. msg_seq_num is written last as the ready bit. */
+	memset(&this->ctrl_mailbox[slot], 0, sizeof(nccl_net_ofi_ctrl_msg_t));
+	this->ctrl_mailbox[slot].entries[0].num_recvs = 1;
 	if (recv_completion_optional) {
 		this->ctrl_mailbox[slot].entries[0].flags |= NCCL_OFI_RDMA_FLAG_RECV_COMPLETION_OPT;
 	}
+
+	/* Populate entry 0 */
+	nccl_net_ofi_ctrl_msg_entry_t *entry = &this->ctrl_mailbox[slot].entries[0];
+	entry->buff_offset = (uintptr_t)buff - buff_mr_handle->base_addr;
+	entry->buff_len = size;
+	entry->tag = 0;
 
 	uint16_t rail_id = 0;
 	for (; rail_id < this->num_rails; rail_id++) {
@@ -2919,8 +2932,11 @@ int nccl_net_ofi_rdma_recv_comm::allocate_recv_req(
 			return -ENOENT;
 		}
 
-		this->ctrl_mailbox[slot].mr_key[rail_id] = rkey;
+		entry->mr_key[rail_id] = rkey;
 	}
+
+	/* Write msg_seq_num last as the ready bit */
+	this->ctrl_mailbox[slot].entries[0].msg_seq_num = req->msg_seq_num & MSG_SEQ_NUM_MASK;
 
 	*ret_req = req;
 
@@ -5203,11 +5219,11 @@ static int post_eager_copy(nccl_net_ofi_rdma_req *req)
 	rdma_req_rx_buff_data_t *rx_buff_data = get_rx_buff_data(eager_copy_data->eager_rx_buff_req);
 	rdma_req_recv_data_t *recv_data = get_recv_data(eager_copy_data->recv_req);
 
-	/* Validate size of data */
-	if (recv_data->dst_len < rx_buff_data->recv_len) {
+	/* Validate size of data (eager only used for single recv, so use recvs[0]) */
+	if (recv_data->recvs[0].dst_len < rx_buff_data->recv_len) {
 		NCCL_OFI_TRACE(NCCL_NET, "Recv buffer (%zu) smaller than eager send size (%zu)",
-			       recv_data->dst_len, rx_buff_data->recv_len);
-		rx_buff_data->recv_len = recv_data->dst_len;
+			       recv_data->recvs[0].dst_len, rx_buff_data->recv_len);
+		rx_buff_data->recv_len = recv_data->recvs[0].dst_len;
 	}
 
 	// Get communicator rail information to xfer the req
@@ -5220,7 +5236,7 @@ static int post_eager_copy(nccl_net_ofi_rdma_req *req)
 		(freelist_regmr_fn_handle_t *)rx_buff_data->rx_buff_fl_elem->mr_handle;
 	nccl_net_ofi_rdma_mr_handle_t *rx_mr_handle = fl_handle->mr_handle;
 
-	nccl_net_ofi_rdma_mr_handle_t *dest_mr_handle = recv_data->dest_mr_handle;
+	nccl_net_ofi_rdma_mr_handle_t *dest_mr_handle = recv_data->recvs[0].dest_mr_handle;
 
 	assert(rx_rail_id < dest_mr_handle->num_rails);
 	void *desc = fi_mr_desc(dest_mr_handle->mr[rx_rail_id].get());
@@ -5233,7 +5249,7 @@ static int post_eager_copy(nccl_net_ofi_rdma_req *req)
 	}
 
 	uintptr_t buff_offset = (uintptr_t)rx_buff - rx_mr_handle->base_addr;
-	ssize_t rc = fi_read(comm_rail->local_ep, recv_data->dst_buff,
+	ssize_t rc = fi_read(comm_rail->local_ep, recv_data->recvs[0].dst_buff,
 			     rx_buff_data->recv_len, desc, comm_rail->local_addr,
 			     buff_offset,
 			     rx_key, rdma_req_get_ofi_context(req, rx_rail_id));

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -948,8 +948,8 @@ int nccl_net_ofi_sendrecv_recv_comm::recv(int n, void **buffers,
 		goto error;
 	}
 
-	/* Currently, plugin doesn't support grouped receives */
-	assert(n <= NCCL_OFI_MAX_RECVS);
+	/* Currently, sendrecv plugin doesn't support grouped receives */
+	assert(n == 1);
 	for (int recv_n = 0; recv_n < n; recv_n++) {
 		void *desc = NULL;
 
@@ -1092,8 +1092,8 @@ int nccl_net_ofi_sendrecv_recv_comm::flush(int n, void **buffers,
 	}
 #endif
 
-	/* Plugin only supports one receive per request */
-	assert(n <= NCCL_OFI_MAX_RECVS);
+	/* Sendrecv plugin only supports one receive per request */
+	assert(n == 1);
 
 	/*
 	 * Find the non-zero request for which we will issue flush.

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -4,3 +4,4 @@ nccl_message_transfer
 reuse_listen_comm
 ring
 gin
+grouped_recv

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -33,7 +33,7 @@ CXXLINK = OMPI_CXX="$(CXX)" MPICH_CXX="$(CXX)" \
 if ENABLE_FUNC_TESTS
 noinst_HEADERS = functional_test.h
 
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin
+bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin grouped_recv
 
 base_sources = functional_test.cpp
 
@@ -43,4 +43,5 @@ ring_SOURCES = $(base_sources) ring.cpp
 inflight_close_SOURCES = $(base_sources) inflight_close.cpp
 reuse_listen_comm_SOURCES = $(base_sources) reuse_listen_comm.cpp
 gin_SOURCES = $(base_sources) gin.cpp
+grouped_recv_SOURCES = $(base_sources) grouped_recv.cpp
 endif

--- a/tests/functional/grouped_recv.cpp
+++ b/tests/functional/grouped_recv.cpp
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+/*
+ * This test validates grouped receive functionality (maxRecvs > 1).
+ *
+ * Rank 0 posts N separate isend() calls (one per sub-buffer).
+ * Rank 1 posts one irecv() with N buffers grouped together.
+ * test() returns per-sub-receive completed sizes.
+ *
+ * Grouped receives are supported from ncclNet v9 onwards.
+ */
+
+#include "config.h"
+#include "functional_test.h"
+static constexpr int MAX_RECVS = 8;
+
+class GroupedRecvTest : public TestScenario {
+public:
+	explicit GroupedRecvTest(int num_recvs, size_t buf_size = 4096)
+		: TestScenario("Grouped Recv Test (n=" + std::to_string(num_recvs) + ", size=" + std::to_string(buf_size) + ")"),
+		  n_recvs(num_recvs), buffer_size(buf_size) {}
+
+	void run(ThreadContext& ctx) override {
+		test_nccl_properties_t props = {};
+		OFINCCLTHROW(ext_net->getProperties(0, &props));
+
+		if (props.maxRecvs < n_recvs) {
+			NCCL_OFI_INFO(NCCL_NET,
+				"Skipping: maxRecvs=%d < n_recvs=%d", props.maxRecvs, n_recvs);
+			return;
+		}
+
+		for (size_t dev_idx = 0; dev_idx < ctx.lcomms.size(); dev_idx++) {
+			grouped_send_receive(ctx, dev_idx);
+		}
+	}
+
+private:
+	int n_recvs;
+	size_t buffer_size;
+	static constexpr int TAG = 1;
+
+	void grouped_send_receive(ThreadContext& ctx, int dev_idx) {
+		void *sComm = ctx.scomms[dev_idx];
+		void *rComm = ctx.rcomms[dev_idx];
+
+		auto gdr_support = get_support_gdr(ext_net);
+		int buffer_type = gdr_support[dev_idx] ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+
+		if (ctx.rank == 0) {
+			/* Sender: post n_recvs separate isend() calls */
+			void* send_bufs[MAX_RECVS] = {};
+			void* send_mh[MAX_RECVS] = {};
+			void* send_reqs[MAX_RECVS] = {};
+
+			for (int i = 0; i < n_recvs; i++) {
+				OFINCCLTHROW(allocate_buff(&send_bufs[i], buffer_size, buffer_type));
+				/* Fill each sub-buffer with a distinct pattern */
+				OFINCCLTHROW(initialize_buff(send_bufs[i], buffer_size, buffer_type, 'A' + i));
+				OFINCCLTHROW(ext_net->regMr(sComm, send_bufs[i], buffer_size, buffer_type, &send_mh[i]));
+				post_send(ext_net, sComm, send_bufs[i], buffer_size, TAG, send_mh[i], &send_reqs[i]);
+			}
+
+			/* Poll sends to completion */
+			bool all_done = false;
+			while (!all_done) {
+				all_done = true;
+				for (int i = 0; i < n_recvs; i++) {
+					if (send_reqs[i]) {
+						int done = 0;
+						OFINCCLTHROW(ext_net->test(send_reqs[i], &done, nullptr));
+						if (done) send_reqs[i] = nullptr;
+						else all_done = false;
+					}
+				}
+			}
+
+			for (int i = 0; i < n_recvs; i++) {
+				ext_net->deregMr(sComm, send_mh[i]);
+				deallocate_buffer(send_bufs[i], buffer_type);
+			}
+		} else {
+			/* Receiver: post one grouped irecv() with n_recvs buffers */
+			void* recv_bufs[MAX_RECVS] = {};
+			void* recv_mh[MAX_RECVS] = {};
+			size_t sizes[MAX_RECVS];
+			int tags[MAX_RECVS];
+			void* request = nullptr;
+
+			for (int i = 0; i < n_recvs; i++) {
+				OFINCCLTHROW(allocate_buff(&recv_bufs[i], buffer_size, buffer_type));
+				OFINCCLTHROW(ext_net->regMr(rComm, recv_bufs[i], buffer_size, buffer_type, &recv_mh[i]));
+				sizes[i] = buffer_size;
+				tags[i] = TAG;
+			}
+
+			post_recv(ext_net, rComm, n_recvs, recv_bufs, sizes, tags, recv_mh, &request);
+
+			/* Poll to completion, retrieve per-sub sizes */
+			int done = 0;
+			int recv_sizes[MAX_RECVS] = {};
+			while (!done) {
+				OFINCCLTHROW(ext_net->test(request, &done, recv_sizes));
+			}
+
+			/* Validate per-sub sizes */
+			for (int i = 0; i < n_recvs; i++) {
+				if (recv_sizes[i] != (int)buffer_size) {
+					throw std::runtime_error(
+						"Sub-recv " + std::to_string(i) +
+						": expected size " + std::to_string(buffer_size) +
+						" got " + std::to_string(recv_sizes[i]));
+				}
+			}
+
+			/* Validate data — each sub-buffer should have its distinct pattern */
+			if (buffer_type == NCCL_PTR_HOST) {
+				for (int i = 0; i < n_recvs; i++) {
+					char *expected = nullptr;
+					OFINCCLTHROW(allocate_buff((void**)&expected, buffer_size, NCCL_PTR_HOST));
+					OFINCCLTHROW(initialize_buff(expected, buffer_size, NCCL_PTR_HOST, 'A' + i));
+					OFINCCLTHROW(validate_data((char*)recv_bufs[i], expected, buffer_size, buffer_type));
+					OFINCCLTHROW(deallocate_buffer(expected, NCCL_PTR_HOST));
+				}
+			}
+
+			for (int i = 0; i < n_recvs; i++) {
+				ext_net->deregMr(rComm, recv_mh[i]);
+				deallocate_buffer(recv_bufs[i], buffer_type);
+			}
+		}
+	}
+};
+
+int main(int argc, char* argv[])
+{
+	/* Disable eager to avoid 2-iovec sends with mixed host/device memory */
+	setenv("OFI_NCCL_EAGER_MAX_SIZE", "-1", 0);
+	TestSuite suite;
+
+	/* n=1: regression test (should always work) */
+	GroupedRecvTest test_n1(1);
+
+	/* n=2: basic grouped receive */
+	GroupedRecvTest test_n2(2);
+
+	/* n=8: maximum grouped receive */
+	GroupedRecvTest test_n8(8);
+
+	/* n=8 with larger buffers */
+	GroupedRecvTest test_n8_large(8, 1024 * 1024);
+
+	suite.add(&test_n1);
+	suite.add(&test_n2);
+	suite.add(&test_n8);
+	suite.add(&test_n8_large);
+
+	return suite.run_all();
+}

--- a/tests/functional/grouped_recv.cpp
+++ b/tests/functional/grouped_recv.cpp
@@ -134,6 +134,113 @@ private:
 	}
 };
 
+class GroupedRecvMixedSizeTest : public TestScenario {
+public:
+	GroupedRecvMixedSizeTest(int num_recvs)
+		: TestScenario("Grouped Recv Mixed Sizes (n=" + std::to_string(num_recvs) + ")"),
+		  n_recvs(num_recvs) {}
+
+	void run(ThreadContext& ctx) override {
+		test_nccl_properties_t props = {};
+		OFINCCLTHROW(ext_net->getProperties(0, &props));
+
+		if (props.maxRecvs < n_recvs) {
+			NCCL_OFI_INFO(NCCL_NET,
+				"Skipping: maxRecvs=%d < n_recvs=%d", props.maxRecvs, n_recvs);
+			return;
+		}
+
+		for (size_t dev_idx = 0; dev_idx < ctx.lcomms.size(); dev_idx++) {
+			mixed_send_receive(ctx, dev_idx);
+		}
+	}
+
+private:
+	int n_recvs;
+	static constexpr int TAG = 1;
+
+	/* Each sub-recv gets a different size: 1024*(i+1) */
+	size_t sub_size(int i) { return 1024 * (i + 1); }
+
+	void mixed_send_receive(ThreadContext& ctx, int dev_idx) {
+		void *sComm = ctx.scomms[dev_idx];
+		void *rComm = ctx.rcomms[dev_idx];
+
+		auto gdr_support = get_support_gdr(ext_net);
+		int buffer_type = gdr_support[dev_idx] ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+
+		if (ctx.rank == 0) {
+			void* send_bufs[MAX_RECVS] = {};
+			void* send_mh[MAX_RECVS] = {};
+			void* send_reqs[MAX_RECVS] = {};
+
+			for (int i = 0; i < n_recvs; i++) {
+				size_t sz = sub_size(i);
+				OFINCCLTHROW(allocate_buff(&send_bufs[i], sz, buffer_type));
+				OFINCCLTHROW(initialize_buff(send_bufs[i], sz, buffer_type, 'A' + i));
+				OFINCCLTHROW(ext_net->regMr(sComm, send_bufs[i], sz, buffer_type, &send_mh[i]));
+				post_send(ext_net, sComm, send_bufs[i], sz, TAG, send_mh[i], &send_reqs[i]);
+			}
+
+			bool all_done = false;
+			while (!all_done) {
+				all_done = true;
+				for (int i = 0; i < n_recvs; i++) {
+					if (send_reqs[i]) {
+						int done = 0;
+						OFINCCLTHROW(ext_net->test(send_reqs[i], &done, nullptr));
+						if (done) send_reqs[i] = nullptr;
+						else all_done = false;
+					}
+				}
+			}
+
+			for (int i = 0; i < n_recvs; i++) {
+				ext_net->deregMr(sComm, send_mh[i]);
+				deallocate_buffer(send_bufs[i], buffer_type);
+			}
+		} else {
+			void* recv_bufs[MAX_RECVS] = {};
+			void* recv_mh[MAX_RECVS] = {};
+			size_t sizes[MAX_RECVS];
+			int tags[MAX_RECVS];
+			void* request = nullptr;
+
+			/* Allocate each sub-recv with its own size */
+			for (int i = 0; i < n_recvs; i++) {
+				size_t sz = sub_size(i);
+				OFINCCLTHROW(allocate_buff(&recv_bufs[i], sz, buffer_type));
+				OFINCCLTHROW(ext_net->regMr(rComm, recv_bufs[i], sz, buffer_type, &recv_mh[i]));
+				sizes[i] = sz;
+				tags[i] = TAG;
+			}
+
+			post_recv(ext_net, rComm, n_recvs, recv_bufs, sizes, tags, recv_mh, &request);
+
+			int done = 0;
+			int recv_sizes[MAX_RECVS] = {};
+			while (!done) {
+				OFINCCLTHROW(ext_net->test(request, &done, recv_sizes));
+			}
+
+			/* Validate per-sub sizes match actual sent sizes */
+			for (int i = 0; i < n_recvs; i++) {
+				size_t expected_sz = sub_size(i);
+				if (recv_sizes[i] != (int)expected_sz) {
+					throw std::runtime_error(
+						"Sub-recv " + std::to_string(i) +
+						": expected size " + std::to_string(expected_sz) +
+						" got " + std::to_string(recv_sizes[i]));
+				}
+			}
+
+			for (int i = 0; i < n_recvs; i++) {
+				ext_net->deregMr(rComm, recv_mh[i]);
+				deallocate_buffer(recv_bufs[i], buffer_type);
+			}
+		}
+	}
+};
 int main(int argc, char* argv[])
 {
 	/* Disable eager to avoid 2-iovec sends with mixed host/device memory */
@@ -157,5 +264,12 @@ int main(int argc, char* argv[])
 	suite.add(&test_n8);
 	suite.add(&test_n8_large);
 
+	/* Mixed sizes: each sub-recv has a different size */
+	GroupedRecvMixedSizeTest test_mixed_n2(2);
+	GroupedRecvMixedSizeTest test_mixed_n4(4);
+	suite.add(&test_mixed_n2);
+	suite.add(&test_mixed_n4);
+
 	return suite.run_all();
 }
+

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -16,3 +16,4 @@ param
 platform_manager
 gdrcopy
 spinlock
+ctrl_msg

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -43,6 +43,8 @@ if !ENABLE_NEURON
   LDADD += $(CUDA_LIBS)
   noinst_PROGRAMS += gdrcopy
   gdrcopy_SOURCES = $(base_sources) gdrcopy.cpp
+  noinst_PROGRAMS += ctrl_msg
+  ctrl_msg_SOURCES = $(base_sources) ctrl_msg.cpp
 if WANT_PLATFORM_AWS
   noinst_PROGRAMS += region_based_tuner
   region_based_tuner_SOURCES = $(base_sources) region_based_tuner.cpp

--- a/tests/unit/ctrl_msg.cpp
+++ b/tests/unit/ctrl_msg.cpp
@@ -144,7 +144,7 @@ static int test_ready_bit()
 
 	/* Zero msg_seq_num should NOT match seq_num=1 */
 	ctrl.entries[0].msg_seq_num = 0;
-	if ((ctrl.entries[0].msg_seq_num == (1 & MASK))) {
+	if (ctrl.entries[0].msg_seq_num == (1 & MASK)) {
 		NCCL_OFI_WARN("false positive: seq 0 matched seq 1");
 		return 1;
 	}

--- a/tests/unit/ctrl_msg.cpp
+++ b/tests/unit/ctrl_msg.cpp
@@ -1,0 +1,230 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+/*
+ * Unit test for the fat control message structure (nccl_net_ofi_ctrl_msg_t)
+ * and tag-matching logic used by grouped receives (maxRecvs > 1).
+ *
+ * Tests:
+ *   1. Struct size and field offsets
+ *   2. Tag-matching search across entries
+ *   3. Ready-bit (msg_seq_num) detection
+ *   4. num_recvs boundary conditions
+ */
+
+#include "config.h"
+
+#include <stdio.h>
+#include <string.h>
+
+#include "unit_test.h"
+#include "nccl_ofi.h"
+#include "nccl_ofi_rdma.h"
+
+/* Replicate the tag-matching search from get_ctrl_msg_buff_len / update_send_data_from_remote */
+static nccl_net_ofi_ctrl_msg_entry_t *find_entry_by_tag(nccl_net_ofi_ctrl_msg_t *ctrl, int tag)
+{
+	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
+		if (ctrl->entries[i].tag == tag)
+			return &ctrl->entries[i];
+	}
+	return NULL;
+}
+
+static int test_struct_sizes()
+{
+	/* Entry: 8 (buff_offset) + 32 (mr_key[4]) + 4 (buff_len) + 4 (tag) = 48 */
+	if (sizeof(nccl_net_ofi_ctrl_msg_entry_t) != 64) {
+		NCCL_OFI_WARN("ctrl_msg_entry size: expected 64, got %zu",
+			       sizeof(nccl_net_ofi_ctrl_msg_entry_t));
+		return 1;
+	}
+
+	/* Flat: entries (64 * NCCL_OFI_MAX_RECVS), no separate header */
+	size_t expected = 64 * NCCL_OFI_MAX_RECVS;
+	if (sizeof(nccl_net_ofi_ctrl_msg_t) != expected) {
+		NCCL_OFI_WARN("ctrl_msg size: expected %zu, got %zu",
+			       expected, sizeof(nccl_net_ofi_ctrl_msg_t));
+		return 1;
+	}
+
+	if (NCCL_OFI_MAX_RECVS != 8) {
+		NCCL_OFI_WARN("NCCL_OFI_MAX_RECVS: expected 8, got %d", NCCL_OFI_MAX_RECVS);
+		return 1;
+	}
+
+	/* Total should be 512 bytes */
+	if (sizeof(nccl_net_ofi_ctrl_msg_t) != 512) {
+		NCCL_OFI_WARN("ctrl_msg total size: expected 512, got %zu",
+			       sizeof(nccl_net_ofi_ctrl_msg_t));
+		return 1;
+	}
+
+	printf("PASS: struct sizes\n");
+	return 0;
+}
+
+static int test_tag_matching()
+{
+	nccl_net_ofi_ctrl_msg_t ctrl;
+	memset(&ctrl, 0, sizeof(ctrl));
+
+	/* Populate 4 entries with distinct tags */
+	ctrl.entries[0].num_recvs = 4;
+	for (int i = 0; i < 4; i++) {
+		ctrl.entries[i].tag = 10 + i;
+		ctrl.entries[i].buff_len = 1000 * (i + 1);
+		ctrl.entries[i].buff_offset = 0x1000 * (i + 1);
+	}
+
+	/* Find each tag */
+	for (int i = 0; i < 4; i++) {
+		nccl_net_ofi_ctrl_msg_entry_t *e = find_entry_by_tag(&ctrl, 10 + i);
+		if (!e) {
+			NCCL_OFI_WARN("tag %d not found", 10 + i);
+			return 1;
+		}
+		if (e->buff_len != (uint32_t)(1000 * (i + 1))) {
+			NCCL_OFI_WARN("tag %d: buff_len mismatch: %u vs %u",
+				       10 + i, e->buff_len, 1000 * (i + 1));
+			return 1;
+		}
+	}
+
+	/* Tag not present */
+	if (find_entry_by_tag(&ctrl, 99) != NULL) {
+		NCCL_OFI_WARN("found non-existent tag 99");
+		return 1;
+	}
+
+	/* Search should respect num_recvs boundary — entry[4] exists in memory but num_recvs=4 */
+	ctrl.entries[4].tag = 99;
+	ctrl.entries[4].buff_len = 9999;
+	if (find_entry_by_tag(&ctrl, 99) != NULL) {
+		NCCL_OFI_WARN("found tag 99 beyond num_recvs boundary");
+		return 1;
+	}
+
+	/* Increase num_recvs, now it should be found */
+	ctrl.entries[0].num_recvs = 5;
+	if (find_entry_by_tag(&ctrl, 99) == NULL) {
+		NCCL_OFI_WARN("tag 99 not found after increasing num_recvs");
+		return 1;
+	}
+
+	/* Single entry (n=1) */
+	ctrl.entries[0].num_recvs = 1;
+	nccl_net_ofi_ctrl_msg_entry_t *e = find_entry_by_tag(&ctrl, 10);
+	if (!e || e->buff_len != 1000) {
+		NCCL_OFI_WARN("single entry lookup failed");
+		return 1;
+	}
+	/* Other tags should not be found with num_recvs=1 */
+	if (find_entry_by_tag(&ctrl, 11) != NULL) {
+		NCCL_OFI_WARN("found tag 11 with num_recvs=1");
+		return 1;
+	}
+
+	printf("PASS: tag matching\n");
+	return 0;
+}
+
+static int test_ready_bit()
+{
+	/*
+	 * has_ctrl_msg checks: ctrl_mailbox[slot].msg_seq_num == (seq_num & MSG_SEQ_NUM_MASK)
+	 * MSG_SEQ_NUM_MASK = (1 << 10) - 1 = 0x3FF
+	 */
+	const uint16_t SEQ_BITS = 10;
+	const uint16_t MASK = (1 << SEQ_BITS) - 1;
+
+	nccl_net_ofi_ctrl_msg_t ctrl;
+	memset(&ctrl, 0, sizeof(ctrl));
+
+	/* Zero msg_seq_num should NOT match seq_num=1 */
+	ctrl.entries[0].msg_seq_num = 0;
+	if ((ctrl.entries[0].msg_seq_num == (1 & MASK))) {
+		NCCL_OFI_WARN("false positive: seq 0 matched seq 1");
+		return 1;
+	}
+
+	/* Set msg_seq_num = 42, should match seq_num=42 */
+	ctrl.entries[0].msg_seq_num = 42 & MASK;
+	if (!(ctrl.entries[0].msg_seq_num == (42 & MASK))) {
+		NCCL_OFI_WARN("seq 42 did not match");
+		return 1;
+	}
+
+	/* Wraparound: seq_num that wraps around the mask should still match */
+	uint16_t wrapped = (1 << SEQ_BITS) + 5;  /* 1029 */
+	ctrl.entries[0].msg_seq_num = wrapped & MASK;        /* 5 */
+	if (!(ctrl.entries[0].msg_seq_num == (wrapped & MASK))) {
+		NCCL_OFI_WARN("wrapped seq did not match");
+		return 1;
+	}
+	/* But should not match the unwrapped value if stored differently */
+	if (ctrl.entries[0].msg_seq_num == ((wrapped + 1) & MASK)) {
+		NCCL_OFI_WARN("false positive on wrapped+1");
+		return 1;
+	}
+
+	printf("PASS: ready bit\n");
+	return 0;
+}
+
+static int test_max_recvs_entries()
+{
+	nccl_net_ofi_ctrl_msg_t ctrl;
+	memset(&ctrl, 0, sizeof(ctrl));
+
+	/* Fill all NCCL_OFI_MAX_RECVS entries */
+	ctrl.entries[0].num_recvs = NCCL_OFI_MAX_RECVS;
+	for (int i = 0; i < NCCL_OFI_MAX_RECVS; i++) {
+		ctrl.entries[i].tag = i;
+		ctrl.entries[i].buff_len = 4096;
+		ctrl.entries[i].buff_offset = (uintptr_t)(i * 4096);
+		for (int r = 0; r < MAX_NUM_RAILS; r++)
+			ctrl.entries[i].mr_key[r] = 100 + i * MAX_NUM_RAILS + r;
+	}
+
+	/* Verify all entries are findable */
+	for (int i = 0; i < NCCL_OFI_MAX_RECVS; i++) {
+		nccl_net_ofi_ctrl_msg_entry_t *e = find_entry_by_tag(&ctrl, i);
+		if (!e) {
+			NCCL_OFI_WARN("entry %d not found at max capacity", i);
+			return 1;
+		}
+		if (e->buff_offset != (uintptr_t)(i * 4096)) {
+			NCCL_OFI_WARN("entry %d: wrong buff_offset", i);
+			return 1;
+		}
+		for (int r = 0; r < MAX_NUM_RAILS; r++) {
+			if (e->mr_key[r] != (uint64_t)(100 + i * MAX_NUM_RAILS + r)) {
+				NCCL_OFI_WARN("entry %d rail %d: wrong mr_key", i, r);
+				return 1;
+			}
+		}
+	}
+
+	printf("PASS: max recvs entries\n");
+	return 0;
+}
+
+int main(int argc, char *argv[])
+{
+	unit_test_init();
+
+	int rc = 0;
+	rc |= test_struct_sizes();
+	rc |= test_tag_matching();
+	rc |= test_ready_bit();
+	rc |= test_max_recvs_entries();
+
+	if (rc == 0)
+		printf("All ctrl_msg tests passed\n");
+	else
+		printf("Some ctrl_msg tests FAILED\n");
+
+	return rc;
+}


### PR DESCRIPTION
### Summary

This PR adds support for grouped receives (`maxRecvs > 1`) in the RDMA transport, enabling NCCL's AllToAll with PXN (Proxy Cross-Node) optimization. When NCCL posts a single `irecv()` with N destination buffers (each identified by a tag), the sender issues N separate `isend()` calls on the same communicator, matching by tag. The receiver completes when all N sub-receives arrive.

### Changes

**Wire protocol:**
- Extend the control message to a fat format: an array of up to 8 entries (64 bytes each, cache-line aligned), carrying per-sub-receive buffer address, MR keys, tag, and recv_idx
- Add 3-bit `recv_idx` field to RDMA write immediate data (comm_id reduced from 18 to 15 bits) for per-sub-receive size tracking on write completion

**Sender:**
- Match `send()` tag against ctrl msg entries using `entry_used` flag to prevent double-matching
- Track group state (`group_num_recvs`, `group_sends_remaining`) to advance `next_msg_seq_num` only after all N sub-sends complete

**Receiver:**
- Populate fat ctrl msg with all N sub-entries in `allocate_recv_req()`
- Extract `recv_idx` from write completion immediate data and accumulate per-sub `recv_size`
- Report actual per-sub sizes in `test()` instead of dividing total evenly

**Gating:**
- Grouped receives (`maxRecvs=8`) reported only for ncclNet v9+ (where `irecv` uses `size_t` sizes)
- Neuron/sendrecv protocol reports `maxRecvs=1`

**Tests:**
- Unit tests for fat ctrl msg and tag matching
- Functional tests for grouped receives (n=1, n=2, n=8, n=8 large)
- Mixed-size functional tests validating per-sub size reporting (n=2, n=4)
- Eager disabled in grouped recv tests (`OFI_NCCL_EAGER_MAX_SIZE=-1`)

### Limitations

- Maximum 8 grouped receives (3-bit `recv_idx` in immediate data)
- Maximum 32K communicators (reduced from 256K)
- Eager message support for grouped receives is not yet implemented and will be added in a follow-up

### Testing

- Unit tests: all pass
- Functional tests: grouped_recv (6 tests) pass with `OFI_NCCL_EAGER_MAX_SIZE=-1`
- NCCL alltoall: passes on 2-node p5en (16 ranks)