### PR TITLE
ci: add NVTX to CI container images for CUDA builds

### DIFF
--- a/docker/base/Dockerfile.ubuntu
+++ b/docker/base/Dockerfile.ubuntu
@@ -76,10 +76,16 @@ RUN if [ "$ENABLE_CUDA" = "true" ]; then \
         rm -rf /var/lib/apt/lists/*; \
     fi
 
-# Install lttng if enabled
+# Install tracing packages if enabled.  lttng is always installed
+# when tracing is on; cuda-nvtx is added for CUDA-enabled images so
+# the plugin can be configured with both --with-lttng and
+# --with-nvtx=... and exercise both tracing backends together.
 RUN if [ "$ENABLE_TRACING" = "true" ]; then \
         apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y liblttng-ust-dev && \
+        if [ "$ENABLE_CUDA" = "true" ]; then \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-nvtx-12-6 ; \
+        fi && \
         rm -rf /var/lib/apt/lists/*; \
     fi
 

--- a/docker/base/Dockerfile.ubuntu2404
+++ b/docker/base/Dockerfile.ubuntu2404
@@ -46,9 +46,15 @@ RUN if [ "$ENABLE_CUDA" = "true" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-cudart-dev-12-6 cuda-crt-12-6 ; \
     fi
 
-# Install lttng if enabled
+# Install tracing packages if enabled.  lttng is always installed
+# when tracing is on; cuda-nvtx is added for CUDA-enabled images so
+# the plugin can be configured with both --with-lttng and
+# --with-nvtx=... and exercise both tracing backends together.
 RUN if [ "$ENABLE_TRACING" = "true" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install -y liblttng-ust-dev ; \
+        if [ "$ENABLE_CUDA" = "true" ]; then \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-nvtx-12-6 ; \
+        fi ; \
     fi
 
 RUN rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
*Description of changes:*

NVTX tracing is not built by CI, so build breakages under
--with-nvtx=... have been landing undetected.  For example, the
shared_ptr refactor in PR https://github.com/aws/aws-ofi-nccl/pull/1193 left an implicit pointer cast in
tracing_impl/nvtx.h that no CI job caught.

Extend the tracing-enabled Ubuntu images to install cuda-nvtx in
addition to liblttng-ust-dev whenever ENABLE_CUDA is also set.  The
two tracing backends are independent in the plugin (separate
HAVE_LIBLTTNG_UST and HAVE_NVTX_TRACING guards, each tracepoint
macro expands to calls into both) so they coexist cleanly in a
single container and a single build.  Neuron images still get just
lttng because NVTX requires the CUDA toolkit.

Parameterise the CUDA toolkit release as a CUDA_VERSION build arg
(default 12-6) so cuda-cudart-dev, cuda-crt, and cuda-nvtx all stay
on the same release.

No matrix, workflow, or tag changes: the existing 'lttng' tracing
variant now also brings in NVTX on CUDA containers.  A follow-up
PR will add --with-nvtx=... to the configure line in distcheck.yaml
so the plugin actually gets built with NVTX in CI.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
