### PR TITLE
gin: Set maxComms to the correct value

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -58,7 +58,6 @@ enum gin_msg_type_t : uint8_t {
 #define GIN_IMM_SEQ_SHIFT      (GIN_IMM_COMM_SHIFT + GIN_IMM_COMM_BITS)
 #define GIN_IMM_SEQ_MASK       ((1 << GIN_IMM_SEQ_BITS) - 1)
 #define GIN_IMM_COMM_MASK      ((1 << GIN_IMM_COMM_BITS) - 1)
-#define GIN_MAX_COMMS          (1 << GIN_IMM_COMM_BITS)
 
 #define GIN_IMM_GET_COMM_ID(data)  (((data) >> GIN_IMM_COMM_SHIFT) & GIN_IMM_COMM_MASK)
 #define GIN_IMM_GET_SEQ_NUM(data)  (((data) >> GIN_IMM_SEQ_SHIFT) & GIN_IMM_SEQ_MASK)
@@ -90,6 +89,10 @@ struct nccl_net_ofi_gin_ack_t {
 	uint32_t comm_id:GIN_IMM_COMM_BITS;
 	uint32_t ack_count:GIN_ACK_COUNT_BITS;
 };
+
+
+/* Maximum number of GIN comms */
+#define NCCL_GIN_MAX_COMMS    (1 << GIN_IMM_COMM_BITS)
 
 struct nccl_net_ofi_gin_signal_metadata_msg_t {
 	/* Message type identifier — must be GIN_MSG_TYPE_METADATA */

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -116,7 +116,7 @@ static ncclResult_t nccl_ofi_gin_getProperties(int dev, ncclNetProperties_v11_t 
 	props->speed = ofi_properties.port_speed;
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
-	props->maxComms = ofi_properties.max_communicators;
+	props->maxComms = NCCL_GIN_MAX_COMMS;
 	props->maxRecvs = ofi_properties.max_group_receives;
 	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
@@ -358,7 +358,7 @@ static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v1
 	props->speed = ofi_properties.port_speed;
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
-	props->maxComms = ofi_properties.max_communicators;
+	props->maxComms = NCCL_GIN_MAX_COMMS;
 	props->maxRecvs = ofi_properties.max_group_receives;
 	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -8,7 +8,9 @@
 #include "rdma/gin/nccl_ofi_gin_reqs.h"
 
 #include "nccl_ofi_assert.h"
+#if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
+#endif
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_mr.h"
 #include "nccl_ofi_param.h"
@@ -425,7 +427,7 @@ void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail,
 }
 
 nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
-    : ep_holder(ep_arg.shared_from_this()), gin_comms(), comm_id_pool(GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
+    : ep_holder(ep_arg.shared_from_this()), gin_comms(), comm_id_pool(NCCL_GIN_MAX_COMMS), gin_ep(ep_arg.get_domain()),
       req_fl(nullptr, &freelist_deleter),
       rx_buff_fl(nullptr, &freelist_deleter),
       ack_send_fl(nullptr, &freelist_deleter)


### PR DESCRIPTION
Set the maxComms to reflect the number of bits we are using for comm_id. Also a minor change to include CUDA specific header file only when compiling with CUDA.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
