### PR TITLE
Proxy iget GIN Implementation + Functional Test

### DIFF
--- a/include/nccl_ofi_gin_base.h
+++ b/include/nccl_ofi_gin_base.h
@@ -85,6 +85,11 @@ public:
 			       uint64_t signalValue, uint32_t signalOp,
 			       nccl_ofi_gin_req_t **request) = 0;
 
+	virtual int iget(uint64_t remoteOff, nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
+			 size_t size, uint64_t localOff,
+			 nccl_ofi_gin_symm_mr_handle_t *localMhandle,
+			 uint32_t rank, nccl_ofi_gin_req_t **request) = 0;
+
 	virtual int await_pending_requests() = 0;
 };
 

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -271,6 +271,10 @@ public:
 		       nccl_ofi_gin_symm_mr_handle_t *signalMhandle, uint64_t signalValue, uint32_t signalOp,
 		       nccl_ofi_gin_req_t **request) override;
 
+	int iget(uint64_t remoteOff, nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
+		 size_t size, uint64_t localOff, nccl_ofi_gin_symm_mr_handle_t *localMhandle,
+		 uint32_t rank, nccl_ofi_gin_req_t **request) override;
+
 	/**
 	 * Callback for metadata completion.
 	 *

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -209,6 +209,7 @@ private:
 };
 
 class nccl_net_ofi_gin_write_req_t;
+class nccl_net_ofi_gin_read_req_t;
 class nccl_net_ofi_gin_metadata_send_req_t;
 
 /**
@@ -244,6 +245,33 @@ private:
 	uint16_t msg_seq_num;
 	/* True if sender is requesting an ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
 	bool is_ack_requested;
+};
+
+/**
+ * Umbrella request tracking completion of multiple read sub-requests.
+ * Used by iget operations.
+ */
+class nccl_ofi_gin_iget_req : public nccl_net_ofi_gin_base_req {
+public:
+	nccl_ofi_gin_iget_req(nccl_ofi_gin_resources &resources_arg)
+	    : any_reqs_pending(0), resources(resources_arg)
+	{
+	}
+
+	int test(int *done) override;
+
+	/* Each sub read request holds a pointer to one slot of reqs_pending and
+	   clears it on completion. Aliased with any_reqs_pending so test() can
+	   check all slots in a single load. */
+	union {
+		bool reqs_pending[MAX_NUM_RAILS];
+		uint64_t any_reqs_pending;
+	};
+	static_assert(sizeof(reqs_pending) <= sizeof(any_reqs_pending),
+		      "any_reqs_pending must cover all reqs_pending bytes");
+
+private:
+	nccl_ofi_gin_resources &resources;
 };
 
 /**
@@ -334,6 +362,42 @@ public:
 };
 
 /**
+ * Request for an fi_read operation (used by iget). On CQ completion, clears
+ * its pending_flag back-pointer in the umbrella iget_req and returns itself
+ * to the request pool.
+ */
+class nccl_net_ofi_gin_read_req_t : public nccl_net_ofi_gin_op_req_t {
+public:
+	nccl_net_ofi_gin_read_req_t(nccl_ofi_gin_resources &resources_arg,
+				    struct fid_ep *ep_arg, void *local_buf_arg,
+				    size_t size_arg, void *desc_arg,
+				    fi_addr_t remote_addr_arg, uint64_t remote_offset_arg,
+				    uint64_t remote_key_arg)
+	    : resources(resources_arg), ep(ep_arg), local_buf(local_buf_arg),
+	      size(size_arg), desc(desc_arg), remote_addr(remote_addr_arg),
+	      remote_offset(remote_offset_arg), remote_key(remote_key_arg)
+	{
+	}
+
+	int post() override;
+
+	int handle_cq_entry(struct fi_cq_entry *cq_entry_base, fi_addr_t src_addr,
+			    uint16_t rail_id) override;
+
+	bool *pending_flag = nullptr;
+
+private:
+	nccl_ofi_gin_resources &resources;
+	struct fid_ep *ep;
+	void *local_buf;
+	size_t size;
+	void *desc;
+	fi_addr_t remote_addr;
+	uint64_t remote_offset;
+	uint64_t remote_key;
+};
+
+/**
  * Request for the metadata send operation associated with a put-signal request
  */
 class nccl_net_ofi_gin_metadata_send_req_t : public nccl_net_ofi_gin_op_req_t {
@@ -383,7 +447,9 @@ private:
 	nccl_ofi_rdma_gin_iputsignal_req iputsignal_req;
 	nccl_net_ofi_gin_iputsignal_recv_req iputsignal_recv_req;
 	nccl_net_ofi_gin_write_req_t write_req;
+	nccl_net_ofi_gin_read_req_t read_req;
 	nccl_net_ofi_gin_metadata_send_req_t metadata_send_req;
+	nccl_ofi_gin_iget_req iget_req;
 };
 
 #endif

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -639,6 +639,79 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	return 0;
 }
 
+/* Walk all MAX_NUM_RAILS slots — including any subreqs that returned -FI_EAGAIN
+   on post() and got queued via add_pending_req — so none retain a pending_flag
+   pointing into the umbrella iget_req we are about to free. */
+static inline void clear_read_reqs_pending_back_pointers(
+	std::array<nccl_net_ofi_gin_read_req_t *, MAX_NUM_RAILS> &read_reqs)
+{
+	for (uint16_t i = 0; i < MAX_NUM_RAILS; i++) {
+		if (read_reqs[i]) {
+			read_reqs[i]->pending_flag = nullptr;
+		}
+	}
+}
+
+int nccl_ofi_rdma_gin_put_comm::iget(uint64_t remoteOff,
+				      nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
+				      size_t size, uint64_t localOff,
+				      nccl_ofi_gin_symm_mr_handle_t *localMhandle,
+				      uint32_t dst_rank, nccl_ofi_gin_req_t **request)
+{
+	auto *remote_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(remoteMhandle);
+	auto *local_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(localMhandle);
+	auto &gin_ep = resources.get_ep();
+	auto &rank_comm = rank_comms[dst_rank];
+	auto &remote_mr = remote_mr_handle->remote_mr[dst_rank];
+	auto *local_handle = local_mr_handle->local_handle;
+	auto *scheduler = gin_ep.get_scheduler();
+
+	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
+	auto *iget_req = resources.get_req_from_pool<nccl_ofi_gin_iget_req>(resources);
+	std::array<nccl_net_ofi_gin_read_req_t *, MAX_NUM_RAILS> read_reqs {};
+
+	const auto schedule = scheduler->get_schedule(size, gin_ep.get_num_rails());
+	auto &xfers = schedule->rail_xfer_infos;
+	uint16_t num_xfers = schedule->num_xfer_infos;
+
+	for (uint16_t i = 0; i < num_xfers; i++) {
+		nccl_net_ofi_xfer_info_t *xfer_info = &xfers[i];
+		void *local_buf = static_cast<uint8_t *>(local_mr_handle->input_address) +
+				  localOff + xfer_info->offset;
+		void *desc = fi_mr_desc(local_handle->get_mr(xfer_info->rail_id));
+		uint64_t remote_offset = remote_mr.address_offset + remoteOff + xfer_info->offset;
+
+		auto *read_req = resources.get_req_from_pool<nccl_net_ofi_gin_read_req_t>(
+			resources,
+			gin_ep.get_rail(xfer_info->rail_id).ofi_ep.get(),
+			local_buf, xfer_info->msg_size, desc,
+			rank_comm.address[xfer_info->rail_id],
+			remote_offset, remote_mr.mr_key[xfer_info->rail_id]);
+
+		read_req->pending_flag = &(iget_req->reqs_pending[i]);
+		iget_req->reqs_pending[i] = true;
+		read_reqs[i] = read_req;
+
+		int ret = read_req->post();
+		if (ret == -FI_EAGAIN) {
+			resources.add_pending_req(read_req);
+		} else if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("fi_read iget failed on rail %u: %d",
+				      xfer_info->rail_id, ret);
+			nccl_net_ofi_release_schedule(scheduler, schedule);
+			clear_read_reqs_pending_back_pointers(read_reqs);
+			resources.return_req_to_pool(iget_req);
+			return ret;
+		}
+	}
+
+	nccl_net_ofi_release_schedule(scheduler, schedule);
+
+	*request = iget_req;
+	return 0;
+}
+
 static inline uint32_t get_peer_rank(fi_addr_t src_addr,
 				     std::unordered_map<fi_addr_t, uint32_t> &rank_map)
 {

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -280,7 +280,7 @@ ncclResult_t nccl_ofi_gin_closeListen(void *listenComm)
 
 static ncclResult_t nccl_ofi_gin_test(void *collComm, void *request, int *done)
 {
-	auto *req = static_cast<nccl_ofi_rdma_gin_iputsignal_req *>(request);
+	auto *req = static_cast<nccl_ofi_gin_req_t *>(request);
 	int ret = req->test(done);
 	return nccl_net_ofi_retval_translate(ret);
 }
@@ -314,6 +314,24 @@ static ncclResult_t nccl_ofi_gin_iput(void *collComm, uint64_t srcOff, void *src
 	   iputSignal with a zero'd signal address (instead of a write-without-immediate) */
 	return nccl_ofi_gin_iputSignal(collComm, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
 				       0, nullptr, 0, 0, request);
+}
+
+static ncclResult_t nccl_ofi_gin_iget(void *collComm, uint64_t remoteOff, void *remoteMhandle,
+				      size_t size, uint64_t localOff, void *localMhandle,
+				      uint32_t rank, void **request)
+{
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	auto *remote_mr = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(remoteMhandle);
+	auto *local_mr = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(localMhandle);
+
+	nccl_ofi_gin_req_t *req = nullptr;
+	int ret = gin_comm->iget(remoteOff, remote_mr, size, localOff, local_mr, rank, &req);
+	if (ret != 0) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
+
+	*request = req;
+	return ncclSuccess;
 }
 
 ncclResult_t nccl_ofi_gin_finalize(void *ctx)
@@ -416,6 +434,14 @@ static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint6
 				       signalValue, signalOp, request);
 }
 
+static ncclResult_t nccl_ofi_gin_iget_v13(void *ginCtx, int context, uint64_t remoteOff,
+					  void *remoteMhandle, size_t size, uint64_t localOff,
+					  void *localMhandle, uint32_t rank, void **request)
+{
+	return nccl_ofi_gin_iget(ginCtx, remoteOff, remoteMhandle, size,
+				 localOff, localMhandle, rank, request);
+}
+
 NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	/* Since there is no equivalent of NCCL_NET for GIN, currently we don't
 	   have name fixup depending on env var like nvidia_plugin_name_fixup().
@@ -461,7 +487,7 @@ NCCL_OFI_EXPORT_SYMBOL ncclGin_v13_t ncclGinPlugin_v13 = {
 	.closeListen = nccl_ofi_gin_closeListen,
 	.iput = nccl_ofi_gin_iput_v13,
 	.iputSignal = nccl_ofi_gin_iputSignal_v13,
-	.iget = nullptr,
+	.iget = nccl_ofi_gin_iget_v13,
 	.iflush = nullptr,
 	.test = nccl_ofi_gin_test,
 	.ginProgress = nccl_ofi_gin_ginProgress,

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -300,3 +300,43 @@ nccl_net_ofi_gin_metadata_send_req_t::~nccl_net_ofi_gin_metadata_send_req_t()
 {
 	metadata_fl->entry_free(metadata_elem);
 }
+
+int nccl_net_ofi_gin_read_req_t::post()
+{
+	ssize_t rc = fi_read(ep, local_buf, size, desc, remote_addr,
+			     remote_offset, remote_key, &ctx.ofi_ctx);
+
+	if (rc != 0 && rc != -FI_EAGAIN) {
+		NCCL_OFI_WARN("Failed call to fi_read; RC: %zd", rc);
+	}
+
+	return rc;
+}
+
+int nccl_net_ofi_gin_read_req_t::handle_cq_entry(struct fi_cq_entry * /*cq_entry_base*/,
+						 fi_addr_t /*src_addr*/, uint16_t /*rail_id*/)
+{
+	if (OFI_LIKELY(pending_flag != nullptr)) {
+		*pending_flag = false;
+	}
+
+	resources.return_req_to_pool(this);
+
+	return 0;
+}
+
+int nccl_ofi_gin_iget_req::test(int *done)
+{
+	*done = 0;
+	if (OFI_UNLIKELY(any_reqs_pending == 0)) {
+		*done = 1;
+		auto &gin_ep = resources.get_ep();
+		std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+		resources.return_req_to_pool(this);
+	}
+	/* If subrequests are still pending, NCCL's progress thread continually
+	   calls ginProgress, which drives CQ processing and clears pending
+	   flags as completions arrive. */
+
+	return 0;
+}

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -175,8 +175,8 @@ static int set_mr_req_attr(uint64_t mr_key, nccl_ofi_mr_ckey_ref ckey, uint64_t 
 {
 	int ret = 0;
 
-	/* Basic put-signal access */
-	mr_attr->access = FI_WRITE | FI_REMOTE_WRITE;
+	/* Basic put-signal access + read access for iget */
+	mr_attr->access = FI_WRITE | FI_REMOTE_WRITE | FI_READ | FI_REMOTE_READ;
 	nccl_ofi_mr_ckey_fill_mr_attrs(ckey, mr_attr, flags);
 
 	switch (type) {

--- a/tests/functional/gin.cpp
+++ b/tests/functional/gin.cpp
@@ -276,9 +276,55 @@ int main(int argc, char *argv[])
 	}
 
 	/* Verification */
-	NCCL_OFI_INFO(NCCL_NET, "Verifying result..");
+	NCCL_OFI_INFO(NCCL_NET, "=== Verifying iput/iputSignal result ===");
 	OFINCCLCHECK(verify_buff(rank, put_buff, send_val));
 	OFINCCLCHECK(verify_buff(rank, put_signal_buff, send_val));
+
+	/*
+	 * iget test: rank 0 registers a buffer filled with a distinct value
+	 * (iget_val=99). Rank 1+ uses iget to read it into a local buffer
+	 * (initialized to 0), then verifies the contents are 99.
+	 * This ensures the data came from the remote read, not stale local
+	 * state or leftover iput data (which uses send_val=42).
+	 */
+	const int iget_val = 99;
+	void *get_src_buff = nullptr;
+	void *get_src_mhandle = nullptr;
+	OFINCCLCHECK(alloc_and_reg_buff(extGin, collComm, SEND_SIZE, buffer_type,
+					(rank == 0) ? iget_val : 0, &get_src_buff,
+					&get_src_mhandle));
+
+	void *get_buff = nullptr;
+	void *get_mhandle = nullptr;
+	OFINCCLCHECK(alloc_and_reg_buff(extGin, collComm, SEND_SIZE, buffer_type, 0, &get_buff,
+					&get_mhandle));
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank != 0) {
+		std::deque<void *> get_request_deque;
+
+		void *request = nullptr;
+		OFINCCLCHECK(extGin->iget(proxyCtx, 0, 0, get_src_mhandle, SEND_SIZE, 0,
+					  get_mhandle, 0, &request));
+		assert(request != nullptr);
+		get_request_deque.push_back(request);
+
+		while (!get_request_deque.empty()) {
+			OFINCCLCHECK(poll_request_completion(extGin, get_request_deque, collComm,
+							    proxyCtx));
+		}
+
+		NCCL_OFI_INFO(NCCL_NET, "=== Verifying iget result ===");
+		OFINCCLCHECK(verify_buff(rank, get_buff, iget_val));
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	OFINCCLCHECK(extGin->deregMrSym(collComm, get_src_mhandle));
+	get_src_mhandle = nullptr;
+	OFINCCLCHECK(extGin->deregMrSym(collComm, get_mhandle));
+	get_mhandle = nullptr;
 
 	/* Cleanup APIs */
 	OFINCCLCHECK(extGin->deregMrSym(collComm, signal_mhandle));
@@ -305,6 +351,10 @@ int main(int argc, char *argv[])
 	MPI_Finalize();
 
 	/* Clean up local resources */
+	OFINCCLCHECK(deallocate_buffer(get_src_buff, buffer_type));
+	get_src_buff = nullptr;
+	OFINCCLCHECK(deallocate_buffer(get_buff, buffer_type));
+	get_buff = nullptr;
 	OFINCCLCHECK(deallocate_buffer(signal_buf, buffer_type));
 	signal_buf = nullptr;
 	OFINCCLCHECK(deallocate_buffer(put_signal_buff, buffer_type));


### PR DESCRIPTION
*Description of changes:*
`iget` performs a one-sided RDMA read from a remote peer's registered GPU memory into the caller's local buffer. After symmetric MR registration (which allgathers keys across all ranks), the initiator looks up the remote rank's MR keys and base address, uses the multi-rail scheduler to stripe the transfer across available NICs, and posts one fi_read per stripe.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
