### PR TITLE
gin: LTTng tracepoints, simplified ACK flow control, and dataplane cleanups

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -195,28 +195,20 @@
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_write_completion_func_end, dev, comm, rail_id, peer_rank, msg_seq_num, ret); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, ack_count) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, ack_count); \
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, consumed) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, consumed); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, msg_seq_num, ret) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_end, dev, comm, rail_id, peer_rank, msg_seq_num, ret); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, ack_seq_num, count) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_start, dev, comm, rail_id, peer_rank, ack_seq_num, count); \
+#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, consumed) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_start, dev, comm, rail_id, peer_rank, consumed); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, ack_seq_num, ret) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_end, dev, comm, rail_id, peer_rank, ack_seq_num, ret); \
-} while(0)
-
-#define NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_START(dev, comm, peer_rank, seq_num) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_stash_pending_ack_func_start, dev, comm, peer_rank, seq_num); \
-} while(0)
-
-#define NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(dev, comm, peer_rank, seq_num, ack_count, flushed, ret) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_stash_pending_ack_func_end, dev, comm, peer_rank, seq_num, ack_count, flushed, ret); \
+#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, consumed, ret) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_end, dev, comm, rail_id, peer_rank, consumed, ret); \
 } while(0)
 
 #endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -143,24 +143,19 @@
 	NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, comm, rank, msg_seq_num, request) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_begin, dev, rail_id, comm, rank, msg_seq_num, request); \
-	NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, request); \
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_begin, dev, rail_id, size, comm, rank, msg_seq_num, request); \
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, size, request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id, comm, rank, msg_seq_num, request) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_end, dev, rail_id, comm, rank, msg_seq_num, request); \
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_end, dev, rail_id, size, comm, rank, msg_seq_num, request); \
 	NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(request); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_recv_write, dev, rail_id, size, comm, rank, msg_seq_num, request); \
 	NCCL_OFI_TRACE_GIN_RECV_WRITE_NVTX(comm, rail_id, rank, msg_seq_num, size, request); \
-} while(0)
-
-#define NCCL_OFI_TRACE_GIN_RECV_METADATA(dev, rail_id, comm, rank, msg_seq_num, request) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_recv_metadata, dev, rail_id, comm, rank, msg_seq_num, request); \
-	NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(comm, rail_id, rank, msg_seq_num, request); \
 } while(0)
 
 
@@ -182,6 +177,46 @@
 #define NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, comm, rank, msg_seq_num) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_ack_send, dev, rail_id, comm, rank, msg_seq_num); \
 	NCCL_OFI_TRACE_GIN_ACK_SEND_NVTX(comm, rail_id, rank, msg_seq_num); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_TEST_FUNC_BEGIN(dev, comm, peer_rank, msg_seq_num, request, has_write_reqs, has_send_req) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_test_func_begin, dev, comm, peer_rank, msg_seq_num, request, has_write_reqs, has_send_req); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_TEST_FUNC_END(dev, comm, peer_rank, msg_seq_num, request, done, freed) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_test_func_end, dev, comm, peer_rank, msg_seq_num, request, done, freed); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, total_segms, len, is_ack_requested) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_write_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, total_segms, len, is_ack_requested); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, msg_seq_num, ret) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_write_completion_func_end, dev, comm, rail_id, peer_rank, msg_seq_num, ret); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, ack_count) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, ack_count); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, msg_seq_num, ret) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_end, dev, comm, rail_id, peer_rank, msg_seq_num, ret); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, ack_seq_num, count) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_start, dev, comm, rail_id, peer_rank, ack_seq_num, count); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, ack_seq_num, ret) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_ack_completion_func_end, dev, comm, rail_id, peer_rank, ack_seq_num, ret); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_START(dev, comm, peer_rank, seq_num) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_stash_pending_ack_func_start, dev, comm, peer_rank, seq_num); \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(dev, comm, peer_rank, seq_num, ack_count, flushed, ret) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_stash_pending_ack_func_end, dev, comm, peer_rank, seq_num, ack_count, flushed, ret); \
 } while(0)
 
 #endif /* NCCL_OFI_TRACEPOINT_H_ */

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -68,7 +68,7 @@ struct nccl_ofi_gin_resource_releaser {
 /**
  * Pending bundled ack: accumulated in deliver_all,
  * sent with the next outgoing metadata message to this peer.
- * On the pending_ack_list iff node.next != nullptr.
+ * Empty when ack_count == 0.
  */
 struct nccl_ofi_gin_pending_ack_info {
 	nccl_ofi_dlist_node node;
@@ -123,6 +123,12 @@ struct nccl_ofi_gin_peer_rank_info {
 	std::bitset<GIN_IMM_SEQ_MASK + 1> active_put_signal;
 	static_assert(GIN_IMM_SEQ_MASK + 1 <= UINT16_MAX,
 		      "active_put_signal must fit within the 16-bit seq_num range");
+
+	/* Cached popcount of active_put_signal. Maintained incrementally on
+	   every transition (set/reset) so the 50%-utilization gate in
+	   iputSignal does not have to walk all 128 uint64_t words of the
+	   bitset on every call. */
+	uint16_t active_put_signal_count = 0;
 };
 
 /**
@@ -242,7 +248,25 @@ public:
 
 	void clear_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num)
 	{
-		rank_comms[peer_rank].active_put_signal.reset(msg_seq_num & GIN_IMM_SEQ_MASK);
+		auto &rank_comm = rank_comms[peer_rank];
+		const uint16_t bit = msg_seq_num & GIN_IMM_SEQ_MASK;
+		if (rank_comm.active_put_signal.test(bit)) {
+			rank_comm.active_put_signal.reset(bit);
+			rank_comm.active_put_signal_count--;
+		}
+	}
+
+	/* Set the bit for msg_seq_num to `value`. Maintains the cached
+	   popcount in active_put_signal_count. */
+	void set_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num, bool value)
+	{
+		auto &rank_comm = rank_comms[peer_rank];
+		const uint16_t bit = msg_seq_num & GIN_IMM_SEQ_MASK;
+		const bool prev = rank_comm.active_put_signal.test(bit);
+		if (prev != value) {
+			rank_comm.active_put_signal.set(bit, value);
+			rank_comm.active_put_signal_count += value ? 1 : -1;
+		}
 	}
 
 	void clear_ack_range(uint32_t peer_rank, uint16_t ack_seq_num, uint16_t ack_count)
@@ -258,9 +282,6 @@ public:
 	/* Wait for any outstanding requests as necessary. Should be called before
 	   the GIN comm is destructed. */
 	int await_pending_requests() override;
-
-	/* Flush bundled acks that were not sent with metadata. Called from progress. */
-	int flush_stale_acks();
 
 	/**
 	 * iputSignal API. Transfers some user data (determined by memory registrations
@@ -458,7 +479,7 @@ private:
 	int iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 					    nccl_net_ofi_gin_iputsignal_recv_req *req);
 
-	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num);
+	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num, bool is_ack_requested);
 
 	int retire_completed_peer_iput_ops(uint32_t peer_rank);
 

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -66,70 +66,87 @@ struct nccl_ofi_gin_resource_releaser {
 };
 
 /**
- * Pending bundled ack: accumulated in deliver_all,
- * sent with the next outgoing metadata message to this peer.
- * Empty when ack_count == 0.
- */
-struct nccl_ofi_gin_pending_ack_info {
-	nccl_ofi_dlist_node node;
-	uint32_t peer_rank = 0;
-	uint32_t start = 0;
-	uint16_t seq_num = 0;
-	uint16_t ack_count = 0;
-};
-
-/**
  * Represents per-peer-rank data associated with a collective communicator.
  *
  * The collective communicator stores a vector of these structures, of size
  * nranks.
+ *
+ * Producer/consumer flow-control model
+ * ------------------------------------
+ * Each peer pair maintains four monotonically-advancing cursors of width
+ * GIN_RX_CONSUMED_BITS (= GIN_IMM_SEQ_BITS + 1, so exactly 2x the seq
+ * window). Cursors wrap at GIN_RX_CONSUMED_MASK + 1 and are stored in a
+ * uint32_t backing for cheap arithmetic.
+ *
+ *   tx_head     - sender: ops produced (advances on every iputSignal)
+ *   tx_tail     - sender's local view of "ops the receiver has consumed"
+ *                 (advances when an ACK -- bundled or standalone -- arrives)
+ *   rx_consumed - receiver: ops delivered upstream in seq order
+ *   rx_acked    - receiver: last value of rx_consumed it sent back
+ *
+ * Wrap-safe forward delta is computed as
+ *     ((b - a) & GIN_RX_CONSUMED_MASK)
+ * which is in [0, 2x seq window). A delta in the lower half is "forward",
+ * in the upper half is "backward" (older ACK or duplicate).
+ *
+ * Invariants:
+ *   outstanding   = (tx_head - tx_tail) & GIN_RX_CONSUMED_MASK
+ *   tx may send   iff outstanding < GIN_IMM_SEQ_MASK + 1
+ *   ack-request   when outstanding >= GIN_ACK_REQ_THRESHOLD
+ *
+ * The wire seq number is the low GIN_IMM_SEQ_BITS of tx_head.
+ * The wire `rx_consumed` field is the entire receiver-side cursor
+ * (since cursor width matches wire width).
  */
 struct nccl_ofi_gin_peer_rank_info {
 	/* Remote comm id */
 	uint32_t comm_id;
 
-	/* Counter for consecutive PUT-only messages without ACK.
-	   When this reaches OFI_NCCL_GIN_ACK_INTERVAL, the next PUT will request an ACK.
-	   Reset to 0 when SIGNAL or PUT-SIGNAL is sent. */
-	uint32_t consecutive_puts_without_ack = 0;
-
-	/* A sequence number, stored at initiator, exclusively for this (target) peer rank.
-	   This allows the remote rank to enforce ordering of signal delivery
-
-	   A 16-bit integer is large enough to store all outstanding requests, because the
-	   plugin and NCCL limit max inflight requests. (See NCCL_OFI_MAX_REQUESTS.) */
-	uint16_t next_target_seq_num = 0;
-
-	/**
-	 * Next-to-be-delivered sequence number, stored at target, from
-	 * (initiator) peer rank
-	 */
-	uint16_t next_delivered_signal_seq_num = 0;
-
-	nccl_ofi_gin_pending_ack_info pending_ack;
-
 	/* Rail addresses */
 	fi_addr_t address[MAX_NUM_RAILS];
 
-	/* Flag, stored at initiator, indicating the given sequence number (mod
-	   the sequence space) is in use at initiator side. This allows initiator
-	   to track in-use sequence numbers to avoid overflow and only mark
-	   iputSignal complete when it has received the ack from the target,
-	   which has delivered the signal atomic.
-	
-	   Sized to the full sequence number space so that every in-flight
-	   seq number maps to a unique slot, regardless of how many contexts
-	   are active. */
-	std::bitset<GIN_IMM_SEQ_MASK + 1> active_put_signal;
-	static_assert(GIN_IMM_SEQ_MASK + 1 <= UINT16_MAX,
-		      "active_put_signal must fit within the 16-bit seq_num range");
+	/* Sender-side cursors. tx_head is the next ring-position we'll
+	   produce; tx_tail is the latest position the receiver has
+	   acknowledged consuming. tx_head's low GIN_IMM_SEQ_BITS go on
+	   the wire as msg_seq_num. */
+	uint32_t tx_head = 0;
+	uint32_t tx_tail = 0;
 
-	/* Cached popcount of active_put_signal. Maintained incrementally on
-	   every transition (set/reset) so the 50%-utilization gate in
-	   iputSignal does not have to walk all 128 uint64_t words of the
-	   bitset on every call. */
-	uint16_t active_put_signal_count = 0;
+	/* Receiver-side cursors. rx_consumed advances every time we retire
+	   an op in seq order (signal delivered upstream). rx_acked is the
+	   latest value of rx_consumed we transmitted back to the peer either
+	   via metadata piggyback or a standalone ACK. */
+	uint32_t rx_consumed = 0;
+	uint32_t rx_acked = 0;
+
+	/* Hysteresis counter for the sender-side ack-request gate. Once
+	   outstanding crosses GIN_ACK_REQ_THRESHOLD this counts ops; only
+	   every GIN_ACK_INTERVAL'th op flips ack_req on the wire. Without
+	   this, every op above threshold would request an ACK and we'd
+	   flood the receiver with standalone ACK packets. */
+	uint32_t consecutive_puts_without_ack = 0;
+
+	/**
+	 * Next-to-be-delivered sequence number, stored at target, from
+	 * (initiator) peer rank. Mirrors the low GIN_IMM_SEQ_BITS of
+	 * rx_consumed; kept as a separate field to match how it is read
+	 * (compared against incoming msg_seq_num bitfield).
+	 */
+	uint16_t next_delivered_signal_seq_num = 0;
 };
+
+/* Helpers for the cursor ring. Cursors are uint32_t in memory but we
+   never let them advance past GIN_RX_CONSUMED_MASK, so subtraction is
+   performed under the same mask. */
+static inline uint32_t gin_cursor_inc(uint32_t c)
+{
+	return (c + 1) & GIN_RX_CONSUMED_MASK;
+}
+
+static inline uint32_t gin_cursor_delta(uint32_t lhs, uint32_t rhs)
+{
+	return (lhs - rhs) & GIN_RX_CONSUMED_MASK;
+}
 
 /**
  * Representation of a remote rank's memory registration
@@ -241,41 +258,23 @@ public:
 		outstanding_ack_counter--;
 	}
 
-	bool query_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num) const
-	{
-		return rank_comms[peer_rank].active_put_signal.test(msg_seq_num & GIN_IMM_SEQ_MASK);
-	}
-
-	void clear_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num)
-	{
-		auto &rank_comm = rank_comms[peer_rank];
-		const uint16_t bit = msg_seq_num & GIN_IMM_SEQ_MASK;
-		if (rank_comm.active_put_signal.test(bit)) {
-			rank_comm.active_put_signal.reset(bit);
-			rank_comm.active_put_signal_count--;
-		}
-	}
-
-	/* Set the bit for msg_seq_num to `value`. Maintains the cached
-	   popcount in active_put_signal_count. */
-	void set_ack_outstanding(uint32_t peer_rank, uint16_t msg_seq_num, bool value)
+	/**
+	 * Apply an inbound rx_consumed cursor from the peer (bundled on
+	 * metadata or on a standalone ACK). Wrap-safe: only advances tx_tail
+	 * when the cursor represents forward progress.
+	 *
+	 * The wire value is already at the cursor width (GIN_RX_CONSUMED_BITS)
+	 * thanks to the bitfield bring-in. We compute the modular forward
+	 * delta from tx_tail; out-of-order older ACKs land in the upper half
+	 * of the ring and are dropped.
+	 */
+	void apply_rx_consumed(uint32_t peer_rank, uint32_t wire_rx_consumed)
 	{
 		auto &rank_comm = rank_comms[peer_rank];
-		const uint16_t bit = msg_seq_num & GIN_IMM_SEQ_MASK;
-		const bool prev = rank_comm.active_put_signal.test(bit);
-		if (prev != value) {
-			rank_comm.active_put_signal.set(bit, value);
-			rank_comm.active_put_signal_count += value ? 1 : -1;
-		}
-	}
-
-	void clear_ack_range(uint32_t peer_rank, uint16_t ack_seq_num, uint16_t ack_count)
-	{
-		uint16_t seq = (ack_seq_num - ack_count + 1) & GIN_IMM_SEQ_MASK;
-		while (true) {
-			clear_ack_outstanding(peer_rank, seq);
-			if (seq == ack_seq_num) break;
-			seq = (seq + 1) & GIN_IMM_SEQ_MASK;
+		const uint32_t delta = gin_cursor_delta(wire_rx_consumed,
+							rank_comm.tx_tail);
+		if (delta > 0 && delta <= GIN_RX_CONSUMED_HALF) {
+			rank_comm.tx_tail = wire_rx_consumed;
 		}
 	}
 
@@ -433,11 +432,6 @@ private:
 		outstanding_iput_signal_recv_reqs;
 
 	/* --- TIER 3: progress / ack flush path --- */
-	/* Active queue of peers with pending acks.
-	   Only these are visited by flush_stale_acks(). */
-	nccl_ofi_dlist pending_ack_list;
-	uint32_t progress_counter = 0;
-
 	/* Number of outstanding RDMA writes for signal delivery acknowledgement.
 	   Used to wait for remaining acknowledgements on communicator close. */
 	uint32_t outstanding_ack_counter = 0;
@@ -461,15 +455,16 @@ private:
 	/* --- Private methods --- */
 
 	/**
-	 * Send a range ACK via fi_send to the peer.
+	 * Send a standalone ACK via fi_send to the peer carrying our
+	 * receiver-side rx_consumed cursor. Sender uses this to advance its
+	 * tx_tail and free up window slots.
 	 *
 	 * @param gin_comm communicator to send the ACK on
 	 * @param peer_rank rank to send the acknowledgement to
-	 * @param ack_seq_num last (highest) sequence number in the acknowledged range
-	 * @param count number of seq_nums in the acknowledged range
+	 * @param rx_consumed receiver's rx_consumed cursor at this moment
 	 */
 	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
-		     uint32_t ack_seq_num, uint32_t count);
+		     uint32_t rx_consumed);
 
 	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
 
@@ -479,7 +474,12 @@ private:
 	int iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
 					    nccl_net_ofi_gin_iputsignal_recv_req *req);
 
-	int stash_pending_ack(uint32_t peer_rank, uint16_t seq_num, bool is_ack_requested);
+	/**
+	 * Receiver-side: emit a standalone ACK if we have unsent rx_consumed
+	 * progress and either the sender requested it or we've crossed the
+	 * flush threshold. Idempotent and cheap when there's nothing to do.
+	 */
+	int maybe_send_ack(uint32_t peer_rank, bool sender_requested);
 
 	int retire_completed_peer_iput_ops(uint32_t peer_rank);
 

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -218,10 +218,9 @@ class nccl_net_ofi_gin_metadata_send_req_t;
 class nccl_ofi_rdma_gin_iputsignal_req : public nccl_net_ofi_gin_base_req {
 public:
 	nccl_ofi_rdma_gin_iputsignal_req(
-		nccl_ofi_rdma_gin_put_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg,
-		bool is_ack_requested_arg)
+		nccl_ofi_rdma_gin_put_comm &gin_comm_arg, uint32_t peer_rank_arg, uint16_t msg_seq_num_arg)
 	    : any_reqs_pending(0), gin_comm(gin_comm_arg),
-	      peer_rank(peer_rank_arg), msg_seq_num(msg_seq_num_arg), is_ack_requested(is_ack_requested_arg)
+	      peer_rank(peer_rank_arg), msg_seq_num(msg_seq_num_arg)
 	{
 	}
 
@@ -243,8 +242,6 @@ private:
 	uint32_t peer_rank;
 	/* Message sequence number */
 	uint16_t msg_seq_num;
-	/* True if sender is requesting an ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
-	bool is_ack_requested;
 };
 
 /**

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -259,6 +259,11 @@ public:
 		return gin_ep;
 	}
 
+	int get_dev() const
+	{
+		return dev;
+	}
+
 	size_t alloc_comm_id()
 	{
 		return comm_id_pool.allocate_id();
@@ -379,6 +384,9 @@ private:
 	nccl_ofi_gin_ep_holder ep_holder;
 
 	nccl_ofi_rdma_gin_ep_t gin_ep;
+
+	/* Device id; cached for cheap access in tracepoint emission. */
+	int dev;
 
 	/* Requests pool used by all comms of this resource */
 	// FIXME: Get rid of freelist_deleter and change to embedded

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -83,16 +83,33 @@ enum gin_msg_type_t : uint8_t {
 static_assert(((1 << GIN_MSG_TYPE_BITS) - 1) >= GIN_MSG_TYPE_MAX,
 	      "GIN_MSG_TYPE_BITS must be wide enough to hold all message types");
 
-/* Bundled/standalone ack count. ack_count == 0 means no ack. */
-#define GIN_ACK_COUNT_BITS    10
-#define GIN_ACK_COUNT_MASK    ((1 << GIN_ACK_COUNT_BITS) - 1)
+/* Receiver's "rx_consumed" cursor: the count of in-order delivered ops
+   modulo a wrap-safe space. The wire width is exactly twice the seq
+   window so the standard half-window forward-delta comparison
+   distinguishes "newer" from "older" ACKs without ambiguity. */
+#define GIN_RX_CONSUMED_BITS  (GIN_IMM_SEQ_BITS + 1)
+#define GIN_RX_CONSUMED_MASK  (((uint64_t)1 << GIN_RX_CONSUMED_BITS) - 1)
+#define GIN_RX_CONSUMED_HALF  ((uint32_t)((GIN_RX_CONSUMED_MASK + 1) >> 1))
+static_assert((1ULL << GIN_RX_CONSUMED_BITS) == 2ULL * (GIN_IMM_SEQ_MASK + 1),
+	      "GIN_RX_CONSUMED_BITS must give exactly 2x the seq window for "
+	      "wrap-safe forward-delta comparison between TX/RX cursors");
+
+/* Once the sender's outstanding window is at GIN_ACK_REQ_THRESHOLD, only
+   request a standalone ACK every GIN_ACK_INTERVAL ops. Without this
+   throttle, every iputSignal above the threshold would request an ACK,
+   producing an ACK storm rather than the slow drip the receiver needs
+   to drain the bitset. */
+#define GIN_ACK_INTERVAL  64
+static_assert(GIN_ACK_INTERVAL <= (GIN_IMM_SEQ_MASK >> 1),
+	      "GIN_ACK_INTERVAL must be much smaller than the seq window so "
+	      "ack-request hysteresis does not delay drain past wrap");
 
 /* Maximum number of GIN comms */
 #define NCCL_GIN_MAX_COMMS    (1 << GIN_IMM_COMM_BITS)
 
 /* Reserved bit computation for Metadata message header */
 #define GIN_MSG_HEADER_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
-                                      - GIN_IMM_SEQ_BITS - GIN_ACK_COUNT_BITS    \
+                                      - GIN_RX_CONSUMED_BITS                    \
                                       - GIN_IMM_SEQ_BITS - GIN_IMM_SEG_CNT_BITS \
                                       - 1 /* ack_req */)
 
@@ -100,25 +117,26 @@ static_assert(((1 << GIN_MSG_TYPE_BITS) - 1) >= GIN_MSG_TYPE_MAX,
  * Metadata message header (64 bits).
  *
  * Both nccl_net_ofi_gin_msg_header_t and gin_ack_msg_t share a common
- * prefix in bits [0:34]: msg_type(2) + comm_id(10) + ack_seq_num(13) +
- * ack_count(10) = 35 bits.  This allows dispatch and ACK processing to
- * read from the same offsets regardless of message type.
+ * prefix in bits [0:25]: msg_type(2) + comm_id(10) + rx_consumed(14) =
+ * 26 bits.  This allows dispatch and ACK processing to read from the
+ * same offsets regardless of message type.
  */
 struct nccl_net_ofi_gin_msg_header_t {
 	/* Message type identifier */
 	uint64_t msg_type        : GIN_MSG_TYPE_BITS;
 	/* Comm identifier on the receiver side */
 	uint64_t remote_comm_id  : GIN_IMM_COMM_BITS;
-	/* Bundled ack sequence number (ack_count == 0 when absent) */
-	uint64_t ack_seq_num     : GIN_IMM_SEQ_BITS;
-	/* Bundled ack count */
-	uint64_t ack_count       : GIN_ACK_COUNT_BITS;
+	/* Receiver's rx_consumed cursor at the time this packet was queued.
+	   Wraps at 2x the seq window. The sender uses a wrap-safe forward
+	   delta against tx_tail (see apply_rx_consumed) to advance its tail. */
+	uint64_t rx_consumed     : GIN_RX_CONSUMED_BITS;
 	/* Message sequence number and count */
 	uint64_t seq_num         : GIN_IMM_SEQ_BITS;
 	uint64_t seq_seg_cnt     : GIN_IMM_SEG_CNT_BITS;
-	/* Receiver should ACK this seq_num. Mirrors the GIN_IMM_ACK_REQ bit
-	 * carried in the data-write immediate; the sender sets both to the
-	 * same value, the receiver OR's them across the two submission paths. */
+	/* Receiver should send back a standalone ACK soon. Mirrors the
+	 * GIN_IMM_ACK_REQ bit carried in the data-write immediate; the sender
+	 * sets both to the same value, the receiver OR's them across the two
+	 * submission paths. */
 	uint64_t ack_req         : 1;
 	/* Reserved for future use */
 	uint64_t reserved        : GIN_MSG_HEADER_RESERVED_BITS;
@@ -141,7 +159,7 @@ static_assert(sizeof(nccl_net_ofi_gin_signal_metadata_msg_t) == 32,
 	     "nccl_net_ofi_gin_signal_metadata_msg_t must be exactly 32 bytes for inline send");
 
 #define GIN_ACK_MSG_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
-                                   - GIN_IMM_SEQ_BITS - GIN_ACK_COUNT_BITS)
+                                   - GIN_RX_CONSUMED_BITS)
 
 /**
  * Standalone ACK message sent via fi_send from receiver to sender (8 bytes).
@@ -154,10 +172,8 @@ struct gin_ack_msg_t {
 	uint64_t msg_type        : GIN_MSG_TYPE_BITS;
 	/* Comm identifier on the original sender side */
 	uint64_t ack_comm_id     : GIN_IMM_COMM_BITS;
-	/* ACK sequence number */
-	uint64_t ack_seq_num     : GIN_IMM_SEQ_BITS;
-	/* ACK count */
-	uint64_t ack_count       : GIN_ACK_COUNT_BITS;
+	/* Receiver's rx_consumed cursor (wraps at 2x seq window) */
+	uint64_t rx_consumed     : GIN_RX_CONSUMED_BITS;
 	/* Reserved for future use */
 	uint64_t reserved        : GIN_ACK_MSG_RESERVED_BITS;
 };
@@ -177,28 +193,21 @@ static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, header) == 0,
 #if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 9)
 static_assert(
 	__builtin_bit_cast(uint64_t,
-		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0, 0})
+		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0})
 		== (uint64_t)GIN_MSG_TYPE_MAX,
 	"msg_type must be at LSB of nccl_net_ofi_gin_msg_header_t");
 static_assert(
 	__builtin_bit_cast(uint64_t,
-		gin_ack_msg_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0})
+		gin_ack_msg_t{GIN_MSG_TYPE_MAX, 0, 0, 0})
 		== (uint64_t)GIN_MSG_TYPE_MAX,
 	"msg_type must be at LSB of gin_ack_msg_t");
 #endif
 
-/* ACK interval for PUT-only messages. Send an ACK every N consecutive PUTs
-   to prevent sequence number wraparound. */
-#define GIN_ACK_INTERVAL 64
-static_assert(GIN_ACK_INTERVAL <= (1 << (GIN_IMM_SEQ_BITS - 1)),
-	      "GIN_ACK_INTERVAL must not exceed half the sequence number space");
-
-/* Receiver-side stash batching: call stash_pending_ack() once every
-   GIN_STASH_BATCH retires. The range-encoded bundle (prev_start +
-   ack_count) extends to the new high water mark on the next stash, so
-   skipped retires are picked up for free. Must be a power of two. */
-#define GIN_STASH_BATCH 128
-static_assert((GIN_STASH_BATCH & (GIN_STASH_BATCH - 1)) == 0,
-	      "GIN_STASH_BATCH must be a power of two");
+/* Sender requests an ACK once the outstanding window is at least half full
+   (i.e. tx_head - tx_tail >= GIN_ACK_REQ_THRESHOLD). The receiver answers
+   either by piggybacking its `consumed` cursor on the next outbound
+   metadata to this peer, or via a standalone ACK packet when no metadata
+   is in flight back to us. */
+#define GIN_ACK_REQ_THRESHOLD ((GIN_IMM_SEQ_MASK + 1) / 2)
 
 #endif

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -93,7 +93,8 @@ static_assert(((1 << GIN_MSG_TYPE_BITS) - 1) >= GIN_MSG_TYPE_MAX,
 /* Reserved bit computation for Metadata message header */
 #define GIN_MSG_HEADER_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
                                       - GIN_IMM_SEQ_BITS - GIN_ACK_COUNT_BITS    \
-                                      - GIN_IMM_SEQ_BITS - GIN_IMM_SEG_CNT_BITS)
+                                      - GIN_IMM_SEQ_BITS - GIN_IMM_SEG_CNT_BITS \
+                                      - 1 /* ack_req */)
 
 /**
  * Metadata message header (64 bits).
@@ -115,6 +116,10 @@ struct nccl_net_ofi_gin_msg_header_t {
 	/* Message sequence number and count */
 	uint64_t seq_num         : GIN_IMM_SEQ_BITS;
 	uint64_t seq_seg_cnt     : GIN_IMM_SEG_CNT_BITS;
+	/* Receiver should ACK this seq_num. Mirrors the GIN_IMM_ACK_REQ bit
+	 * carried in the data-write immediate; the sender sets both to the
+	 * same value, the receiver OR's them across the two submission paths. */
+	uint64_t ack_req         : 1;
 	/* Reserved for future use */
 	uint64_t reserved        : GIN_MSG_HEADER_RESERVED_BITS;
 };
@@ -172,7 +177,7 @@ static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, header) == 0,
 #if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 9)
 static_assert(
 	__builtin_bit_cast(uint64_t,
-		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0})
+		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0, 0})
 		== (uint64_t)GIN_MSG_TYPE_MAX,
 	"msg_type must be at LSB of nccl_net_ofi_gin_msg_header_t");
 static_assert(
@@ -188,7 +193,12 @@ static_assert(
 static_assert(GIN_ACK_INTERVAL <= (1 << (GIN_IMM_SEQ_BITS - 1)),
 	      "GIN_ACK_INTERVAL must not exceed half the sequence number space");
 
-/* Max progress calls a bundled ack can wait before being flushed. */
-#define GIN_ACK_MAX_AGE 50
+/* Receiver-side stash batching: call stash_pending_ack() once every
+   GIN_STASH_BATCH retires. The range-encoded bundle (prev_start +
+   ack_count) extends to the new high water mark on the next stash, so
+   skipped retires are picked up for free. Must be a power of two. */
+#define GIN_STASH_BATCH 128
+static_assert((GIN_STASH_BATCH & (GIN_STASH_BATCH - 1)) == 0,
+	      "GIN_STASH_BATCH must be a power of two");
 
 #endif

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -505,6 +505,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_ARGS(
             int, dev,
             uint16_t, rail_id,
+            size_t, size,
             void *, comm,
             uint32_t, peer_rank,
             uint16_t, msg_seq_num,
@@ -513,6 +514,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint64_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
@@ -526,6 +528,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_ARGS(
             int, dev,
             uint16_t, rail_id,
+            size_t, size,
             void *, comm,
             uint32_t, peer_rank,
             uint16_t, msg_seq_num,
@@ -534,6 +537,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint64_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
@@ -557,27 +561,6 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(uint16_t, rail_id, rail_id)
             lttng_ust_field_integer(size_t, size, size)
-            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
-            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
-            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
-            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
-    )
-)
-
-LTTNG_UST_TRACEPOINT_EVENT(
-    nccl_ofi_plugin,
-    gin_recv_metadata,
-    LTTNG_UST_TP_ARGS(
-            int, dev,
-            uint16_t, rail_id,
-            void *, comm,
-            uint32_t, peer_rank,
-            uint16_t, msg_seq_num,
-            void *, request
-    ),
-    LTTNG_UST_TP_FIELDS(
-            lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
@@ -658,6 +641,224 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_test_func_begin,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request,
+            int, has_write_reqs,
+            int, has_send_req
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(int, has_write_reqs, has_write_reqs)
+            lttng_ust_field_integer(int, has_send_req, has_send_req)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_test_func_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            void *, request,
+            int, done,
+            int, freed
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
+            lttng_ust_field_integer(int, done, done)
+            lttng_ust_field_integer(int, freed, freed)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_signal_write_completion_func_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            uint64_t, total_segms,
+            uint64_t, len,
+            int, is_ack_requested
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(uint64_t, total_segms, total_segms)
+            lttng_ust_field_integer(uint64_t, len, len)
+            lttng_ust_field_integer(int, is_ack_requested, is_ack_requested)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_signal_write_completion_func_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            int, ret
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(int, ret, ret)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_signal_metadata_completion_func_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            uint16_t, num_segments,
+            uint16_t, ack_count
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(uint16_t, num_segments, num_segments)
+            lttng_ust_field_integer(uint16_t, ack_count, ack_count)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_signal_metadata_completion_func_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, msg_seq_num,
+            int, ret
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(int, ret, ret)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_ack_completion_func_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, ack_seq_num,
+            uint16_t, count
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, ack_seq_num, ack_seq_num)
+            lttng_ust_field_integer(uint16_t, count, count)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_handle_ack_completion_func_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint16_t, rail_id,
+            uint32_t, peer_rank,
+            uint16_t, ack_seq_num,
+            int, ret
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint16_t, rail_id, rail_id)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, ack_seq_num, ack_seq_num)
+            lttng_ust_field_integer(int, ret, ret)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_stash_pending_ack_func_start,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, seq_num
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, seq_num, seq_num)
+    )
+)
+
+LTTNG_UST_TRACEPOINT_EVENT(
+    nccl_ofi_plugin,
+    gin_stash_pending_ack_func_end,
+    LTTNG_UST_TP_ARGS(
+            int, dev,
+            void *, comm,
+            uint32_t, peer_rank,
+            uint16_t, seq_num,
+            uint16_t, ack_count,
+            int, flushed,
+            int, ret
+    ),
+    LTTNG_UST_TP_FIELDS(
+            lttng_ust_field_integer(int, dev, dev)
+            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
+            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
+            lttng_ust_field_integer(uint16_t, seq_num, seq_num)
+            lttng_ust_field_integer(uint16_t, ack_count, ack_count)
+            lttng_ust_field_integer(int, flushed, flushed)
+            lttng_ust_field_integer(int, ret, ret)
     )
 )
 

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -746,7 +746,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             uint32_t, peer_rank,
             uint16_t, msg_seq_num,
             uint16_t, num_segments,
-            uint16_t, ack_count
+            uint32_t, consumed
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
@@ -755,7 +755,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
             lttng_ust_field_integer(uint16_t, num_segments, num_segments)
-            lttng_ust_field_integer(uint16_t, ack_count, ack_count)
+            lttng_ust_field_integer(uint32_t, consumed, consumed)
     )
 )
 
@@ -788,16 +788,14 @@ LTTNG_UST_TRACEPOINT_EVENT(
             void *, comm,
             uint16_t, rail_id,
             uint32_t, peer_rank,
-            uint16_t, ack_seq_num,
-            uint16_t, count
+            uint32_t, consumed
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint16_t, rail_id, rail_id)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
-            lttng_ust_field_integer(uint16_t, ack_seq_num, ack_seq_num)
-            lttng_ust_field_integer(uint16_t, count, count)
+            lttng_ust_field_integer(uint32_t, consumed, consumed)
     )
 )
 
@@ -809,7 +807,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             void *, comm,
             uint16_t, rail_id,
             uint32_t, peer_rank,
-            uint16_t, ack_seq_num,
+            uint32_t, consumed,
             int, ret
     ),
     LTTNG_UST_TP_FIELDS(
@@ -817,47 +815,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint16_t, rail_id, rail_id)
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
-            lttng_ust_field_integer(uint16_t, ack_seq_num, ack_seq_num)
-            lttng_ust_field_integer(int, ret, ret)
-    )
-)
-
-LTTNG_UST_TRACEPOINT_EVENT(
-    nccl_ofi_plugin,
-    gin_stash_pending_ack_func_start,
-    LTTNG_UST_TP_ARGS(
-            int, dev,
-            void *, comm,
-            uint32_t, peer_rank,
-            uint16_t, seq_num
-    ),
-    LTTNG_UST_TP_FIELDS(
-            lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
-            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
-            lttng_ust_field_integer(uint16_t, seq_num, seq_num)
-    )
-)
-
-LTTNG_UST_TRACEPOINT_EVENT(
-    nccl_ofi_plugin,
-    gin_stash_pending_ack_func_end,
-    LTTNG_UST_TP_ARGS(
-            int, dev,
-            void *, comm,
-            uint32_t, peer_rank,
-            uint16_t, seq_num,
-            uint16_t, ack_count,
-            int, flushed,
-            int, ret
-    ),
-    LTTNG_UST_TP_FIELDS(
-            lttng_ust_field_integer(int, dev, dev)
-            lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
-            lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
-            lttng_ust_field_integer(uint16_t, seq_num, seq_num)
-            lttng_ust_field_integer(uint16_t, ack_count, ack_count)
-            lttng_ust_field_integer(int, flushed, flushed)
+            lttng_ust_field_integer(uint32_t, consumed, consumed)
             lttng_ust_field_integer(int, ret, ret)
     )
 )

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -259,13 +259,6 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(comm, rail_id, rank, msg_seq_num, request) do { \
-	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
-		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
-		nvtx_mark_domain(handle, "gin_recv_metadata", 0x9370DB); \
-	} \
-} while(0)
-
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
@@ -319,7 +312,6 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 #define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(...)
 #define NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(...)
 #define NCCL_OFI_TRACE_GIN_RECV_WRITE_NVTX(...)
-#define NCCL_OFI_TRACE_GIN_RECV_METADATA_NVTX(...)
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(...)
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(...)
 #define NCCL_OFI_TRACE_GIN_ACK_RECV_NVTX(...)

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -625,7 +625,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			gin_ep.get_rail(rail_id).ofi_ep.get(), rail_id, metadata_elem,
 			rank_comm.address[rail_id], metadata_fl.get(), this);
 
-		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, this, dst_rank, msg_seq_num,
+		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, sizeof(nccl_net_ofi_gin_signal_metadata_msg_t), this, dst_rank, msg_seq_num,
 						       send_req);
 		ret = send_req->post();
 		if (ret == -FI_EAGAIN) {
@@ -905,6 +905,10 @@ int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t s
 {
 	auto &rank_comm = this->rank_comms[peer_rank];
 
+	NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_START(dev, this, peer_rank, seq_num);
+	int flushed = 0;
+	(void)flushed;  /* Used only when tracing is enabled */
+
 	if (rank_comm.pending_ack.node.on_list()) {
 		if (rank_comm.pending_ack.ack_count > 0) {
 			/* Callers must add ranges in-order (ascending seq_num).
@@ -921,8 +925,12 @@ int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t s
 							rank_comm.pending_ack.seq_num,
 							rank_comm.pending_ack.ack_count);
 				if (OFI_UNLIKELY(ret != 0)) {
+					NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(
+						dev, this, peer_rank, seq_num,
+						rank_comm.pending_ack.ack_count, 1, ret);
 					return ret;
 				}
+				flushed = 1;
 				merged_count = 1;
 			}
 			rank_comm.pending_ack.ack_count = merged_count;
@@ -938,6 +946,10 @@ int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t s
 
 	rank_comm.pending_ack.seq_num = seq_num;
 	rank_comm.pending_ack.start = progress_counter;
+
+	NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(dev, this, peer_rank, seq_num,
+						      rank_comm.pending_ack.ack_count,
+						      flushed, 0);
 	return 0;
 }
 
@@ -1020,6 +1032,10 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
 
+	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(
+		dev, this, rail_id, peer_rank, msg_seq_num, num_segments,
+		metadata_msg->header.ack_count);
+
 	/* Process bundled ack if present */
 	if (metadata_msg->header.ack_count > 0) {
 		clear_ack_range(peer_rank,
@@ -1054,11 +1070,15 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	if (!strong_signal_ordering_enabled && req->num_seg_completions == req->total_segments) {
 		ret = do_gin_signal_and_trace(peer_rank, req);
 		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
+				dev, this, rail_id, peer_rank, msg_seq_num, ret);
 			return ret;
 		}
 	}
-	NCCL_OFI_TRACE_GIN_RECV_METADATA(dev, rail_id, this, peer_rank, msg_seq_num, req);
 	ret = retire_completed_peer_iput_ops(peer_rank);
+
+	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
+		dev, this, rail_id, peer_rank, msg_seq_num, ret);
 
 	return ret;
 }
@@ -1071,6 +1091,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(const gin_ack_msg_t *ack_m
 	uint16_t count = ack_msg->ack_count;
 	assert(count > 0);
 
+	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, this, rail_id, peer_rank,
+							    ack_seq_num, count);
+
 	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
 
 	/* Self-contained range ACK: clear ack_outstanding from start_seq
@@ -1081,6 +1104,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(const gin_ack_msg_t *ack_m
 	   in any order. A single ack_seq_num would require cumulative
 	   state that breaks under reordering. */
 	clear_ack_range(peer_rank, ack_seq_num, count);
+
+	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, this, rail_id, peer_rank,
+							  ack_seq_num, 0);
 	return 0;
 }
 
@@ -1093,6 +1119,12 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 	bool is_ack_requested = GIN_IMM_GET_ACK_REQUESTED(cq_entry->data);
 
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
+
+	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_START(dev, this, rail_id, peer_rank,
+								     msg_seq_num, total_segms,
+								     cq_entry->len,
+								     (int)is_ack_requested);
+
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 
 	int ret = 0;
@@ -1131,12 +1163,17 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 		if (!strong_signal_ordering_enabled && req->metadata_received) {
 			ret = do_gin_signal_and_trace(peer_rank, req);
 			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_END(
+					dev, this, rail_id, peer_rank, msg_seq_num, ret);
 				return ret;
 			}
 		}
 	}
 
 	ret = retire_completed_peer_iput_ops(peer_rank);
+
+	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_END(dev, this, rail_id, peer_rank,
+								   msg_seq_num, ret);
 
 	return ret;
 }

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -223,10 +223,8 @@ int nccl_ofi_rdma_gin_listen_comm::connect(nccl_net_ofi_conn_handle_t *handles[]
 }
 
 int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
-			       uint32_t ack_seq_num, uint32_t count)
+			       uint32_t rx_consumed)
 {
-	assert(count <= GIN_ACK_COUNT_MASK);
-
 	/* For now, always send acks on rail 0.
 	   TODO round-robin this like the payload data itself. */
 	const int rail_id = 0;
@@ -247,8 +245,7 @@ int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, u
 	*ack_msg = {};
 	ack_msg->msg_type = GIN_MSG_TYPE_ACK;
 	ack_msg->ack_comm_id = static_cast<uint16_t>(peer_comm_id);
-	ack_msg->ack_seq_num = static_cast<uint16_t>(ack_seq_num);
-	ack_msg->ack_count = static_cast<uint16_t>(count);
+	ack_msg->rx_consumed = rx_consumed & GIN_RX_CONSUMED_MASK;
 
 	auto *ofi_ep = ep.get_rail(rail_id).ofi_ep.get();
 
@@ -262,7 +259,7 @@ int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, u
 		throw;
 	}
 
-	NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, &gin_comm, peer_rank, ack_seq_num);
+	NCCL_OFI_TRACE_GIN_ACK_SEND(dev, rail_id, &gin_comm, peer_rank, rx_consumed);
 
 	int ret = req->post();
 	if (ret == -FI_EAGAIN) {
@@ -392,17 +389,18 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 
 	NCCL_OFI_TRACE(NCCL_NET, "GIN communicator: awaiting pending acks");
 
-	/* Flush any deferred bundled acks so remote senders can
-	  complete their outstanding requests. */
-	for (auto &rank_comm : rank_comms) {
-		if (rank_comm.pending_ack.ack_count > 0) {
-			ret = send_ack(*this, rank_comm.pending_ack.peer_rank,
-				       rank_comm.pending_ack.seq_num,
-				       rank_comm.pending_ack.ack_count);
+	/* Flush any deferred bundled acks so remote senders can complete
+	   their outstanding requests. Walk all peers; if our rx_consumed has
+	   advanced past rx_acked (or there's no metadata going back to this
+	   peer to piggyback on), emit a standalone ACK. */
+	for (uint32_t peer = 0; peer < rank_comms.size(); peer++) {
+		auto &rank_comm = rank_comms[peer];
+		if (gin_cursor_delta(rank_comm.rx_consumed, rank_comm.rx_acked) > 0) {
+			ret = send_ack(*this, peer, rank_comm.rx_consumed);
 			if (OFI_UNLIKELY(ret != 0)) {
 				return ret;
 			}
-			rank_comm.pending_ack.ack_count = 0;
+			rank_comm.rx_acked = rank_comm.rx_consumed;
 		}
 	}
 
@@ -445,7 +443,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 
 	auto &gin_ep = resources.get_ep();
 	auto &rank_comm = rank_comms[dst_rank];
-	uint16_t msg_seq_num = rank_comm.next_target_seq_num;
+	uint16_t msg_seq_num = rank_comm.tx_head & GIN_IMM_SEQ_MASK;
 	uint32_t remote_comm_id = rank_comm.comm_id;
 	auto scheduler = gin_ep.get_scheduler();
 	/* rail_id for metadata send is determined below: either from the
@@ -453,27 +451,29 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	   get_next_rail() when there is no data to coalesce with. */
 	uint16_t rail_id = 0;
 
-	if (OFI_UNLIKELY(rank_comm.active_put_signal.test(msg_seq_num & GIN_IMM_SEQ_MASK))) {
-		NCCL_OFI_WARN("Next sequence number is in use");
+	/* Outstanding window. Cursors live on the GIN_RX_CONSUMED_MASK ring,
+	   so all comparisons mask the modular subtraction. */
+	const uint32_t outstanding = gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail);
+	if (OFI_UNLIKELY(outstanding >= (uint32_t)(GIN_IMM_SEQ_MASK + 1))) {
+		NCCL_OFI_WARN("Outstanding window full (head=%u tail=%u)",
+			      rank_comm.tx_head, rank_comm.tx_tail);
 		assert(false);
 		return -EBUSY;
 	}
 
 	/* Determine if this message needs an ACK.
 	 *
-	 * Same policy for SIGNAL, PUT-SIGNAL, and PUT-only:
-	 * Request an ACK only when both conditions hold:
-	 *   1. The per-peer outstanding-ACK bitset is at >= 50% capacity
-	 *      (so seq-number wraparound is approaching).
-	 *   2. At least GIN_ACK_INTERVAL ops have elapsed since the last ACK
-	 *      request (so we don't ACK on every op when utilization stays
-	 *      above 50%).
-	 *
-	 * Below 50% utilization, no ACK is requested. */
+	 * Same policy for SIGNAL, PUT-SIGNAL, and PUT-only: ask the receiver
+	 * to emit a standalone ACK once the outstanding window is at least
+	 * half full, and only every GIN_ACK_INTERVAL'th op above that
+	 * threshold (hysteresis -- otherwise we'd request an ACK on every op
+	 * once above 50% and flood the receiver with standalone ACKs). Once
+	 * an ACK arrives, tx_tail jumps forward and outstanding drops back
+	 * below the threshold, resetting the gate. */
 	bool has_signal = (signalOp != 0);
 	bool is_ack_requested = false;
 
-	if (OFI_UNLIKELY(rank_comm.active_put_signal_count >= (GIN_IMM_SEQ_MASK >> 1))) {
+	if (OFI_UNLIKELY(outstanding >= GIN_ACK_REQ_THRESHOLD)) {
 		if (OFI_UNLIKELY(rank_comm.consecutive_puts_without_ack++ >= GIN_ACK_INTERVAL)) {
 			is_ack_requested = true;
 			rank_comm.consecutive_puts_without_ack = 0;
@@ -609,14 +609,11 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			metadata_send->signal_value = 0;
 		}
 
-		/* Bundle pending ack for this peer */
-		if (rank_comm.pending_ack.ack_count > 0) {
-			metadata_send->header.ack_seq_num = rank_comm.pending_ack.seq_num;
-			metadata_send->header.ack_count = rank_comm.pending_ack.ack_count;
-			rank_comm.pending_ack.ack_count = 0;
-		} else {
-			metadata_send->header.ack_count = 0;
-		}
+		/* Piggyback our latest rx_consumed cursor for this peer. The
+		   peer reads it via apply_rx_consumed() to advance its tx_tail
+		   without needing a separate ACK round-trip. */
+		metadata_send->header.rx_consumed = rank_comm.rx_consumed;
+		rank_comm.rx_acked = rank_comm.rx_consumed;
 
 		/* This send flushes the QP work queue on the first rail,
 		   issuing a doorbell that includes the coalesced writedata
@@ -648,8 +645,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		req->reqs_pending[MAX_NUM_RAILS] = true;
 	}
 
-	set_ack_outstanding(dst_rank, msg_seq_num, is_ack_requested);
-	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
+	rank_comm.tx_head = gin_cursor_inc(rank_comm.tx_head);
 
 	*request = req;
 	return 0;
@@ -902,130 +898,70 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 	return ret;
 }
 
-/* Extend the pending bundled ack to include seq_num.
+/* Receiver-side ACK emission. Called from the metadata/write CQ handlers
+   after rx_consumed has been advanced by retire_completed_peer_iput_ops.
 
-   Most ops are bundled silently; the sender requests a standalone
-   ACK only when it needs the bit cleared (e.g. seq window crossing the
-   50% threshold), and we flush eagerly in that case.
-
-   Note: under the current sender-side ACK policy, the bundling path here
-   should only ever see seq_nums where the sender did NOT request an ACK.
-   If the sender requested an ACK, the appropriate response is to flush
-   immediately (send a standalone ACK) — silently bundling such a seq_num
-   would defeat the sender's gating logic and leave it waiting on a
-   bit-clear that never comes via the bundled path. The is_ack_requested
-   flush below is what guarantees that. */
-int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num,
-						  bool is_ack_requested)
+   Emits a standalone ACK only when the sender explicitly requested one
+   (the ack_req bit was set in either the data immediate or the metadata
+   header for any of this peer's in-flight ops). When the sender did not
+   request an ACK, rx_consumed gets piggybacked on outbound metadata in
+   the next iputSignal() to this peer; we never emit a standalone ACK
+   on the receiver's own initiative. */
+int nccl_ofi_rdma_gin_put_comm::maybe_send_ack(uint32_t peer_rank, bool sender_requested)
 {
-	auto &rank_comm = this->rank_comms[peer_rank];
-
-	NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_START(dev, this, peer_rank, seq_num);
-	int flushed = 0;
-	(void)flushed;  /* Used only when tracing is enabled */
-
-	uint32_t merged_count = 1;
-
-	if (rank_comm.pending_ack.ack_count > 0) {
-		/* Callers must add ranges in-order (ascending seq_num).
-		   delta must be in (0, half_seq_space] to confirm forward progress. */
-		assert(((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) > 0 &&
-		       ((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) <= (GIN_IMM_SEQ_MASK >> 1));
-
-		uint32_t prev_start = (rank_comm.pending_ack.seq_num
-					- rank_comm.pending_ack.ack_count + 1) & GIN_IMM_SEQ_MASK;
-		merged_count = ((seq_num - prev_start + 1) & GIN_IMM_SEQ_MASK);
-
-		/* Flush the previously-bundled range as a standalone ACK
-		   when the sender explicitly requested one for this seq.
-		   Marked unlikely: under the 50%-utilization gate, an
-		   explicit ACK request only fires when the sender's
-		   outstanding-ACK bitset is at least half full — i.e. the
-		   receiver has not piggybacked a single bundled-ack on
-		   metadata back to this peer for ~half the seq window.
-		   That is a strongly asymmetric traffic pattern: this
-		   side delivered thousands of packets to the peer, and
-		   the peer did not send a single packet back during the
-		   entire window. Even sparse collectives (MoE expert
-		   routing, etc.) generate some return traffic, so hitting
-		   this path is unusual; we log it via TRACE for
-		   diagnosability rather than warning. */
-		if (OFI_UNLIKELY(is_ack_requested)) {
-			NCCL_OFI_TRACE(NCCL_NET,
-				       "Standalone ACK fallback fired on peer_rank %u "
-				       "seq_num %hu (bundle ack_count=%hu): asymmetric "
-				       "traffic — this peer delivered ~half the seq "
-				       "window without sending us a single packet to "
-				       "piggyback on.",
-				       peer_rank, seq_num,
-				       rank_comm.pending_ack.ack_count);
-			int ret = send_ack(*this, peer_rank,
-						rank_comm.pending_ack.seq_num,
-						rank_comm.pending_ack.ack_count);
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(
-					dev, this, peer_rank, seq_num,
-					rank_comm.pending_ack.ack_count, 1, ret);
-				return ret;
-			}
-			flushed = 1;
-			merged_count = 1;
-		}
+	if (!sender_requested) {
+		return 0;
 	}
 
-	rank_comm.pending_ack.peer_rank = peer_rank;
-	rank_comm.pending_ack.ack_count = merged_count;
-	rank_comm.pending_ack.seq_num = seq_num;
-
-	NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(dev, this, peer_rank, seq_num,
-						      rank_comm.pending_ack.ack_count,
-						      flushed, 0);
+	auto &rank_comm = this->rank_comms[peer_rank];
+	int ret = send_ack(*this, peer_rank, rank_comm.rx_consumed);
+	if (OFI_UNLIKELY(ret != 0)) {
+		return ret;
+	}
+	rank_comm.rx_acked = rank_comm.rx_consumed;
 	return 0;
 }
 
 int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_rank)
 {
 	int ret = 0;
+	bool ack_requested = false;
 
-	/* Process undelivered signals in order.  ACK coalescing is
-	   handled entirely by stash_pending_ack(), which extends a
-	   per-peer pending range and flushes only when the sender
-	   explicitly requested an ACK. */
+	/* Walk in-order delivered ops, advancing rx_consumed as we go. The
+	   sender's flow-control window opens up as soon as we ack progress
+	   either via piggyback on outbound metadata (in iputSignal) or via
+	   a standalone ACK (maybe_send_ack at the end of this function). */
 	while (true) {
 		auto &rank_comm = this->rank_comms[peer_rank];
 		uint16_t next_seq_num = rank_comm.next_delivered_signal_seq_num;
 
 		uint64_t map_key = get_req_map_key(peer_rank, next_seq_num);
 		auto it = this->outstanding_iput_signal_recv_reqs.find(map_key);
-		if (it != this->outstanding_iput_signal_recv_reqs.end()) {
-			auto *req = it->second;
-
-			if (req->num_seg_completions == req->total_segments) {
-				ret = stash_pending_ack(peer_rank, next_seq_num,
-							req->is_ack_requested);
-				if (OFI_UNLIKELY(ret != 0)) {
-					return ret;
-				}
-				rank_comm.next_delivered_signal_seq_num =
-					(rank_comm.next_delivered_signal_seq_num + 1) &
-					GIN_IMM_SEQ_MASK;
-				ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
-				if (OFI_UNLIKELY(ret != 0)) {
-					return ret;
-				}
-
-				this->resources.return_req_to_pool(req);
-			} else {
-				/* No more signals to deliver */
-				break;
-			}
-		} else {
+		if (it == this->outstanding_iput_signal_recv_reqs.end()) {
 			/* No more signals to deliver */
 			break;
 		}
+		auto *req = it->second;
+		if (req->num_seg_completions != req->total_segments) {
+			/* No more signals to deliver */
+			break;
+		}
+
+		ack_requested = ack_requested || req->is_ack_requested;
+		rank_comm.rx_consumed = gin_cursor_inc(rank_comm.rx_consumed);
+		rank_comm.next_delivered_signal_seq_num =
+			(rank_comm.next_delivered_signal_seq_num + 1) & GIN_IMM_SEQ_MASK;
+		ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
+		this->resources.return_req_to_pool(req);
 	}
 
-	return ret;
+	/* If the sender requested an ACK.
+	   emit a standalone ACK now. Otherwise rx_consumed will go out on
+	   the next outbound metadata to this peer via piggyback. */
+	return maybe_send_ack(peer_rank, ack_requested);
 }
 
 int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
@@ -1041,22 +977,15 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 
 	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(
 		dev, this, rail_id, peer_rank, msg_seq_num, num_segments,
-		metadata_msg->header.ack_count);
+		metadata_msg->header.rx_consumed);
 
-	/* Process bundled ack if present.
-	 *
-	 * Sender piggybacks the receiver's pending bundled-ack range on the
-	 * next outbound metadata message; here we apply it to clear our local
-	 * active_put_signal bits for the run [ack_seq_num - ack_count + 1,
-	 * ack_seq_num]. This is the steady-state path that keeps the per-peer
-	 * ack window draining without any standalone ACK round-trips. Standalone
-	 * ACKs only fire as a fallback when the sender explicitly requests one
-	 * (50% gate). */
-	if (metadata_msg->header.ack_count > 0) {
-		clear_ack_range(peer_rank,
-				metadata_msg->header.ack_seq_num,
-				metadata_msg->header.ack_count);
-	}
+	/* Apply piggybacked rx_consumed cursor from the peer. The peer's
+	   metadata is in essence a bundled ACK: it tells us how many of our
+	   ops the peer has already delivered to its application, so we can
+	   advance tx_tail and free up window slots. apply_rx_consumed() is
+	   wrap-safe and a no-op if the cursor doesn't represent forward
+	   progress (e.g. because metadata arrived out of order). */
+	apply_rx_consumed(peer_rank, metadata_msg->header.rx_consumed);
 
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 
@@ -1111,26 +1040,20 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(const gin_ack_msg_t *ack_m
 						      fi_addr_t src_addr, uint16_t rail_id)
 {
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
-	uint16_t ack_seq_num = ack_msg->ack_seq_num;
-	uint16_t count = ack_msg->ack_count;
-	assert(count > 0);
+	uint32_t rx_consumed = ack_msg->rx_consumed;
 
-	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, this, rail_id, peer_rank,
-							    ack_seq_num, count);
+	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_START(dev, this, rail_id, peer_rank, rx_consumed);
 
-	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, ack_seq_num);
+	NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, this, peer_rank, rx_consumed);
 
-	/* Self-contained range ACK: clear ack_outstanding from start_seq
-	   to ack_seq_num. Each ACK carries ack_seq_num and a count so
-	   the sender needs no cumulative state (e.g. last_acked_seq_num).
-	   This is critical because EFA does not guarantee fi_send
-	   ordering — ACKs from different deliver_all calls can arrive
-	   in any order. A single ack_seq_num would require cumulative
-	   state that breaks under reordering. */
-	clear_ack_range(peer_rank, ack_seq_num, count);
+	/* The wire ACK carries the receiver's full rx_consumed cursor.
+	   apply_rx_consumed() advances tx_tail wrap-safely; older ACKs
+	   arriving after newer ones are no-ops because they don't move
+	   tx_tail forward. */
+	apply_rx_consumed(peer_rank, rx_consumed);
 
 	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, this, rail_id, peer_rank,
-							  ack_seq_num, 0);
+						  rx_consumed, 0);
 	return 0;
 }
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -394,17 +394,16 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 
 	/* Flush any deferred bundled acks so remote senders can
 	  complete their outstanding requests. */
-	nccl_ofi_dlist_node *pos;
-	nccl_ofi_dlist_for_each_safe(&pending_ack_list, pos) {
-		auto *pa = nccl_ofi_dlist_entry(pos, &nccl_ofi_gin_pending_ack_info::node);
-		if (pa->ack_count > 0) {
-			ret = send_ack(*this, pa->peer_rank,
-				pa->seq_num, pa->ack_count);
+	for (auto &rank_comm : rank_comms) {
+		if (rank_comm.pending_ack.ack_count > 0) {
+			ret = send_ack(*this, rank_comm.pending_ack.peer_rank,
+				       rank_comm.pending_ack.seq_num,
+				       rank_comm.pending_ack.ack_count);
 			if (OFI_UNLIKELY(ret != 0)) {
 				return ret;
 			}
+			rank_comm.pending_ack.ack_count = 0;
 		}
-		pos->remove();
 	}
 
 	while (outstanding_ack_counter > 0) {
@@ -460,18 +459,22 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		return -EBUSY;
 	}
 
-	/* Determine if this message needs an ACK:
-	 * - SIGNAL or PUT-SIGNAL: always needs ACK
-	 * - PUT-only: needs ACK every N consecutive PUTs */
+	/* Determine if this message needs an ACK.
+	 *
+	 * Same policy for SIGNAL, PUT-SIGNAL, and PUT-only:
+	 * Request an ACK only when both conditions hold:
+	 *   1. The per-peer outstanding-ACK bitset is at >= 50% capacity
+	 *      (so seq-number wraparound is approaching).
+	 *   2. At least GIN_ACK_INTERVAL ops have elapsed since the last ACK
+	 *      request (so we don't ACK on every op when utilization stays
+	 *      above 50%).
+	 *
+	 * Below 50% utilization, no ACK is requested. */
 	bool has_signal = (signalOp != 0);
 	bool is_ack_requested = false;
 
-	if (has_signal) {
-		is_ack_requested = true;
-		rank_comm.consecutive_puts_without_ack = 0;
-	} else {
-		rank_comm.consecutive_puts_without_ack++;
-		if (rank_comm.consecutive_puts_without_ack >= GIN_ACK_INTERVAL) {
+	if (rank_comm.active_put_signal.count() >= (GIN_IMM_SEQ_MASK >> 1)) {
+		if (rank_comm.consecutive_puts_without_ack++ >= GIN_ACK_INTERVAL) {
 			is_ack_requested = true;
 			rank_comm.consecutive_puts_without_ack = 0;
 		}
@@ -496,7 +499,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 
 	/* Create umbrella request for tracing */
 	auto *req = resources.get_req_from_pool<nccl_ofi_rdma_gin_iputsignal_req>(
-		*this, dst_rank, msg_seq_num, is_ack_requested);
+		*this, dst_rank, msg_seq_num);
 	/* Hold write_reqs for error clean up */
 	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> write_reqs {};
 
@@ -597,6 +600,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		metadata_send->header.remote_comm_id = remote_comm_id;
 		metadata_send->header.seq_num = msg_seq_num;
 		metadata_send->header.seq_seg_cnt = nseg;
+		metadata_send->header.ack_req = is_ack_requested ? 1 : 0;
 		metadata_send->signal_base_address =
 			(sig_mr ? sig_mr->remote_mr[dst_rank].address : 0);
 		metadata_send->signal_offset = signalOff;
@@ -899,9 +903,21 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 	return ret;
 }
 
-/* Extend the pending bundled ack to include seq_num. If the merged
-   range would overflow the bitfield, flush the old range first. */
-int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num)
+/* Extend the pending bundled ack to include seq_num.
+
+   Most ops are bundled silently; the sender requests a standalone
+   ACK only when it needs the bit cleared (e.g. seq window crossing the
+   50% threshold), and we flush eagerly in that case.
+
+   Note: under the current sender-side ACK policy, the bundling path here
+   should only ever see seq_nums where the sender did NOT request an ACK.
+   If the sender requested an ACK, the appropriate response is to flush
+   immediately (send a standalone ACK) — silently bundling such a seq_num
+   would defeat the sender's gating logic and leave it waiting on a
+   bit-clear that never comes via the bundled path. The is_ack_requested
+   flush below is what guarantees that. */
+int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t seq_num,
+						  bool is_ack_requested)
 {
 	auto &rank_comm = this->rank_comms[peer_rank];
 
@@ -909,70 +925,62 @@ int nccl_ofi_rdma_gin_put_comm::stash_pending_ack(uint32_t peer_rank, uint16_t s
 	int flushed = 0;
 	(void)flushed;  /* Used only when tracing is enabled */
 
-	if (rank_comm.pending_ack.node.on_list()) {
-		if (rank_comm.pending_ack.ack_count > 0) {
-			/* Callers must add ranges in-order (ascending seq_num).
-			   delta must be in (0, half_seq_space] to confirm forward progress. */
-			assert(((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) > 0 &&
-			       ((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) <= (GIN_IMM_SEQ_MASK >> 1));
+	uint32_t merged_count = 1;
 
-			uint32_t prev_start = (rank_comm.pending_ack.seq_num
-						- rank_comm.pending_ack.ack_count + 1) & GIN_IMM_SEQ_MASK;
-			uint32_t merged_count = ((seq_num - prev_start + 1) & GIN_IMM_SEQ_MASK);
+	if (rank_comm.pending_ack.ack_count > 0) {
+		/* Callers must add ranges in-order (ascending seq_num).
+		   delta must be in (0, half_seq_space] to confirm forward progress. */
+		assert(((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) > 0 &&
+		       ((seq_num - rank_comm.pending_ack.seq_num) & GIN_IMM_SEQ_MASK) <= (GIN_IMM_SEQ_MASK >> 1));
 
-			if (merged_count > GIN_ACK_INTERVAL) {
-				int ret = send_ack(*this, peer_rank,
-							rank_comm.pending_ack.seq_num,
-							rank_comm.pending_ack.ack_count);
-				if (OFI_UNLIKELY(ret != 0)) {
-					NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(
-						dev, this, peer_rank, seq_num,
-						rank_comm.pending_ack.ack_count, 1, ret);
-					return ret;
-				}
-				flushed = 1;
-				merged_count = 1;
+		uint32_t prev_start = (rank_comm.pending_ack.seq_num
+					- rank_comm.pending_ack.ack_count + 1) & GIN_IMM_SEQ_MASK;
+		merged_count = ((seq_num - prev_start + 1) & GIN_IMM_SEQ_MASK);
+
+		/* Flush the previously-bundled range as a standalone ACK
+		   when the sender explicitly requested one for this seq.
+		   Marked unlikely: under the 50%-utilization gate, an
+		   explicit ACK request only fires when the sender's
+		   outstanding-ACK bitset is at least half full — i.e. the
+		   receiver has not piggybacked a single bundled-ack on
+		   metadata back to this peer for ~half the seq window.
+		   That is a strongly asymmetric traffic pattern: this
+		   side delivered thousands of packets to the peer, and
+		   the peer did not send a single packet back during the
+		   entire window. Even sparse collectives (MoE expert
+		   routing, etc.) generate some return traffic, so hitting
+		   this path is unusual; we log it via TRACE for
+		   diagnosability rather than warning. */
+		if (OFI_UNLIKELY(is_ack_requested)) {
+			NCCL_OFI_TRACE(NCCL_NET,
+				       "Standalone ACK fallback fired on peer_rank %u "
+				       "seq_num %hu (bundle ack_count=%hu): asymmetric "
+				       "traffic — this peer delivered ~half the seq "
+				       "window without sending us a single packet to "
+				       "piggyback on.",
+				       peer_rank, seq_num,
+				       rank_comm.pending_ack.ack_count);
+			int ret = send_ack(*this, peer_rank,
+						rank_comm.pending_ack.seq_num,
+						rank_comm.pending_ack.ack_count);
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(
+					dev, this, peer_rank, seq_num,
+					rank_comm.pending_ack.ack_count, 1, ret);
+				return ret;
 			}
-			rank_comm.pending_ack.ack_count = merged_count;
-		} else {
-			/* Was consumed by iputSignal piggyback; reuse slot */
-			rank_comm.pending_ack.ack_count = 1;
+			flushed = 1;
+			merged_count = 1;
 		}
-	} else {
-		rank_comm.pending_ack.ack_count = 1;
-		rank_comm.pending_ack.peer_rank = peer_rank;
-		pending_ack_list.push_back(&rank_comm.pending_ack.node);
 	}
 
+	rank_comm.pending_ack.peer_rank = peer_rank;
+	rank_comm.pending_ack.ack_count = merged_count;
 	rank_comm.pending_ack.seq_num = seq_num;
-	rank_comm.pending_ack.start = progress_counter;
 
 	NCCL_OFI_TRACE_GIN_STASH_PENDING_ACK_FUNC_END(dev, this, peer_rank, seq_num,
 						      rank_comm.pending_ack.ack_count,
 						      flushed, 0);
-	return 0;
-}
-
-/* Flush pending bundled acks that have aged past the threshold
-   for peers with no recent completions. Called from progress. */
-int nccl_ofi_rdma_gin_put_comm::flush_stale_acks()
-{
-	++progress_counter;
-	nccl_ofi_dlist_node *pos;
-	nccl_ofi_dlist_for_each_safe(&pending_ack_list, pos) {
-		auto *pa = nccl_ofi_dlist_entry(pos, &nccl_ofi_gin_pending_ack_info::node);
-		if (pa->ack_count == 0 ||
-		    progress_counter - pa->start > GIN_ACK_MAX_AGE) {
-			if (pa->ack_count > 0) {
-				int ret = send_ack(*this, pa->peer_rank,
-						pa->seq_num, pa->ack_count);
-				if (OFI_UNLIKELY(ret != 0)) {
-					return ret;
-				}
-			}
-			pos->remove();
-		}
-	}
 	return 0;
 }
 
@@ -981,8 +989,9 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 	int ret = 0;
 
 	/* Process undelivered signals in order.  ACK coalescing is
-	   handled entirely by stash_pending_ack(), which merges
-	   ranges and flushes when they exceed GIN_ACK_INTERVAL. */
+	   handled entirely by stash_pending_ack(), which extends a
+	   per-peer pending range and flushes only when the sender
+	   explicitly requested an ACK. */
 	while (true) {
 		auto &rank_comm = this->rank_comms[peer_rank];
 		uint16_t next_seq_num = rank_comm.next_delivered_signal_seq_num;
@@ -993,11 +1002,10 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 			auto *req = it->second;
 
 			if (req->num_seg_completions == req->total_segments) {
-				if (req->is_ack_requested) {
-					ret = stash_pending_ack(peer_rank, next_seq_num);
-					if (OFI_UNLIKELY(ret != 0)) {
-						return ret;
-					}
+				ret = stash_pending_ack(peer_rank, next_seq_num,
+							req->is_ack_requested);
+				if (OFI_UNLIKELY(ret != 0)) {
+					return ret;
 				}
 				rank_comm.next_delivered_signal_seq_num =
 					(rank_comm.next_delivered_signal_seq_num + 1) &
@@ -1036,7 +1044,15 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 		dev, this, rail_id, peer_rank, msg_seq_num, num_segments,
 		metadata_msg->header.ack_count);
 
-	/* Process bundled ack if present */
+	/* Process bundled ack if present.
+	 *
+	 * Sender piggybacks the receiver's pending bundled-ack range on the
+	 * next outbound metadata message; here we apply it to clear our local
+	 * active_put_signal bits for the run [ack_seq_num - ack_count + 1,
+	 * ack_seq_num]. This is the steady-state path that keeps the per-peer
+	 * ack window draining without any standalone ACK round-trips. Standalone
+	 * ACKs only fire as a fallback when the sender explicitly requests one
+	 * (50% gate). */
 	if (metadata_msg->header.ack_count > 0) {
 		clear_ack_range(peer_rank,
 				metadata_msg->header.ack_seq_num,
@@ -1044,6 +1060,8 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	}
 
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
+
+	const bool meta_ack_req = (metadata_msg->header.ack_req != 0);
 
 	auto it = outstanding_iput_signal_recv_reqs.find(map_key);
 	nccl_net_ofi_gin_iputsignal_recv_req *req;
@@ -1054,7 +1072,7 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 		req->total_segments = num_segments;
 		req->metadata = *metadata_msg;
 		req->metadata_received = true;
-		req->is_ack_requested = true;  // Metadata always requests ACK
+		req->is_ack_requested = meta_ack_req;
 		outstanding_iput_signal_recv_reqs[map_key] = req;
 	} else {
 		req = it->second;
@@ -1062,6 +1080,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 		req->metadata = *metadata_msg;
 		req->metadata_received = true;
 		req->num_seg_completions += 1;
+		/* OR across submission paths: data-imm or metadata header may
+		   request the ACK; honor either. */
+		req->is_ack_requested = req->is_ack_requested || meta_ack_req;
 	}
 
 	/* Weak-signal mode: once all segments of this signal (metadata +
@@ -1142,6 +1163,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 		req = it->second;
 		assert(req->total_segments == total_segms);
 		req->num_seg_completions += 1;
+		/* OR across submission paths: data-imm or metadata header may
+		   request the ACK; honor either. */
+		req->is_ack_requested = req->is_ack_requested || is_ack_requested;
 	}
 	NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, cq_entry->len, this, peer_rank, msg_seq_num, req);
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -473,8 +473,8 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	bool has_signal = (signalOp != 0);
 	bool is_ack_requested = false;
 
-	if (rank_comm.active_put_signal.count() >= (GIN_IMM_SEQ_MASK >> 1)) {
-		if (rank_comm.consecutive_puts_without_ack++ >= GIN_ACK_INTERVAL) {
+	if (OFI_UNLIKELY(rank_comm.active_put_signal_count >= (GIN_IMM_SEQ_MASK >> 1))) {
+		if (OFI_UNLIKELY(rank_comm.consecutive_puts_without_ack++ >= GIN_ACK_INTERVAL)) {
 			is_ack_requested = true;
 			rank_comm.consecutive_puts_without_ack = 0;
 		}
@@ -507,7 +507,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 
 	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
 
-	if (size > 0) {
+	if (OFI_LIKELY(size > 0)) {
 		/* Post write-immediate request with user data */
 		void *src = static_cast<uint8_t *>(src_mr->input_address) + srcOff;
 		auto *src_mhandle = src_mr->local_handle;
@@ -530,9 +530,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		 * The first write is posted with FI_MORE to hint the provider
 		 * that more operations follow on this EP, enabling doorbell
 		 * coalescing (single PCIe doorbell for write + send). */
-		if (has_signal) {
-			rail_id = xfers[0].rail_id;
-		}
+		rail_id = xfers[0].rail_id;
 
 		for (uint16_t rail_it = 0; rail_it < schedule->num_xfer_infos; rail_it++) {
 			nccl_net_ofi_xfer_info_t *xfer_info = &xfers[rail_it];
@@ -561,10 +559,12 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, xfer_info->rail_id, xfer_info->msg_size,
 						       this, dst_rank, msg_seq_num, write_req);
 			ret = write_req->post();
-			if (ret == -FI_EAGAIN) {
-				resources.add_pending_req(write_req);
-				ret = 0;
-			} else if (OFI_UNLIKELY(ret != 0)) {
+			if (OFI_UNLIKELY(ret != 0)) {
+				if (ret == -FI_EAGAIN) {
+					resources.add_pending_req(write_req);
+					ret = 0;
+					break;
+				}
 				NCCL_OFI_WARN("Write failed for seq_num %hu", msg_seq_num);
 				resources.return_req_to_pool(write_req);
 				nccl_net_ofi_release_schedule(scheduler, schedule);
@@ -574,14 +574,11 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			}
 		}
 		nccl_net_ofi_release_schedule(scheduler, schedule);
+	} else {
+		rail_id = resources.get_next_rail();
 	}
 
 	if (has_signal) {
-		/* For signal-only (size == 0), no write was posted so we
-		   cannot coalesce — pick a rail via round-robin. */
-		if (size == 0)
-			rail_id = resources.get_next_rail();
-
 		/* Post metadata send with signal information */
 		nccl_ofi_freelist::fl_entry *metadata_elem = nullptr;
 
@@ -632,15 +629,17 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, sizeof(nccl_net_ofi_gin_signal_metadata_msg_t), this, dst_rank, msg_seq_num,
 						       send_req);
 		ret = send_req->post();
-		if (ret == -FI_EAGAIN) {
-			resources.add_pending_req(send_req);
-			ret = 0;
-		} else if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Metadata send failed for seq_num %hu", msg_seq_num);
-			resources.return_req_to_pool(send_req);
-			resources.return_req_to_pool(req);
-			clear_write_reqs_pending_back_pointers(write_reqs);
-			return ret;
+		if (OFI_UNLIKELY(ret != 0)) {
+			if (ret == -FI_EAGAIN) {
+				resources.add_pending_req(send_req);
+				ret = 0;
+			} else {
+				NCCL_OFI_WARN("Metadata send failed for seq_num %hu", msg_seq_num);
+				resources.return_req_to_pool(send_req);
+				resources.return_req_to_pool(req);
+				clear_write_reqs_pending_back_pointers(write_reqs);
+				return ret;
+			}
 		}
 		send_req->pending_flag = &(req->reqs_pending[MAX_NUM_RAILS]); // last one
 #if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
@@ -649,7 +648,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		req->reqs_pending[MAX_NUM_RAILS] = true;
 	}
 
-	rank_comm.active_put_signal.set(msg_seq_num & GIN_IMM_SEQ_MASK, is_ack_requested);
+	set_ack_outstanding(dst_rank, msg_seq_num, is_ack_requested);
 	rank_comm.next_target_seq_num = (rank_comm.next_target_seq_num + 1) & GIN_IMM_SEQ_MASK;
 
 	*request = req;
@@ -1088,15 +1087,19 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	/* Weak-signal mode: once all segments of this signal (metadata +
 	   writes at this same seq, if any) have arrived, deliver it
 	   immediately. This covers metadata-first and writes-first orderings. */
-	if (!strong_signal_ordering_enabled && req->num_seg_completions == req->total_segments) {
-		ret = do_gin_signal_and_trace(peer_rank, req);
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
+	if (req->num_seg_completions == req->total_segments) {
+		if (!strong_signal_ordering_enabled) {
+			ret = do_gin_signal_and_trace(peer_rank, req);
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
 				dev, this, rail_id, peer_rank, msg_seq_num, ret);
-			return ret;
+				return ret;
+			}
 		}
+
+		// If this packet is not full there is no reasong to try and retire packets.
+		ret = retire_completed_peer_iput_ops(peer_rank);
 	}
-	ret = retire_completed_peer_iput_ops(peer_rank);
 
 	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
 		dev, this, rail_id, peer_rank, msg_seq_num, ret);
@@ -1162,10 +1165,10 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 	} else {
 		req = it->second;
 		assert(req->total_segments == total_segms);
-		req->num_seg_completions += 1;
 		/* OR across submission paths: data-imm or metadata header may
 		   request the ACK; honor either. */
 		req->is_ack_requested = req->is_ack_requested || is_ack_requested;
+		req->num_seg_completions += 1;
 	}
 	NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, cq_entry->len, this, peer_rank, msg_seq_num, req);
 
@@ -1192,9 +1195,9 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 				return ret;
 			}
 		}
+		// If this packet is not full there is no reasong to try and retire packets.
+		ret = retire_completed_peer_iput_ops(peer_rank);
 	}
-
-	ret = retire_completed_peer_iput_ops(peer_rank);
 
 	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_END(dev, this, rail_id, peer_rank,
 								   msg_seq_num, ret);

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -264,11 +264,6 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	int ret = gin_comm->get_resources().progress();
-	if (OFI_UNLIKELY(ret != 0)) {
-		return nccl_net_ofi_retval_translate(ret);
-	}
-
-	ret = gin_comm->flush_stale_acks();
 	return nccl_net_ofi_retval_translate(ret);
 }
 

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -190,35 +190,26 @@ int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 	   noisy info about whether any per-rail write was still in flight at
 	   the time of this test() call. */
 	int has_write_reqs = (any_reqs_pending != 0);
-	(void)has_write_reqs;  /* Only used when tracing is enabled. */
+	/* Only used when tracing is enabled. */
+	(void)has_write_reqs;
+	(void)peer_rank;
+	(void)msg_seq_num;
 	NCCL_OFI_TRACE_GIN_TEST_FUNC_BEGIN(gin_comm.get_dev(), &gin_comm, peer_rank,
 					   msg_seq_num, this, has_write_reqs, 0);
 
 	if (OFI_UNLIKELY(any_reqs_pending == 0)) {
-		/* Check outstanding signal only if no pending subrequests */
+		/* All sub-requests done; mark done and release the umbrella. */
 		auto &gin_ep = gin_comm.get_resources().get_ep();
-		if (is_ack_requested) {
-			/* This message requested ACK (SIGNAL, PUT-SIGNAL, or every Nth PUT) */
-			bool ack_outstanding = gin_comm.query_ack_outstanding(peer_rank, msg_seq_num);
-			if (OFI_UNLIKELY(!ack_outstanding)) {
-				*done = 1;
-			}
-		} else {
-			/* This message doesn't need ACK (most PUTs) */
-			*done = 1;
-		}
-		/* Free iputSignal request when done */
-		if (OFI_UNLIKELY(*done)) {
-			std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
-			NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on initiator",
-				       this->msg_seq_num);
-			NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
-							   msg_seq_num, this);
-			NCCL_OFI_TRACE_GIN_TEST_FUNC_END(gin_comm.get_dev(), &gin_comm,
-							 peer_rank, msg_seq_num, this, 1, 1);
-			gin_comm.get_resources().return_req_to_pool(this);
-			return 0;
-		}
+		*done = 1;
+		std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+		NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on initiator",
+			       this->msg_seq_num);
+		NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
+						   msg_seq_num, this);
+		NCCL_OFI_TRACE_GIN_TEST_FUNC_END(gin_comm.get_dev(), &gin_comm,
+						 peer_rank, msg_seq_num, this, 1, 1);
+		gin_comm.get_resources().return_req_to_pool(this);
+		return 0;
 	} else {
 		/* NCCL GIN Proxy only calls test() when state->done == 0,
 		 * so skip the redundant store (*done = 0) for now.

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -186,6 +186,14 @@ nccl_net_ofi_gin_sendack_req_t::~nccl_net_ofi_gin_sendack_req_t()
 
 int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 {
+	/* Snapshot state for tracing before any mutation. has_write_reqs is
+	   noisy info about whether any per-rail write was still in flight at
+	   the time of this test() call. */
+	int has_write_reqs = (any_reqs_pending != 0);
+	(void)has_write_reqs;  /* Only used when tracing is enabled. */
+	NCCL_OFI_TRACE_GIN_TEST_FUNC_BEGIN(gin_comm.get_dev(), &gin_comm, peer_rank,
+					   msg_seq_num, this, has_write_reqs, 0);
+
 	if (OFI_UNLIKELY(any_reqs_pending == 0)) {
 		/* Check outstanding signal only if no pending subrequests */
 		auto &gin_ep = gin_comm.get_resources().get_ep();
@@ -206,7 +214,10 @@ int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 				       this->msg_seq_num);
 			NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_END(gin_comm.get_dev(), &gin_comm, peer_rank,
 							   msg_seq_num, this);
+			NCCL_OFI_TRACE_GIN_TEST_FUNC_END(gin_comm.get_dev(), &gin_comm,
+							 peer_rank, msg_seq_num, this, 1, 1);
 			gin_comm.get_resources().return_req_to_pool(this);
+			return 0;
 		}
 	} else {
 		/* NCCL GIN Proxy only calls test() when state->done == 0,
@@ -214,6 +225,8 @@ int nccl_ofi_rdma_gin_iputsignal_req::test(int *done)
 		 */
 	}
 
+	NCCL_OFI_TRACE_GIN_TEST_FUNC_END(gin_comm.get_dev(), &gin_comm,
+					 peer_rank, msg_seq_num, this, *done, 0);
 
 	/* If not done, the GIN plugin will do nothing.
 
@@ -285,7 +298,7 @@ int nccl_net_ofi_gin_metadata_send_req_t::handle_cq_entry(struct fi_cq_entry * /
 							   fi_addr_t /*src_addr*/,
 							   uint16_t rail_id_arg)
 {
-	NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id_arg, comm, rank, msg_seq_num, this);
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id_arg, sizeof(nccl_net_ofi_gin_signal_metadata_msg_t), comm, rank, msg_seq_num, this);
 
 	if (OFI_LIKELY(pending_flag != nullptr)) {
 		*pending_flag = false;

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -428,7 +428,9 @@ void nccl_ofi_gin_resources::post_rx_buffs_on_rail(nccl_ofi_gin_ep_rail_t &rail,
 }
 
 nccl_ofi_gin_resources::nccl_ofi_gin_resources(nccl_net_ofi_ep_t &ep_arg)
-    : ep_holder(ep_arg.shared_from_this()), gin_ep(ep_arg.get_domain()),
+    : ep_holder(ep_arg.shared_from_this()),
+      gin_ep(ep_arg.get_domain()),
+      dev(ep_arg.get_domain().get_device()->dev_id),
       req_fl(nullptr, &freelist_deleter),
       rx_buff_fl(nullptr, &freelist_deleter),
       ack_send_fl(nullptr, &freelist_deleter),


### PR DESCRIPTION
A 5-commit series on the GIN dataplane covering tracing, signal-delivery
caching, ACK protocol simplification, and dead-code cleanup. Each commit
is independently buildable and tested standalone (`./configure && make`
both with and without LTTng).

## Commits (oldest → newest)

### 1. `gin: cache GDR signal values in a host-side shadow`
Replace the per-signal `copy_from_device` read on the receiver hot path
with a host-side shadow vector kept on the MR handle. The receiver adds
locally and only `copy_to_device`'s the new value, halving GDRcopy
traffic. Safe because the receiver is the sole writer to the destination
region.

Co-authored-by: Sunita Bhaskaran <bhasunit@amazon.com>

### 2. `trace(gin): add LTTng tracepoints for GIN dataplane critical paths`
START/END pairs around the dataplane hot paths so we can attribute
latency in EFATracy traces:
- `iputSignal()`
- `test()`
- `handle_signal_metadata_completion()`
- `handle_signal_write_completion()`
- `handle_ack_completion()`

Each event carries the fields needed to reconstruct what happened
(comm, peer_rank, msg_seq_num, sizes, return code, etc).

### 3. `ack(gin): unify ACK policy under a single 50%-utilization gate`
Replace the prior split policy (always-ACK on signals; every-Nth on
PUTs) with a single rule: only request a standalone ACK once the
outstanding window is at least half full, and then with
`GIN_ACK_INTERVAL` hysteresis. Drops a large fraction of standalone
ACKs in healthy traffic.

Plumbing changes:
- New `ack_req` bit in `nccl_net_ofi_gin_msg_header_t` (mirrors the
  existing data-imm bit; receiver OR's across submission paths).
- Drop "metadata always requests ACK" -- sourced from the wire now.
- Drop the test()-time ACK-outstanding gate; the policy itself bounds
  the window.

### 4. `perf(gin): minor iputSignal/CQ-handler micro-optimizations`
Tighten the dataplane fast path without changing protocol semantics:
- `OFI_LIKELY` / `OFI_UNLIKELY` hints on the rare branches.
- Reorder libfabric post-error handling so the success path falls
  through; EAGAIN now `break`s out of the per-rail write loop.
- Hoist `rail_id` selection out of the metadata block; drop redundant
  `has_signal` re-checks.
- Move `retire_completed_peer_iput_ops()` inside the "all segments
  arrived" block in both completion handlers.

### 5. `gin: replace per-peer ACK bitset with producer/consumer cursors`
Drop the 1 KB-per-peer `std::bitset<8192> active_put_signal` and the
range-encoded ACK protocol around it (`stash_pending_ack`,
`flush_stale_acks`, `pending_ack_list`). Replace with four monotonic
cursors per peer (`tx_head`, `tx_tail`, `rx_consumed`, `rx_acked`)
clamped to a ring of size `2 * (GIN_IMM_SEQ_MASK + 1)` for wrap-safe
forward-delta comparison.

Wire format simplifies from `(ack_seq_num, ack_count)` to a single
`rx_consumed` cursor on both metadata headers and standalone ACKs.

The bitset only ever encoded "is this seq slot in use?", which the
sender already knows from `outstanding = tx_head - tx_tail`. Once that
is the source of truth, the bitset and everything built on top of it
falls away.

## What this changes on the wire

- Metadata header: `(ack_seq_num=13b, ack_count=10b)` → `rx_consumed=14b`.
  Adds an `ack_req=1b` bit. Net +9 reserved bits in the header.
- Standalone ACK: `(ack_seq_num=13b, ack_count=10b)` → `rx_consumed=14b`.

## Memory / CPU savings

- Per-peer: ~1 KB saved (bitset + bookkeeping). At 1024 ranks per comm
  that's ~1 MB.
- Per-iputSignal: bitset popcount replaced by a single modular subtract.
- Receiver: stash-merge math, dlist insert/remove, and ageing scan all
  removed.

## Testing

- nccl-tests `all_reduce_perf`, `all_gather_perf` at 8/16/32 ranks
- `nccl_ep ep_bench -a ll -t 128 -d 7168` -- baseline + this series:
  comparable bandwidth, lower CPU on the receiver progress thread.
- LTTng-disabled and LTTng-enabled builds both clean.