### PR TITLE
Fix grouped recv completion tracking for multi-recv

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -389,12 +389,6 @@ typedef struct {
 typedef struct {
 	/* Pointer to recv parent request */
 	nccl_net_ofi_rdma_req *recv_req;
-	/* For grouped receives: running total of expected segments across all senders.
-	 * Updated dynamically as we learn each sender's segment count from immediate data. */
-	int total_expected_segms;
-	/* Number of distinct senders whose segment count we've registered */
-	int num_senders_registered;
-	int num_expected_senders;
 } rdma_req_recv_segms_data_t;
 
 /*

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -542,16 +542,14 @@ static inline void set_request_state_to_error(nccl_net_ofi_rdma_req *req)
  * To update the state of subrequests, use the subrequest specific
  * update functions.
  *
- * @param	req
- *		The request
+ * @param	recv_data
+ *		The recv data
  * @param	size
  *		Size of the completion
- * @param	total_ncompls
- *		Total number of expected request completions
  * @return	0, on success
  *		non-zero, on error
  */
-static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req, size_t size, int total_nsegms);
+static inline int inc_recv_seg_completion(rdma_req_recv_data_t *recv_data, size_t size);
 
 static inline int inc_req_completion(nccl_net_ofi_rdma_req *req,
 				     size_t size, int total_ncompls)
@@ -624,7 +622,7 @@ static inline int set_eager_copy_completed(nccl_net_ofi_rdma_req *req)
 
 	/* Add completion to parent request */
 	if (recv_data->num_recvs > 1) {
-		ret = inc_recv_seg_completion(recv_data->recv_segms_req, size, recv_data->num_recvs);
+		ret = inc_recv_seg_completion(recv_data, size);
 	} else {
 		ret = inc_req_completion(recv_req, size, recv_data->total_num_compls);
 	}
@@ -682,13 +680,14 @@ static inline int set_write_ctrl_completed(nccl_net_ofi_rdma_req *req)
  * @return	0, on success
  *		non-zero, on error
  */
-static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
-					  size_t size, int total_nsegms)
+static inline int inc_recv_seg_completion(rdma_req_recv_data_t *recv_data,
+					  size_t size)
 {
-	assert(req->type == NCCL_OFI_RDMA_RECV_SEGMS);
 	int ret = 0;
 	bool segms_received;
-	
+	nccl_net_ofi_rdma_req *req = recv_data->recv_segms_req;
+	assert(req->type == NCCL_OFI_RDMA_RECV_SEGMS);
+
 	nccl_net_ofi_mutex_lock(&req->req_lock);
 
 	rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(req);
@@ -700,13 +699,12 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
 
 	/* The arrival of the last sub req is treated as a single
 	 * request completion of the parent request */
-	segms_received = (req->ncompls == total_nsegms);
+	segms_received = (req->ncompls == recv_data->num_recvs);
 
 	/* Mark receive segments request and receive request as completed */
 	if (segms_received) {
 		/* recv_segms_data already available from outer scope */
 		nccl_net_ofi_rdma_req *recv_req = recv_segms_data->recv_req;
-		rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 
 		/* Total number of completions have arrived */
 		req->state = NCCL_OFI_RDMA_REQ_COMPLETED;
@@ -937,7 +935,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 			return ret;
 		}
 		if (recv_data->num_recvs > 1) {
-			ret = inc_recv_seg_completion(recv_data->recv_segms_req, 0, recv_data->num_recvs);
+			ret = inc_recv_seg_completion(recv_data, 0);
 		} else {
 			ret = inc_req_completion(recv_req, 0, recv_data->total_num_compls);
 		}
@@ -1125,7 +1123,6 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 	assert(req->type == NCCL_OFI_RDMA_RECV);
 
 	rdma_req_recv_data_t *recv_data = get_recv_data(req);
-	nccl_net_ofi_rdma_req *recv_segms_req = recv_data->recv_segms_req;
 
 	uint64_t total_segms = GET_NUM_SEG_FROM_IMM(cq_entry->data);
 	uint8_t recv_idx = GET_RECV_IDX_FROM_IMM(cq_entry->data);
@@ -1137,7 +1134,7 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 
 	/* Only when entire sub recv completed, update parent req */
 	if (recv_data->recvs[recv_idx].ncompls == (int)total_segms) {
-		ret = inc_recv_seg_completion(recv_segms_req, recv_data->recvs[recv_idx].recv_size, recv_data->num_recvs);
+		ret = inc_recv_seg_completion(recv_data, recv_data->recvs[recv_idx].recv_size);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
 		}

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -624,7 +624,7 @@ static inline int set_eager_copy_completed(nccl_net_ofi_rdma_req *req)
 
 	/* Add completion to parent request */
 	if (recv_data->num_recvs > 1) {
-		ret = inc_recv_seg_completion(recv_data->recv_segms_req, size, 1);
+		ret = inc_recv_seg_completion(recv_data->recv_segms_req, size, recv_data->num_recvs);
 	} else {
 		ret = inc_req_completion(recv_req, size, recv_data->total_num_compls);
 	}
@@ -698,23 +698,10 @@ static inline int inc_recv_seg_completion(nccl_net_ofi_rdma_req *req,
 	/* Sum up number of segments */
 	req->ncompls++;
 
-	/* Detect when a completion belongs to a new sender we haven't
-	 * registered yet. Each sender's first segment pushes ncompls past
-	 * the sum of all previously registered senders' segment counts.
-	 * When that happens, we register this sender's total_nsegms.
-	 * For single recv (1 sender), this fires once on the first completion.
-	 * For grouped recv (N senders), this fires N times as each sender's
-	 * first completion crosses the running total. */
-	if (req->ncompls > recv_segms_data->total_expected_segms) {
-		recv_segms_data->total_expected_segms += total_nsegms;
-		recv_segms_data->num_senders_registered++;
-	}
-
-	/* The arrival of the last segment is treated as a single
+	/* The arrival of the last sub req is treated as a single
 	 * request completion of the parent request */
-	segms_received = (req->ncompls == recv_segms_data->total_expected_segms) &&
-			   (recv_segms_data->num_senders_registered == recv_segms_data->num_expected_senders);
-	
+	segms_received = (req->ncompls == total_nsegms);
+
 	/* Mark receive segments request and receive request as completed */
 	if (segms_received) {
 		/* recv_segms_data already available from outer scope */
@@ -950,7 +937,7 @@ static inline int handle_eager_recv(nccl_net_ofi_rdma_recv_comm *r_comm,
 			return ret;
 		}
 		if (recv_data->num_recvs > 1) {
-			ret = inc_recv_seg_completion(recv_data->recv_segms_req, 0, 1);
+			ret = inc_recv_seg_completion(recv_data->recv_segms_req, 0, recv_data->num_recvs);
 		} else {
 			ret = inc_req_completion(recv_req, 0, recv_data->total_num_compls);
 		}
@@ -1143,12 +1130,17 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 	uint64_t total_segms = GET_NUM_SEG_FROM_IMM(cq_entry->data);
 	uint8_t recv_idx = GET_RECV_IDX_FROM_IMM(cq_entry->data);
 
-	/* Accumulate per-sub-receive size for grouped receives */
+	/* Accumulate per-sub-receive size and ncompls for grouped receives */
 	recv_data->recvs[recv_idx].recv_size += cq_entry->len;
+	recv_data->recvs[recv_idx].total_segms = total_segms;
+	recv_data->recvs[recv_idx].ncompls++;
 
-	ret = inc_recv_seg_completion(recv_segms_req, cq_entry->len, total_segms);
-	if (OFI_UNLIKELY(ret != 0)) {
-		return ret;
+	/* Only when entire sub recv completed, update parent req */
+	if (recv_data->recvs[recv_idx].ncompls == (int)total_segms) {
+		ret = inc_recv_seg_completion(recv_segms_req, recv_data->recvs[recv_idx].recv_size, recv_data->num_recvs);
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
 	}
 
 	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(req->dev_id, rail_id, req->comm, cq_entry->len, req, req->msg_seq_num);
@@ -2948,9 +2940,6 @@ static inline int insert_recv_segms_req(
 
 	rdma_req_recv_segms_data_t *recv_segms_data = get_recv_segms_data(recv_segms_req);
 	recv_segms_data->recv_req = recv_req;
-	recv_segms_data->total_expected_segms = 0;
-	recv_segms_data->num_senders_registered = 0;
-	recv_segms_data->num_expected_senders = num_recvs;
 
 	rdma_req_recv_data_t *recv_data = get_recv_data(recv_req);
 	recv_data->recv_segms_req = recv_segms_req;

--- a/tests/functional/grouped_recv.cpp
+++ b/tests/functional/grouped_recv.cpp
@@ -241,22 +241,438 @@ private:
 		}
 	}
 };
+/*
+ * Pattern-based tests below exercise realistic multi-recv traffic patterns
+ * observed in production NCCL alltoall workloads.
+ */
+static constexpr size_t BUF_SIZE = 524288;   /* 512KB - matches NCCL_P2P_NET_CHUNKSIZE */
+static constexpr size_t LARGE_SEND = 262144; /* 256KB - dominant send size in traces */
+
+struct Phase {
+	int sends_per_recv;
+	int num_recvs;
+};
+
+static const Phase pattern[] = {
+	{8, 20}, {3, 1}, {8, 10}, {4, 1}, {1, 1}, {8, 10},
+	{7, 1}, {5, 1}, {8, 4}, {2, 1}, {1, 1}, {8, 4}, {7, 1},
+};
+static constexpr int NUM_PHASES = sizeof(pattern) / sizeof(pattern[0]);
+
+class GroupedRecvPatternTest : public TestScenario {
+public:
+	explicit GroupedRecvPatternTest(size_t sz = LARGE_SEND)
+		: TestScenario("Grouped Recv Pattern Test (send_size=" + std::to_string(sz) + ")"),
+		  send_size(sz) {}
+
+	void run(ThreadContext& ctx) override {
+		test_nccl_properties_t props = {};
+		OFINCCLTHROW(ext_net->getProperties(0, &props));
+
+		if (props.maxRecvs < MAX_RECVS) {
+			NCCL_OFI_INFO(NCCL_NET,
+				"Skipping: maxRecvs=%d < %d", props.maxRecvs, MAX_RECVS);
+			return;
+		}
+
+		for (size_t dev_idx = 0; dev_idx < ctx.lcomms.size(); dev_idx++) {
+			run_pattern(ctx, dev_idx);
+		}
+	}
+
+private:
+	size_t send_size;
+	static constexpr int TAG = 1;
+
+	void run_pattern(ThreadContext& ctx, int dev_idx) {
+		void *sComm = ctx.scomms[dev_idx];
+		void *rComm = ctx.rcomms[dev_idx];
+
+		auto gdr_support = get_support_gdr(ext_net);
+		int buffer_type = gdr_support[dev_idx] ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+
+		if (ctx.rank == 0) {
+			sender_side(sComm, buffer_type);
+		} else {
+			receiver_side(rComm, buffer_type);
+		}
+	}
+
+	void sender_side(void* sComm, int buffer_type) {
+		void* send_bufs[MAX_RECVS] = {};
+		void* send_mh[MAX_RECVS] = {};
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&send_bufs[i], send_size, buffer_type));
+			OFINCCLTHROW(initialize_buff(send_bufs[i], send_size, buffer_type, 'A' + i));
+			OFINCCLTHROW(ext_net->regMr(sComm, send_bufs[i], send_size, buffer_type, &send_mh[i]));
+		}
+
+		for (int p = 0; p < NUM_PHASES; p++) {
+			int n_sends = pattern[p].sends_per_recv;
+			int n_recvs = pattern[p].num_recvs;
+
+			for (int r = 0; r < n_recvs; r++) {
+				void* send_reqs[MAX_RECVS] = {};
+				for (int i = 0; i < n_sends; i++) {
+					post_send(ext_net, sComm, send_bufs[i], send_size,
+						  TAG, send_mh[i], &send_reqs[i]);
+				}
+
+				bool all_done = false;
+				while (!all_done) {
+					all_done = true;
+					for (int i = 0; i < n_sends; i++) {
+						if (send_reqs[i]) {
+							int done = 0;
+							OFINCCLTHROW(ext_net->test(send_reqs[i], &done, nullptr));
+							if (done) send_reqs[i] = nullptr;
+							else all_done = false;
+						}
+					}
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(sComm, send_mh[i]);
+			deallocate_buffer(send_bufs[i], buffer_type);
+		}
+	}
+
+	void receiver_side(void* rComm, int buffer_type) {
+		void* recv_bufs[MAX_RECVS] = {};
+		void* recv_mh[MAX_RECVS] = {};
+		size_t sizes[MAX_RECVS];
+		int tags[MAX_RECVS];
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&recv_bufs[i], BUF_SIZE, buffer_type));
+			OFINCCLTHROW(ext_net->regMr(rComm, recv_bufs[i], BUF_SIZE, buffer_type, &recv_mh[i]));
+			sizes[i] = BUF_SIZE;
+			tags[i] = TAG;
+		}
+
+		for (int p = 0; p < NUM_PHASES; p++) {
+			int n = pattern[p].sends_per_recv;
+			int num_recvs = pattern[p].num_recvs;
+
+			for (int r = 0; r < num_recvs; r++) {
+				void* request = nullptr;
+				post_recv(ext_net, rComm, n, recv_bufs, sizes, tags,
+					  recv_mh, &request);
+
+				int done = 0;
+				int recv_sizes[MAX_RECVS] = {};
+				while (!done) {
+					OFINCCLTHROW(ext_net->test(request, &done, recv_sizes));
+				}
+
+				for (int i = 0; i < n; i++) {
+					if (recv_sizes[i] != (int)send_size) {
+						throw std::runtime_error(
+							"Phase " + std::to_string(p) +
+							" recv " + std::to_string(r) +
+							" sub " + std::to_string(i) +
+							": expected " + std::to_string(send_size) +
+							" got " + std::to_string(recv_sizes[i]));
+					}
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(rComm, recv_mh[i]);
+			deallocate_buffer(recv_bufs[i], buffer_type);
+		}
+	}
+};
+
+/*
+ * Alternating uniform 256KB and variable sizes, always n=8.
+ */
+class GroupedRecvMixedPatternTest : public TestScenario {
+public:
+	GroupedRecvMixedPatternTest()
+		: TestScenario("Grouped Recv Mixed Pattern (alternating uniform/variable sizes)") {}
+
+	void run(ThreadContext& ctx) override {
+		test_nccl_properties_t props = {};
+		OFINCCLTHROW(ext_net->getProperties(0, &props));
+
+		if (props.maxRecvs < MAX_RECVS) {
+			NCCL_OFI_INFO(NCCL_NET,
+				"Skipping: maxRecvs=%d < %d", props.maxRecvs, MAX_RECVS);
+			return;
+		}
+
+		for (size_t dev_idx = 0; dev_idx < ctx.lcomms.size(); dev_idx++) {
+			run_mixed(ctx, dev_idx);
+		}
+	}
+
+private:
+	static constexpr size_t var_sizes[MAX_RECVS] = {
+		67256, 89968, 134984, 55608, 147104, 53024, 157472, 101080
+	};
+	static constexpr int NUM_ITERATIONS = 10;
+	static constexpr int TAG = 1;
+
+	void run_mixed(ThreadContext& ctx, int dev_idx) {
+		void *sComm = ctx.scomms[dev_idx];
+		void *rComm = ctx.rcomms[dev_idx];
+
+		auto gdr_support = get_support_gdr(ext_net);
+		int buffer_type = gdr_support[dev_idx] ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+
+		if (ctx.rank == 0) {
+			mixed_sender(sComm, buffer_type);
+		} else {
+			mixed_receiver(rComm, buffer_type);
+		}
+	}
+
+	void mixed_sender(void* sComm, int buffer_type) {
+		void* send_bufs[MAX_RECVS] = {};
+		void* send_mh[MAX_RECVS] = {};
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&send_bufs[i], LARGE_SEND, buffer_type));
+			OFINCCLTHROW(initialize_buff(send_bufs[i], LARGE_SEND, buffer_type, 'A' + i));
+			OFINCCLTHROW(ext_net->regMr(sComm, send_bufs[i], LARGE_SEND, buffer_type, &send_mh[i]));
+		}
+
+		for (int iter = 0; iter < NUM_ITERATIONS; iter++) {
+			void* send_reqs[MAX_RECVS] = {};
+
+			for (int i = 0; i < MAX_RECVS; i++) {
+				size_t sz = (iter % 2 == 0) ? LARGE_SEND : var_sizes[i];
+				post_send(ext_net, sComm, send_bufs[i], sz,
+					  TAG, send_mh[i], &send_reqs[i]);
+			}
+
+			bool all_done = false;
+			while (!all_done) {
+				all_done = true;
+				for (int i = 0; i < MAX_RECVS; i++) {
+					if (send_reqs[i]) {
+						int done = 0;
+						OFINCCLTHROW(ext_net->test(send_reqs[i], &done, nullptr));
+						if (done) send_reqs[i] = nullptr;
+						else all_done = false;
+					}
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(sComm, send_mh[i]);
+			deallocate_buffer(send_bufs[i], buffer_type);
+		}
+	}
+
+	void mixed_receiver(void* rComm, int buffer_type) {
+		void* recv_bufs[MAX_RECVS] = {};
+		void* recv_mh[MAX_RECVS] = {};
+		size_t sizes[MAX_RECVS];
+		int tags[MAX_RECVS];
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&recv_bufs[i], BUF_SIZE, buffer_type));
+			OFINCCLTHROW(ext_net->regMr(rComm, recv_bufs[i], BUF_SIZE, buffer_type, &recv_mh[i]));
+			sizes[i] = BUF_SIZE;
+			tags[i] = TAG;
+		}
+
+		for (int iter = 0; iter < NUM_ITERATIONS; iter++) {
+			void* request = nullptr;
+			post_recv(ext_net, rComm, MAX_RECVS, recv_bufs, sizes, tags,
+				  recv_mh, &request);
+
+			int done = 0;
+			int recv_sizes[MAX_RECVS] = {};
+			while (!done) {
+				OFINCCLTHROW(ext_net->test(request, &done, recv_sizes));
+			}
+
+			for (int i = 0; i < MAX_RECVS; i++) {
+				size_t expected = (iter % 2 == 0) ? LARGE_SEND : var_sizes[i];
+				if (recv_sizes[i] != (int)expected) {
+					throw std::runtime_error(
+						"Iter " + std::to_string(iter) +
+						" sub " + std::to_string(i) +
+						": expected " + std::to_string(expected) +
+						" got " + std::to_string(recv_sizes[i]));
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(rComm, recv_mh[i]);
+			deallocate_buffer(recv_bufs[i], buffer_type);
+		}
+	}
+};
+
+/*
+ * Variable num_recvs (1..8) with variable sizes within each group.
+ */
+class GroupedRecvMixedNumRecvsAndSizesTest : public TestScenario {
+public:
+	GroupedRecvMixedNumRecvsAndSizesTest()
+		: TestScenario("Grouped Recv Mixed num_recvs + sizes") {}
+
+	void run(ThreadContext& ctx) override {
+		test_nccl_properties_t props = {};
+		OFINCCLTHROW(ext_net->getProperties(0, &props));
+
+		if (props.maxRecvs < MAX_RECVS) {
+			NCCL_OFI_INFO(NCCL_NET,
+				"Skipping: maxRecvs=%d < %d", props.maxRecvs, MAX_RECVS);
+			return;
+		}
+
+		for (size_t dev_idx = 0; dev_idx < ctx.lcomms.size(); dev_idx++) {
+			run_test(ctx, dev_idx);
+		}
+	}
+
+private:
+	struct Group {
+		int num_sends;
+		size_t sizes[MAX_RECVS];
+	};
+
+	static constexpr Group groups[] = {
+		{8, {262144, 131072, 65536, 262144, 32768, 131072, 65536, 262144}},
+		{1, {262144}},
+		{8, {67256, 89968, 134984, 55608, 147104, 53024, 157472, 101080}},
+		{1, {32768}},
+		{4, {262144, 131072, 65536, 262144}},
+		{8, {262144, 262144, 262144, 262144, 262144, 262144, 262144, 262144}},
+		{1, {65536}},
+		{2, {131072, 262144}},
+		{8, {32768, 65536, 131072, 262144, 262144, 131072, 65536, 32768}},
+		{1, {131072}},
+		{3, {262144, 67256, 134984}},
+		{8, {147104, 53024, 157472, 101080, 67256, 89968, 262144, 131072}},
+	};
+	static constexpr int NUM_GROUPS = sizeof(groups) / sizeof(groups[0]);
+	static constexpr int NUM_ITERATIONS = 5;
+	static constexpr int TAG = 1;
+
+	void run_test(ThreadContext& ctx, int dev_idx) {
+		void *sComm = ctx.scomms[dev_idx];
+		void *rComm = ctx.rcomms[dev_idx];
+
+		auto gdr_support = get_support_gdr(ext_net);
+		int buffer_type = gdr_support[dev_idx] ? NCCL_PTR_CUDA : NCCL_PTR_HOST;
+
+		if (ctx.rank == 0) {
+			sender(sComm, buffer_type);
+		} else {
+			receiver(rComm, buffer_type);
+		}
+	}
+
+	void sender(void* sComm, int buffer_type) {
+		void* send_bufs[MAX_RECVS] = {};
+		void* send_mh[MAX_RECVS] = {};
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&send_bufs[i], LARGE_SEND, buffer_type));
+			OFINCCLTHROW(initialize_buff(send_bufs[i], LARGE_SEND, buffer_type, 'A' + i));
+			OFINCCLTHROW(ext_net->regMr(sComm, send_bufs[i], LARGE_SEND, buffer_type, &send_mh[i]));
+		}
+
+		for (int iter = 0; iter < NUM_ITERATIONS; iter++) {
+			for (int g = 0; g < NUM_GROUPS; g++) {
+				const Group& grp = groups[g];
+				void* send_reqs[MAX_RECVS] = {};
+
+				for (int i = 0; i < grp.num_sends; i++) {
+					post_send(ext_net, sComm, send_bufs[i], grp.sizes[i],
+						  TAG, send_mh[i], &send_reqs[i]);
+				}
+
+				bool all_done = false;
+				while (!all_done) {
+					all_done = true;
+					for (int i = 0; i < grp.num_sends; i++) {
+						if (send_reqs[i]) {
+							int done = 0;
+							OFINCCLTHROW(ext_net->test(send_reqs[i], &done, nullptr));
+							if (done) send_reqs[i] = nullptr;
+							else all_done = false;
+						}
+					}
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(sComm, send_mh[i]);
+			deallocate_buffer(send_bufs[i], buffer_type);
+		}
+	}
+
+	void receiver(void* rComm, int buffer_type) {
+		void* recv_bufs[MAX_RECVS] = {};
+		void* recv_mh[MAX_RECVS] = {};
+		size_t sizes[MAX_RECVS];
+		int tags[MAX_RECVS];
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			OFINCCLTHROW(allocate_buff(&recv_bufs[i], BUF_SIZE, buffer_type));
+			OFINCCLTHROW(ext_net->regMr(rComm, recv_bufs[i], BUF_SIZE, buffer_type, &recv_mh[i]));
+			sizes[i] = BUF_SIZE;
+			tags[i] = TAG;
+		}
+
+		for (int iter = 0; iter < NUM_ITERATIONS; iter++) {
+			for (int g = 0; g < NUM_GROUPS; g++) {
+				const Group& grp = groups[g];
+				void* request = nullptr;
+
+				post_recv(ext_net, rComm, grp.num_sends, recv_bufs, sizes,
+					  tags, recv_mh, &request);
+
+				int done = 0;
+				int recv_sizes[MAX_RECVS] = {};
+				while (!done) {
+					OFINCCLTHROW(ext_net->test(request, &done, recv_sizes));
+				}
+
+				for (int i = 0; i < grp.num_sends; i++) {
+					if (recv_sizes[i] != (int)grp.sizes[i]) {
+						throw std::runtime_error(
+							"Iter " + std::to_string(iter) +
+							" group " + std::to_string(g) +
+							" sub " + std::to_string(i) +
+							": expected " + std::to_string(grp.sizes[i]) +
+							" got " + std::to_string(recv_sizes[i]));
+					}
+				}
+			}
+		}
+
+		for (int i = 0; i < MAX_RECVS; i++) {
+			ext_net->deregMr(rComm, recv_mh[i]);
+			deallocate_buffer(recv_bufs[i], buffer_type);
+		}
+	}
+};
+
 int main(int argc, char* argv[])
 {
 	/* Disable eager to avoid 2-iovec sends with mixed host/device memory */
 	setenv("OFI_NCCL_EAGER_MAX_SIZE", "-1", 0);
 	TestSuite suite;
 
-	/* n=1: regression test (should always work) */
+	/* Basic grouped recv tests */
 	GroupedRecvTest test_n1(1);
-
-	/* n=2: basic grouped receive */
 	GroupedRecvTest test_n2(2);
-
-	/* n=8: maximum grouped receive */
 	GroupedRecvTest test_n8(8);
-
-	/* n=8 with larger buffers */
 	GroupedRecvTest test_n8_large(8, 1024 * 1024);
 
 	suite.add(&test_n1);
@@ -269,6 +685,15 @@ int main(int argc, char* argv[])
 	GroupedRecvMixedSizeTest test_mixed_n4(4);
 	suite.add(&test_mixed_n2);
 	suite.add(&test_mixed_n4);
+
+	/* Pattern-based tests */
+	GroupedRecvPatternTest pattern_test;
+	GroupedRecvMixedPatternTest mixed_pattern_test;
+	GroupedRecvMixedNumRecvsAndSizesTest mixed_both_test;
+
+	suite.add(&pattern_test);
+	suite.add(&mixed_pattern_test);
+	suite.add(&mixed_both_test);
 
 	return suite.run_all();
 }


### PR DESCRIPTION
**Summary**

Fixes a bug in the RDMA protocol where a grouped receive request (irecv with n > 1) could fail to complete even after all RDMA writes were received, when using multi-rail.

**Problem**

The completion logic for grouped receives used a heuristic to detect when segments from a new sender arrived: it tracked a running total_expected_segms and assumed that when ncompls exceeded it, a new sender's segments had started arriving. This was incorrect with multi-rail:

  - With multi-rail, each send is split into multiple segments across rails
  - Segments from different sub-receives can complete in arbitrary order
  - The heuristic could misattribute a segment to the wrong sender, causing the final completion condition to never be satisfied

Result: all RDMA writes land successfully, but the recv request never completes.

**Fix**

Track completions per sub-receive using the recv_idx from the immediate data. Each sub-receive independently tracks its segment count and completion count. Only when all segments for a sub-receive arrive does it signal the parent. The parent completes when all num_recvs  sub-receives report done.

**Changes:**

  - Remove total_expected_segms, num_senders_registered, num_expected_senders from rdma_req_recv_segms_data_t
  - In handle_write_comp: accumulate per recv_idx, propagate to parent only when that sub-recv is fully done
  - Simplify inc_recv_seg_completion: parent completes when ncompls == num_recvs
  - Fix eager path to pass num_recvs instead of 1
 
**Testing**

  - Added grouped_recv_pattern functional test exercising realistic multi-recv traffic patterns derived from production traces:
    - Varying group sizes (1–8 sends per recv) with phase transitions
    - Mixed message sizes within groups
    - Post-all-then-poll-all pattern repeated 20 times

  - Ran functional tests with multi-rail on p5en (2 nodes)
  - Ran nccl-tests alltoall with multi-recv enabled on p5en (2 nodes)