### PR TITLE
nvtx: fix missing .get() on shared_ptr cast in RECV_SEGMENT_COMPLETE tracepoint

### DIFF
--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -175,7 +175,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(request->comm->ep)->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(request->comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Recv_segment_complete", 0xff0000); \
 	} \
 } while(0)


### PR DESCRIPTION
*Description of changes:*

One macro in `include/tracing_impl/nvtx.h`
  (`NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX`) casts `request->comm->ep`
  directly, but since PR #1193 (shared_ptr refactor), `ep` is a
  `std::shared_ptr` rather than a raw pointer.  The cast fails to
  compile with `--with-nvtx=...`.

  Add the missing `.get()` call.  Every other similar cast in this
  file already does this correctly; this single line was missed.

  This went undetected because the CI matrix does not include an
  `--with-nvtx` build.  Adding NVTX to CI is a separate follow-up so
  these kinds of regressions get caught before merge.





By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
