### PR TITLE
GIN: Optimize test() and CQ completion paths

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -274,83 +274,58 @@ public:
 	/**
 	 * Callback for metadata completion.
 	 *
+	 * @param metadata_msg: metadata message
 	 * @param src_addr: source address of the signal
 	 * @param rail_id: rail ID of the signal
-	 * @param metadata_msg: metadata message
 	 *
 	 * @return: 0 on success, non-zero on failure
 	 */
 	int handle_signal_metadata_completion(
-		fi_addr_t src_addr, uint16_t rail_id,
-		const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg);
+		const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg,
+		fi_addr_t src_addr, uint16_t rail_id);
 
 	/**
 	 * Callback for write completion (data signals only).
 	 *
+	 * @param cq_entry: completion queue entry
 	 * @param src_addr: source address of the signal
 	 * @param rail_id: rail ID of the signal
-	 * @param msg_seq_num: sequence number of the signal
-	 * @param total_segms: total number of segments in the signal
-	 * @param len: length of the signal
-	 * @param is_ack_requested: whether the sender is requesting an ACK
 	 */
-	int handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
-					   uint16_t msg_seq_num, uint64_t total_segms,
-					   size_t len, bool is_ack_requested);
+	int handle_signal_write_completion(struct fi_cq_data_entry * cq_entry,
+					   fi_addr_t src_addr, uint16_t rail_id);
 
 	/**
 	 * Callback for ACK message received via fi_recv.
 	 *
+	 * @param ack_msg: the received ACK message
 	 * @param src_addr: source address of the ACK sender
 	 * @param rail_id: rail on which the ACK was received
-	 * @param ack_msg: the received ACK message
 	 */
-	int handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
-				  const gin_ack_msg_t *ack_msg);
+	int handle_ack_completion(const gin_ack_msg_t *ack_msg, fi_addr_t src_addr,
+				  uint16_t rail_id);
 
 private:
+	/* Member layout is ordered by access frequency (higher to lower). */
+	/* --- TIER 1: every iputSignal + every CQ completion --- */
 	nccl_ofi_gin_resources &resources;
+	/* Keep resource_releaser declared before free lists, to destroy it
+	   late after metadata_fl and other members whose destructors need the
+	   resources/endpoint alive. */
 	nccl_ofi_gin_resource_releaser resource_releaser;
-
-	uint32_t local_comm_id;
-
-	int rank;
-	int nranks;
-	int dev;
-
-	/* AllGather ring for metadata exchange */
-	nccl_ofi_gin_allgather_comm ag_comm;
 
 	/* Remote comm info book */
 	std::vector<nccl_ofi_gin_peer_rank_info> rank_comms;
 
-	/* For each rail, map of fi_addr => peer comm rank */
-	std::unordered_map<fi_addr_t, uint32_t> rank_map[MAX_NUM_RAILS];
+	/**
+	 * Freelist of buffers storing signal information (type
+	 * nccl_net_ofi_gin_signal_metadata_msg_t). An entry is allocated from
+	 * this freelist for each putSignal operation.
+	 */
+	// FIXME: Get rid of freelist_deleter and change to embedded
+	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> metadata_fl;
+	int dev;
 
-	/* Map of <rank, msg_seq_num> => recv_req
-	 *
-	 * This key is guaranteed to be unique because each initiating rank
-	 * maintains a monotonically increasing sequence counter for each target
-	 * rank. */
-	std::unordered_map<uint64_t, nccl_net_ofi_gin_iputsignal_recv_req *>
-		outstanding_iput_signal_recv_reqs;
-
-	/* Map from pointers to memory registration handle. Used to look up
-	   GDRCopy handle for signal delivery.
-
-	   TODO: we could also just pass this in the handle to avoid a map
-	   lookup. Not sure yet if that is the right thing to do. */
-	std::unordered_map<void *, nccl_ofi_rdma_gin_symm_mr_handle *> mr_handle_map;
-
-	/* Number of outstanding RDMA writes for signal delivery acknowledgement
-	   Used to wait for remaining acknowledgements on communicator close. */
-	size_t outstanding_ack_counter = 0;
-
-	/* Active queue of peers with pending acks.
-	   Only these are visited by flush_stale_acks(). */
-	nccl_ofi_dlist pending_ack_list;
-	uint32_t progress_counter = 0;
-
+	/* --- TIER 2: Receiver side — every CQ completion --- */
 	/* Controls signal delivery ordering on this communicator
 	   (env: OFI_NCCL_GIN_STRONG_SIGNAL, default true).
 	 *
@@ -386,6 +361,45 @@ private:
 	 *     for the weak-mode early-deliver paths. */
 	bool strong_signal_ordering_enabled;
 
+	/* For each rail, map of fi_addr => peer comm rank */
+	std::unordered_map<fi_addr_t, uint32_t> rank_map[MAX_NUM_RAILS];
+
+	/* Map of <rank, msg_seq_num> => recv_req
+	 *
+	 * This key is guaranteed to be unique because each initiating rank
+	 * maintains a monotonically increasing sequence counter for each target
+	 * rank. */
+	std::unordered_map<uint64_t, nccl_net_ofi_gin_iputsignal_recv_req *>
+		outstanding_iput_signal_recv_reqs;
+
+	/* --- TIER 3: progress / ack flush path --- */
+	/* Active queue of peers with pending acks.
+	   Only these are visited by flush_stale_acks(). */
+	nccl_ofi_dlist pending_ack_list;
+	uint32_t progress_counter = 0;
+
+	/* Number of outstanding RDMA writes for signal delivery acknowledgement.
+	   Used to wait for remaining acknowledgements on communicator close. */
+	uint32_t outstanding_ack_counter = 0;
+
+	/* --- TIER 4: signal delivery (do_gin_signal) --- */
+	/* Map from pointers to memory registration handle. Used to look up
+	   GDRCopy handle for signal delivery.
+
+	   TODO: we could also just pass this in the handle to avoid a map
+	   lookup. Not sure yet if that is the right thing to do. */
+	std::unordered_map<void *, nccl_ofi_rdma_gin_symm_mr_handle *> mr_handle_map;
+
+	/* --- TIER 5: setup / teardown only --- */
+	uint32_t local_comm_id;
+	int rank;
+	int nranks;
+
+	/* AllGather ring for metadata exchange */
+	nccl_ofi_gin_allgather_comm ag_comm;
+
+	/* --- Private methods --- */
+
 	/**
 	 * Send a range ACK via fi_send to the peer.
 	 *
@@ -396,13 +410,6 @@ private:
 	 */
 	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
 		     uint32_t ack_seq_num, uint32_t count);
-
-	/**
-	 * Freelist of buffers storing signal information (type
-	 * nccl_net_ofi_gin_signal_metadata_msg_t). An entry is allocated from
-	 * this freelist for each putSignal operation.
-	 */
-	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> metadata_fl;
 
 	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
 

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -66,6 +66,11 @@ public:
 		return this->fl_elem;
 	}
 
+#if HAVE_NVTX_TRACING
+	/* NVTX tracing support - public for macro access */
+	nvtxRangeId_t trace_id;
+#endif
+
 private:
 	/* Source freelist element. This allows the request to be returned to a
 	   request freelist when complete */
@@ -76,6 +81,7 @@ private:
  * Represents a GIN request submitted to Libfabric.
  */
 class nccl_net_ofi_gin_op_req_t : public nccl_net_ofi_gin_base_req {
+
 public:
 	virtual ~nccl_net_ofi_gin_op_req_t() = default;
 
@@ -102,7 +108,26 @@ public:
 	virtual int handle_cq_entry(struct fi_cq_entry *cq_entry_base, fi_addr_t src_addr,
 				    uint16_t rail_id) = 0;
 
+#if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
+	/**
+	 * Set the trace information for LTTNG and NVTX
+	 * @param dev_arg: device ID
+	 * @param rank_arg: rank number
+	 * @param msg_seq_num_arg: message sequence number
+	 */
+	inline void set_info(int dev_arg, uint32_t rank_arg, uint16_t msg_seq_num_arg) {
+		dev = dev_arg;
+		rank = rank_arg;
+		msg_seq_num = msg_seq_num_arg;
+	}
+#endif
+
 protected:
+#if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
+	int dev;
+	uint32_t rank;
+	uint16_t msg_seq_num;
+#endif
 	/**
 	 * Implementation of nccl_net_ofi_gin_context which just calls the
 	 * virtual methods above.
@@ -193,26 +218,22 @@ class nccl_ofi_rdma_gin_iputsignal_req : public nccl_net_ofi_gin_base_req {
 public:
 	nccl_ofi_rdma_gin_iputsignal_req(
 		nccl_ofi_rdma_gin_put_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg,
-		std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs_arg,
-		nccl_net_ofi_gin_metadata_send_req_t *send_req_arg,
 		bool is_ack_requested_arg)
-	    : write_reqs(write_reqs_arg), send_req(send_req_arg), gin_comm(gin_comm_arg),
+	    : any_reqs_pending(0), gin_comm(gin_comm_arg),
 	      peer_rank(peer_rank_arg), msg_seq_num(msg_seq_num_arg), is_ack_requested(is_ack_requested_arg)
 	{
 	}
 
 	int test(int *done);
 
-	/* Subrequests - public to match RDMA struct pattern */
-	/* Write requests */
-	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs;
-	/* Metadata send request */
-	nccl_net_ofi_gin_metadata_send_req_t *send_req;
-
-	/* NVTX tracing support - public for macro access */
-#if HAVE_NVTX_TRACING
-	nvtxRangeId_t trace_id;
-#endif
+	/* Each subrequest hold a pointer to reqs_pending and unset when it's done. */
+	union {
+		/* Index: write requests: 0 to (MAX_NUM_RAILS - 1); send request: MAX_NUM_RAILS */
+		bool reqs_pending[MAX_NUM_RAILS + 1];
+		uint64_t any_reqs_pending;
+	};
+	static_assert(sizeof(reqs_pending) <= sizeof(any_reqs_pending),
+		      "any_reqs_pending must cover all reqs_pending bytes");
 
 private:
 	/* Associated Comm object */
@@ -235,12 +256,6 @@ private:
  * nccl_ofi_rdma_gin_put_comm. That class is added as a friend.
  */
 class nccl_net_ofi_gin_iputsignal_recv_req : public nccl_net_ofi_gin_base_req {
-	/* NVTX tracing support - public for macro access */
-#if HAVE_NVTX_TRACING
-public:
-	nvtxRangeId_t signal_delivery_trace_id;
-#endif
-
 private:
 	/**
 	 * Total number of segments in the signal.
@@ -280,43 +295,19 @@ private:
  */
 class nccl_net_ofi_gin_write_req_t : public nccl_net_ofi_gin_op_req_t {
 public:
-	bool done = false;
-	void *comm;
-	int dev;
-	uint32_t rank;
-	uint16_t msg_seq_num;
-
 	nccl_net_ofi_gin_write_req_t(struct fid_ep *ep_arg, void *src_arg, size_t size_arg,
 				     void *desc_arg, uint64_t imm_data_arg,
 				     fi_addr_t remote_addr_arg, uint64_t dest_arg, uint64_t key_arg,
-				     void *comm_arg, int dev_arg, uint32_t rank_arg,
-				     uint16_t msg_seq_num_arg, uint64_t msg_flags = 0)
-	    : comm(comm_arg), dev(dev_arg), rank(rank_arg), msg_seq_num(msg_seq_num_arg),
-	      ep(ep_arg), src(src_arg), size(size_arg), desc(desc_arg), imm_data(imm_data_arg),
-	      remote_addr(remote_addr_arg), dest(dest_arg), key(key_arg), flags(msg_flags)
+				     void* comm_arg, uint64_t msg_flags = 0)
+	    : ep(ep_arg), src(src_arg), size(size_arg), desc(desc_arg), imm_data(imm_data_arg),
+	      remote_addr(remote_addr_arg), dest(dest_arg), key(key_arg), flags(msg_flags),
+	      comm(comm_arg)
 	{
 	}
-
 	int post() override;
 
-	int handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/, fi_addr_t /*src_addr*/,
-			    uint16_t rail_id) override
-	{
-		NCCL_OFI_TRACE_GIN_WRITE_END(dev, rail_id, comm, rank, msg_seq_num, this);
-		done = true;
-		return 0;
-	}
-
-	int test(int *done_out) override
-	{
-		*done_out = this->done ? 1 : 0;
-		return 0;
-	}
-
-	/* NVTX tracing support - public for macro access */
-#if HAVE_NVTX_TRACING
-	nvtxRangeId_t trace_id;
-#endif
+	int handle_cq_entry(struct fi_cq_entry *cq_entry_base, fi_addr_t src_addr,
+			    uint16_t rail_id) override;
 
 private:
 	struct fid_ep *ep;
@@ -331,6 +322,15 @@ private:
 	   request must be handled immediately and should not remain
 	   pending in the queue. */
 	uint64_t flags;
+public:
+	/* Placed after private fields for cache locality with post() hot path above.
+	   handle_cq_entry() accesses these on completion.
+	   Note: moving comm to the base class (op_req_t) would deduplicate it
+	   across write_req and metadata_send_req, but would shadow or conflict
+	   with local variables named gin_comm in other op_req_t subclasses
+	   (e.g. recv_req_t), so we keep it here. */
+	void *comm;
+	bool *pending_flag;
 };
 
 /**
@@ -338,47 +338,21 @@ private:
  */
 class nccl_net_ofi_gin_metadata_send_req_t : public nccl_net_ofi_gin_op_req_t {
 public:
-	bool done = false;
-	void *comm;
-	int dev;
-	uint32_t rank;
-	uint16_t msg_seq_num;
-
 	nccl_net_ofi_gin_metadata_send_req_t(struct fid_ep *ep_arg, uint16_t rail_id_arg,
 					     nccl_ofi_freelist::fl_entry *metadata_elem_arg,
 					     fi_addr_t remote_addr_arg,
-					     nccl_ofi_freelist *metadata_fl_arg, void *comm_arg,
-					     int dev_arg, uint32_t rank_arg,
-					     uint16_t msg_seq_num_arg)
-	    : comm(comm_arg), dev(dev_arg), rank(rank_arg), msg_seq_num(msg_seq_num_arg),
-	      ep(ep_arg), rail_id(rail_id_arg), metadata_elem(metadata_elem_arg),
-	      remote_addr(remote_addr_arg), metadata_fl(metadata_fl_arg)
+					     nccl_ofi_freelist *metadata_fl_arg,
+					     void *comm_arg)
+	    : ep(ep_arg), rail_id(rail_id_arg), metadata_elem(metadata_elem_arg),
+	      remote_addr(remote_addr_arg), metadata_fl(metadata_fl_arg), comm(comm_arg)
 	{
 	}
-
 	int post() override;
 
-	int handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/, fi_addr_t /*src_addr*/,
-			    uint16_t rail_id_arg) override
-	{
-		NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id_arg, comm, rank, msg_seq_num,
-						     this);
-		done = true;
-		return 0;
-	}
-
-	int test(int *done_out) override
-	{
-		*done_out = this->done ? 1 : 0;
-		return 0;
-	}
+	int handle_cq_entry(struct fi_cq_entry *cq_entry_base, fi_addr_t src_addr,
+			    uint16_t rail_id_arg) override;
 
 	virtual ~nccl_net_ofi_gin_metadata_send_req_t() override;
-
-	/* NVTX tracing support - public for macro access */
-#if HAVE_NVTX_TRACING
-	nvtxRangeId_t trace_id;
-#endif
 
 private:
 	struct fid_ep *ep;
@@ -386,6 +360,16 @@ private:
 	nccl_ofi_freelist::fl_entry *metadata_elem;
 	fi_addr_t remote_addr;
 	nccl_ofi_freelist *metadata_fl;
+
+public:
+	/* Placed after private fields for cache locality with post() hot path above.
+	   handle_cq_entry() accesses these on completion.
+	   Note: moving comm to the base class (op_req_t) would deduplicate it
+	   across write_req and metadata_send_req, but would shadow or conflict
+	   with local variables named gin_comm in other op_req_t subclasses
+	   (e.g. recv_req_t), so we keep it here. */
+	void *comm;
+	bool *pending_flag;
 };
 
 /**

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -361,6 +361,7 @@ private:
 	uint16_t next_rail_id = 0;
 
 	/* Requests pool used by all comms of this resource */
+	// FIXME: Get rid of freelist_deleter and change to embedded
 	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> req_fl;
 
 	/**

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -269,13 +269,13 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
-		(request)->signal_delivery_trace_id = nvtx_start_domain(true, handle, "gin_signal_delivery", 0x32CD32); \
+		(request)->trace_id = nvtx_start_domain(true, handle, "gin_signal_delivery", 0x32CD32); \
 	} \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
-		nvtx_end_domain(0, (request)->signal_delivery_trace_id); \
+		nvtx_end_domain(0, (request)->trace_id); \
 	} \
 } while(0)
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -29,10 +29,11 @@ struct gin_connect_handle {
 nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &resources_arg, int rank_, int nranks_,
 				     nccl_net_ofi_send_comm *s_comm_,
 				     nccl_net_ofi_recv_comm *r_comm_)
-    : resources(resources_arg), resource_releaser { resources }, rank(rank_), nranks(nranks_),
-      dev(s_comm_->dev_id), ag_comm(s_comm_, r_comm_, rank_, nranks_),
+    : resources(resources_arg), resource_releaser { resources },
+      metadata_fl(nullptr, &freelist_deleter), dev(s_comm_->dev_id),
       strong_signal_ordering_enabled(ofi_nccl_gin_strong_signal()),
-      metadata_fl(nullptr, &freelist_deleter)
+      rank(rank_), nranks(nranks_),
+      ag_comm(s_comm_, r_comm_, rank_, nranks_)
 {
 	auto &ep = resources.get_ep();
 
@@ -403,6 +404,17 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 	return ret;
 }
 
+static inline void clear_write_reqs_pending_back_pointers(
+	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> &write_reqs)
+{
+	/* For posted write requests, clear their back-pointers only */
+	for (uint16_t i = 0; i < MAX_NUM_RAILS; i++) {
+		if (write_reqs[i]) {
+			write_reqs[i]->pending_flag = nullptr;
+		}
+	}
+}
+
 int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size,
 				  uint64_t dstOff, nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t dst_rank,
 				  uint64_t signalOff, nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
@@ -468,13 +480,14 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		       srcOff, srcMhandle, size, dstOff, dstMhandle, dst_rank, signalOff,
 		       signalMhandle, signalValue, signalOp, msg_seq_num, is_ack_requested);
 
-	int ret = 0;
-	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs {};
-	nccl_net_ofi_gin_metadata_send_req_t *send_req = nullptr;
 
-	/* Create umbrella request first for tracing */
+	/* Create umbrella request for tracing */
 	auto *req = resources.get_req_from_pool<nccl_ofi_rdma_gin_iputsignal_req>(
-		*this, dst_rank, msg_seq_num, write_reqs, nullptr, is_ack_requested);
+		*this, dst_rank, msg_seq_num, is_ack_requested);
+	/* Hold write_reqs for error clean up */
+	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs {};
+
+	int ret = 0;
 
 	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
 
@@ -520,9 +533,15 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 				(void *)((uintptr_t)src + xfer_info->offset), xfer_info->msg_size,
 				desc, data, rank_comm.address[xfer_info->rail_id],
 				dest + xfer_info->offset, dest_remote_mr.mr_key[xfer_info->rail_id],
-				this, dev, dst_rank, msg_seq_num, wr_flags);
+				this, wr_flags);
 
+			write_req->pending_flag = &(req->reqs_pending[wr_it]);
+#if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
+			write_req->set_info(dev, dst_rank, msg_seq_num);
+#endif
+			req->reqs_pending[wr_it] = true;
 			write_reqs[wr_it++] = write_req;
+
 			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, xfer_info->rail_id, xfer_info->msg_size,
 						       this, dst_rank, msg_seq_num, write_req);
 			ret = write_req->post();
@@ -533,17 +552,13 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 				NCCL_OFI_WARN("Write failed for seq_num %hu", msg_seq_num);
 				resources.return_req_to_pool(write_req);
 				nccl_net_ofi_release_schedule(scheduler, schedule);
+				clear_write_reqs_pending_back_pointers(write_reqs);
 				resources.return_req_to_pool(req);
 				return ret;
 			}
 		}
 		nccl_net_ofi_release_schedule(scheduler, schedule);
 	}
-
-	/* Update umbrella request with write_reqs */
-	req->write_reqs = write_reqs;
-
-	nccl_ofi_freelist::fl_entry *metadata_elem = nullptr;
 
 	if (has_signal) {
 		/* For signal-only (size == 0), no write was posted so we
@@ -552,10 +567,12 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			rail_id = resources.get_next_rail();
 
 		/* Post metadata send with signal information */
+		nccl_ofi_freelist::fl_entry *metadata_elem = nullptr;
 
 		metadata_elem = metadata_fl.get()->entry_alloc();
 		if (!metadata_elem) {
 			NCCL_OFI_WARN("Failed to allocate metadata freelist entry");
+			clear_write_reqs_pending_back_pointers(write_reqs);
 			resources.return_req_to_pool(req);
 			return -ENOMEM;
 		}
@@ -590,10 +607,10 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		/* This send flushes the QP work queue on the first rail,
 		   issuing a doorbell that includes the coalesced writedata
 		   WQE posted with FI_MORE above. */
+		nccl_net_ofi_gin_metadata_send_req_t *send_req;
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
 			gin_ep.get_rail(rail_id).ofi_ep.get(), rail_id, metadata_elem,
-			rank_comm.address[rail_id], metadata_fl.get(), this, dev, dst_rank,
-			msg_seq_num);
+			rank_comm.address[rail_id], metadata_fl.get(), this);
 
 		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, this, dst_rank, msg_seq_num,
 						       send_req);
@@ -605,12 +622,15 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			NCCL_OFI_WARN("Metadata send failed for seq_num %hu", msg_seq_num);
 			resources.return_req_to_pool(send_req);
 			resources.return_req_to_pool(req);
+			clear_write_reqs_pending_back_pointers(write_reqs);
 			return ret;
 		}
+		send_req->pending_flag = &(req->reqs_pending[MAX_NUM_RAILS]); // last one
+#if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
+		send_req->set_info(dev, dst_rank, msg_seq_num);
+#endif
+		req->reqs_pending[MAX_NUM_RAILS] = true;
 	}
-
-	/* Update umbrella request with send_req */
-	req->send_req = send_req;
 
 	rank_comm.active_put_signal.set(msg_seq_num & GIN_IMM_SEQ_MASK, is_ack_requested);
 	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
@@ -840,8 +860,8 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 }
 
 int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
-	fi_addr_t src_addr, uint16_t rail_id,
-	const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg)
+	const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg,
+	fi_addr_t src_addr, uint16_t rail_id)
 {
 	int ret = 0;
 
@@ -893,8 +913,8 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	return ret;
 }
 
-int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(fi_addr_t src_addr, uint16_t rail_id,
-					     const gin_ack_msg_t *ack_msg)
+int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(const gin_ack_msg_t *ack_msg,
+						      fi_addr_t src_addr, uint16_t rail_id)
 {
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
 	uint16_t ack_seq_num = ack_msg->ack_seq_num;
@@ -914,15 +934,18 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(fi_addr_t src_addr, uint16
 	return 0;
 }
 
-int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(fi_addr_t src_addr, uint16_t rail_id,
-						      uint16_t msg_seq_num, uint64_t total_segms,
-						      size_t len, bool is_ack_requested)
+int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data_entry * cq_entry,
+						      fi_addr_t src_addr, uint16_t rail_id)
 {
-	int ret = 0;
+	/* RDMA write-immediate completion */
+	uint64_t total_segms = GIN_IMM_GET_SEG_CNT(cq_entry->data);
+	uint16_t msg_seq_num = GIN_IMM_GET_SEQ_NUM(cq_entry->data);
+	bool is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
-
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
+
+	int ret = 0;
 
 	auto it = outstanding_iput_signal_recv_reqs.find(map_key);
 	nccl_net_ofi_gin_iputsignal_recv_req *req;
@@ -938,7 +961,7 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(fi_addr_t src_add
 		assert(req->total_segments == total_segms);
 		req->num_seg_completions += 1;
 	}
-	NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, len, this, peer_rank, msg_seq_num, req);
+	NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, cq_entry->len, this, peer_rank, msg_seq_num, req);
 
 	if (req->num_seg_completions == req->total_segments) {
 		/* Fill in the fields related to metadata */

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -81,17 +81,9 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 	if (cq_entry->flags & FI_REMOTE_WRITE) {
 		/* RDMA write-immediate completion */
 		uint32_t comm_id = GIN_IMM_GET_COMM_ID(cq_entry->data);
-		uint16_t msg_seq_num = GIN_IMM_GET_SEQ_NUM(cq_entry->data);
-
 		auto &gin_comm = resources.get_comm(comm_id);
 
-		uint64_t total_segms = GIN_IMM_GET_SEG_CNT(cq_entry->data);
-		bool is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
-		size_t len = cq_entry->len;
-
-		ret = gin_comm.handle_signal_write_completion(src_addr, rail_id_arg,
-							      msg_seq_num, total_segms,
-							      len, is_ack_requested);
+		ret = gin_comm.handle_signal_write_completion(cq_entry, src_addr, rail_id_arg);
 		if (ret != 0) {
 			NCCL_OFI_WARN("gin_handle_signal_write_completion failure");
 			return ret;
@@ -103,8 +95,7 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 		if (msg_type == GIN_MSG_TYPE_ACK) {
 			auto &gin_comm = resources.get_comm(ack_msg->ack_comm_id);
 
-			ret = gin_comm.handle_ack_completion(src_addr, rail_id_arg,
-							     ack_msg);
+			ret = gin_comm.handle_ack_completion(ack_msg, src_addr, rail_id_arg);
 			if (ret != 0) {
 				NCCL_OFI_WARN("handle_ack_completion failure");
 				return ret;
@@ -115,8 +106,8 @@ int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_ba
 
 			auto &gin_comm = resources.get_comm(msg->header.remote_comm_id);
 
-			ret = gin_comm.handle_signal_metadata_completion(src_addr,
-									 rail_id_arg, msg);
+			ret = gin_comm.handle_signal_metadata_completion(msg, src_addr,
+									 rail_id_arg);
 			if (ret != 0) {
 				NCCL_OFI_WARN(
 					"gin_handle_signal_metadata_completion failure");
@@ -194,58 +185,34 @@ nccl_net_ofi_gin_sendack_req_t::~nccl_net_ofi_gin_sendack_req_t()
 
 int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 {
-	*done = 0;
-
-	auto &gin_ep = gin_comm.get_resources().get_ep();
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
-
-	bool all_writes_done = true;
-	for (auto &write_req : write_reqs) {
-		if (write_req) {
-			int write_done = 0;
-			int ret = write_req->test(&write_done);
-			if (ret != 0)
-				return ret;
-			if (write_done) {
-				gin_comm.get_resources().return_req_to_pool(write_req);
-				write_req = nullptr;
-			} else {
-				all_writes_done = false;
-				break;
-			}
-		}
-	}
-
-	if (send_req) {
-		int send_done = 0;
-		int ret = send_req->test(&send_done);
-		if (ret != 0)
-			return ret;
-		if (send_done) {
-			gin_comm.get_resources().return_req_to_pool(send_req);
-			send_req = nullptr;
-		}
-	}
-
-	bool reqs_done = all_writes_done && !send_req;
-	if (reqs_done) {
+	if (OFI_UNLIKELY(any_reqs_pending == 0)) {
+		/* Check outstanding signal only if no pending subrequests */
+		auto &gin_ep = gin_comm.get_resources().get_ep();
 		if (is_ack_requested) {
 			/* This message requested ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
 			bool ack_outstanding = gin_comm.query_ack_outstanding(peer_rank, msg_seq_num);
-			*done = !ack_outstanding;
+			if (OFI_UNLIKELY(!ack_outstanding)) {
+				*done = 1;
+			}
 		} else {
 			/* This message doesn't need ACK (most PUTs) */
 			*done = 1;
 		}
+		/* Free iputSignal request when done */
+		if (OFI_UNLIKELY(*done)) {
+			std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+			NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on initiator",
+				       this->msg_seq_num);
+			NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
+							   msg_seq_num, this);
+			gin_comm.get_resources().return_req_to_pool(this);
+		}
+	} else {
+		/* NCCL GIN Proxy only calls test() when state->done == 0,
+		 * so skip the redundant store (*done = 0) for now.
+		 */
 	}
 
-	if (*done) {
-		NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on initiator",
-			       this->msg_seq_num);
-		NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
-						   msg_seq_num, this);
-		gin_comm.get_resources().return_req_to_pool(this);
-	}
 
 	/* If not done, the GIN plugin will do nothing.
 
@@ -276,11 +243,26 @@ int nccl_net_ofi_gin_write_req_t::post()
 	/* Drop FI_MORE for retry — must not remain pending in the queue */
 	flags &= ~FI_MORE;
 
-	if (rc != 0 && rc != -FI_EAGAIN) {
+	if (OFI_UNLIKELY(rc != 0 && rc != -FI_EAGAIN)) {
 		NCCL_OFI_WARN("Failed call to fi_writemsg; RC: %zd", rc);
 	}
 
 	return rc;
+}
+
+int nccl_net_ofi_gin_write_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/,
+						   fi_addr_t /*src_addr*/, uint16_t rail_id)
+{
+	NCCL_OFI_TRACE_GIN_WRITE_END(dev, rail_id, comm, rank, msg_seq_num, this);
+
+	if (OFI_LIKELY(pending_flag != nullptr)) {
+		*pending_flag = false;
+	}
+
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(comm);
+	gin_comm->get_resources().return_req_to_pool(this);
+
+	return 0;
 }
 
 int nccl_net_ofi_gin_metadata_send_req_t::post()
@@ -296,6 +278,22 @@ int nccl_net_ofi_gin_metadata_send_req_t::post()
 	}
 
 	return rc;
+}
+
+int nccl_net_ofi_gin_metadata_send_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/,
+							   fi_addr_t /*src_addr*/,
+							   uint16_t rail_id_arg)
+{
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id_arg, comm, rank, msg_seq_num, this);
+
+	if (OFI_LIKELY(pending_flag != nullptr)) {
+		*pending_flag = false;
+	}
+
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(comm);
+	gin_comm->get_resources().return_req_to_pool(this);
+
+	return 0;
 }
 
 nccl_net_ofi_gin_metadata_send_req_t::~nccl_net_ofi_gin_metadata_send_req_t()

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -87,17 +87,17 @@ int nccl_ofi_rdma_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
 {
 	assert(rail_id < num_rails);
 
-	auto &rail = this->get_rail(rail_id);
 	struct fi_cq_data_entry cqe_buffers[cq_read_count];
 	fi_addr_t src_addrs[cq_read_count];
+	auto *rail_cq = this->get_rail(rail_id).rail_cq.get();
 	ssize_t rc = 0;
-	int ret = 0;
 	size_t iter = 0;
+	int ret = 0;
 
 	do {
 		++iter;
 		/* Receive completions for the given rail */
-		rc = fi_cq_readfrom(rail.rail_cq.get(), cqe_buffers, cq_read_count, src_addrs);
+		rc = fi_cq_readfrom(rail_cq, cqe_buffers, cq_read_count, src_addrs);
 		if (rc > 0) {
 			ret = gin_process_completions(cqe_buffers, src_addrs, rc, rail_id);
 			if (OFI_UNLIKELY(ret != 0))
@@ -110,7 +110,7 @@ int nccl_ofi_rdma_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
 			 */
 			struct fi_cq_err_entry err_entry = {};
 
-			ret = fi_cq_readerr(rail.rail_cq.get(), &err_entry, 0);
+			ret = fi_cq_readerr(rail_cq, &err_entry, 0);
 			if (OFI_UNLIKELY(ret == -FI_EAGAIN)) {
 				/*
 				 * Error not available yet.
@@ -126,7 +126,7 @@ int nccl_ofi_rdma_gin_ep_t::gin_process_cq_rail(uint16_t rail_id)
 				goto exit;
 			}
 
-			ret = gin_process_error_entry(&err_entry, rail.rail_cq.get(), rail_id);
+			ret = gin_process_error_entry(&err_entry, rail_cq, rail_id);
 			if (ret != 0) {
 				goto exit;
 			}
@@ -153,7 +153,7 @@ int nccl_ofi_rdma_gin_ep_t::process_cq()
 	/* Process completion queues for all rails */
 	for (uint16_t rail_id = 0; rail_id < num_rails; ++rail_id) {
 		ret = gin_process_cq_rail(rail_id);
-		if (ret != 0) {
+		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Failed to process CQ for rail %u: %d", rail_id, ret);
 			return ret;
 		}


### PR DESCRIPTION
The PR optimizes `test()` and CQ completion paths for the GIN plugin's hot paths called by NCCL GIN Proxy.

`test()`: Replace per-subrequest polling loop with a single uint64 check on a pending bitmap. Subrequest CQ handlers clear their flag directly, making the common case (still pending) a single branch-and-return.

CQ handlers (`handle_cq_entry`): Make write and metadata send subrequests self-return to pool on CQ completion instead of being polled and freed by `test()`. Move field extraction into the callee; reorder parameters to preserve caller register positions and avoid register shuffling on the hot paths.

Additional changes:
- `iputSignal()`: Use new request construction pattern for above changes
- Reorder put_comm members by access frequency and relevance
- Add `OFI_LIKELY/OFI_UNLIKELY` annotations on hot/error paths
- Wrap tracing-only fields (`dev`, `rank`, `msg_seq_num`) in `#if` guards
- Narrow variable types to reduce struct padding




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
