### PR TITLE
gin: add opt-in weak-signal delivery on the receive side

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -380,4 +380,22 @@ OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSIO
  */
 OFI_NCCL_PARAM(bool, gin_gdaki, "GIN_GDAKI", false);
 
+/*
+ * Enable strong-signal semantics for the GIN plugin.
+ *
+ * When true, completed requests are delivered to the application in
+ * sequence-number order: the plugin waits for any earlier in-flight
+ * request to complete before propagating a later one up. A signal
+ * completion therefore implies all prior puts on the same (comm, peer)
+ * stream have been delivered to the application.
+ *
+ * When false, completed requests are propagated up as soon as they are
+ * fully received, without waiting for earlier requests. Per-token data
+ * can become visible to the application out of order. ACK emission to
+ * the sender is still ordered (seq-num stream + bundled range ACKs).
+ *
+ * Default: true (preserves current behavior).
+ */
+OFI_NCCL_PARAM(bool, gin_strong_signal, "GIN_STRONG_SIGNAL", true);
+
 #endif // End NCCL_OFI_PARAM_H_

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -351,6 +351,41 @@ private:
 	nccl_ofi_dlist pending_ack_list;
 	uint32_t progress_counter = 0;
 
+	/* Controls signal delivery ordering on this communicator
+	   (env: OFI_NCCL_GIN_STRONG_SIGNAL, default true).
+	 *
+	 * true  (strong-signal mode, default):
+	 *   Completed requests are released up the stack in sequence-number
+	 *   order on a per-(comm, peer) basis. A signal visible to the
+	 *   application therefore implies that:
+	 *     - this signal's own data has landed at the target, and
+	 *     - all prior puts and signals on the same (comm, peer) stream
+	 *       have also landed and been delivered.
+	 *   Out-of-order arrivals are buffered and held until earlier
+	 *   seq_nums complete (see iput_signal_deliver_all and
+	 *   next_delivered_signal_seq_num). This is the contract most NCCL
+	 *   kernels rely on: a single terminal signal proves a whole batch
+	 *   of prior writes is visible, with no per-write verification.
+	 *
+	 * false (weak-signal mode, opt-in):
+	 *   Each signal is delivered as soon as its own segments (metadata +
+	 *   data write) have arrived — no waiting for earlier seq_nums.
+	 *   Per-item payloads may become visible out of order, so the
+	 *   application must verify each item independently (e.g. a per-token
+	 *   SignalInc in MoE low-latency dispatch). Reduces head-of-line
+	 *   blocking when the kernel already handles its own ordering.
+	 *
+	 * Notes:
+	 *   - ACK emission back to the sender stays ordered in both modes
+	 *     (seq-num stream + bundled range ACKs); only the app-visible
+	 *     completion order changes.
+	 *   - The proxy thread supports both modes; this flag is a per-comm
+	 *     selector captured at construction from ofi_nccl_gin_strong_signal(),
+	 *     not a dynamic capability bit.
+	 *   - See handle_signal_metadata_completion / handle_signal_write_completion
+	 *     for the weak-mode early-deliver paths. */
+	bool strong_signal_ordering_enabled;
+
 	/**
 	 * Send a range ACK via fi_send to the peer.
 	 *
@@ -371,11 +406,15 @@ private:
 
 	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
 
+	int do_gin_signal_and_trace(uint32_t peer_rank,
+				    nccl_net_ofi_gin_iputsignal_recv_req *req);
+
 	int iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 					    nccl_net_ofi_gin_iputsignal_recv_req *req);
 
 	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num);
-	int iput_signal_deliver_all(uint32_t peer_rank);
+
+	int retire_completed_peer_iput_ops(uint32_t peer_rank);
 
 	friend class nccl_ofi_rdma_gin_listen_comm;
 

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -290,10 +290,10 @@ public:
 				     void *desc_arg, uint64_t imm_data_arg,
 				     fi_addr_t remote_addr_arg, uint64_t dest_arg, uint64_t key_arg,
 				     void *comm_arg, int dev_arg, uint32_t rank_arg,
-				     uint16_t msg_seq_num_arg)
+				     uint16_t msg_seq_num_arg, uint64_t msg_flags = 0)
 	    : comm(comm_arg), dev(dev_arg), rank(rank_arg), msg_seq_num(msg_seq_num_arg),
 	      ep(ep_arg), src(src_arg), size(size_arg), desc(desc_arg), imm_data(imm_data_arg),
-	      remote_addr(remote_addr_arg), dest(dest_arg), key(key_arg)
+	      remote_addr(remote_addr_arg), dest(dest_arg), key(key_arg), flags(msg_flags)
 	{
 	}
 
@@ -327,6 +327,10 @@ private:
 	fi_addr_t remote_addr;
 	uint64_t dest;
 	uint64_t key;
+	/* Flags for fi_writemsg. On retry FI_MORE is dropped as the
+	   request must be handled immediately and should not remain
+	   pending in the queue. */
+	uint64_t flags;
 };
 
 /**

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -8,6 +8,7 @@
 
 #include "nccl_ofi_assert.h"
 #include "nccl_ofi_gdrcopy.h"
+#include "nccl_ofi_param.h"
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_tracepoint.h"
 
@@ -30,6 +31,7 @@ nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &r
 				     nccl_net_ofi_recv_comm *r_comm_)
     : resources(resources_arg), resource_releaser { resources }, rank(rank_), nranks(nranks_),
       dev(s_comm_->dev_id), ag_comm(s_comm_, r_comm_, rank_, nranks_),
+      strong_signal_ordering_enabled(ofi_nccl_gin_strong_signal()),
       metadata_fl(nullptr, &freelist_deleter)
 {
 	auto &ep = resources.get_ep();
@@ -663,6 +665,21 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_meta
 	return 0;
 }
 
+int nccl_ofi_rdma_gin_put_comm::do_gin_signal_and_trace(uint32_t peer_rank,
+					      nccl_net_ofi_gin_iputsignal_recv_req *req)
+{
+	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
+						 req->metadata.header.seq_num, req);
+	int ret = do_gin_signal(req->metadata);
+	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
+					       req->metadata.header.seq_num, req);
+	if (OFI_UNLIKELY(ret != 0)) {
+		NCCL_OFI_WARN("Failed to complete signal seq_num %hu",
+			      req->metadata.header.seq_num);
+	}
+	return ret;
+}
+
 int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 						       nccl_net_ofi_gin_iputsignal_recv_req *req)
 {
@@ -671,16 +688,11 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 	NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on target",
 		       req->metadata.header.seq_num);
 
-	if (req->metadata_received) {
-		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
-							 req->metadata.header.seq_num, req);
-		ret = do_gin_signal(req->metadata);
-		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
-						       req->metadata.header.seq_num, req);
-	}
-
-	if (ret != 0) {
-		return ret;
+	if (req->metadata_received && strong_signal_ordering_enabled) {
+		ret = do_gin_signal_and_trace(peer_rank, req);
+		if (ret != 0) {
+			return ret;
+		}
 	}
 
 	/* Remove this request entry from the map */
@@ -755,7 +767,7 @@ int nccl_ofi_rdma_gin_put_comm::flush_stale_acks()
 	return 0;
 }
 
-int nccl_ofi_rdma_gin_put_comm::iput_signal_deliver_all(uint32_t peer_rank)
+int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_rank)
 {
 	int ret = 0;
 
@@ -783,8 +795,6 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_deliver_all(uint32_t peer_rank)
 					GIN_IMM_SEQ_MASK;
 				ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
 				if (OFI_UNLIKELY(ret != 0)) {
-					NCCL_OFI_WARN("Failed to complete signal seq_num %hu",
-						      next_seq_num);
 					return ret;
 				}
 
@@ -840,8 +850,18 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 		req->metadata_received = true;
 		req->num_seg_completions += 1;
 	}
+
+	/* Weak-signal mode: once all segments of this signal (metadata +
+	   writes at this same seq, if any) have arrived, deliver it
+	   immediately. This covers metadata-first and writes-first orderings. */
+	if (!strong_signal_ordering_enabled && req->num_seg_completions == req->total_segments) {
+		ret = do_gin_signal_and_trace(peer_rank, req);
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
+	}
 	NCCL_OFI_TRACE_GIN_RECV_METADATA(dev, rail_id, this, peer_rank, msg_seq_num, req);
-	ret = iput_signal_deliver_all(peer_rank);
+	ret = retire_completed_peer_iput_ops(peer_rank);
 
 	return ret;
 }
@@ -898,9 +918,25 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(fi_addr_t src_add
 		req->metadata.header.seq_num = msg_seq_num;
 		req->metadata.header.seq_seg_cnt = req->total_segments;
 		req->metadata.header.msg_type = GIN_MSG_TYPE_METADATA;
+
+		/* Weak-signal mode: from GIN's perspective, iput+signal is a
+		 * single logical operation sharing one sequence number.
+		 * However, from libfabric's perspective these are two separate
+		 * packets — an RDMA write-with-immediate and an fi_send — that
+		 * can complete in either order on the receiver. We therefore
+		 * need to check for signal delivery here (when the last write
+		 * completes after metadata) in addition to
+		 * handle_signal_metadata_completion() (when metadata completes
+		 * after writes). */
+		if (!strong_signal_ordering_enabled && req->metadata_received) {
+			ret = do_gin_signal_and_trace(peer_rank, req);
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+		}
 	}
 
-	ret = iput_signal_deliver_all(peer_rank);
+	ret = retire_completed_peer_iput_ops(peer_rank);
 
 	return ret;
 }

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -423,8 +423,11 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	auto &rank_comm = rank_comms[dst_rank];
 	uint16_t msg_seq_num = rank_comm.next_target_seq_num;
 	uint32_t remote_comm_id = rank_comm.comm_id;
-	uint16_t rail_id = resources.get_next_rail();
 	auto scheduler = gin_ep.get_scheduler();
+	/* rail_id for metadata send is determined below: either from the
+	   scheduler's first write rail (for coalescing) or from
+	   get_next_rail() when there is no data to coalesce with. */
+	uint16_t rail_id = 0;
 
 	if (OFI_UNLIKELY(rank_comm.active_put_signal.test(msg_seq_num & GIN_IMM_SEQ_MASK))) {
 		NCCL_OFI_WARN("Next sequence number is in use");
@@ -435,10 +438,10 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	/* Determine if this message needs an ACK:
 	 * - SIGNAL or PUT-SIGNAL: always needs ACK
 	 * - PUT-only: needs ACK every N consecutive PUTs */
-	bool is_signal = (signalOp != 0);
+	bool has_signal = (signalOp != 0);
 	bool is_ack_requested = false;
 
-	if (is_signal) {
+	if (has_signal) {
 		is_ack_requested = true;
 		rank_comm.consecutive_puts_without_ack = 0;
 	} else {
@@ -452,7 +455,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
 	/* Determine how many segments to send */
 	uint16_t nseg = 0;
-	if (signalOp != 0) {
+	if (has_signal) {
 		/* For signal operations (putSignal or signal only), send
 		   metadata message */
 		nseg += 1;
@@ -493,15 +496,31 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		uint64_t dest = dest_remote_mr.address_offset + dstOff;
 		int wr_it = 0;
 
+		/* When sending both data and metadata (put+signal), colocate
+		 * the first write and the metadata send on the same rail.
+		 * The first write is posted with FI_MORE to hint the provider
+		 * that more operations follow on this EP, enabling doorbell
+		 * coalescing (single PCIe doorbell for write + send). */
+		if (has_signal) {
+			rail_id = xfers[0].rail_id;
+		}
+
 		for (uint16_t rail_it = 0; rail_it < schedule->num_xfer_infos; rail_it++) {
 			nccl_net_ofi_xfer_info_t *xfer_info = &xfers[rail_it];
 			void *desc = fi_mr_desc(src_mhandle->get_mr(xfer_info->rail_id));
+
+			/* Set FI_MORE on the first write when it shares a rail
+			 * with the subsequent metadata send */
+			uint64_t wr_flags = FI_REMOTE_CQ_DATA;
+			if (has_signal && rail_it == 0)
+				wr_flags |= FI_MORE;
+
 			auto write_req = resources.get_req_from_pool<nccl_net_ofi_gin_write_req_t>(
 				gin_ep.get_rail(xfer_info->rail_id).ofi_ep.get(),
 				(void *)((uintptr_t)src + xfer_info->offset), xfer_info->msg_size,
 				desc, data, rank_comm.address[xfer_info->rail_id],
 				dest + xfer_info->offset, dest_remote_mr.mr_key[xfer_info->rail_id],
-				this, dev, dst_rank, msg_seq_num);
+				this, dev, dst_rank, msg_seq_num, wr_flags);
 
 			write_reqs[wr_it++] = write_req;
 			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, xfer_info->rail_id, xfer_info->msg_size,
@@ -526,7 +545,12 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 
 	nccl_ofi_freelist::fl_entry *metadata_elem = nullptr;
 
-	if (signalOp != 0) {
+	if (has_signal) {
+		/* For signal-only (size == 0), no write was posted so we
+		   cannot coalesce — pick a rail via round-robin. */
+		if (size == 0)
+			rail_id = resources.get_next_rail();
+
 		/* Post metadata send with signal information */
 
 		metadata_elem = metadata_fl.get()->entry_alloc();
@@ -563,6 +587,9 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			metadata_send->header.ack_count = 0;
 		}
 
+		/* This send flushes the QP work queue on the first rail,
+		   issuing a doorbell that includes the coalesced writedata
+		   WQE posted with FI_MORE above. */
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
 			gin_ep.get_rail(rail_id).ofi_ep.get(), rail_id, metadata_elem,
 			rank_comm.address[rail_id], metadata_fl.get(), this, dev, dst_rank,
@@ -674,8 +701,8 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal_and_trace(uint32_t peer_rank,
 	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
 					       req->metadata.header.seq_num, req);
 	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Failed to complete signal seq_num %hu",
-			      req->metadata.header.seq_num);
+		NCCL_OFI_WARN("Failed to complete signal seq_num %lu",
+			      (unsigned long)req->metadata.header.seq_num);
 	}
 	return ret;
 }

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -259,11 +259,25 @@ int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 
 int nccl_net_ofi_gin_write_req_t::post()
 {
-	ssize_t rc =
-		fi_writedata(ep, src, size, desc, imm_data, remote_addr, dest, key, &ctx.ofi_ctx);
+	struct iovec iov = { .iov_base = src, .iov_len = size };
+	struct fi_rma_iov rma_iov = { .addr = dest, .len = size, .key = key };
+	struct fi_msg_rma msg = {};
+	msg.msg_iov = &iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = remote_addr;
+	msg.rma_iov = &rma_iov;
+	msg.rma_iov_count = 1;
+	msg.context = &ctx.ofi_ctx;
+	msg.data = imm_data;
+
+	ssize_t rc = fi_writemsg(ep, &msg, flags);
+
+	/* Drop FI_MORE for retry — must not remain pending in the queue */
+	flags &= ~FI_MORE;
 
 	if (rc != 0 && rc != -FI_EAGAIN) {
-		NCCL_OFI_WARN("Failed call to fi_writedata; RC: %zd", rc);
+		NCCL_OFI_WARN("Failed call to fi_writemsg; RC: %zd", rc);
 	}
 
 	return rc;


### PR DESCRIPTION
Adds GIN_STRONG_SIGNAL (default true) that gates whether a received signal is delivered to the application in sequence-number order or as soon as all of its own segments arrive. In strong mode a signal completion still implies all prior puts on the same (comm, peer) stream have been delivered; in weak mode per-token data can surface out of order. ACK emission to the sender stays ordered in both modes, so this is invisible on the wire.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
