### PR TITLE
gin: Refactor message headers and expand GIN_IMM_SEQ_BITS to 13

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -22,6 +22,7 @@ struct nccl_ofi_gin_ep_rail_t;
 enum gin_msg_type_t : uint8_t {
 	GIN_MSG_TYPE_METADATA = 0,
 	GIN_MSG_TYPE_ACK = 1,
+	GIN_MSG_TYPE_MAX = GIN_MSG_TYPE_ACK,
 };
 
 /**
@@ -40,8 +41,8 @@ enum gin_msg_type_t : uint8_t {
  * ACKs are no longer sent via immediate data — they use fi_send with
  * gin_ack_msg_t.  The immediate data is used only for data signals:
  *
- *  31        27  26  25      22 21             11 10            1  0
- *  [  unused  ] [ar] [seg_cnt ] [  msg_seq_num  ] [   comm_id   ] [0]
+ *  31      29  28  27      24 23             11 10            1  0
+ *  [unused:3] [ar] [seg_cnt ] [  msg_seq_num  ] [   comm_id   ] [0]
  *
  * Bit 0 is reserved (always 0 for data signals).
  *
@@ -53,7 +54,9 @@ enum gin_msg_type_t : uint8_t {
 /* Common fields (same position in both formats) */
 #define GIN_IMM_TYPE_BITS      1
 #define GIN_IMM_COMM_BITS      10
-#define GIN_IMM_SEQ_BITS       11
+#define GIN_IMM_SEQ_BITS       13  /* can expand up to 15 without further
+                                      changes to uint16_t seq vars or the
+                                      32-bit immediate data layout */
 #define GIN_IMM_COMM_SHIFT     GIN_IMM_TYPE_BITS
 #define GIN_IMM_SEQ_SHIFT      (GIN_IMM_COMM_SHIFT + GIN_IMM_COMM_BITS)
 #define GIN_IMM_SEQ_MASK       ((1 << GIN_IMM_SEQ_BITS) - 1)
@@ -75,63 +78,109 @@ enum gin_msg_type_t : uint8_t {
 	(((ack_req) << GIN_IMM_ACK_REQ_SHIFT) | ((nseg) << GIN_IMM_SEG_CNT_SHIFT) |               \
 	 ((seq) << GIN_IMM_SEQ_SHIFT) | ((comm_id) << GIN_IMM_COMM_SHIFT))
 
-/* Packed sequence number + segment count (16 bits). */
-struct nccl_net_ofi_gin_metadata_seq_t {
-	uint16_t seq_num:GIN_IMM_SEQ_BITS;
-	uint16_t num_segments:GIN_IMM_SEG_CNT_BITS;
-};
+/* msg_type in message headers (2 values currently. Reserving one more bit for now) */
+#define GIN_MSG_TYPE_BITS      2
+static_assert(((1 << GIN_MSG_TYPE_BITS) - 1) >= GIN_MSG_TYPE_MAX,
+	      "GIN_MSG_TYPE_BITS must be wide enough to hold all message types");
 
-/* Bundled ack payload (32 bits). ack_count == 0 means no ack. */
+/* Bundled/standalone ack count. ack_count == 0 means no ack. */
 #define GIN_ACK_COUNT_BITS    10
 #define GIN_ACK_COUNT_MASK    ((1 << GIN_ACK_COUNT_BITS) - 1)
-struct nccl_net_ofi_gin_ack_t {
-	uint32_t ack_seq_num:GIN_IMM_SEQ_BITS;
-	uint32_t comm_id:GIN_IMM_COMM_BITS;
-	uint32_t ack_count:GIN_ACK_COUNT_BITS;
-};
-
 
 /* Maximum number of GIN comms */
 #define NCCL_GIN_MAX_COMMS    (1 << GIN_IMM_COMM_BITS)
 
-struct nccl_net_ofi_gin_signal_metadata_msg_t {
-	/* Message type identifier — must be GIN_MSG_TYPE_METADATA */
-	gin_msg_type_t msg_type;
+/* Reserved bit computation for Metadata message header */
+#define GIN_MSG_HEADER_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
+                                      - GIN_IMM_SEQ_BITS - GIN_ACK_COUNT_BITS    \
+                                      - GIN_IMM_SEQ_BITS - GIN_IMM_SEG_CNT_BITS)
 
+/**
+ * Metadata message header (64 bits).
+ *
+ * Both nccl_net_ofi_gin_msg_header_t and gin_ack_msg_t share a common
+ * prefix in bits [0:34]: msg_type(2) + comm_id(10) + ack_seq_num(13) +
+ * ack_count(10) = 35 bits.  This allows dispatch and ACK processing to
+ * read from the same offsets regardless of message type.
+ */
+struct nccl_net_ofi_gin_msg_header_t {
+	/* Message type identifier */
+	uint64_t msg_type        : GIN_MSG_TYPE_BITS;
 	/* Comm identifier on the receiver side */
-	uint8_t remote_comm_id;
+	uint64_t remote_comm_id  : GIN_IMM_COMM_BITS;
+	/* Bundled ack sequence number (ack_count == 0 when absent) */
+	uint64_t ack_seq_num     : GIN_IMM_SEQ_BITS;
+	/* Bundled ack count */
+	uint64_t ack_count       : GIN_ACK_COUNT_BITS;
+	/* Message sequence number and count */
+	uint64_t seq_num         : GIN_IMM_SEQ_BITS;
+	uint64_t seq_seg_cnt     : GIN_IMM_SEG_CNT_BITS;
+	/* Reserved for future use */
+	uint64_t reserved        : GIN_MSG_HEADER_RESERVED_BITS;
+};
+static_assert(sizeof(nccl_net_ofi_gin_msg_header_t) <= 8,
+	      "nccl_net_ofi_gin_msg_header_t fields must fit in 64 bits");
 
-	/* Message sequence number and segment count */
-	nccl_net_ofi_gin_metadata_seq_t seq;
-
-	/* Bundled ack (ack_count == 0 when absent) */
-	nccl_net_ofi_gin_ack_t ack;
+/**
+ * Metadata message (32 bytes for inline send).
+ */
+struct nccl_net_ofi_gin_signal_metadata_msg_t {
+	nccl_net_ofi_gin_msg_header_t header;
 
 	/* Signal information (if applicable) */
 	uint64_t signal_base_address;
 	uint64_t signal_offset;
 	uint64_t signal_value;
 };
-
-static_assert(sizeof(struct nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
+static_assert(sizeof(nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
 	     "nccl_net_ofi_gin_signal_metadata_msg_t must be exactly 32 bytes for inline send");
 
+#define GIN_ACK_MSG_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
+                                   - GIN_IMM_SEQ_BITS - GIN_ACK_COUNT_BITS)
+
 /**
- * ACK message sent via fi_send from receiver to sender.
+ * Standalone ACK message sent via fi_send from receiver to sender (8 bytes).
+ *
+ * Shares the common prefix layout with nccl_net_ofi_gin_msg_header_t
+ * so msg_type-based dispatch works at the same bit position.
  */
 struct gin_ack_msg_t {
-	/* Message type identifier — must be set explicitly (freelist memory) */
-	gin_msg_type_t msg_type;
-	uint8_t reserved;
-	/* Ack payload — same format as bundled ack in metadata */
-	nccl_net_ofi_gin_ack_t ack;
+	/* Message type identifier */
+	uint64_t msg_type        : GIN_MSG_TYPE_BITS;
+	/* Comm identifier on the original sender side */
+	uint64_t ack_comm_id     : GIN_IMM_COMM_BITS;
+	/* ACK sequence number */
+	uint64_t ack_seq_num     : GIN_IMM_SEQ_BITS;
+	/* ACK count */
+	uint64_t ack_count       : GIN_ACK_COUNT_BITS;
+	/* Reserved for future use */
+	uint64_t reserved        : GIN_ACK_MSG_RESERVED_BITS;
 };
+static_assert(sizeof(gin_ack_msg_t) <= 8,
+	      "gin_ack_msg_t must be exactly 8 bytes for inline send");
 
-static_assert(sizeof(gin_ack_msg_t) == 8, "gin_ack_msg_t must be exactly 8 bytes for inline send");
-static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, msg_type) == 0,
-	     "msg_type must be at offset 0 for type-based dispatch");
-static_assert(offsetof(gin_ack_msg_t, msg_type) == 0,
-	     "msg_type must be at offset 0 for type-based dispatch");
+/* Above layout assume little-endian byte order, as well as following static
+   assert checks. All message structs must have msg_type at the lowest bits
+   so that type-based dispatch can read the first bits without knowing the
+   concrete type. */
+static_assert(__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__,
+	      "GIN message struct layout assumes little-endian byte order");
+static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, header) == 0,
+	      "header must be at offset 0 for type-based dispatch");
+/* Verify msg_type is at the LSB of each struct. Clang does not yet support
+   constexpr bit_cast on bitfield structs, so only check on GCC. */
+#if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 9)
+static_assert(
+	__builtin_bit_cast(uint64_t,
+		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0})
+		== (uint64_t)GIN_MSG_TYPE_MAX,
+	"msg_type must be at LSB of nccl_net_ofi_gin_msg_header_t");
+static_assert(
+	__builtin_bit_cast(uint64_t,
+		gin_ack_msg_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0})
+		== (uint64_t)GIN_MSG_TYPE_MAX,
+	"msg_type must be at LSB of gin_ack_msg_t");
+#endif
 
 /* ACK interval for PUT-only messages. Send an ACK every N consecutive PUTs
    to prevent sequence number wraparound. */

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -228,11 +228,11 @@ int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, u
 	}
 
 	auto *ack_msg = static_cast<gin_ack_msg_t *>(ack_elem->ptr);
+	*ack_msg = {};
 	ack_msg->msg_type = GIN_MSG_TYPE_ACK;
-	ack_msg->reserved = 0;
-	ack_msg->ack.comm_id = static_cast<uint16_t>(peer_comm_id);
-	ack_msg->ack.ack_seq_num = static_cast<uint16_t>(ack_seq_num);
-	ack_msg->ack.ack_count = static_cast<uint16_t>(count);
+	ack_msg->ack_comm_id = static_cast<uint16_t>(peer_comm_id);
+	ack_msg->ack_seq_num = static_cast<uint16_t>(ack_seq_num);
+	ack_msg->ack_count = static_cast<uint16_t>(count);
 
 	auto *ofi_ep = ep.get_rail(rail_id).ofi_ep.get();
 
@@ -537,10 +537,10 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		auto *metadata_send =
 			static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(metadata_elem->ptr);
 
-		metadata_send->seq.seq_num = msg_seq_num;
-		metadata_send->seq.num_segments = nseg;
-		metadata_send->remote_comm_id = remote_comm_id;
-		metadata_send->msg_type = GIN_MSG_TYPE_METADATA;
+		metadata_send->header.msg_type = GIN_MSG_TYPE_METADATA;
+		metadata_send->header.remote_comm_id = remote_comm_id;
+		metadata_send->header.seq_num = msg_seq_num;
+		metadata_send->header.seq_seg_cnt = nseg;
 		metadata_send->signal_base_address =
 			(sig_mr ? sig_mr->remote_mr[dst_rank].address : 0);
 		metadata_send->signal_offset = signalOff;
@@ -554,13 +554,11 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 
 		/* Bundle pending ack for this peer */
 		if (rank_comm.pending_ack.ack_count > 0) {
-			metadata_send->ack.ack_seq_num = rank_comm.pending_ack.seq_num;
-			/* comm_id is only used for standalone ACKs, setting it here for struct completeness */
-			metadata_send->ack.comm_id = rank_comm.comm_id;
-			metadata_send->ack.ack_count = rank_comm.pending_ack.ack_count;
+			metadata_send->header.ack_seq_num = rank_comm.pending_ack.seq_num;
+			metadata_send->header.ack_count = rank_comm.pending_ack.ack_count;
 			rank_comm.pending_ack.ack_count = 0;
 		} else {
-			metadata_send->ack.ack_count = 0;
+			metadata_send->header.ack_count = 0;
 		}
 
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
@@ -671,14 +669,14 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 	int ret = 0;
 
 	NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on target",
-		       req->metadata.seq.seq_num);
+		       req->metadata.header.seq_num);
 
 	if (req->metadata_received) {
 		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
-							 req->metadata.seq.seq_num, req);
+							 req->metadata.header.seq_num, req);
 		ret = do_gin_signal(req->metadata);
 		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
-						       req->metadata.seq.seq_num, req);
+						       req->metadata.header.seq_num, req);
 	}
 
 	if (ret != 0) {
@@ -810,16 +808,16 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 {
 	int ret = 0;
 
-	uint16_t msg_seq_num = metadata_msg->seq.seq_num;
-	uint16_t num_segments = metadata_msg->seq.num_segments;
+	uint16_t msg_seq_num = metadata_msg->header.seq_num;
+	uint16_t num_segments = metadata_msg->header.seq_seg_cnt;
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
 
 	/* Process bundled ack if present */
-	if (metadata_msg->ack.ack_count > 0) {
+	if (metadata_msg->header.ack_count > 0) {
 		clear_ack_range(peer_rank,
-				metadata_msg->ack.ack_seq_num,
-				metadata_msg->ack.ack_count);
+				metadata_msg->header.ack_seq_num,
+				metadata_msg->header.ack_count);
 	}
 
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
@@ -852,8 +850,8 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(fi_addr_t src_addr, uint16
 					     const gin_ack_msg_t *ack_msg)
 {
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
-	uint16_t ack_seq_num = ack_msg->ack.ack_seq_num;
-	uint16_t count = ack_msg->ack.ack_count;
+	uint16_t ack_seq_num = ack_msg->ack_seq_num;
+	uint16_t count = ack_msg->ack_count;
 	assert(count > 0);
 
 	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
@@ -897,9 +895,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(fi_addr_t src_add
 
 	if (req->num_seg_completions == req->total_segments) {
 		/* Fill in the fields related to metadata */
-		req->metadata.seq.seq_num = msg_seq_num;
-		req->metadata.seq.num_segments = req->total_segments;
-		req->metadata.msg_type = GIN_MSG_TYPE_METADATA;
+		req->metadata.header.seq_num = msg_seq_num;
+		req->metadata.header.seq_seg_cnt = req->total_segments;
+		req->metadata.header.msg_type = GIN_MSG_TYPE_METADATA;
 	}
 
 	ret = iput_signal_deliver_all(peer_rank);

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -98,12 +98,10 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 		}
 	} else {
 		/* Dispatch by msg_type — at offset 0 in both message structs. */
-		auto msg_type = static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr)->msg_type;
+		auto *ack_msg = static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr);
+		auto msg_type = static_cast<gin_msg_type_t>(ack_msg->msg_type);
 		if (msg_type == GIN_MSG_TYPE_ACK) {
-			auto *ack_msg =
-				static_cast<gin_ack_msg_t *>(rx_buff_elem->ptr);
-
-			auto &gin_comm = resources.get_comm(ack_msg->ack.comm_id);
+			auto &gin_comm = resources.get_comm(ack_msg->ack_comm_id);
 
 			ret = gin_comm.handle_ack_completion(src_addr, rail_id_arg,
 							     ack_msg);
@@ -115,7 +113,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 			auto *msg = static_cast<nccl_net_ofi_gin_signal_metadata_msg_t *>(
 				rx_buff_elem->ptr);
 
-			auto &gin_comm = resources.get_comm(msg->remote_comm_id);
+			auto &gin_comm = resources.get_comm(msg->header.remote_comm_id);
 
 			ret = gin_comm.handle_signal_metadata_completion(src_addr,
 									 rail_id_arg, msg);


### PR DESCRIPTION
Found "Next sequence number is in use" error during NCCL EP High-Throughput (HT) tests, indicating more in-flight requests than the existing active signal space (2048 entries at 11 bits). The HT test creates 32 contexts by default (Ref: [nccl_ep.cc#L804-L814](https://github.com/NVIDIA/nccl/blob/v2.30.4/contrib/nccl_ep/nccl_ep.cc#L804-L814) / [nccl_ep.cc#L846-L848](https://github.com/NVIDIA/nccl/blob/v2.30.4/contrib/nccl_ep/nccl_ep.cc#L846-L848)) in comparison with 16 contexts mentioned in #1204 . 

Hence:

1. Refactor the metadata send and ACK message structures into flat 64-bit bitfield structs (`nccl_net_ofi_gin_msg_header_t`, `gin_ack_msg_t`), dissolving the old `nccl_net_ofi_gin_metadata_seq_t` and `nccl_net_ofi_gin_ack_t` types. This reclaims unused bits from the previous byte-aligned layout and allows future expansion of `GIN_IMM_SEQ_BITS` without changing message sizes.

2. Increase `GIN_IMM_SEQ_BITS` from 11 to 13 (sequence space 8192), which provides sufficient headroom for current NCCL EP HT workloads. The value can be expanded up to 15 without further code changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
