### PR TITLE
Gate PR CI build with approved authors change only

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -184,7 +184,7 @@ pipeline {
                         PERM_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
                             "https://api.github.com/repos/aws/aws-ofi-nccl/collaborators/${CHANGE_AUTHOR}/permission")
                         PERM=$(echo "$PERM_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('permission','none'))" 2>/dev/null || echo "none")
-                        if grep -qx "${CHANGE_AUTHOR}" /tmp/approved_authors.txt; then
+                        if awk '{print $1}' /tmp/approved_authors.txt | grep -qx "${CHANGE_AUTHOR}"; then
                             echo "✅ ${CHANGE_AUTHOR} is on the approved authors list"
                             exit 0
                         fi

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -172,6 +172,28 @@ pipeline {
         REGION="us-west-2"
     }
     stages {
+        stage('Authorize PR Author') {
+            when { changeRequest() }
+            steps {
+                script {
+                    def AWS_ACCOUNT_ID = get_account_id()
+                    sh "aws s3 cp s3://aws-ofi-nccl-github-approved-authors-${AWS_ACCOUNT_ID}/ofi_nccl_approved_author_list/approved_authors.txt /tmp/approved_authors.txt"
+                }
+                withCredentials([string(credentialsId: 'github-pat-read-org', variable: 'GH_TOKEN')]) {
+                    sh '''
+                        PERM_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
+                            "https://api.github.com/repos/aws/aws-ofi-nccl/collaborators/${CHANGE_AUTHOR}/permission")
+                        PERM=$(echo "$PERM_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('permission','none'))" 2>/dev/null || echo "none")
+                        if grep -qx "${CHANGE_AUTHOR}" /tmp/approved_authors.txt; then
+                            echo "✅ ${CHANGE_AUTHOR} is on the approved authors list"
+                            exit 0
+                        fi
+                        echo "❌ ${CHANGE_AUTHOR} is not authorized to run CI"
+                        exit 1
+                    '''
+                }
+            }
+        }
         stage("Download and extract PortaFiducia") {
             steps {
                 script {

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -184,6 +184,11 @@ pipeline {
                         PERM_JSON=$(curl -s -H "Authorization: token $GH_TOKEN" \
                             "https://api.github.com/repos/aws/aws-ofi-nccl/collaborators/${CHANGE_AUTHOR}/permission")
                         PERM=$(echo "$PERM_JSON" | python3 -c "import sys,json; print(json.load(sys.stdin).get('permission','none'))" 2>/dev/null || echo "none")
+                        if [ "$PERM" = "admin" ] || [ "$PERM" = "write" ]; then
+                            echo "✅ ${CHANGE_AUTHOR} has ${PERM} access — authorized"
+                            exit 0
+                        fi
+                        echo "${CHANGE_AUTHOR} has ${PERM} repo access, checking approved authors list..."
                         if awk '{print $1}' /tmp/approved_authors.txt | grep -qx "${CHANGE_AUTHOR}"; then
                             echo "✅ ${CHANGE_AUTHOR} is on the approved authors list"
                             exit 0


### PR DESCRIPTION
Gate PR CI builds so that CI builds fail close for unauthorized authors

*Issue #, if available:*

*Description of changes:* 
- Add an approved_authors.txt. 
- Add a stage in Jenkinsfile that checks if the PR change author is a member and checks the PR change author against the approved_authors.txt in master branch and fail the CI if the change author is neither a member nor in the approved_authors.txt. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
