### PR TITLE
rdma: drive progress in send path for FI_PROGRESS_MANUAL providers

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -5587,6 +5587,20 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 
 	have_ctrl = has_ctrl_msg(s_comm, msg_seq_num, tag);
 
+	/*
+	 * In some transports with FI_PROGRESS_MANUAL, inbound RDMA writes
+	 * (carrying control messages) may not complete until the target
+	 * calls a progress function.  If the control message has not
+	 * arrived yet, drive progress and re-check.
+	 */
+	if (OFI_UNLIKELY(!data_progress_auto && !have_ctrl)) {
+		ret = endpoint->ofi_process_cq();
+		if (OFI_UNLIKELY(ret != 0)) {
+			goto error;
+		}
+		have_ctrl = has_ctrl_msg(s_comm, msg_seq_num, tag);
+	}
+
 	/* If ctrl msg indicates a grouped recv, start tracking the group */
 	if (have_ctrl && !in_group) {
 		uint16_t slot = msg_seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;


### PR DESCRIPTION
With FI_PROGRESS_MANUAL, inbound RDMA writes carrying control messages may not complete until the target calls a progress function. If the sender calls send() before the receiver's control message has arrived, and there are no pending requests to trigger CQ polling, the control message never lands and the send path returns without making progress.

Fix by calling ofi_process_cq() when the control message is not found and the provider uses manual progress, then re-checking the mailbox.

This resolves hangs observed with the OPX provider during alltoall_perf.

Reported-by: Brian Belynam <belynam@github>
Fixes: https://github.com/aws/aws-ofi-nccl/issues/908

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
