### PR TITLE
Proxy GIN Flush Implementation + Functional Test

### DIFF
--- a/include/nccl_ofi_gin_base.h
+++ b/include/nccl_ofi_gin_base.h
@@ -90,6 +90,9 @@ public:
 			 nccl_ofi_gin_symm_mr_handle_t *localMhandle,
 			 uint32_t rank, nccl_ofi_gin_req_t **request) = 0;
 
+	virtual int iflush(nccl_ofi_gin_symm_mr_handle_t *mhandle,
+			   uint32_t rank, nccl_ofi_gin_req_t **request) = 0;
+
 	virtual int await_pending_requests() = 0;
 };
 

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -276,6 +276,22 @@ public:
 		 uint32_t rank, nccl_ofi_gin_req_t **request) override;
 
 	/**
+	 * Fence prior iget operations to ensure data is visible locally.
+	 *
+	 * Posts a loopback fi_read on each rail from a local GPU buffer into
+	 * a host buffer. PCIe ordering guarantees that completion of the read
+	 * implies all prior NIC writes (from igets) are committed to memory.
+	 *
+	 * @param mhandle: memory handle associated with the flushed region
+	 * @param rank: rank whose prior igets are being fenced
+	 * @param request: request to be returned to caller
+	 *
+	 * @return: 0 on success, non-zero on failure
+	 */
+	int iflush(nccl_ofi_gin_symm_mr_handle_t *mhandle, uint32_t rank,
+		   nccl_ofi_gin_req_t **request) override;
+
+	/**
 	 * Callback for metadata completion.
 	 *
 	 * @param metadata_msg: metadata message

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -274,6 +274,36 @@ private:
 	nccl_ofi_gin_resources &resources;
 };
 
+#define NCCL_OFI_GIN_FLUSH_SENTINEL_VAL (0xdeadbeefdeadbeefULL)
+
+/**
+ * Flush request that uses sentinel-based polling to detect completion.
+ *
+ * Instead of waiting for CQ completions, test() polls the host flush buffer
+ * for the sentinel value. The fi_read copies the sentinel from the GPU buffer
+ * into the host buffer; once visible, all prior operations are fenced.
+ * Sub-requests still self-return to pool via their CQ completion handler.
+ *
+ * Only one iflush may be outstanding per resources instance at a time (the
+ * host flush buffer is shared). NCCL guarantees this by polling to completion.
+ */
+class nccl_ofi_gin_iflush_req : public nccl_net_ofi_gin_base_req {
+public:
+	nccl_ofi_gin_iflush_req(nccl_ofi_gin_resources &resources_arg,
+				void *host_buff_arg, uint16_t num_rails_arg)
+	    : resources(resources_arg), host_buff(host_buff_arg),
+	      num_rails(num_rails_arg)
+	{
+	}
+
+	int test(int *done) override;
+
+private:
+	nccl_ofi_gin_resources &resources;
+	void *host_buff;
+	uint16_t num_rails;
+};
+
 /**
  * Represents an in-progress iputSignal operation on the target side.
  *
@@ -450,6 +480,7 @@ private:
 	nccl_net_ofi_gin_read_req_t read_req;
 	nccl_net_ofi_gin_metadata_send_req_t metadata_send_req;
 	nccl_ofi_gin_iget_req iget_req;
+	nccl_ofi_gin_iflush_req iflush_req;
 };
 
 #endif

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -256,6 +256,26 @@ public:
 		return ack_send_fl.get();
 	}
 
+	void *get_flush_buff() const
+	{
+		return flush_buff;
+	}
+
+	void *get_flush_buff_gpu() const
+	{
+		return flush_buff_gpu;
+	}
+
+	nccl_ofi_gin_mr_handle_t *get_flush_buff_mr_handle() const
+	{
+		return flush_buff_mr_handle;
+	}
+
+	nccl_ofi_gin_mr_handle_t *get_flush_buff_gpu_mr_handle() const
+	{
+		return flush_buff_gpu_mr_handle;
+	}
+
 	/**
 	 * Get a request from the freelist
 	 *
@@ -340,6 +360,8 @@ public:
 	}
 
 private:
+	void init_flush_buffers(uint16_t num_rails);
+
 	/* === Tier 1 — accessed every CQ completion and/or iputSignal === */
 	nccl_ofi_gin_ep_holder ep_holder;
 
@@ -367,6 +389,16 @@ private:
 	 */
 	std::deque<nccl_net_ofi_gin_op_req_t *> pending_requests;
 
+	/* Pre-allocated host buffer used as the local DMA target for iflush
+	   fi_read operations. One cache-line slot per rail. */
+	void *flush_buff = nullptr;
+	nccl_ofi_gin_mr_handle_t *flush_buff_mr_handle = nullptr;
+
+	/* GPU-resident flush buffer — source of the local fi_read. The NIC
+	   reads from this GPU buffer into flush_buff (host) via loopback,
+	   which forces the NIC to drain its PCIe write/read queue. */
+	void *flush_buff_gpu = nullptr;
+	nccl_ofi_gin_mr_handle_t *flush_buff_gpu_mr_handle = nullptr;
 
 	/* === Tier 3 — accessed only at connect/disconnect time === */
 	nccl_ofi_idpool_t comm_id_pool;

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -725,6 +725,70 @@ int nccl_ofi_rdma_gin_put_comm::iget(uint64_t remoteOff,
 	return 0;
 }
 
+int nccl_ofi_rdma_gin_put_comm::iflush(nccl_ofi_gin_symm_mr_handle_t * /*mhandle*/,
+					uint32_t /*dst_rank*/,
+					nccl_ofi_gin_req_t **request)
+{
+	/* mhandle and dst_rank are unused — flush is a local loopback fi_read
+	   that fences all prior igets on every rail, regardless of peer or MR. */
+	auto &gin_ep = resources.get_ep();
+	auto *flush_host_buff = resources.get_flush_buff();
+	auto *flush_host_mr = resources.get_flush_buff_mr_handle();
+	auto *flush_gpu_mr = resources.get_flush_buff_gpu_mr_handle();
+	auto &self_rank_comm = rank_comms[rank];
+	const uint16_t num_rails = gin_ep.get_num_rails();
+
+	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
+	/* Clear host buffer slots so we can detect when the sentinel arrives */
+	for (uint16_t rail_id = 0; rail_id < num_rails; rail_id++) {
+		auto *slot = reinterpret_cast<volatile uint64_t *>(
+			static_cast<uint8_t *>(flush_host_buff) +
+			(NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE * rail_id));
+		*slot = 0;
+	}
+
+	auto *iflush_req = resources.get_req_from_pool<nccl_ofi_gin_iflush_req>(
+		resources, flush_host_buff, num_rails);
+
+	for (uint16_t rail_id = 0; rail_id < num_rails; rail_id++) {
+		/* Destination: per-rail slot in host flush buffer */
+		void *local_buf = static_cast<uint8_t *>(flush_host_buff) +
+				  (NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE * rail_id);
+		void *desc = fi_mr_desc(flush_host_mr->get_mr(rail_id));
+
+		/* Source: local GPU flush buffer via loopback (own rank's AV entry).
+		   GPU buffer is pre-filled with sentinel value. */
+		uint64_t gpu_key = fi_mr_key(flush_gpu_mr->get_mr(rail_id));
+		fi_addr_t loopback_addr = self_rank_comm.address[rail_id];
+		uint64_t remote_offset = virt_addr_mr
+			? (uintptr_t)resources.get_flush_buff_gpu()
+			: 0;
+
+		auto *read_req = resources.get_req_from_pool<nccl_net_ofi_gin_read_req_t>(
+			resources,
+			gin_ep.get_rail(rail_id).ofi_ep.get(),
+			local_buf, NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE, desc,
+			loopback_addr, remote_offset, gpu_key);
+
+		/* No pending_flag — completion detected via sentinel polling */
+		read_req->pending_flag = nullptr;
+
+		int ret = read_req->post();
+		if (ret == -FI_EAGAIN) {
+			resources.add_pending_req(read_req);
+		} else if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("fi_read iflush failed on rail %u: %d",
+				      rail_id, ret);
+			resources.return_req_to_pool(iflush_req);
+			return ret;
+		}
+	}
+
+	*request = iflush_req;
+	return 0;
+}
+
 static inline uint32_t get_peer_rank(fi_addr_t src_addr,
 				     const std::vector<uint32_t> &rank_map_rail)
 {

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -442,6 +442,22 @@ static ncclResult_t nccl_ofi_gin_iget_v13(void *ginCtx, int context, uint64_t re
 				 localOff, localMhandle, rank, request);
 }
 
+static ncclResult_t nccl_ofi_gin_iflush_v13(void *ginCtx, int context, void *mhandle,
+					    uint32_t rank, void **request)
+{
+	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(ginCtx);
+	auto *mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(mhandle);
+
+	nccl_ofi_gin_req_t *req = nullptr;
+	int ret = gin_comm->iflush(mr_handle, rank, &req);
+	if (ret != 0) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
+
+	*request = req;
+	return ncclSuccess;
+}
+
 NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	/* Since there is no equivalent of NCCL_NET for GIN, currently we don't
 	   have name fixup depending on env var like nvidia_plugin_name_fixup().
@@ -488,7 +504,7 @@ NCCL_OFI_EXPORT_SYMBOL ncclGin_v13_t ncclGinPlugin_v13 = {
 	.iput = nccl_ofi_gin_iput_v13,
 	.iputSignal = nccl_ofi_gin_iputSignal_v13,
 	.iget = nccl_ofi_gin_iget_v13,
-	.iflush = nullptr,
+	.iflush = nccl_ofi_gin_iflush_v13,
 	.test = nccl_ofi_gin_test,
 	.ginProgress = nccl_ofi_gin_ginProgress,
 	.queryLastError = nullptr,

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -7,6 +7,7 @@
 #include "rdma/gin/nccl_ofi_gin.h"
 #include "rdma/gin/nccl_ofi_gin_reqs.h"
 #include "rdma/gin/nccl_ofi_gin_resources.h"
+#include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_tracepoint.h"
 
 int nccl_net_ofi_gin_op_req_t::op_req_ctx::handle_cq_entry(struct fi_cq_entry *cq_entry_base,
@@ -338,5 +339,28 @@ int nccl_ofi_gin_iget_req::test(int *done)
 	   calls ginProgress, which drives CQ processing and clears pending
 	   flags as completions arrive. */
 
+	return 0;
+}
+
+int nccl_ofi_gin_iflush_req::test(int *done)
+{
+	*done = 0;
+
+	/* Poll host buffer for sentinel value — avoids waiting for CQ entries.
+	   The fi_read copies the sentinel from GPU into each per-rail slot;
+	   once visible here, all prior operations on that rail are fenced. */
+	for (uint16_t rail_id = 0; rail_id < num_rails; rail_id++) {
+		auto *slot = reinterpret_cast<volatile uint64_t *>(
+			static_cast<uint8_t *>(host_buff) +
+			(NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE * rail_id));
+		if (READ_ONCE(*slot) != NCCL_OFI_GIN_FLUSH_SENTINEL_VAL) {
+			return 0;
+		}
+	}
+
+	*done = 1;
+	auto &gin_ep = resources.get_ep();
+	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+	resources.return_req_to_pool(this);
 	return 0;
 }

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -8,6 +8,7 @@
 #include "rdma/gin/nccl_ofi_gin_reqs.h"
 
 #include "nccl_ofi_assert.h"
+#include <cstdlib>
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif
@@ -464,10 +465,81 @@ nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
 	req_fl_tmp = new nccl_ofi_freelist(sizeof(nccl_net_ofi_gin_union_req), 1024, 1024, 0,
 					   nullptr, nullptr, "GIN Requests", true);
 	this->req_fl.reset(req_fl_tmp);
+
+	init_flush_buffers(num_rails);
+}
+
+void nccl_ofi_gin_resources::init_flush_buffers(uint16_t num_rails)
+{
+	size_t flush_buff_size = NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE * num_rails;
+
+	auto cleanup = [&]() {
+		if (flush_buff_gpu_mr_handle) { gin_ep.dereg_mr(flush_buff_gpu_mr_handle); flush_buff_gpu_mr_handle = nullptr; }
+		if (flush_buff_gpu) { nccl_net_ofi_gpu_mem_free(flush_buff_gpu); flush_buff_gpu = nullptr; }
+		if (flush_buff_mr_handle) { gin_ep.dereg_mr(flush_buff_mr_handle); flush_buff_mr_handle = nullptr; }
+		if (flush_buff) { std::free(flush_buff); flush_buff = nullptr; }
+	};
+
+	flush_buff = std::aligned_alloc(NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE, flush_buff_size);
+	if (!flush_buff) {
+		throw std::runtime_error("Failed to allocate flush buffer");
+	}
+
+	try {
+		auto ckey = nccl_ofi_mr_ckey_mk_vec(flush_buff, flush_buff_size, nullptr);
+		if (gin_ep.reg_mr(&ckey, NCCL_PTR_HOST, &flush_buff_mr_handle) != 0) {
+			throw std::runtime_error("Failed to register flush buffer");
+		}
+
+		if (nccl_net_ofi_gpu_mem_alloc(&flush_buff_gpu, flush_buff_size) != 0) {
+			throw std::runtime_error("Failed to allocate GPU flush buffer");
+		}
+
+		auto gpu_ckey = nccl_ofi_mr_ckey_mk_vec(flush_buff_gpu, flush_buff_size, nullptr);
+		if (gin_ep.reg_mr(&gpu_ckey, NCCL_PTR_CUDA, &flush_buff_gpu_mr_handle) != 0) {
+			throw std::runtime_error("Failed to register GPU flush buffer");
+		}
+
+		/* Fill GPU buffer with sentinel. Polling host buffer for this
+		   value after fi_read confirms all prior operations are fenced. */
+		uint64_t sentinel_line[NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE / sizeof(uint64_t)];
+		for (auto &v : sentinel_line) {
+			v = NCCL_OFI_GIN_FLUSH_SENTINEL_VAL;
+		}
+		for (uint16_t i = 0; i < num_rails; i++) {
+			if (nccl_net_ofi_gpu_mem_copy_host_to_device(
+				    static_cast<uint8_t *>(flush_buff_gpu) +
+					    (NCCL_OFI_DEFAULT_CPU_CACHE_LINE_SIZE * i),
+				    sentinel_line, sizeof(sentinel_line)) != 0) {
+				throw std::runtime_error("Failed to init GPU flush buffer sentinel");
+			}
+		}
+	} catch (...) {
+		cleanup();
+		throw;
+	}
 }
 
 nccl_ofi_gin_resources::~nccl_ofi_gin_resources()
 {
+	/* Deregister and free flush buffer before closing endpoints */
+	if (flush_buff_gpu_mr_handle) {
+		gin_ep.dereg_mr(flush_buff_gpu_mr_handle);
+		flush_buff_gpu_mr_handle = nullptr;
+	}
+	if (flush_buff_gpu) {
+		nccl_net_ofi_gpu_mem_free(flush_buff_gpu);
+		flush_buff_gpu = nullptr;
+	}
+	if (flush_buff_mr_handle) {
+		gin_ep.dereg_mr(flush_buff_mr_handle);
+		flush_buff_mr_handle = nullptr;
+	}
+	if (flush_buff) {
+		std::free(flush_buff);
+		flush_buff = nullptr;
+	}
+
 	/* For non-endpoint-MR providers, we first close the OFI endpoint, then
 	   let resources clean up in reverse-order. */
 	gin_ep.close_ofi_eps();

--- a/tests/functional/gin.cpp
+++ b/tests/functional/gin.cpp
@@ -321,6 +321,78 @@ int main(int argc, char *argv[])
 
 	MPI_Barrier(MPI_COMM_WORLD);
 
+	/*
+	 * iflush correctness test:
+	 * 1. Rank 0 fills its buffer with a distinct value (flush_val=77)
+	 * 2. Rank 1 does iget to read rank 0's buffer into a local buffer
+	 * 3. Rank 1 does iflush to ensure the iget data is visible locally
+	 * 4. Rank 1 verifies the local buffer contains the expected value
+	 *
+	 * This proves iflush fences prior igets — the contract NCCL relies on
+	 * when the GPU kernel issues a flush after reading remote data.
+	 */
+	{
+		const int flush_val = 77; /* distinct from send_val(42) and iget_val(99) */
+		void *flush_src_buff = nullptr;
+		void *flush_src_mhandle = nullptr;
+		OFINCCLCHECK(alloc_and_reg_buff(extGin, collComm, SEND_SIZE, buffer_type,
+						(rank == 0) ? flush_val : 0,
+						&flush_src_buff, &flush_src_mhandle));
+
+		void *flush_dst_buff = nullptr;
+		void *flush_dst_mhandle = nullptr;
+		OFINCCLCHECK(alloc_and_reg_buff(extGin, collComm, SEND_SIZE, buffer_type,
+						0, &flush_dst_buff, &flush_dst_mhandle));
+
+		MPI_Barrier(MPI_COMM_WORLD);
+
+		if (rank == 1) {
+			/* iget: read rank 0's buffer into local buffer */
+			std::deque<void *> get_deque;
+			void *request = nullptr;
+			OFINCCLCHECK(extGin->iget(proxyCtx, 0, 0, flush_src_mhandle,
+						  SEND_SIZE, 0, flush_dst_mhandle, 0,
+						  &request));
+			assert(request != nullptr);
+			get_deque.push_back(request);
+
+			while (!get_deque.empty()) {
+				OFINCCLCHECK(poll_request_completion(extGin, get_deque,
+								    collComm, proxyCtx));
+			}
+
+			/* iflush: fence the iget to ensure data is visible */
+			std::deque<void *> flush_deque;
+			void *flush_request = nullptr;
+			OFINCCLCHECK(extGin->iflush(proxyCtx, 0, flush_dst_mhandle,
+						    0, &flush_request));
+			assert(flush_request != nullptr);
+			flush_deque.push_back(flush_request);
+
+			while (!flush_deque.empty()) {
+				OFINCCLCHECK(poll_request_completion(extGin, flush_deque,
+								    collComm, proxyCtx));
+			}
+
+			/* Verify data is visible after flush */
+			NCCL_OFI_INFO(NCCL_NET, "=== Verifying iflush result ===");
+			OFINCCLCHECK(verify_buff(rank, flush_dst_buff, flush_val));
+		}
+
+		MPI_Barrier(MPI_COMM_WORLD);
+
+		OFINCCLCHECK(extGin->deregMrSym(collComm, flush_src_mhandle));
+		flush_src_mhandle = nullptr;
+		OFINCCLCHECK(extGin->deregMrSym(collComm, flush_dst_mhandle));
+		flush_dst_mhandle = nullptr;
+		OFINCCLCHECK(deallocate_buffer(flush_src_buff, buffer_type));
+		flush_src_buff = nullptr;
+		OFINCCLCHECK(deallocate_buffer(flush_dst_buff, buffer_type));
+		flush_dst_buff = nullptr;
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
 	OFINCCLCHECK(extGin->deregMrSym(collComm, get_src_mhandle));
 	get_src_mhandle = nullptr;
 	OFINCCLCHECK(extGin->deregMrSym(collComm, get_mhandle));


### PR DESCRIPTION
*Description of changes:*

Implement `iflush` for the GIN host proxy path along with a functional correctness test. The implementation mirrors the RDMA flush approach: a cache line `fi_read` is posted on every rail from the remote rank's registered memory into a local host flush buffer. The completion of these reads guarantees that all prior RDMA writes on each rail have been committed to the remote GPU's memory.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.