### PR TITLE
gin: Optimize rank_map and gin_comms

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -73,9 +73,9 @@ struct nccl_ofi_gin_resource_releaser {
 struct nccl_ofi_gin_pending_ack_info {
 	nccl_ofi_dlist_node node;
 	uint32_t peer_rank = 0;
+	uint32_t start = 0;
 	uint16_t seq_num = 0;
 	uint16_t ack_count = 0;
-	uint32_t start = 0;
 };
 
 /**
@@ -88,8 +88,10 @@ struct nccl_ofi_gin_peer_rank_info {
 	/* Remote comm id */
 	uint32_t comm_id;
 
-	/* Rail addresses */
-	fi_addr_t address[MAX_NUM_RAILS];
+	/* Counter for consecutive PUT-only messages without ACK.
+	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
+	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
+	uint32_t consecutive_puts_without_ack = 0;
 
 	/* A sequence number, stored at initiator, exclusively for this (target) peer rank.
 	   This allows the remote rank to enforce ordering of signal delivery
@@ -104,6 +106,11 @@ struct nccl_ofi_gin_peer_rank_info {
 	 */
 	uint16_t next_delivered_signal_seq_num = 0;
 
+	nccl_ofi_gin_pending_ack_info pending_ack;
+
+	/* Rail addresses */
+	fi_addr_t address[MAX_NUM_RAILS];
+
 	/* Flag, stored at initiator, indicating the given sequence number (mod
 	   the sequence space) is in use at initiator side. This allows initiator
 	   to track in-use sequence numbers to avoid overflow and only mark
@@ -116,13 +123,6 @@ struct nccl_ofi_gin_peer_rank_info {
 	std::bitset<GIN_IMM_SEQ_MASK + 1> active_put_signal;
 	static_assert(GIN_IMM_SEQ_MASK + 1 <= UINT16_MAX,
 		      "active_put_signal must fit within the 16-bit seq_num range");
-
-	/* Counter for consecutive PUT-only messages without ACK.
-	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
-	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
-	size_t consecutive_puts_without_ack = 0;
-
-	nccl_ofi_gin_pending_ack_info pending_ack;
 };
 
 /**
@@ -361,8 +361,10 @@ private:
 	 *     for the weak-mode early-deliver paths. */
 	bool strong_signal_ordering_enabled;
 
-	/* For each rail, map of fi_addr => peer comm rank */
-	std::unordered_map<fi_addr_t, uint32_t> rank_map[MAX_NUM_RAILS];
+	/* For each rail, direct-indexed table of fi_addr => peer comm rank.
+	 * Requires FI_AV_TABLE so that fi_addr_t values are dense 0-based
+	 * indices. Unused slots are set to UINT32_MAX as a sentinel. */
+	std::vector<uint32_t> rank_map[MAX_NUM_RAILS];
 
 	/* Map of <rank, msg_seq_num> => recv_req
 	 *

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -7,6 +7,7 @@
 
 #include "rdma/fabric.h"
 
+#include <array>
 #include <deque>
 #include <stdexcept>
 #include <vector>
@@ -105,7 +106,6 @@ public:
 	void close_ofi_eps();
 
 	std::mutex ep_lock;
-
 private:
 	nccl_net_ofi_domain_t &domain;
 
@@ -218,28 +218,27 @@ public:
 	 * Get GIN communicator with given comm_id from map. Throw exception if
 	 * not found.
 	 */
-	nccl_ofi_rdma_gin_put_comm &get_comm(uint32_t comm_id)
+	nccl_ofi_rdma_gin_put_comm &get_comm(uint16_t comm_id)
 	{
-		auto it = gin_comms.find(comm_id);
-		if (it == gin_comms.end()) {
+		if (OFI_UNLIKELY(comm_id >= NCCL_GIN_MAX_COMMS || gin_comms[comm_id] == nullptr)) {
 			NCCL_OFI_WARN("Invalid comm_id %d", comm_id);
 			throw std::runtime_error("Failed to find comm_id");
 		}
 
-		return *(it->second);
+		return *gin_comms[comm_id];
 	}
 
 	/**
 	 * Set a GIN communicator with given comm_id in map. Throw exception if
 	 * comm_id already exists.
 	 */
-	void set_comm(uint32_t comm_id, nccl_ofi_rdma_gin_put_comm &comm)
+	void set_comm(uint16_t comm_id, nccl_ofi_rdma_gin_put_comm &comm)
 	{
-		auto it = gin_comms.insert({ comm_id, &comm });
-		if (!it.second) {
+		if (OFI_UNLIKELY(comm_id >= NCCL_GIN_MAX_COMMS || gin_comms[comm_id] != nullptr)) {
 			NCCL_OFI_WARN("Failed to insert duplicate comm_id %d", comm_id);
 			throw std::runtime_error("Failed to insert comm_id");
 		}
+		gin_comms[comm_id] = &comm;
 	}
 
 	nccl_ofi_rdma_gin_ep_t &get_ep()
@@ -341,43 +340,49 @@ public:
 	}
 
 private:
+	/* === Tier 1 — accessed every CQ completion and/or iputSignal === */
 	nccl_ofi_gin_ep_holder ep_holder;
 
-	std::unordered_map<uint32_t, nccl_ofi_rdma_gin_put_comm *> gin_comms;
-
-	nccl_ofi_idpool_t comm_id_pool;
-
 	nccl_ofi_rdma_gin_ep_t gin_ep;
+
+	/* Requests pool used by all comms of this resource */
+	// FIXME: Get rid of freelist_deleter and change to embedded
+	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> req_fl;
+
+	/* Pool of buffers for recv requests */
+	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> rx_buff_fl;
+
+	/* Reqs for RX buffers */
+	std::vector<nccl_net_ofi_gin_recv_req_t> recv_reqs;
+
+	/* === Tier 2 — accessed on iputSignal / ACK / retry paths === */
+	/* For rail scheduling. Currently we do round-robin among rails. */
+	uint16_t next_rail_id = 0;
+
+	/* Pool of registered buffers for ACK send messages */
+	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> ack_send_fl;
 
 	/**
 	 * Queue of pending Libfabric requests to be retried
 	 */
 	std::deque<nccl_net_ofi_gin_op_req_t *> pending_requests;
 
+
+	/* === Tier 3 — accessed only at connect/disconnect time === */
+	nccl_ofi_idpool_t comm_id_pool;
+
 	/* Number of associated comms */
 	size_t ref_cnt = 0;
 
-	/* For rail scheduling. Currently we do round-robin among rails. */
-	uint16_t next_rail_id = 0;
-
-	/* Requests pool used by all comms of this resource */
-	// FIXME: Get rid of freelist_deleter and change to embedded
-	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> req_fl;
+	/* === Self-contained lookup — 8KB array at end to avoid pushing
+	   other hot members apart === */
+	std::array<nccl_ofi_rdma_gin_put_comm *, NCCL_GIN_MAX_COMMS> gin_comms{};
 
 	/**
 	 * Retry requests that were pending due to EAGAIN or lack of space in
 	 * completion queue
 	 */
 	int retry_pending_reqs();
-
-	/* Pool of buffers for recv requests */
-	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> rx_buff_fl;
-
-	/* Pool of registered buffers for ACK send messages */
-	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> ack_send_fl;
-
-	/* Reqs for RX buffers */
-	std::vector<nccl_net_ofi_gin_recv_req_t> recv_reqs;
 
 	/* Post all recv buffers for a given rail */
 	void post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail, size_t num_buffers);

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -90,7 +90,7 @@ static inline void set_rail_address(nccl_ofi_gin_ep_rail_t &rail, nccl_ofi_addr 
 
 static inline int rail_addr_insert(nccl_ofi_gin_ep_rail_t &rail, const nccl_ofi_addr &ep_addr,
 				   uint32_t peer_rank, fi_addr_t &ofi_addr,
-				   std::unordered_map<fi_addr_t, uint32_t> &rank_map)
+				   std::vector<uint32_t> &rank_map_rail)
 {
 	int ret = fi_av_insert(rail.av.get(), ep_addr.addr, 1, &ofi_addr, 0, nullptr);
 	/* fi_av_insert() returns the number of addresses that were successfully inserted */
@@ -100,12 +100,19 @@ static inline int rail_addr_insert(nccl_ofi_gin_ep_rail_t &rail, const nccl_ofi_
 		return -EIO;
 	}
 
-	auto res = rank_map.insert(std::make_pair(ofi_addr, peer_rank));
-	if (res.second == false) {
+	/* Validate that fi_addr_t is a dense index (FI_AV_TABLE assumption) */
+	if (OFI_UNLIKELY(ofi_addr >= rank_map_rail.size())) {
+		NCCL_OFI_WARN("fi_addr %lu out of range (size %zu) for peer rank %d. "
+			      "Is the address vector using FI_AV_TABLE?",
+			      ofi_addr, rank_map_rail.size(), peer_rank);
+		return -EIO;
+	}
+	if (OFI_UNLIKELY((rank_map_rail[ofi_addr] != UINT32_MAX))) {
 		NCCL_OFI_WARN("Invalid duplicate address %lu for peer rank %d", ofi_addr,
 			      peer_rank);
 		return -EIO;
 	}
+	rank_map_rail[ofi_addr] = peer_rank;
 
 	return 0;
 }
@@ -174,6 +181,12 @@ int nccl_ofi_rdma_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[]
 	}
 
 	gin_comm->rank_comms.resize(nranks);
+
+	/* Pre-allocate rank_map vectors for direct fi_addr_t indexing.
+	 * UINT32_MAX serves as "not populated" sentinel. */
+	for (int r = 0; r < num_rails; ++r) {
+		gin_comm->rank_map[r].assign(nranks, UINT32_MAX);
+	}
 
 	/**
 	 * Exchange connection metadata with all ranks using bootstrap ring
@@ -640,14 +653,14 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 }
 
 static inline uint32_t get_peer_rank(fi_addr_t src_addr,
-				     std::unordered_map<fi_addr_t, uint32_t> &rank_map)
+				     const std::vector<uint32_t> &rank_map_rail)
 {
-	auto it = rank_map.find(src_addr);
-	if (it == rank_map.end()) {
+	if (OFI_UNLIKELY(src_addr >= rank_map_rail.size()
+			 || rank_map_rail[src_addr] == UINT32_MAX)) {
 		NCCL_OFI_WARN("Failed to find rank for src addr %lu", src_addr);
 		throw std::runtime_error("Failed to find rank");
 	}
-	return it->second;
+	return rank_map_rail[src_addr];
 }
 
 static inline uint64_t get_req_map_key(uint32_t peer_rank, uint16_t msg_seq_num)

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -80,7 +80,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 
 	if (cq_entry->flags & FI_REMOTE_WRITE) {
 		/* RDMA write-immediate completion */
-		uint32_t comm_id = GIN_IMM_GET_COMM_ID(cq_entry->data);
+		uint16_t comm_id = GIN_IMM_GET_COMM_ID(cq_entry->data);
 		auto &gin_comm = resources.get_comm(comm_id);
 
 		ret = gin_comm.handle_signal_write_completion(cq_entry, src_addr, rail_id_arg);

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -96,7 +96,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 			auto &gin_comm = resources.get_comm(ack_msg->ack_comm_id);
 
 			ret = gin_comm.handle_ack_completion(ack_msg, src_addr, rail_id_arg);
-			if (ret != 0) {
+			if (OFI_UNLIKELY(ret != 0)) {
 				NCCL_OFI_WARN("handle_ack_completion failure");
 				return ret;
 			}

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -427,10 +427,11 @@ void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail,
 }
 
 nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
-    : ep_holder(ep_arg.shared_from_this()), gin_comms(), comm_id_pool(NCCL_GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
+    : ep_holder(ep_arg.shared_from_this()), gin_ep(ep_arg.get_domain()),
       req_fl(nullptr, &freelist_deleter),
       rx_buff_fl(nullptr, &freelist_deleter),
-      ack_send_fl(nullptr, &freelist_deleter)
+      ack_send_fl(nullptr, &freelist_deleter),
+      comm_id_pool(NCCL_GIN_MAX_COMMS)
 {
 	auto num_rails = gin_ep.get_num_rails();
 


### PR DESCRIPTION
This PR contains two parts of GIN related optimization:

#### 1. Replace gin_comms with std::array in GIN resource

In `nccl_ofi_gin_resources`, replace `std::unordered_map<uint32_t, ...>` with `std::array<..., GIN_MAX_COMMS>` for gin_comms, converting get_comm/set_comm to direct O(1) array indexing with bounds checks. This eliminates hash table overhead on the hot CQ completion path.

In addition, regroup member variables of nccl_ofi_gin_resources by access frequency to improve cache locality, including:
- Move gin_ep to the beginning due to frequent lock access.
- Group comm_id_pool and ref_cnt together.
- Place the 8KB gin_comms array at the end to avoid pushing other members apart


#### 2. Refactor rank_map from unordred map into std::vector
- In `nccl_ofi_gin_pu`GIN put comm, change rank_map from unordered map into `std:vector<>` for better lookup performance. 
- Rename duplicate rank_map variables to avoid confusion.
- Reorder members in nccl_ofi_gin_peer_rank_info for better alignment.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
