### PR TITLE
Thread Analysis: Make plugin and device things const

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -15,6 +15,7 @@
 #include <rdma/fi_cm.h>
 #include <rdma/fi_tagged.h>
 #include <rdma/fi_rma.h>
+#include <string>
 #include <nccl/net.h>
 
 #include "nccl_ofi_log.h"
@@ -332,26 +333,26 @@ public:
 	const nccl_net_ofi_plugin_t *const plugin = nullptr;
 
 	/* this device's index in the plugin's devices array */
-	int dev_id;
+	const int dev_id;
 
 	/*
 	 * Globally unique identifier for the device. An opaque identifier
 	 * returned to NCCL without assumptions about individual platforms.
 	 */
-	uint64_t guid;
+	const uint64_t guid;
 
 	/*
 	 * name of the device - should include the provider name, but may be
 	 * augmented (in the case of mrail).  Set during the transport's
 	 * initialization, and should be read-only from that point.
 	 */
-	char *name = nullptr;
+	const std::string name;
 
 	/* do we need to use an mr rkey pool?  This is a
 	 * provider-specific behavior determined when providers are
 	 * selected.
 	 */
-	bool need_mr_rkey_pool;
+	const bool need_mr_rkey_pool;
 
 	/* Lock for concurrency since domains can be shared by
 	 * multiple entities. */
@@ -362,9 +363,11 @@ public:
 	 * 
 	 * Releases resources associated with base device.
 	 */
-	virtual ~nccl_net_ofi_device_t();
+	virtual ~nccl_net_ofi_device_t() = default;
 
 protected:
+
+	static bool compute_need_mr_rkey_pool(struct fi_info *info);
 
 	/*
 	 * create a new domain.  This funcion is a private pure

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -738,7 +738,8 @@ public:
 	 * is called from nccl_net_ofi_create_plugin() and should properly resize the p_devs vector
 	 * to the number of devices derived from the created topology.
 	 */
-	nccl_net_ofi_plugin_t()
+	nccl_net_ofi_plugin_t(const nccl_ofi_topo_t *topo_arg)
+		: topo(topo_arg)
 	{}
 
 	/**
@@ -748,8 +749,9 @@ public:
 	 * This is expected to be called from the transport-specific SENDRECV plugin creation
 	 * function, which is called from nccl_net_ofi_create_plugin().
 	 */
-	nccl_net_ofi_plugin_t(size_t num_devices)
-		: p_devs(num_devices, nullptr)
+	nccl_net_ofi_plugin_t(size_t num_devices, const nccl_ofi_topo_t *topo_arg)
+		: p_devs(num_devices, nullptr),
+		  topo(topo_arg)
 	{
 		/* Validate that at least one Libfabric NIC was found */
 		assert(!p_devs.empty());
@@ -823,7 +825,7 @@ public:
 	 * data.  Plugins must not free this pointer; the static
 	 * unique_ptr handles cleanup automatically.
 	 */
-	nccl_ofi_topo_t *topo = nullptr;
+	const nccl_ofi_topo_t *const topo = nullptr;
 };
 
 

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -800,6 +800,11 @@ public:
 		return p_devs.size();
 	}
 
+	inline const nccl_ofi_topo_t *get_topo() const
+	{
+		return topo;
+	}
+
 	/**
 	 * @brief	Set properties obtained from libfabric NIC Info.
 	 *
@@ -813,7 +818,6 @@ protected:
 	/* Array of devices */
 	std::vector<nccl_net_ofi_device_t *> p_devs;
 
-public:
 	/*
 	 * Hardware topology (non-owning pointer).
 	 *

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -283,7 +283,7 @@ public:
 	 * Expectation is that this will be called by a transport's device
 	 * constructor 
 	 */
-	nccl_net_ofi_device_t(nccl_net_ofi_plugin_t *plugin_arg,
+	nccl_net_ofi_device_t(const nccl_net_ofi_plugin_t *plugin_arg,
 			      int device_index,
 			      struct fi_info *info);
 
@@ -329,7 +329,7 @@ public:
 	 */
 	void remove_domain_from_map(nccl_net_ofi_domain_t *domain);
 
-	nccl_net_ofi_plugin_t *plugin = nullptr;
+	const nccl_net_ofi_plugin_t *const plugin = nullptr;
 
 	/* this device's index in the plugin's devices array */
 	int dev_id;
@@ -786,7 +786,7 @@ public:
 		return 0;
 	}
 
-	inline nccl_net_ofi_device_t *get_device(size_t device_index)
+	inline nccl_net_ofi_device_t *get_device(size_t device_index) const
 	{
 		if (device_index >= get_num_devices()) {
 			NCCL_OFI_WARN("Invalid device index %zu", device_index);
@@ -795,7 +795,7 @@ public:
 		return p_devs[device_index];
 	}
 
-	inline size_t get_num_devices()
+	inline size_t get_num_devices() const
 	{
 		return p_devs.size();
 	}
@@ -808,7 +808,7 @@ public:
 	int nccl_net_ofi_info_properties(struct fi_info *nic_prov,
 					 int dev_id,
 					 int num_devices,
-					 nccl_ofi_properties_t *props);
+					 nccl_ofi_properties_t *props) const;
 protected:
 	/* Array of devices */
 	std::vector<nccl_net_ofi_device_t *> p_devs;

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -296,7 +296,7 @@ public:
 	 * transport; in that case, this will be the info object associated with the 
 	 * "leader NIC"
 	 */
-	virtual struct fi_info *get_ofi_info_for_cm() = 0;
+	virtual struct fi_info *get_ofi_info_for_cm() const = 0;
 
 	/**
 	 * Retrieve fi_info object associated with this device with rail index.
@@ -307,7 +307,7 @@ public:
 	 * instead, currently this doesn't work with EFA provider. Once that
 	 * works, that is the preferred approach.
 	 */
-	virtual struct fi_info *get_ofi_info(uint16_t rail_id = 0) = 0;
+	virtual struct fi_info *get_ofi_info(uint16_t rail_id = 0) const = 0;
 
 	/* Retrieve a domain associated with this device.  There may
 	 * be more than one domain per device, depending on a number

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -104,7 +104,7 @@ public:
 	 * @param	info	Fabric info structure
 	 * @param	device	Network device to set GUID for
 	 */
-	virtual void device_set_guid(struct fi_info *info, nccl_net_ofi_device_t *device) = 0;
+	virtual uint64_t device_get_guid(struct fi_info *info, int dev_id) = 0;
 };
 
 using PlatformPtr = std::unique_ptr<Platform>;
@@ -116,14 +116,14 @@ public:
 	int init(const char **provider_filter) override { return 0; }
 	int config_endpoint(struct fi_info *info, struct fid_ep *ep) override { return 0; }
 	void sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups) override {}
-	void device_set_guid(struct fi_info *info, nccl_net_ofi_device_t *device) override {
+	uint64_t device_get_guid(struct fi_info *info, int dev_id) override {
 		uint32_t node_id = nccl_ofi_get_unique_node_id();
 		/*
 		 * Use device_index as lower 8 bits
 		 * Use node_id as next 32 bits (bits 8-39)
 		 * Upper 24 bits remain 0
 		 */
-		device->guid = (static_cast<uint64_t>(node_id) << 8) | device->dev_id;
+		return (static_cast<uint64_t>(node_id) << 8) | dev_id;
 	}
 };
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1545,7 +1545,7 @@ public:
 	nccl_net_ofi_rdma_device_t(nccl_net_ofi_plugin_t *plugin,
 				   int dev_id,
 				   struct fi_info *info_list,
-				   nccl_ofi_topo_t *topo);
+				   const nccl_ofi_topo_t *topo);
 
 	int get_properties(nccl_ofi_properties_t *props) override;
 

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -876,10 +876,7 @@ public:
 		return num_rails;
 	}
 
-	inline nccl_net_ofi_rdma_device_t *rdma_domain_get_device()
-	{
-		return reinterpret_cast<nccl_net_ofi_rdma_device_t *>(device);
-	}
+	inline nccl_net_ofi_rdma_device_t *rdma_domain_get_device();
 
 	inline nccl_net_ofi_rdma_domain_rail_t *rdma_domain_get_rail(uint16_t rail_id)
 	{
@@ -1567,7 +1564,7 @@ public:
 	 */
 	inline nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin()
 	{
-		return reinterpret_cast<nccl_net_ofi_rdma_plugin_t*>(plugin);
+		return static_cast<nccl_net_ofi_rdma_plugin_t*>(plugin);
 	}
 
 	/**
@@ -1606,7 +1603,7 @@ public:
 	 */
 	inline nccl_net_ofi_rdma_send_comm *rdma_device_get_send_comm(uint32_t local_comm_id)
 	{
-		auto s_comm = reinterpret_cast<nccl_net_ofi_rdma_send_comm *>
+		auto s_comm = static_cast<nccl_net_ofi_rdma_send_comm *>
 			(rdma_device_get_comm(local_comm_id));
 		if (OFI_UNLIKELY(s_comm == nullptr)) {
 			/* Received a ctrl message for a non-existent send comm */
@@ -1621,7 +1618,7 @@ public:
 	 */
 	inline nccl_net_ofi_rdma_recv_comm *rdma_device_get_recv_comm(uint32_t local_comm_id)
 	{
-		auto r_comm = reinterpret_cast<nccl_net_ofi_rdma_recv_comm *>
+		auto r_comm = static_cast<nccl_net_ofi_rdma_recv_comm *>
 			(rdma_device_get_comm(local_comm_id));
 		if (OFI_UNLIKELY(r_comm == nullptr)) {
 			/* Received a message for a non-existent recv comm */
@@ -1699,5 +1696,14 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 			   nccl_net_ofi_plugin_t **plugin_p,
 			   bool *found_multi_rail,
 			   nccl_ofi_topo_t *topo);
+
+
+
+
+inline nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_domain_t::rdma_domain_get_device()
+{
+	return static_cast<nccl_net_ofi_rdma_device_t *>(device);
+}
+
 
 #endif // End NCCL_OFI_RDMA_H_

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1562,9 +1562,9 @@ public:
 	/**
 	 * @brief	Return RDMA transport plugin
 	 */
-	inline nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin()
+	inline const nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin()
 	{
-		return static_cast<nccl_net_ofi_rdma_plugin_t*>(plugin);
+		return static_cast<const nccl_net_ofi_rdma_plugin_t*>(plugin);
 	}
 
 	/**

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -1546,13 +1546,13 @@ public:
 
 	int get_properties(nccl_ofi_properties_t *props) override;
 
-	inline struct fi_info *get_ofi_info_for_cm() override
+	inline struct fi_info *get_ofi_info_for_cm() const override
 	{
 		assert(!device_rails.empty());
 		return device_rails[0].info;
 	}
 
-	inline struct fi_info *get_ofi_info(uint16_t rail_id) override
+	inline struct fi_info *get_ofi_info(uint16_t rail_id) const override
 	{
 		assert(!this->device_rails.empty());
 		assert(rail_id < num_rails);
@@ -1562,7 +1562,7 @@ public:
 	/**
 	 * @brief	Return RDMA transport plugin
 	 */
-	inline const nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin()
+	inline const nccl_net_ofi_rdma_plugin_t *rdma_device_get_plugin() const
 	{
 		return static_cast<const nccl_net_ofi_rdma_plugin_t*>(plugin);
 	}
@@ -1580,7 +1580,7 @@ public:
 	/**
 	 * @brief	Get endpoint communicator with given ID
 	 */
-	inline nccl_net_ofi_comm *rdma_device_get_comm(uint32_t local_comm_id)
+	inline nccl_net_ofi_comm *rdma_device_get_comm(uint32_t local_comm_id) const
 	{
 		assert(local_comm_id < NCCL_OFI_RDMA_MAX_COMMS);
 		assert(local_comm_id < num_comm_ids);
@@ -1601,7 +1601,7 @@ public:
 	/**
 	 * @brief	Get endpoint send communicator with given ID
 	 */
-	inline nccl_net_ofi_rdma_send_comm *rdma_device_get_send_comm(uint32_t local_comm_id)
+	inline nccl_net_ofi_rdma_send_comm *rdma_device_get_send_comm(uint32_t local_comm_id) const
 	{
 		auto s_comm = static_cast<nccl_net_ofi_rdma_send_comm *>
 			(rdma_device_get_comm(local_comm_id));
@@ -1616,7 +1616,7 @@ public:
 	/**
 	 * @brief	Get endpoint recv communicator with given comm_id
 	 */
-	inline nccl_net_ofi_rdma_recv_comm *rdma_device_get_recv_comm(uint32_t local_comm_id)
+	inline nccl_net_ofi_rdma_recv_comm *rdma_device_get_recv_comm(uint32_t local_comm_id) const
 	{
 		auto r_comm = static_cast<nccl_net_ofi_rdma_recv_comm *>
 			(rdma_device_get_comm(local_comm_id));

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -192,10 +192,7 @@ public:
 		return 1;
 	}
 	
-	inline nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device()
-	{
-		return reinterpret_cast<nccl_net_ofi_sendrecv_device_t *>(device);
-	}
+	inline nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device();
 
 	/* Caller must hold the device lock */
 	std::shared_ptr<nccl_net_ofi_ep_t> create_endpoint() override;
@@ -381,7 +378,7 @@ public:
 
 	inline nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin()
 	{
-		return reinterpret_cast<nccl_net_ofi_sendrecv_plugin_t*>(plugin);
+		return static_cast<nccl_net_ofi_sendrecv_plugin_t*>(plugin);
 	}
 
 	/* Device provider */
@@ -465,5 +462,11 @@ public:
 int nccl_net_ofi_sendrecv_init(const char *provider_filter,
 			       nccl_net_ofi_plugin_t **plugin_p,
 			       const nccl_ofi_topo_t *topo);
+
+
+inline nccl_net_ofi_sendrecv_device_t *nccl_net_ofi_sendrecv_domain_t::sendrecv_domain_get_device()
+{
+	return static_cast<nccl_net_ofi_sendrecv_device_t *>(device);
+}
 
 #endif // End NCCL_OFI_SENDRECV_H_

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -365,18 +365,18 @@ public:
 
 	int get_properties(nccl_ofi_properties_t *props) override;
 
-	inline struct fi_info *get_ofi_info_for_cm() override
+	inline struct fi_info *get_ofi_info_for_cm() const override
 	{
 		return info;
 	}
 
-	inline struct fi_info *get_ofi_info(uint16_t rail_id = 0) override
+	inline struct fi_info *get_ofi_info(uint16_t rail_id = 0) const override
 	{
 		assert(rail_id == 0);
 		return info;
 	}
 
-	inline const nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin()
+	inline const nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin() const
 	{
 		return static_cast<const nccl_net_ofi_sendrecv_plugin_t*>(plugin);
 	}

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -324,8 +324,9 @@ public:
 	 * @brief	Default SENDRECV plugin constructor
 	 */
 	nccl_net_ofi_sendrecv_plugin_t(size_t num_devices,
-				       struct fi_info *provider_list_arg)
-		: nccl_net_ofi_plugin_t(num_devices),
+				       struct fi_info *provider_list_arg,
+				       const nccl_ofi_topo_t *topo_arg)
+		: nccl_net_ofi_plugin_t(num_devices, topo_arg),
 		  provider_list(provider_list_arg)
 	{}
 
@@ -462,6 +463,7 @@ public:
  * @brief	Initialize plugin with sendrecv protocol structures
  */
 int nccl_net_ofi_sendrecv_init(const char *provider_filter,
-			       nccl_net_ofi_plugin_t **plugin_p);
+			       nccl_net_ofi_plugin_t **plugin_p,
+			       const nccl_ofi_topo_t *topo);
 
 #endif // End NCCL_OFI_SENDRECV_H_

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -376,9 +376,9 @@ public:
 		return info;
 	}
 
-	inline nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin()
+	inline const nccl_net_ofi_sendrecv_plugin_t *sendrecv_device_get_plugin()
 	{
-		return static_cast<nccl_net_ofi_sendrecv_plugin_t*>(plugin);
+		return static_cast<const nccl_net_ofi_sendrecv_plugin_t*>(plugin);
 	}
 
 	/* Device provider */

--- a/include/nccl_ofi_system.h
+++ b/include/nccl_ofi_system.h
@@ -27,7 +27,7 @@ uint32_t nccl_ofi_get_unique_node_id(void);
  *          address of the host. Platforms can override with with
  *          platform_device_set_guid() as needed.
  */
-void nccl_net_ofi_device_set_guid(struct fi_info *info, nccl_net_ofi_device_t *device);
+void nccl_net_ofi_device_set_guid(struct fi_info *info, int dev_id);
 /*
  * @brief   Reads the product name from the DMI information.
  *          The caller must free the returned string.

--- a/include/nccl_ofi_topo.h
+++ b/include/nccl_ofi_topo.h
@@ -314,18 +314,6 @@ int nccl_ofi_topo_num_info_lists(nccl_ofi_topo_t *topo, int *num_lists);
 struct fi_info *nccl_ofi_topo_next_info_list(nccl_ofi_topo_data_iterator_t *iter);
 
 /*
- * @brief	Dump NCCL topology into file
- *
- * @param	topo
- * 		The topology
- * @param	file
- *		The file
- * @return	0, on success
- *		non-zero, on error
- */
-int nccl_ofi_topo_write_nccl_topology(nccl_ofi_topo_t *topo, FILE *file);
-
-/*
  * @brief	Check if topology has EFA/ENA devices
  *
  * @param	topo

--- a/include/nccl_ofi_topo.h
+++ b/include/nccl_ofi_topo.h
@@ -107,7 +107,7 @@ typedef struct nccl_ofi_topo {
  * @brief	Set topology user data iterator to the first element of NCCL OFI
  *		topologies's user data array
  */
-int nccl_ofi_topo_set_to_begin(nccl_ofi_topo_t *topo,
+int nccl_ofi_topo_set_to_begin(const nccl_ofi_topo_t *topo,
 			       nccl_ofi_topo_data_iterator_t *iter);
 
 /*
@@ -283,7 +283,7 @@ int nccl_ofi_topo_populate(nccl_ofi_topo_t *ofi_topo, struct fi_info *info_list)
  * @return	0, on success
  *		non-zero, on error
  */
-int nccl_ofi_topo_write(nccl_ofi_topo_t *topo, FILE *file);
+int nccl_ofi_topo_write(const nccl_ofi_topo_t *topo, FILE *file);
 
 /*
  * @brief	Return number of topology nodes that store a libfabric NIC info
@@ -298,7 +298,7 @@ int nccl_ofi_topo_write(nccl_ofi_topo_t *topo, FILE *file);
  *		ncclSuccess, on success
  *
  */
-int nccl_ofi_topo_num_info_lists(nccl_ofi_topo_t *topo, int *num_lists);
+int nccl_ofi_topo_num_info_lists(const nccl_ofi_topo_t *topo, int *num_lists);
 
 /*
  * @brief	Return next libfabric NIC info list from NCCL OFI topology
@@ -321,6 +321,6 @@ struct fi_info *nccl_ofi_topo_next_info_list(nccl_ofi_topo_data_iterator_t *iter
  * @return	true, if EFA or ENA device detected
  *		false, topo is null or EFA/ENA device not detected.
  */
-bool nccl_ofi_topo_has_efa_ena_devices(nccl_ofi_topo_t* topo);
+bool nccl_ofi_topo_has_efa_ena_devices(const nccl_ofi_topo_t* topo);
 
 #endif // End NCCL_NET_OFI_TOPO_H_

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -35,7 +35,7 @@ public:
 	int init(const char **provider_filter) override;
 	int config_endpoint(struct fi_info *info, struct fid_ep *ep) override;
 	void sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups) override;
-	void device_set_guid(struct fi_info *info, nccl_net_ofi_device_t *device) override;
+	uint64_t device_get_guid(struct fi_info *info, int dev_id) override;
 
 protected:
 	struct ec2_platform_data {

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -724,7 +724,7 @@ std::shared_ptr<nccl_net_ofi_domain_t> nccl_net_ofi_device_t::get_domain(unsigne
 	auto *raw_domain = this->create_domain();
 	if (raw_domain == nullptr) {
 		NCCL_OFI_WARN("Initializing a new domain for device %s failed",
-			      this->name);
+			      this->name.c_str());
 		return nullptr;
 	}
 
@@ -732,7 +732,7 @@ std::shared_ptr<nccl_net_ofi_domain_t> nccl_net_ofi_device_t::get_domain(unsigne
 	this->domain_table.insert(std::make_pair(domain_key, domain_ptr));
 
 	NCCL_OFI_TRACE(NCCL_NET, "Domain %p for device #%d (%s) is created",
-		       raw_domain, this->dev_id, this->name);
+		       raw_domain, this->dev_id, this->name.c_str());
 
 	return domain_ptr;
 }
@@ -753,40 +753,27 @@ std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_device_t::get_ep(unsigned int do
 }
 
 
+bool nccl_net_ofi_device_t::compute_need_mr_rkey_pool(struct fi_info *info)
+{
+	bool result = true;
+	int ret = nccl_ofi_mr_keys_need_own_key(info, &result);
+	if (ret != 0) {
+		NCCL_OFI_WARN("MR key config parsing failed: %s", strerror(-ret));
+		throw std::runtime_error("Base device constructor: MR key config parse failed");
+	}
+	return result;
+}
+
 nccl_net_ofi_device_t::nccl_net_ofi_device_t(const nccl_net_ofi_plugin_t *plugin_arg,
 					     int device_index,
 					     struct fi_info *info)
 	: plugin(plugin_arg),
 	  dev_id(device_index),
-	  name(strdup(info->fabric_attr->prov_name))
+	  guid(PlatformManager::get_global().get_platform().device_get_guid(info, device_index)),
+	  name(info->fabric_attr->prov_name),
+	  need_mr_rkey_pool(compute_need_mr_rkey_pool(info))
 {
-	int ret = 0;
-
 	assert(this->plugin != nullptr);
-
-	if (this->name == nullptr) {
-		NCCL_OFI_WARN("Unable to allocate device name");
-		throw std::runtime_error("Base device constructor: device name alloc failed");
-	}
-
-	PlatformManager::get_global().get_platform().device_set_guid(info, this);
-
-	/* Initialize mr rkey handling */
-	this->need_mr_rkey_pool = true;
-	ret = nccl_ofi_mr_keys_need_own_key(info, &this->need_mr_rkey_pool);
-	if (ret != 0) {
-		NCCL_OFI_WARN("MR key config parsing failed: %s",
-			      strerror(-ret));
-		throw std::runtime_error("Base device constructor: MR key config parse failed");
-	}
-}
-
-
-nccl_net_ofi_device_t::~nccl_net_ofi_device_t()
-{
-	if (this->name != nullptr) {
-		free(this->name);
-	}
 }
 
 

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -500,7 +500,7 @@ static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov,
 							int dev_id,
 							int num_devices,
-							nccl_ofi_properties_t *props)
+							nccl_ofi_properties_t *props) const
 {
 	int ret = 0;
 	struct fid_nic *nic_info = nullptr;
@@ -753,7 +753,7 @@ std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_device_t::get_ep(unsigned int do
 }
 
 
-nccl_net_ofi_device_t::nccl_net_ofi_device_t(nccl_net_ofi_plugin_t *plugin_arg,
+nccl_net_ofi_device_t::nccl_net_ofi_device_t(const nccl_net_ofi_plugin_t *plugin_arg,
 					     int device_index,
 					     struct fi_info *info)
 	: plugin(plugin_arg),

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -261,7 +261,7 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 
 		switch (ofi_nccl_protocol.get()) {
 		case PROTOCOL::SENDRECV:
-			ret = nccl_net_ofi_sendrecv_init(provider_filter, &plugin);
+			ret = nccl_net_ofi_sendrecv_init(provider_filter, &plugin, topo.get());
 			if (ret != 0) {
 				NCCL_OFI_WARN("Failed to initialize sendrecv protocol");
 				goto exit;
@@ -297,7 +297,8 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		if (!have_multiple_rails || rdma_plugin == NULL) {
 			try {
 				ret = nccl_net_ofi_sendrecv_init(provider_filter,
-								 &sendrecv_plugin);
+								 &sendrecv_plugin,
+								 topo.get());
 			}
 			catch (const std::exception &e) {
 				NCCL_OFI_WARN("Caught exception in sendrecv_init: %s", e.what());
@@ -333,10 +334,6 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_NET, "Using transport protocol %s",
 			      ofi_nccl_protocol.get_string());
 	}
-
-	/* Set non-owning topo pointer on the winning plugin so that
-	 * complete_init and get_properties can access it. */
-	plugin->topo = topo.get();
 
 	ret = plugin->complete_init();
 	if (ret != 0) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -408,7 +408,7 @@ static inline size_t ofi_info_list_length(struct fi_info *info_list)
 int nccl_net_ofi_rdma_device_t::get_properties(nccl_ofi_properties_t *props)
 {
 	int ret;
-	nccl_net_ofi_rdma_plugin_t *plugin_ptr = this->rdma_device_get_plugin();
+	const nccl_net_ofi_rdma_plugin_t *plugin_ptr = this->rdma_device_get_plugin();
 	assert(plugin_ptr != nullptr);
 
 	/* Retrieve NIC properties of first rail */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -420,7 +420,7 @@ int nccl_net_ofi_rdma_device_t::get_properties(nccl_ofi_properties_t *props)
 	/* Scale speed by the total number of rails. Assume that all
 	 * reails have the same speed. */
 	if (ret == 0) {
-		props->port_speed *= plugin_ptr->topo->max_group_size;
+		props->port_speed *= plugin_ptr->get_topo()->max_group_size;
 		static_assert(NCCL_OFI_RDMA_COMM_ID_BITS < 31,
 					  "NCCL_OFI_RDMA_COMM_ID_BITS must be less than 31 so max_communicators fits in an integer");
 		props->max_communicators = NCCL_OFI_RDMA_MAX_COMMS;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -236,7 +236,7 @@ nccl_net_ofi_rdma_recv_comm_rail_t *nccl_net_ofi_rdma_recv_comm::get_data_rail(u
  * @param	0, on success
  *		non-zero, on error
  */
-static int write_topo_file(nccl_ofi_topo_t *topo)
+static int write_topo_file(const nccl_ofi_topo_t *topo)
 {
 	int ret = 0;
 	int topo_fd = -1;
@@ -6883,7 +6883,7 @@ nccl_net_ofi_rdma_device_t::~nccl_net_ofi_rdma_device_t()
 nccl_net_ofi_rdma_device_t::nccl_net_ofi_rdma_device_t(nccl_net_ofi_plugin_t *plugin_arg,
 							int device_id,
 							struct fi_info *info_list,
-							nccl_ofi_topo_t *topo)
+							const nccl_ofi_topo_t *topo)
 	: nccl_net_ofi_device_t(plugin_arg, device_id, info_list),
 	  num_comm_ids(static_cast<uint32_t>(NCCL_OFI_RDMA_MAX_COMMS)),
 	  comm_idpool(num_comm_ids),
@@ -7089,6 +7089,7 @@ int nccl_net_ofi_rdma_plugin_t::complete_init()
 
 
 nccl_net_ofi_rdma_plugin_t::nccl_net_ofi_rdma_plugin_t(struct fi_info *provider_list, nccl_ofi_topo_t *global_topo)
+	: nccl_net_ofi_plugin_t(global_topo)
 {
 	int ret = 0;
 	int num_devices = 0;

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -79,7 +79,7 @@ int nccl_net_ofi_sendrecv_device_t::get_properties(nccl_ofi_properties_t *props)
 	
 	size_t num_devices = this->plugin->get_num_devices();
 	int ret;
-	nccl_net_ofi_sendrecv_plugin_t *plugin_ptr = this->sendrecv_device_get_plugin();
+	const nccl_net_ofi_sendrecv_plugin_t *plugin_ptr = this->sendrecv_device_get_plugin();
 
 	/* Validate libfabric NIC info */
 	if (OFI_UNLIKELY(this->info == nullptr)) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -2278,7 +2278,8 @@ int nccl_net_ofi_sendrecv_plugin_t::complete_init()
 
 
 int nccl_net_ofi_sendrecv_init(const char *provider_filter,
-			       nccl_net_ofi_plugin_t **plugin_p)
+			       nccl_net_ofi_plugin_t **plugin_p,
+			       const nccl_ofi_topo_t *topo)
 {
 	int ret = 0;
 	struct fi_info *provider_list = NULL;
@@ -2459,7 +2460,7 @@ found:
 		return ret;
 	}
 
-	plugin = new nccl_net_ofi_sendrecv_plugin_t(num_providers, provider_list);
+	plugin = new nccl_net_ofi_sendrecv_plugin_t(num_providers, provider_list, topo);
 
 	*plugin_p = plugin;
 

--- a/src/nccl_ofi_topo.cpp
+++ b/src/nccl_ofi_topo.cpp
@@ -79,7 +79,7 @@ static nccl_ofi_topo_data_vec_t *nccl_ofi_topo_data_vec_create(size_t size)
 	return vec;
 }
 
-int nccl_ofi_topo_set_to_begin(nccl_ofi_topo_t *topo, nccl_ofi_topo_data_iterator_t *iter)
+int nccl_ofi_topo_set_to_begin(const nccl_ofi_topo_t *topo, nccl_ofi_topo_data_iterator_t *iter)
 {
 	if (!topo) {
 		NCCL_OFI_WARN("Invalid NCCL OFI topology");
@@ -1729,7 +1729,7 @@ static int write_nccl_topo_rec(hwloc_topology_t topo, hwloc_obj_t node, FILE *fi
 	return ret;
 }
 
-int nccl_ofi_topo_write(nccl_ofi_topo_t *topo, FILE *file)
+int nccl_ofi_topo_write(const nccl_ofi_topo_t *topo, FILE *file)
 {
 	int ret = 0;
 	int bridge_depth = 0;
@@ -1757,7 +1757,7 @@ int nccl_ofi_topo_write(nccl_ofi_topo_t *topo, FILE *file)
 	return ret;
 }
 
-int nccl_ofi_topo_num_info_lists(nccl_ofi_topo_t *topo, int *num_lists)
+int nccl_ofi_topo_num_info_lists(const nccl_ofi_topo_t *topo, int *num_lists)
 {
 	if (!topo || !topo->data_vec) {
 		NCCL_OFI_WARN("Invalid topology. Topology is not initialized.");
@@ -1794,7 +1794,7 @@ struct fi_info *nccl_ofi_topo_next_info_list(nccl_ofi_topo_data_iterator_t *iter
 	return info_list;
 }
 
-bool nccl_ofi_topo_has_efa_ena_devices(nccl_ofi_topo_t* topo) {
+bool nccl_ofi_topo_has_efa_ena_devices(const nccl_ofi_topo_t* topo) {
 	if (topo == nullptr || topo->topo == nullptr) {
 		return false;
 	}

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -936,24 +936,26 @@ const PlatformAWS::platform_aws_node_guid* PlatformAWS::get_node_guid_fields(str
 	}
 }
 
-void PlatformAWS::device_set_guid(struct fi_info *info, nccl_net_ofi_device_t *device)
+uint64_t PlatformAWS::device_get_guid(struct fi_info *info, int dev_id)
 {
 	const PlatformAWS::platform_aws_node_guid* fields = get_node_guid_fields(info);
 	uint32_t node_id = nccl_ofi_get_unique_node_id();
+	uint64_t guid;
 
 	if (!fields ||
 	    strcmp("0xefa0", info->nic->device_attr->device_id) == 0 ||
 	    strcmp("0xefa1", info->nic->device_attr->device_id) == 0 ||
 	    strcmp("0xefa2", info->nic->device_attr->device_id) == 0) {
 
-		device->guid = (static_cast<uint64_t>(node_id) << 32) | device->dev_id;
+		guid = (static_cast<uint64_t>(node_id) << 32) | dev_id;
 	} else {
-		device->guid = (static_cast<uint64_t>(node_id) << 32) |
+		guid = (static_cast<uint64_t>(node_id) << 32) |
 			       (fields->per_card_pci_domain << 8) |
 				fields->per_card_pci_bus;
 	}
 
-	NCCL_OFI_INFO(NCCL_INIT, "GUID for dev[%d]: %032lx", device->dev_id, device->guid);
+	NCCL_OFI_INFO(NCCL_INIT, "GUID for dev[%d]: %032lx", dev_id, guid);
+	return guid;
 }
 
 /*


### PR DESCRIPTION
This is phase 2 of trying to get better notations for our thread safety (phase 1 was getting the TSA infrastructure committed).  In this PR, we don't actually annotate anything with TSA annotations, but instead mark a bunch of fields in the plugin and device class that are readonly as `const`, which makes their thread safety fairly straight forward.  A later PR will add TSA notations to the remaining fields (and tackle all the other classes, but this seemed like a sufficiently long PR).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
