### PR TITLE
Multirecv tracing and barrier improvements

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -12,11 +12,11 @@
 
 /***** SENDRECV PROTOCOL *****/
 #define NCCL_OFI_TRACE_SEND_SENDRECV(dev, size, comm, msg_seq_num, request, nccl_req) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, 0, msg_seq_num, request, nccl_req); \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm, 0, msg_seq_num, request, nccl_req, 0, 0); \
 } while (0)
 
 #define NCCL_OFI_TRACE_RECV_SENDRECV(dev, comm, size, request, nccl_req) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm, 0, size, request, nccl_req); \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm, 0, size, request, nccl_req, 0); \
 } while(0)
 
 #define NCCL_OFI_TRACE_FLUSH_SENDRECV(request, nccl_req) do { \
@@ -29,10 +29,10 @@
 
 /***** RDMA PROTOCL *****/
 
-#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req) do { \
+#define NCCL_OFI_TRACE_SEND(dev, size, comm, msg_seq_num, request, nccl_req, tag, recv_idx) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Send, dev, size, comm,\
 			     comm->get_data_rail(0)->remote_addr, \
-			     msg_seq_num, request, nccl_req); \
+			     msg_seq_num, request, nccl_req, tag, recv_idx); \
 	NCCL_OFI_TRACE_SEND_NVTX(dev, size, comm, msg_seq_num, request, nccl_req); \
 } while(0)
 
@@ -71,9 +71,9 @@
 	NCCL_OFI_TRACE_SEND_WRITE_SEG_COMPLETE_NVTX(dev, rail_id, comm, msg_seq_num, request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV(dev, comm, size, request, nccl_req) do { \
+#define NCCL_OFI_TRACE_RECV(dev, comm, size, request, nccl_req, num_recvs) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, Recv, dev, comm, \
-			     comm->get_data_rail(0)->remote_addr, size, request, nccl_req); \
+			     comm->get_data_rail(0)->remote_addr, size, request, nccl_req, num_recvs); \
 	NCCL_OFI_TRACE_RECV_NVTX(dev, comm, size, request, nccl_req); \
 } while(0)
 

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -57,7 +57,9 @@ LTTNG_UST_TRACEPOINT_EVENT(
             uint64_t, peer_addr,
             uint16_t, msg_seq_num,
             void *, request,
-            void *, nccl_req
+            void *, nccl_req,
+            int, tag,
+            uint16_t, recv_idx
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
@@ -67,6 +69,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+            lttng_ust_field_integer(int, tag, tag)
+            lttng_ust_field_integer(uint16_t, recv_idx, recv_idx)
     )
 )
 
@@ -243,7 +247,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             uint64_t, peer_addr,
             size_t, size,
             void *, request,
-            void *, nccl_req
+            void *, nccl_req,
+            uint16_t, num_recvs
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
@@ -252,6 +257,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer_hex(uint64_t, nccl_req, (uint64_t)nccl_req)
+            lttng_ust_field_integer(uint16_t, num_recvs, num_recvs)
     )
 )
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2357,6 +2357,11 @@ static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t se
 	if (READ_ONCE(s_comm->ctrl_mailbox[slot].entries[0].msg_seq_num) != expected) {
 		return false;
 	}
+
+	// create barrier point so that no code which depends on a valid
+	// control message is hoisted above the msg_seq_num check
+	std::atomic_thread_fence(std::memory_order_acquire);
+
 	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
 	if (ctrl->entries[0].num_recvs <= 1) {
 		return true;
@@ -5630,8 +5635,6 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 			goto error;
 		}
 	} else if (!in_group || s_comm->group_sends_remaining == s_comm->group_num_recvs) {
-		/* Memory synchronization point - only on first send of a group or non-grouped */
-		std::atomic_thread_fence(std::memory_order_acquire);
 		s_comm->n_ctrl_received += 1;
 	}
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -3270,7 +3270,7 @@ int nccl_net_ofi_rdma_recv_comm::recv(int n, void **buffers,
 	/* At this point, we've successfully inserted a new request, so update the num inflight. */
 	(this->num_inflight_reqs)++;
 
-	NCCL_OFI_TRACE_RECV(device_id, this, sizes[0], req, base_req);
+	NCCL_OFI_TRACE_RECV(device_id, this, sizes[0], req, base_req, n);
 
 	/* Send ctrl msg */
 	this->n_ctrl_sent += 1;
@@ -5667,7 +5667,7 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 		(s_comm->num_inflight_writes)++;
 	}
 
-	NCCL_OFI_TRACE_SEND(req->dev_id, size, s_comm, msg_seq_num, req, base_req);
+	NCCL_OFI_TRACE_SEND(req->dev_id, size, s_comm, msg_seq_num, req, base_req, tag, get_send_data(req)->recv_idx);
 
 	/* Try posting RDMA write for received RDMA control messages */
 	if (have_ctrl || eager) {


### PR DESCRIPTION
Two slightly unrelated changes related in that they touch multirecv.  First, fix a hypothetical issue where we load the num_recvs value before verifying that the ready bit is set.  Second, add some multirecv-related tracing data to the rdma interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
