### PR TITLE
rdma: init no_target_completion on send_req alloc

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -4957,6 +4957,7 @@ static int alloc_rdma_send_req(nccl_net_ofi_rdma_send_comm *s_comm,
 	send_data->buff_len = size;
 	send_data->buff_mr_handle = buff_mr_handle;
 	send_data->tag = tag;
+	send_data->no_target_completion = false;
 
 	/* If this is not an eager send, the schedule is created after knowing the
 	   remote length received in the control message.


### PR DESCRIPTION
Fixes a bug where when allocating send requests, we were not setting the rdma_req_send_data_t field "no_target_completion" (target side early completion) to the default value of false (using "fi_writedata"). This led to issues where after "no_target_completion" was correctly set to true (using "fi_write") for a particular send request and the request was eventually freed, the request's freelist entry was returned to the freelist with "no_target_completion" still set to true. The next request that was allocated using the same freelist entry would have "no_target_completion" set to true even if the target side was not using early completion.

This just adds setting "no_target_completion" to false when allocating the send request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
