### PR TITLE
Remove redundant l_comm->ep assignment from listen() callers

### DIFF
--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -181,9 +181,6 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 		}
 
 		ret = ep->listen(static_cast<nccl_net_ofi_conn_handle_t *>(handle), listen_comm);
-		if (ret == 0 && *listen_comm != nullptr) {
-			(*listen_comm)->ep = ep;
-		}
 	}
 	catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in plugin listen: %s", e.what());

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -172,14 +172,6 @@ ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void **listen
 			return nccl_net_ofi_retval_translate(ret);
 		}
 
-		/* TODO: ep->listen() creates the listen_comm but does
-		 * not set l_comm->ep. The API listen() path sets it
-		 * after ep->listen() returns. GIN calls ep->listen()
-		 * directly, so it must also set l_comm->ep here.
-		 * Both callers need this for accept() to propagate
-		 * the ep to the recv_comm. */
-		l_comm->ep = ep;
-
 		*listenComm = new nccl_ofi_rdma_gin_listen_comm(dev, ep, l_comm);
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Caught exception in GIN listen: %s", e.what());


### PR DESCRIPTION
Both ep->listen() implementations (RDMA and sendrecv) already set l_comm->ep = shared_from_this() internally, added in dbe6612. The caller-side assignments in nccl_ofi_api.cpp and nccl_ofi_gin_api.cpp were overwriting with an equivalent shared_ptr, making them redundant.

Remove the dead assignments and a stale TODO comment in the GIN path that incorrectly stated listen() does not set l_comm->ep.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
