### PR TITLE
[1.19.2] Don't disable dma-buf on EFAv1-3 cherry-pick

### DIFF
--- a/RELEASENOTES.md
+++ b/RELEASENOTES.md
@@ -17,6 +17,7 @@ This release has been tested with [Libfabric v2.4.0](https://github.com/aws/libf
 
 - Fixed correctness issues with multirecv feature
 - Fixed RCCL build when building from release tarballs
+- Re-enabled dma-buf on EFAv1–v3
 
 # v1.19.1 (2026-05)
 

--- a/src/nccl_ofi_dmabuf.cpp
+++ b/src/nccl_ofi_dmabuf.cpp
@@ -104,37 +104,5 @@ int nccl_ofi_dmabuf_viable_and_supported(struct fi_info *nic_prov) {
 		FI_VERSION_GE(nic_prov->fabric_attr->api_version, FI_VERSION(1, 20)) &&
 		nccl_ofi_dmabuf_viable();
 
-	if (dmabuf_support && strncmp("efa", nic_prov->fabric_attr->prov_name, strlen("efa")) == 0) {
-		// Generations 1-3 of EFA have a firmware issue that can result
-		// in communication failures with MRs that cover a large number
-		// of page entries.  This is not usually a problem, because page
-		// merging greatly reduces the number of page entries in the MR.
-		// However, the RDMA subsystem in the Linux kernel did not
-		// properly execute page merging for dmabuf entries until a
-		// recent patch
-		// (https://web.git.kernel.org/pub/scm/linux/kernel/git/rdma/rdma.git/commit/?id=486055f5e09df9),
-		// and the lack of page merging increased the probability of
-		// hitting the EFA issue.  Testing for the fixed kernel version
-		// is effectively impossible (the issue can also be fixed in the
-		// EFA kmod itself, and backports are likely, so a simple kernel
-		// version check is insufficient), so instead we only support
-		// dmabuf by default in Generation 4 of EFA.  When the
-		// communication failure issue is resolved in previous
-		// generations, this code will be removed and dmabuf will be
-		// available by default everywhere.
-		if (nic_prov->nic == NULL || nic_prov->nic->device_attr == NULL) {
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-				       "DMA-BUF disabled due to missing nic data");
-			dmabuf_support = false;
-		} else if (strcmp("0xefa0", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("0xefa1", nic_prov->nic->device_attr->device_id) == 0 ||
-			   strcmp("0xefa2", nic_prov->nic->device_attr->device_id) == 0) {
-			NCCL_OFI_TRACE(NCCL_INIT | NCCL_NET,
-				       "DMA-BUF disabled due to EFA device id %s",
-				       nic_prov->nic->device_attr->device_id);
-			dmabuf_support = false;
-		}
-	}
-
 	return dmabuf_support;
 }


### PR DESCRIPTION
Backport of [`0f285d5`](https://github.com/aws/aws-ofi-nccl/commit/0f285d5670cd6b38bd742def645979041ac373b6).

Also adds a bullet to the `v1.19.2` release notes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
