### PR TITLE
 gin/gdaki: signal and counter endpoints with hardware counters

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -346,6 +346,8 @@ AS_IF([test "${enable_gdaki}" = "yes"],
              [AC_MSG_ERROR([--enable-gdaki requires a libfabric build with FI_EFA_GDA_OPS support (libfabric >= 2.3.0).])])
        AS_IF([test "${have_device_interface}" != "cuda"],
              [AC_MSG_ERROR([--enable-gdaki requires CUDA support.])])
+       AS_IF([test "${have_fi_efa_comp_cntr}" != "1"],
+             [AC_MSG_ERROR([--enable-gdaki requires libfabric with the fi_efa_ops_gda hardware-counter ABI (libfabric >= 2.5.0).])])
        have_gdaki=1],
       [have_gdaki=0])
 AC_DEFINE_UNQUOTED([HAVE_GDAKI], [${have_gdaki}], [Defined to 1 if GDAKI support is enabled])

--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -84,6 +84,29 @@ int nccl_net_ofi_gpu_host_get_device_pointer(void **dev_ptr, void *host_ptr);
 int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int *fd, size_t *offset);
 
 /*
+ * @brief Allocate GPU memory using the CUDA VMM API (cuMemCreate + cuMemMap)
+ * with gpuDirectRDMACapable flag. This allocation supports DMA-BUF export.
+ *
+ * The requested `size` is rounded up to the VMM allocation granularity
+ * (typically 2 MB on Hopper / Blackwell). The actual allocated size is
+ * returned via *out_alloc_size. The caller MUST pass that value back to
+ * nccl_net_ofi_gpu_vmm_free; passing the original (smaller) size results
+ * in cuMemUnmap / cuMemAddressFree being called with the wrong size and
+ * leaks the rest of the mapping.
+ *
+ * @return 0 on success, -1 on error
+ */
+int nccl_net_ofi_gpu_vmm_alloc(void **ptr, size_t size, size_t *out_alloc_size);
+
+/*
+ * @brief Free GPU memory allocated with nccl_net_ofi_gpu_vmm_alloc.
+ *        `alloc_size` must be the value returned via out_alloc_size from
+ *        the matching nccl_net_ofi_gpu_vmm_alloc call.
+ * @return 0 on success, -1 on error
+ */
+int nccl_net_ofi_gpu_vmm_free(void *ptr, size_t alloc_size);
+
+/*
  * @brief	query CU_DEVICE_ATTRIBUTE_DMA_BUF_SUPPORTED
 
  * @return	true if attr is fetched successfully and true.

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -145,6 +145,62 @@ struct nccl_ofi_gin_gdaki_cq {
 };
 
 /**
+ * Common per-endpoint state.
+ * Holds the GPU-resident QP/CQ, per-peer addressing, the per-QP
+ * spinlock that serializes the device-side WQE-post sequence, and
+ * the counter-based completion tracking fields. Used directly as
+ * the `data` member of nccl_ofi_gin_gdaki_dev_handle.
+ *
+ * Layout is shared with the NCCL mirror in
+ * nccl_device/gin/efa_gda/gin_efa_gda_dev.h — keep them in sync.
+ */
+struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
+	/* GPU-resident QP for this endpoint. */
+	struct nccl_ofi_gin_gdaki_qp *qp;
+
+	/* GPU-resident CQ for this endpoint. */
+	struct nccl_ofi_gin_gdaki_cq *cq;
+
+	/* Per-peer addressing for this endpoint's QP. [nranks] in GPU mem. */
+	uint16_t *address_handles;
+	uint16_t *remote_qpns;
+	uint32_t *qkey;
+
+	/* Per-QP spinlock used by the device-side WQE post path. efa-dp-direct's
+	 * start_sq_batch / sq_batch_place_wr / flush_sq_wrs sequence must be
+	 * serialized per QP (per the efa-dp-direct CUDA README). One lock here
+	 * lets multiple CTAs posting on different endpoints proceed in
+	 * parallel; only CTAs targeting the same endpoint contend. */
+	uint32_t sq_lock;
+
+	/* Counter-based completion tracking.
+	 *
+	 * `local_cntr_value` points at the FI_WRITE hardware counter for this
+	 * endpoint's QP. The NIC increments it on every locally-completed
+	 * outgoing WR (regardless of remote semantics). The kernel reads it
+	 * directly from GPU memory.
+	 *
+	 * `submitted_count` is incremented by the device under the sq_lock
+	 * after a successful flush_sq_wrs. The difference
+	 * (submitted_count - *local_cntr_value) gives the number of WRs
+	 * still in flight on this QP — used by the SQ-overflow backpressure
+	 * check and by Flush to wait for local completion.
+	 *
+	 * `local_cntr_value` is NULL when the endpoint has no hardware counter
+	 * bound. In that case the device-side Put / Flush silently skip the
+	 * counter operations on this endpoint. */
+	volatile uint64_t *local_cntr_value;
+	uint64_t submitted_count;
+
+	/* SQ ring size for this endpoint's QP. Used by the device-side Put
+	 * to gate new batches against in-flight WRs (efa-dp-direct's
+	 * start_sq_batch does not validate ring overflow on its own). The
+	 * kernel spins until (submitted_count - *local_cntr_value + batch_size)
+	 * <= sq_size before reserving slots. */
+	uint32_t sq_size;
+};
+
+/**
  * Device-visible handle returned from createContext.
  *
  * This struct is allocated in GPU memory. The pointer is stored in
@@ -154,24 +210,12 @@ struct nccl_ofi_gin_gdaki_cq {
  * All member pointers refer to GPU-accessible memory.
  */
 struct nccl_ofi_gin_gdaki_dev_handle {
-	/* GPU-resident QP descriptor (layout-compatible with efa_cuda_qp). */
-	struct nccl_ofi_gin_gdaki_qp *qp;
-
-	/* GPU-resident CQ descriptor (layout-compatible with efa_cuda_cq). */
-	struct nccl_ofi_gin_gdaki_cq *cq;
-
-	/* Per-peer address handle numbers, indexed by rank. [nranks] in GPU mem. */
-	uint16_t *address_handles;
-
-	/* Per-peer remote QP numbers, indexed by rank. [nranks] in GPU mem. */
-	uint16_t *remote_qpns;
-
-	/* Per-peer Q keys, indexed by rank. [nranks] in GPU mem. */
-	uint32_t *qkey;
-
-	/* Count of outstanding requests tracked on the device. Used by Flush.
-	 * Initialized to 0. */
-	uint64_t pending_reqs;
+	/* Data endpoint (qp / cq / addressing / sq_lock /
+	 * counter completion tracking via local_cntr_value /
+	 * submitted_count / sq_size). The data endpoint binds a
+	 * FI_WRITE counter and populates data.local_cntr_value at
+	 * createContext time. */
+	struct nccl_ofi_gin_gdaki_dev_endpoint_handle data;
 
 	/* Number of ranks participating in this context. */
 	int32_t nranks;

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -39,21 +39,44 @@ extern "C" {
 #define NCCL_OFI_GDAKI_CQ_INITIAL_PHASE 1
 
 /**
+ * Per-peer MR metadata used by EFA GDA WQE construction.
+ *
+ * EFA uses FI_MR_VIRT_ADDR, so WQEs take absolute virtual addresses for
+ * both local and remote buffers. The kernel passes an offset (srcOff /
+ * dstOff) and we compute the absolute address by adding the base VA.
+ */
+struct nccl_ofi_gin_gdaki_mr_peer {
+	/* Remote rank's base virtual address for this MR. */
+	uint64_t remote_addr;
+	/* Remote rank's rkey for this MR. */
+	uint32_t rkey;
+	/* Padding to keep the struct 16-byte sized for natural alignment. */
+	uint32_t pad;
+};
+
+/**
  * GDAKI memory registration handle returned via ginHandle from regMrSym.
  *
  * Allocated in host memory. The lkey is used by the kernel for local SGEs.
- * The rkeys array (one per rank) is used for remote RDMA write destinations.
- * The kernel receives this as a ncclGinWindow_t (void*).
+ * The peers[] array holds per-rank (remote_addr, rkey) pairs used as the
+ * destination of remote RDMA writes. The kernel receives this as a
+ * ncclGinWindow_t (void*).
+ *
+ * Layout is shared with the NCCL mirror in
+ * nccl_device/gin/efa_gda/gin_efa_gda_dev.h — keep them in sync.
  */
 struct nccl_ofi_gin_gdaki_mr_handle {
 	/* Local key for this MR on the efa-direct domain. */
 	uint32_t lkey;
 
-	/* Number of ranks (size of rkeys array). */
+	/* Number of ranks (size of peers[] array). */
 	int32_t nranks;
 
-	/* Per-peer remote keys, indexed by rank. [nranks] elements follow. */
-	uint32_t rkeys[];
+	/* Local (this rank's) base virtual address for this MR. */
+	uint64_t local_addr;
+
+	/* Per-peer remote metadata. */
+	struct nccl_ofi_gin_gdaki_mr_peer peers[];
 };
 
 /**

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -265,6 +265,32 @@ struct nccl_ofi_gin_gdaki_dev_handle {
 
 	/* Rank of the local process within the context. */
 	int32_t rank;
+
+	/* Signal-only scratch buffer support.
+	 *
+	 * net.signal(team, peer, ...) (used by ncclBarrierSession) routes
+	 * through ncclGinApi_Put with hasWins=false, bytes=0. EFA needs an
+	 * actual remote memory destination to bump the receiver's
+	 * FI_REMOTE_WRITE counter on the signal endpoint, so the plugin
+	 * allocates a small buffer per createContext, registers it on the
+	 * proxy domain, and allgathers the (local_addr, rkey) per rank. The
+	 * GPU kernel uses these to post a 4-byte RDMA write to the peer's
+	 * scratch region whenever it needs a signal-only delivery. The
+	 * buffer content is never read — only the RDMA write event itself
+	 * increments the receiver's FI_REMOTE_WRITE counter.
+	 */
+	/* Local lkey for the scratch buffer on the proxy domain. */
+	uint32_t scratch_lkey;
+	uint32_t scratch_pad;
+
+	/* Local source address for scratch writes (this rank's scratch). */
+	uint64_t scratch_local_addr;
+
+	/* Per-peer remote scratch base addresses, indexed by rank. [nranks] in GPU mem. */
+	uint64_t *scratch_remote_addrs;
+
+	/* Per-peer remote scratch rkeys, indexed by rank. [nranks] in GPU mem. */
+	uint32_t *scratch_remote_rkeys;
 };
 
 #ifdef __cplusplus

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -145,11 +145,12 @@ struct nccl_ofi_gin_gdaki_cq {
 };
 
 /**
- * Common per-endpoint state.
- * Holds the GPU-resident QP/CQ, per-peer addressing, the per-QP
- * spinlock that serializes the device-side WQE-post sequence, and
- * the counter-based completion tracking fields. Used directly as
- * the `data` member of nccl_ofi_gin_gdaki_dev_handle.
+ * Common per-endpoint state shared by the data, counter, and signal
+ * device handles. Holds the GPU-resident QP/CQ, per-peer addressing,
+ * the per-QP spinlock that serializes the device-side WQE-post
+ * sequence, and the counter-based completion tracking fields.
+ * Used directly as the `data` member of nccl_ofi_gin_gdaki_dev_handle,
+ * and embedded as a `base` member in nccl_ofi_gin_gdaki_dev_counter_handle.
  *
  * Layout is shared with the NCCL mirror in
  * nccl_device/gin/efa_gda/gin_efa_gda_dev.h — keep them in sync.
@@ -201,6 +202,36 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
 };
 
 /**
+ * Per-signal/counter endpoint handle, visible to device code.
+ *
+ * Composes nccl_ofi_gin_gdaki_dev_endpoint_handle (qp / cq / addressing /
+ * sq_lock / counter completion tracking) and adds the hardware counter
+ * value pointer that the kernel reads to observe signal arrivals
+ * (FI_REMOTE_WRITE) or counter increments (FI_WRITE). The hardware
+ * counter value lives in GPU memory and is updated by the NIC directly.
+ *
+ * For signals: the GPU kernel reads *cntr_value to detect remote writes
+ *              (FI_REMOTE_WRITE counter). The per-peer arrays let the
+ *              sender target this QP on the remote rank.
+ *
+ * For counters: the GPU kernel reads *cntr_value to track local write
+ *               completions (FI_WRITE counter). The QP is used by the
+ *               local rank to post writes that need completion tracking.
+ *
+ * Layout is shared with the NCCL mirror in
+ * nccl_device/gin/efa_gda/gin_efa_gda_dev.h — keep them in sync.
+ */
+struct nccl_ofi_gin_gdaki_dev_counter_handle {
+	/* Endpoint-common fields (qp, cq, addressing, sq_lock,
+	 * counter completion tracking). */
+	struct nccl_ofi_gin_gdaki_dev_endpoint_handle base;
+
+	/* Pointer to the hardware counter value in GPU-accessible memory.
+	 * For signals: FI_REMOTE_WRITE count. For counters: FI_WRITE count. */
+	volatile uint64_t *cntr_value;
+};
+
+/**
  * Device-visible handle returned from createContext.
  *
  * This struct is allocated in GPU memory. The pointer is stored in
@@ -216,6 +247,18 @@ struct nccl_ofi_gin_gdaki_dev_handle {
 	 * FI_WRITE counter and populates data.local_cntr_value at
 	 * createContext time. */
 	struct nccl_ofi_gin_gdaki_dev_endpoint_handle data;
+
+	/* Per-counter device handle array, [nCounters]. NULL when nCounters == 0. */
+	struct nccl_ofi_gin_gdaki_dev_counter_handle **counter_handles;
+
+	/* Per-signal device handle array, [nSignals]. NULL when nSignals == 0. */
+	struct nccl_ofi_gin_gdaki_dev_counter_handle **signal_handles;
+
+	/* Number of counter_handles entries. 0 means counter_handles is NULL. */
+	int32_t nCounters;
+
+	/* Number of signal_handles entries. 0 means signal_handles is NULL. */
+	int32_t nSignals;
 
 	/* Number of ranks participating in this context. */
 	int32_t nranks;

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -24,18 +24,18 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 #include <string>
 #include <vector>
+#include <unistd.h>
 
 #include <rdma/fabric.h>
 #include <rdma/fi_domain.h>
 #include <rdma/fi_endpoint.h>
 #include <rdma/fi_ext_efa.h>
 
-#if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
-#endif
 #include "rdma/gin/nccl_ofi_gin_gdaki_dev.h"
 
 /**
@@ -189,12 +189,18 @@ public:
 	}
 
 	/*
-	 * Open EP + CQ + AV on `domain`, using ref_info to derive our own
-	 * fi_info via fi_getinfo. cq_size is the fi_cq_attr size passed
-	 * to fi_cq_open.
+	 * Open EP + CQ + AV on `domain`, bind CQ and AV.
+	 * Does NOT enable — caller must call enable() after any
+	 * additional binds (e.g. counters).
 	 */
 	void open(struct fid_domain *domain, struct fi_info *ref_info,
 		  size_t cq_size);
+
+	/*
+	 * Enable the endpoint. Must be called after open() and
+	 * any additional binds.
+	 */
+	void enable();
 };
 
 /**
@@ -269,6 +275,197 @@ public:
 };
 
 /**
+ * A hardware completion counter backed by GPU-accessible external memory.
+ *
+ * The NIC writes the counter value directly into GPU memory via
+ * cntr_open_ext with FI_EFA_COMP_CNTR_INIT_WITH_COMP_EXTERNAL_MEM.
+ * The GPU kernel reads *gpu_ptr to observe completions without any
+ * host round-trip.
+ *
+ * Destruction closes the counter and frees the GPU memory.
+ */
+class gdaki_hw_counter {
+public:
+	gdaki_hw_counter() = default;
+	gdaki_hw_counter(const gdaki_hw_counter &) = delete;
+	gdaki_hw_counter &operator=(const gdaki_hw_counter &) = delete;
+
+	/**
+	 * Create the hardware counter with GPU memory via DMA-BUF.
+	 *
+	 * Uses the CUDA VMM API (cuMemCreate + cuMemMap) with
+	 * gpuDirectRDMACapable so the allocation supports DMA-BUF export.
+	 * The NIC writes the counter value directly to GPU HBM.
+	 *
+	 * @param gda_ops  GDA ops handle (from fi_open_ops on the domain)
+	 * @param domain   libfabric domain to create counter on
+	 */
+	void create(struct fi_efa_ops_gda *gda_ops, struct fid_domain *domain)
+	{
+		void *gpu_mem = nullptr;
+		size_t actual_size = 0;
+		if (nccl_net_ofi_gpu_vmm_alloc(&gpu_mem, sizeof(uint64_t),
+					       &actual_size) != 0) {
+			throw std::runtime_error("gdaki_hw_counter: gpu_vmm_alloc failed");
+		}
+
+		/* Get DMA-BUF fd. The DMA-BUF must cover the full mapped region
+		 * (rounded to VMM granularity, typically 2 MB), not just the
+		 * 8 bytes we logically use. */
+		int fd = -1;
+		size_t offset = 0;
+		if (nccl_net_ofi_gpu_get_dma_buf_fd(gpu_mem, actual_size, &fd, &offset) != 0) {
+			nccl_net_ofi_gpu_vmm_free(gpu_mem, actual_size);
+			throw std::runtime_error("gdaki_hw_counter: get_dma_buf_fd failed");
+		}
+
+		struct fi_cntr_attr cntr_attr = {};
+		cntr_attr.events = FI_CNTR_EVENTS_COMP;
+
+		struct fi_efa_comp_cntr_init_attr efa_attr = {};
+		efa_attr.flags = FI_EFA_COMP_CNTR_INIT_WITH_COMP_EXTERNAL_MEM;
+		efa_attr.comp_cntr_ext_mem.type = FI_EFA_MEMORY_LOCATION_DMABUF;
+		efa_attr.comp_cntr_ext_mem.dmabuf.fd = fd;
+		efa_attr.comp_cntr_ext_mem.dmabuf.offset = offset;
+
+		struct fid_cntr *c = nullptr;
+		int ret = gda_ops->cntr_open_ext(domain, &cntr_attr, &c, nullptr, &efa_attr);
+		if (ret != 0) {
+			close(fd);
+			nccl_net_ofi_gpu_vmm_free(gpu_mem, actual_size);
+			throw std::runtime_error("gdaki_hw_counter: cntr_open_ext failed: " +
+						 std::string(fi_strerror(-ret)));
+		}
+
+		cntr = c;
+		d_mem = gpu_mem;
+		dmabuf_fd = fd;
+		alloc_size = actual_size;
+	}
+
+	/** The fid_cntr for binding to an endpoint. */
+	struct fid_cntr *get() const { return cntr; }
+
+	/** GPU pointer to the counter value (for kernel to read). */
+	volatile uint64_t *gpu_ptr() const
+	{
+		return static_cast<volatile uint64_t *>(d_mem);
+	}
+
+	~gdaki_hw_counter()
+	{
+		if (cntr) {
+			fi_close(&cntr->fid);
+		}
+		if (dmabuf_fd >= 0) {
+			close(dmabuf_fd);
+		}
+		if (d_mem) {
+			nccl_net_ofi_gpu_vmm_free(d_mem, alloc_size);
+		}
+	}
+
+private:
+	struct fid_cntr *cntr = nullptr;
+	void *d_mem = nullptr;
+	int dmabuf_fd = -1;
+	size_t alloc_size = 0;
+};
+
+/**
+ * Host-side state for a libfabric endpoint plus its GPU-side queue
+ * descriptors and per-peer addressing.
+ *
+ * Used as the inner state of gdaki_data_endpoint for the data (main)
+ * endpoint.
+ *
+ * Owns: fid_ep + fid_cq + fid_av (via gdaki_fi_endpoint), GPU-mapped
+ * SQ buffer + doorbell BAR regions, GPU-resident QP and CQ descriptors,
+ * per-peer ahn/qpn/qkey arrays in GPU memory.
+ *
+ * Destruction order (reverse declaration): peers, gpu_cq, gpu_qp,
+ * sq_doorbell, sq_buffer, endpoint. The libfabric EP closes last so any
+ * GPU mappings of its BAR regions are torn down before the EP itself.
+ * When this class is composed AFTER hardware counters in a wrapping
+ * class's declaration order, the inner EP additionally closes before
+ * the counters bound to it — required by libfabric.
+ */
+class gdaki_endpoint {
+public:
+	gdaki_fi_endpoint     endpoint;
+	gdaki_mmio_region     sq_buffer;
+	gdaki_mmio_region     sq_doorbell;
+	gdaki_gpu_qp          gpu_qp;
+	gdaki_gpu_cq          gpu_cq;
+	gdaki_peer_addressing peers;
+	uint32_t              sq_size = 0;       /* SQ ring depth, populated by populate() */
+
+	gdaki_endpoint() = default;
+	/* Implicit dtor: members destroy in reverse declaration order. */
+	gdaki_endpoint(const gdaki_endpoint &) = delete;
+	gdaki_endpoint &operator=(const gdaki_endpoint &) = delete;
+
+	/**
+	 * Open EP + CQ + AV on the proxy domain and enable.
+	 */
+	void open(struct fid_domain *domain, struct fi_info *ref_info, size_t cq_size);
+
+	/**
+	 * Query EFA QP/CQ attributes, map the SQ MMIO regions for GPU
+	 * access, build the GPU-resident QP/CQ descriptors, and populate
+	 * per-peer addressing from the allgathered peer addresses.
+	 * Must be called after open().
+	 */
+	void populate(struct fi_efa_ops_gda *gda_ops,
+		      const std::vector<uint8_t> &peer_addrs,
+		      size_t ep_addr_len, int nranks);
+};
+
+/**
+ * Host-side state for the data (main) endpoint.
+ *
+ * Composes a gdaki_endpoint plus a FI_WRITE hardware counter for
+ * tracking local completion of outgoing data-only writes. The kernel
+ * spins on this counter (instead of polling the CQ) to determine when
+ * Put has completed locally.
+ *
+ * Member declaration order is critical: write_cntr MUST be declared
+ * BEFORE base so the inner libfabric endpoint closes before the
+ * counter bound to it (closing a counter while it is still bound to
+ * an open endpoint returns EBUSY in libfabric).
+ *
+ * The SQ ring depth is exposed via base.sq_size after populate()
+ * returns; createContext uses it to populate the dev_handle.data field
+ * the device-side SQ-overflow backpressure check reads.
+ */
+class gdaki_data_endpoint {
+public:
+	gdaki_data_endpoint() = default;
+	gdaki_data_endpoint(const gdaki_data_endpoint &) = delete;
+	gdaki_data_endpoint &operator=(const gdaki_data_endpoint &) = delete;
+
+	gdaki_hw_counter write_cntr;        /* FI_WRITE (local completion) */
+	gdaki_endpoint   base;          /* AFTER counter → EP closes first */
+
+	/**
+	 * Open the inner endpoint, create the FI_WRITE counter, and bind
+	 * the counter before enabling.
+	 */
+	void open(struct fid_domain *domain, struct fi_info *ref_info,
+		  struct fi_efa_ops_gda *gda_ops);
+
+	/**
+	 * Populate the inner endpoint's GPU descriptors (QP/CQ attrs,
+	 * SQ MMIO BAR mapping, GPU-resident QP/CQ, per-peer addressing).
+	 * Must be called after open().
+	 */
+	void populate(struct fi_efa_ops_gda *gda_ops,
+		      const std::vector<uint8_t> &peer_addrs,
+		      size_t ep_addr_len, int nranks);
+};
+
+
+/**
  * The composed GDAKI context.
  *
  * All members are lifecycle-managed objects; the destructor is
@@ -282,22 +479,13 @@ struct nccl_ofi_gin_gdaki_context {
 	int nranks = 0;
 	int rank = 0;
 
-	/* libfabric endpoint on the reused proxy domain. Opened first;
-	 * destroyed last (after MMIO regions are unregistered). */
-	gdaki_fi_endpoint endpoint;
+	/* Data (main) endpoint: libfabric EP on the reused proxy domain plus
+	 * its GPU-side SQ buffer/doorbell mappings, GPU-resident QP/CQ
+	 * descriptors, per-peer addressing, and a FI_WRITE hardware counter
+	 * for completion tracking. The kernel polls the counter rather than
+	 * the CQ for data-EP Flush. */
+	gdaki_data_endpoint data;
 
-	/* EFA SQ buffer and doorbell mapped into GPU address space.
-	 * Both must be unregistered BEFORE endpoint teardown: the BAR
-	 * mapping is owned by the endpoint. */
-	gdaki_mmio_region sq_buffer;
-	gdaki_mmio_region sq_doorbell;
-
-	/* GPU-resident QP and CQ descriptors. */
-	gdaki_gpu_qp gpu_qp;
-	gdaki_gpu_cq gpu_cq;
-
-	/* Per-peer addressing tables in GPU memory. */
-	gdaki_peer_addressing peers;
 
 	/* GPU-resident device handle. Populated last; points into the
 	 * GPU buffers owned by the members above. */

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -201,6 +201,12 @@ public:
 	 * any additional binds.
 	 */
 	void enable();
+
+	/**
+	 * Bind a fid (e.g. counter) to the endpoint with the given flags.
+	 * Throws on failure.
+	 */
+	void bind(struct fid *fid, uint64_t flags);
 };
 
 /**
@@ -376,8 +382,8 @@ private:
  * Host-side state for a libfabric endpoint plus its GPU-side queue
  * descriptors and per-peer addressing.
  *
- * Used as the inner state of gdaki_data_endpoint for the data (main)
- * endpoint.
+ * Used directly for the data (main) endpoint, and composed inside
+ * gdaki_sc_endpoint for the signal/counter endpoints.
  *
  * Owns: fid_ep + fid_cq + fid_av (via gdaki_fi_endpoint), GPU-mapped
  * SQ buffer + doorbell BAR regions, GPU-resident QP and CQ descriptors,
@@ -386,9 +392,9 @@ private:
  * Destruction order (reverse declaration): peers, gpu_cq, gpu_qp,
  * sq_doorbell, sq_buffer, endpoint. The libfabric EP closes last so any
  * GPU mappings of its BAR regions are torn down before the EP itself.
- * When this class is composed AFTER hardware counters in a wrapping
- * class's declaration order, the inner EP additionally closes before
- * the counters bound to it — required by libfabric.
+ * When this class is composed inside gdaki_sc_endpoint AFTER the
+ * hardware counters in declaration order, the inner EP additionally
+ * closes before the counters bound to it — required by libfabric.
  */
 class gdaki_endpoint {
 public:
@@ -427,7 +433,9 @@ public:
  * Composes a gdaki_endpoint plus a FI_WRITE hardware counter for
  * tracking local completion of outgoing data-only writes. The kernel
  * spins on this counter (instead of polling the CQ) to determine when
- * Put has completed locally.
+ * Put has completed locally; same model as gdaki_sc_endpoint, just
+ * without the FI_REMOTE_WRITE counter (the data EP isn't a signal
+ * target).
  *
  * Member declaration order is critical: write_cntr MUST be declared
  * BEFORE base so the inner libfabric endpoint closes before the
@@ -464,6 +472,54 @@ public:
 		      size_t ep_addr_len, int nranks);
 };
 
+/**
+ * Host-side state for a single signal or counter endpoint.
+ *
+ * Composes a gdaki_endpoint plus two hardware counters (FI_WRITE for
+ * local completion, FI_REMOTE_WRITE for remote notification) and two
+ * per-EP device handles returned to the kernel through
+ * counter_handles[] / signal_handles[].
+ *
+ * Member declaration order is critical: counters MUST be declared
+ * BEFORE `ep` so the inner libfabric endpoint closes before the
+ * counters bound to it. Closing a counter while it is still bound to
+ * an open endpoint returns EBUSY in libfabric, which our destructors
+ * silently swallow today; getting this order wrong leaks the counter
+ * and (worse) hangs the kernel module on subsequent process exit.
+ */
+class gdaki_sc_endpoint {
+public:
+	gdaki_sc_endpoint() = default;
+	gdaki_sc_endpoint(const gdaki_sc_endpoint &) = delete;
+	gdaki_sc_endpoint &operator=(const gdaki_sc_endpoint &) = delete;
+
+	gdaki_hw_counter write_cntr;        /* FI_WRITE (local completion) */
+	gdaki_hw_counter remote_write_cntr; /* FI_REMOTE_WRITE (signal) */
+	gdaki_endpoint   base;          /* AFTER counters → EP closes first */
+	/* counter_dev_handle exposes the WRITE (local completion) counter via cntr_value.
+	 * Returned to the kernel through counter_handles[]. */
+	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle> counter_dev_handle;
+	/* signal_dev_handle exposes the REMOTE_WRITE (signal) counter via cntr_value.
+	 * Returned to the kernel through signal_handles[]. Same QP/CQ/addressing as
+	 * counter_dev_handle; only cntr_value differs. */
+	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle> signal_dev_handle;
+
+	/**
+	 * Open the inner endpoint with hardware counters bound. Creates
+	 * the counters, opens the inner EP without enable, binds the
+	 * counters, then enables.
+	 */
+	void open(struct fid_domain *domain, struct fi_info *ref_info,
+		  struct fi_efa_ops_gda *gda_ops);
+
+	/**
+	 * Populate the inner endpoint's GPU descriptors and build the
+	 * per-EP device handles. Must be called after open().
+	 */
+	void populate(struct fi_efa_ops_gda *gda_ops,
+		      const std::vector<uint8_t> &peer_addrs,
+		      size_t ep_addr_len, int nranks);
+};
 
 /**
  * The composed GDAKI context.
@@ -486,6 +542,14 @@ struct nccl_ofi_gin_gdaki_context {
 	 * the CQ for data-EP Flush. */
 	gdaki_data_endpoint data;
 
+	/* Signal/counter endpoints. Empty when nSignals == 0 && nCounters == 0. */
+	int nSignals = 0;
+	int nCounters = 0;
+	std::vector<std::unique_ptr<gdaki_sc_endpoint>> sc_endpoints;
+
+	/* GPU-resident arrays of device handle pointers for counter/signal. */
+	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_counter_handles;
+	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_signal_handles;
 
 	/* GPU-resident device handle. Populated last; points into the
 	 * GPU buffers owned by the members above. */

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -551,6 +551,36 @@ struct nccl_ofi_gin_gdaki_context {
 	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_counter_handles;
 	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_signal_handles;
 
+	/* Signal-only scratch buffer.
+	 *
+	 * `net.signal(team, peer, ...)` (the path used by ncclBarrierSession)
+	 * routes through ncclGinApi_Put with hasWins=false, bytes=0. EFA needs
+	 * a real remote address to bump the receiver's FI_REMOTE_WRITE counter,
+	 * so we register a small per-rank buffer on the proxy domain and
+	 * allgather the (addr, rkey) pair across all ranks. The GPU kernel
+	 * issues a 4-byte RDMA write to the peer's scratch on the signal
+	 * endpoint when it needs a signal-only delivery. Cleanup is automatic:
+	 * fi_close on the MR before free of the host buffer.
+	 */
+	void *scratch_buf = nullptr;
+	struct fid_mr *scratch_mr = nullptr;
+	uint32_t scratch_lkey = 0;
+	uint64_t scratch_local_addr = 0;
+	gdaki_gpu_buf<uint64_t> scratch_remote_addrs_buf;
+	gdaki_gpu_buf<uint32_t> scratch_remote_rkeys_buf;
+
+	~nccl_ofi_gin_gdaki_context()
+	{
+		if (scratch_mr) {
+			fi_close(&scratch_mr->fid);
+			scratch_mr = nullptr;
+		}
+		if (scratch_buf) {
+			free(scratch_buf);
+			scratch_buf = nullptr;
+		}
+	}
+
 	/* GPU-resident device handle. Populated last; points into the
 	 * GPU buffers owned by the members above. */
 	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_handle> dev_handle;

--- a/m4/check_pkg_libfabric.m4
+++ b/m4/check_pkg_libfabric.m4
@@ -86,6 +86,18 @@ AC_DEFUN([CHECK_PKG_LIBFABRIC], [
 #include <rdma/fi_ext_efa.h>
 #endif]])])
 
+  dnl Check for hardware counter support (cntr_open_ext) in the GDA ops.
+  AS_IF([test "${check_pkg_found}" = "yes"],
+        [AC_CHECK_TYPES([struct fi_efa_comp_cntr_init_attr],
+                  [have_fi_efa_comp_cntr=1],
+                  [have_fi_efa_comp_cntr=0],
+                  [AC_INCLUDES_DEFAULT
+[#ifdef HAVE_RDMA_FI_EXT_EFA_H
+#include <rdma/fi_ext_efa.h>
+#endif]])
+         AC_DEFINE_UNQUOTED([HAVE_FI_EFA_COMP_CNTR], [$have_fi_efa_comp_cntr],
+                            [Define to 1 if libfabric has fi_efa_comp_cntr_init_attr, 0 otherwise])])
+
   AS_IF([test "${check_pkg_found}" = "yes"],
         [$1],
         [CPPFLAGS="${check_pkg_CPPFLAGS_save}"

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -88,6 +88,14 @@ DECLARE_CUDA_FUNCTION(cuMemcpy, 4000);
 DECLARE_CUDA_FUNCTION(cuMemHostRegister, 6050);
 DECLARE_CUDA_FUNCTION(cuMemHostGetDevicePointer, 3020);
 DECLARE_CUDA_FUNCTION(cuMemHostUnregister, 4000);
+DECLARE_CUDA_FUNCTION(cuMemCreate, 10020);
+DECLARE_CUDA_FUNCTION(cuMemRelease, 10020);
+DECLARE_CUDA_FUNCTION(cuMemAddressReserve, 10020);
+DECLARE_CUDA_FUNCTION(cuMemAddressFree, 10020);
+DECLARE_CUDA_FUNCTION(cuMemMap, 10020);
+DECLARE_CUDA_FUNCTION(cuMemUnmap, 10020);
+DECLARE_CUDA_FUNCTION(cuMemSetAccess, 10020);
+DECLARE_CUDA_FUNCTION(cuMemGetAllocationGranularity, 10020);
 
 int nccl_net_ofi_gpu_init(void)
 {
@@ -161,6 +169,14 @@ int nccl_net_ofi_gpu_init(void)
 	RESOLVE_CUDA_FUNCTION(cuMemHostRegister, 6050);
 	RESOLVE_CUDA_FUNCTION(cuMemHostGetDevicePointer, 3020);
 	RESOLVE_CUDA_FUNCTION(cuMemHostUnregister, 4000);
+	RESOLVE_CUDA_FUNCTION(cuMemCreate, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemRelease, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemAddressReserve, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemAddressFree, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemMap, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemUnmap, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemSetAccess, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemGetAllocationGranularity, 10020);
 
 	cu_ret = pfn_cuDriverGetVersion(&driverVersion);
 	if (cu_ret != CUDA_SUCCESS) {
@@ -274,6 +290,95 @@ int nccl_net_ofi_gpu_get_dma_buf_fd(void *aligned_ptr, size_t aligned_size, int 
 #else
 	return -EINVAL;
 #endif
+}
+
+int nccl_net_ofi_gpu_vmm_alloc(void **ptr, size_t size, size_t *out_alloc_size)
+{
+	if (ptr == nullptr || out_alloc_size == nullptr) {
+		return -EINVAL;
+	}
+
+	CUdevice cu_dev;
+	if (pfn_cuCtxGetDevice(&cu_dev) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("vmm_alloc: cuCtxGetDevice failed");
+		return -EINVAL;
+	}
+
+	CUmemAllocationProp prop = {};
+	prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+	prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+	prop.location.id = cu_dev;
+
+	int flag = 0;
+	pfn_cuDeviceGetAttribute(&flag, CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED, cu_dev);
+	if (flag) prop.allocFlags.gpuDirectRDMACapable = 1;
+
+	size_t granularity = 0;
+	if (pfn_cuMemGetAllocationGranularity(&granularity, &prop, CU_MEM_ALLOC_GRANULARITY_MINIMUM) != CUDA_SUCCESS)
+		return -1;
+
+	size_t alloc_size = (size + granularity - 1) & ~(granularity - 1);
+	CUmemGenericAllocationHandle handle;
+	if (pfn_cuMemCreate(&handle, alloc_size, &prop, 0) != CUDA_SUCCESS)
+		return -1;
+
+	CUdeviceptr dptr = 0;
+	if (pfn_cuMemAddressReserve(&dptr, alloc_size, granularity, 0, 0) != CUDA_SUCCESS) {
+		pfn_cuMemRelease(handle);
+		return -1;
+	}
+
+	if (pfn_cuMemMap(dptr, alloc_size, 0, handle, 0) != CUDA_SUCCESS) {
+		pfn_cuMemAddressFree(dptr, alloc_size);
+		pfn_cuMemRelease(handle);
+		return -1;
+	}
+
+	CUmemAccessDesc access = {};
+	access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+	access.location.id = cu_dev;
+	access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+	if (pfn_cuMemSetAccess(dptr, alloc_size, &access, 1) != CUDA_SUCCESS) {
+		pfn_cuMemUnmap(dptr, alloc_size);
+		pfn_cuMemAddressFree(dptr, alloc_size);
+		pfn_cuMemRelease(handle);
+		return -1;
+	}
+
+	/*
+	 * Drop our reference to the handle now that the mapping owns it.
+	 * Per the CUDA driver API: "The memory allocation will be freed
+	 * when all outstanding mappings to the memory are unmapped and
+	 * when all outstanding references to the handle ... are also
+	 * released." Without this release, the handle's refcount stays at
+	 * 1 forever and cuMemUnmap on free would not actually release
+	 * the underlying physical memory — every alloc/free cycle would
+	 * leak.
+	 */
+	if (pfn_cuMemRelease(handle) != CUDA_SUCCESS) {
+		pfn_cuMemUnmap(dptr, alloc_size);
+		pfn_cuMemAddressFree(dptr, alloc_size);
+		return -1;
+	}
+
+	if (cudaMemset((void *)dptr, 0, alloc_size) != cudaSuccess) {
+		NCCL_OFI_WARN("vmm_alloc: cudaMemset failed");
+		pfn_cuMemUnmap(dptr, alloc_size);
+		pfn_cuMemAddressFree(dptr, alloc_size);
+		return -EINVAL;
+	}
+
+	*ptr = (void *)dptr;
+	*out_alloc_size = alloc_size;
+	return 0;
+}
+
+int nccl_net_ofi_gpu_vmm_free(void *ptr, size_t alloc_size)
+{
+	if (!ptr) return 0;
+	pfn_cuMemUnmap((CUdeviceptr)ptr, alloc_size);
+	pfn_cuMemAddressFree((CUdeviceptr)ptr, alloc_size);
+	return 0;
 }
 
 int nccl_net_ofi_get_gpu_device_for_addr(void *ptr, int *dev_id)

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7529,7 +7529,28 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 	}
 
 	get_hints(hints);
-	api_version = nccl_ofi_dmabuf_viable() ? FI_VERSION(1, 20) : FI_VERSION(1, 18);
+	/*
+	 * Select libfabric API version.
+	 *   - GDAKI: hard requirements — CUDA, DMA-BUF, libfabric 2.5+.
+	 *     The proxy domain opened here is reused by the GDAKI plugin,
+	 *     so the domain must be created with the 2.5 ABI to expose the
+	 *     EFA hardware-counter ops via fi_open_ops. Fail loudly if any
+	 *     prerequisite is missing.
+	 *   - Proxy: 1.20 with DMA-BUF (FI_MR_DMABUF support), 1.18 otherwise.
+	 */
+	if (ofi_nccl_gin_type.get() == GIN_TYPE::GDAKI) {
+#if !HAVE_CUDA
+		NCCL_OFI_WARN("OFI_NCCL_GIN_TYPE=GDAKI set but plugin built without CUDA");
+		return -FI_EINVAL;
+#endif
+		if (!nccl_ofi_dmabuf_viable()) {
+			NCCL_OFI_WARN("OFI_NCCL_GIN_TYPE=GDAKI set but DMA-BUF is not viable");
+			return -FI_EINVAL;
+		}
+		api_version = FI_VERSION(2, 5);
+	} else {
+		api_version = nccl_ofi_dmabuf_viable() ? FI_VERSION(1, 20) : FI_VERSION(1, 18);
+	}
 	ret = nccl_ofi_ofiutils_get_providers(provider_filter, api_version, hints,
 					      &provider_list, &num_providers);
 	if (ret == 0) {

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -297,12 +297,15 @@ static ncclResult_t nccl_ofi_gin_gdaki_destroyContext(void *ginCtx)
  *      on the GDAKI endpoint; no second registration is needed.
  *   2. Reach through the plugin mhandle to obtain the underlying fid_mr*.
  *   3. Query the local key via gda_ops->get_mr_lkey().
- *   4. Read the plugin's already-allgathered per-peer rkeys from
- *      mhandle->remote_mr[i].mr_key[0] — no second MPI allgather needed.
- *   5. Package lkey + rkeys[nranks] into an nccl_ofi_gin_gdaki_mr_handle
- *      (the layout declared in nccl_ofi_gin_gdaki_dev.h) and return it via
- *      ginHandle. The GPU kernel reads lkey for local SGEs and rkeys[peer]
- *      for remote RDMA writes.
+ *   4. Read the plugin's already-allgathered per-peer (base VA, rkey)
+ *      from mhandle->remote_mr[i].address / mr_key[0] — no second MPI
+ *      allgather needed.
+ *   5. Package lkey + local_addr + peers[nranks] into an
+ *      nccl_ofi_gin_gdaki_mr_handle (the layout declared in
+ *      nccl_ofi_gin_gdaki_dev.h) and return it via ginHandle. The GPU
+ *      kernel reads lkey for local SGEs and peers[peer].remote_addr +
+ *      peers[peer].rkey to compute absolute remote VAs for RDMA writes
+ *      (FI_MR_VIRT_ADDR mode).
  *
  * The device-visible handle owns no libfabric resources — the underlying
  * fid_mr is owned by the proxy regMrSym path and torn down by its dereg.
@@ -346,9 +349,9 @@ static ncclResult_t nccl_ofi_gin_gdaki_regMrSym(void *collComm, void *data, size
 	uint32_t lkey = (uint32_t)gda_ops->get_mr_lkey(mr);
 
 	/* Step 4/5: allocate and populate the device-visible handle.
-	 * Layout: base struct + flex rkeys[nranks]. */
+	 * Layout: base struct + flex peers[nranks]. */
 	size_t handle_size = sizeof(nccl_ofi_gin_gdaki_mr_handle) +
-			     (size_t)nranks * sizeof(uint32_t);
+			     (size_t)nranks * sizeof(nccl_ofi_gin_gdaki_mr_peer);
 	auto *gdaki_handle = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(
 		calloc(1, handle_size));
 	if (gdaki_handle == nullptr) {
@@ -358,10 +361,13 @@ static ncclResult_t nccl_ofi_gin_gdaki_regMrSym(void *collComm, void *data, size
 
 	gdaki_handle->lkey = lkey;
 	gdaki_handle->nranks = nranks;
+	gdaki_handle->local_addr = (uint64_t)data;
 	for (int i = 0; i < nranks; i++) {
-		/* remote_mr[i].mr_key[0] is the peer rkey on rail 0, stored
-		 * by the shared regMrSymDmaBuf after its internal allgather. */
-		gdaki_handle->rkeys[i] = (uint32_t)sym->remote_mr[i].mr_key[0];
+		/* remote_mr[i].address is the peer's base VA, allgathered by
+		 * the shared regMrSym. remote_mr[i].mr_key[0] is the peer's
+		 * rkey on rail 0. */
+		gdaki_handle->peers[i].remote_addr = (uint64_t)sym->remote_mr[i].address;
+		gdaki_handle->peers[i].rkey        = (uint32_t)sym->remote_mr[i].mr_key[0];
 	}
 
 	/* Stash on the mhandle so deregMrSym can free it. The mhandle and

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -105,6 +105,106 @@ static std::vector<uint8_t> allgather_ep_addr(struct fid_ep *ep,
 	return all_addrs;
 }
 
+/*
+ * Allocate the per-context signal-only scratch buffer, register it on the
+ * proxy domain, and allgather (addr, rkey) across ranks. The kernel uses
+ * this for net.signal()-style writes that have no payload (hasWins=false,
+ * bytes=0) — EFA still needs a registered remote address to bump the
+ * receiver's FI_REMOTE_WRITE counter.
+ *
+ * Throws std::runtime_error on any libfabric / allgather failure; the
+ * caller's catch handler unwinds via the ctx's RAII members.
+ */
+static void setup_scratch_buffer(nccl_ofi_gin_gdaki_context *ctx,
+				 struct fid_domain *ofi_domain,
+				 nccl_ofi_rdma_gin_put_comm *put_comm,
+				 int nranks, int rank)
+{
+	constexpr size_t kScratchBytes = sizeof(uint64_t);
+	ctx->scratch_buf = calloc(1, kScratchBytes);
+	if (ctx->scratch_buf == nullptr) {
+		throw std::runtime_error("scratch calloc failed");
+	}
+
+	struct iovec iov = { .iov_base = ctx->scratch_buf,
+			     .iov_len = kScratchBytes };
+	struct fi_mr_attr mr_attr = {};
+	mr_attr.mr_iov = &iov;
+	mr_attr.iov_count = 1;
+	/* The buffer is only used as the source/target of RDMA WRITE on the
+	 * signal endpoints; FI_SEND / FI_RECV are not required. */
+	mr_attr.access = FI_REMOTE_WRITE | FI_WRITE;
+	mr_attr.iface = FI_HMEM_SYSTEM;
+
+	int mret = fi_mr_regattr(ofi_domain, &mr_attr, 0, &ctx->scratch_mr);
+	if (mret != 0) {
+		throw std::runtime_error(
+			"scratch fi_mr_regattr failed: " +
+			std::string(fi_strerror(-mret)));
+	}
+
+	ctx->scratch_lkey = (uint32_t)fi_mr_key(ctx->scratch_mr);
+	ctx->scratch_local_addr = (uint64_t)ctx->scratch_buf;
+
+	/* Allgather (local_addr, local_rkey) across ranks. */
+	std::vector<uint64_t> scratch_all_addrs(nranks, 0);
+	std::vector<uint32_t> scratch_all_rkeys(nranks, 0);
+	scratch_all_addrs[rank] = ctx->scratch_local_addr;
+	scratch_all_rkeys[rank] = ctx->scratch_lkey;
+
+	if (put_comm->get_ag_comm().all_gather(
+		    scratch_all_addrs.data(), sizeof(uint64_t)) != 0) {
+		throw std::runtime_error("scratch allgather addrs failed");
+	}
+	if (put_comm->get_ag_comm().all_gather(
+		    scratch_all_rkeys.data(), sizeof(uint32_t)) != 0) {
+		throw std::runtime_error("scratch allgather rkeys failed");
+	}
+
+	ctx->scratch_remote_addrs_buf.allocate(nranks);
+	ctx->scratch_remote_rkeys_buf.allocate(nranks);
+	for (int i = 0; i < nranks; i++) {
+		ctx->scratch_remote_addrs_buf.host[i] = scratch_all_addrs[i];
+		ctx->scratch_remote_rkeys_buf.host[i] = scratch_all_rkeys[i];
+	}
+	ctx->scratch_remote_addrs_buf.commit();
+	ctx->scratch_remote_rkeys_buf.commit();
+}
+
+/*
+ * Populate the GPU-resident device handle from the built context and
+ * upload it to GPU memory via commit().
+ */
+static void populate_dev_handle(nccl_ofi_gin_gdaki_context *ctx,
+				const ncclGinConfig_v13_t *config,
+				int nranks, int rank)
+{
+	ctx->dev_handle.allocate(1);
+	nccl_ofi_gin_gdaki_dev_handle &h = *ctx->dev_handle.host;
+	h.data.qp = ctx->data.base.gpu_qp.dev();
+	h.data.cq = ctx->data.base.gpu_cq.dev();
+	h.data.address_handles = ctx->data.base.peers.ahs.dev;
+	h.data.remote_qpns = ctx->data.base.peers.qpns.dev;
+	h.data.qkey = ctx->data.base.peers.qkeys.dev;
+	h.data.sq_lock = 0;
+	h.data.local_cntr_value = ctx->data.write_cntr.gpu_ptr();
+	h.data.submitted_count = 0;
+	h.data.sq_size = ctx->data.base.sq_size;
+	h.counter_handles = (config->nCounters > 0) ? ctx->d_counter_handles.dev : nullptr;
+	h.signal_handles  = (config->nSignals  > 0) ? ctx->d_signal_handles.dev  : nullptr;
+	h.nCounters = config->nCounters;
+	h.nSignals  = config->nSignals;
+	h.nranks = nranks;
+	h.rank = rank;
+	h.scratch_lkey         = ctx->scratch_lkey;
+	h.scratch_pad          = 0;
+	h.scratch_local_addr   = ctx->scratch_local_addr;
+	h.scratch_remote_addrs = ctx->scratch_remote_addrs_buf.dev;
+	h.scratch_remote_rkeys = ctx->scratch_remote_rkeys_buf.dev;
+	/* Upload the populated host-side struct to GPU memory. */
+	ctx->dev_handle.commit();
+}
+
 static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConfig_v13_t *config,
 						     void **ginCtx,
 						     ncclNetDeviceHandle_v11_t **devHandle)
@@ -200,7 +300,7 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		ctx->data.populate(gda_ops, all_addrs, ep_addr_len, nranks);
 
 		/*
-		 * Step 7: Create signal/counter endpoints if requested.
+		 * Step 5: Create signal/counter endpoints if requested.
 		 *
 		 * Each endpoint has its own QP plus two hardware counters
 		 * (FI_WRITE for local completion, FI_REMOTE_WRITE for remote
@@ -243,26 +343,28 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		}
 
 		/*
-		 * Step 8: Populate and upload the device-visible handle.
+		 * Step 6: Allocate signal-only scratch buffer and allgather
+		 * (addr, rkey) per rank.
+		 *
+		 * net.signal(team, peer) (the path used by ncclBarrierSession)
+		 * routes through ncclGinApi_Put with hasWins=false, bytes=0. EFA
+		 * still requires a registered remote address to bump the
+		 * receiver's FI_REMOTE_WRITE counter — even for a 0-byte write —
+		 * so we register a small per-rank buffer on the proxy domain and
+		 * allgather (addr, rkey) across ranks.
+		 *
+		 * Allocated unconditionally (not gated on n_sc > 0) so any
+		 * caller that creates a context — even one that doesn't request
+		 * signal/counter endpoints today but later issues a signal-only
+		 * Put — has a valid scratch destination. The cost is ~8 bytes
+		 * of host memory + one small MR registration; negligible.
 		 */
-		ctx->dev_handle.allocate(1);
-		nccl_ofi_gin_gdaki_dev_handle &h = *ctx->dev_handle.host;
-		h.data.qp = ctx->data.base.gpu_qp.dev();
-		h.data.cq = ctx->data.base.gpu_cq.dev();
-		h.data.address_handles = ctx->data.base.peers.ahs.dev;
-		h.data.remote_qpns = ctx->data.base.peers.qpns.dev;
-		h.data.qkey = ctx->data.base.peers.qkeys.dev;
-		h.data.sq_lock = 0;
-		h.data.local_cntr_value = ctx->data.write_cntr.gpu_ptr();
-		h.data.submitted_count = 0;
-		h.data.sq_size = ctx->data.base.sq_size;
-		h.counter_handles = (config->nCounters > 0) ? ctx->d_counter_handles.dev : nullptr;
-		h.signal_handles  = (config->nSignals  > 0) ? ctx->d_signal_handles.dev  : nullptr;
-		h.nCounters = config->nCounters;
-		h.nSignals  = config->nSignals;
-		h.nranks = nranks;
-		h.rank = rank;
-		ctx->dev_handle.commit();
+		setup_scratch_buffer(ctx.get(), ofi_domain, put_comm, nranks, rank);
+
+		/*
+		 * Step 7: Populate and upload the device-visible handle.
+		 */
+		populate_dev_handle(ctx.get(), config, nranks, rank);
 
 		/*
 		 * Step 8: Publish the host-side ncclNetDeviceHandle_v11_t.

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -18,6 +18,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 
+#include <algorithm>
 #include <memory>
 #include <vector>
 
@@ -77,12 +78,53 @@ static ncclResult_t nccl_ofi_gin_gdaki_get_properties(int dev, ncclNetProperties
 	return ncclSuccess;
 }
 
+/*
+ * Read this rank's libfabric EP address into a per-rank slot of an
+ * allgather buffer, then allgather across the team. Returns the buffer.
+ *
+ * Used by createContext for both the data endpoint and each
+ * signal/counter endpoint.
+ *
+ * Throws std::runtime_error on fi_getname / allgather failure.
+ */
+static std::vector<uint8_t> allgather_ep_addr(struct fid_ep *ep,
+					      nccl_ofi_rdma_gin_put_comm *put_comm,
+					      int nranks, int rank,
+					      size_t ep_addr_len)
+{
+	std::vector<uint8_t> all_addrs(nranks * ep_addr_len, 0);
+	size_t addrlen = ep_addr_len;
+	int ret = fi_getname(&ep->fid, &all_addrs[rank * ep_addr_len], &addrlen);
+	if (ret != 0) {
+		throw std::runtime_error("fi_getname failed: " +
+					 std::string(fi_strerror(-ret)));
+	}
+	if (put_comm->get_ag_comm().all_gather(all_addrs.data(), ep_addr_len) != 0) {
+		throw std::runtime_error("allgather of ep addresses failed");
+	}
+	return all_addrs;
+}
+
 static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConfig_v13_t *config,
 						     void **ginCtx,
 						     ncclNetDeviceHandle_v11_t **devHandle)
 {
 	if (collComm == nullptr || config == nullptr || ginCtx == nullptr || devHandle == nullptr) {
 		NCCL_OFI_WARN("gin GDAKI: createContext received NULL argument");
+		return ncclInvalidArgument;
+	}
+
+	NCCL_OFI_INFO(NCCL_NET,
+		      "gin GDAKI: createContext request: nSignals=%d nCounters=%d "
+		      "nContexts=%d queueDepth=%d",
+		      config->nSignals, config->nCounters,
+		      config->nContexts, config->queueDepth);
+
+	if (config->nSignals > 0 || config->nCounters > 0) {
+		NCCL_OFI_WARN(
+			"gin GDAKI: caller requested nSignals=%d nCounters=%d "
+			"but signal/counter endpoints are not supported",
+			config->nSignals, config->nCounters);
 		return ncclInvalidArgument;
 	}
 
@@ -137,17 +179,9 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		}
 
 		/*
-		 * Step 2: Open the libfabric endpoint on the reused domain.
-		 * gdaki_fi_endpoint owns the EP, CQ, AV, and fi_info; it
-		 * derives its own fi_info via fi_getinfo with hints narrowed
-		 * to the proxy's fabric + domain name.
-		 */
-		ctx->endpoint.open(ofi_domain, proxy_info, ofi_nccl_cq_size());
-
-		/*
-		 * Step 3: Open FI_EFA_GDA_OPS on the reused domain and query
-		 * the SQ / RQ / CQ attributes needed to populate the
-		 * GPU-resident QP / CQ descriptors.
+		 * Step 2: Open FI_EFA_GDA_OPS on the reused domain. Used by
+		 * data.open() (to bind the FI_WRITE counter), data.populate(),
+		 * and the sc_endpoint loop below.
 		 */
 		struct fi_efa_ops_gda *gda_ops = nullptr;
 		int ret = fi_open_ops(&ofi_domain->fid, FI_EFA_GDA_OPS, 0,
@@ -159,80 +193,34 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				std::string(ret ? fi_strerror(-ret) : "no ops table"));
 		}
 
-		struct fi_efa_wq_attr sq_attr = {}, rq_attr = {};
-		ret = gda_ops->query_qp_wqs(ctx->endpoint.ep, &sq_attr, &rq_attr);
-		if (ret != 0) {
-			throw std::runtime_error("query_qp_wqs failed: " +
-						 std::string(fi_strerror(-ret)));
-		}
-
-		struct fi_efa_cq_attr efa_cq_attr = {};
-		ret = gda_ops->query_cq(ctx->endpoint.cq, &efa_cq_attr);
-		if (ret != 0) {
-			throw std::runtime_error("query_cq failed: " +
-						 std::string(fi_strerror(-ret)));
-		}
-
 		/*
-		 * Step 4: Map SQ BAR regions into the GPU address space.
-		 *
-		 * The SQ buffer and doorbell are device MMIO (BAR) regions
-		 * that require cuMemHostRegister with IOMEMORY | DEVICEMAP for
-		 * GPU kernels to write WQEs and ring the doorbell.
-		 *
-		 * The CQ buffer is not mapped for GPU access: attempts to
-		 * register it with cuMemHostRegister(IOMEMORY|DEVICEMAP) on
-		 * P5en fail, and the host pointer is usable from both the CPU
-		 * and CUDA kernels for CQ polling.
+		 * Step 3: Open the data endpoint on the reused domain.
 		 */
-		ctx->sq_buffer.map(sq_attr.buffer,
-				   (size_t)sq_attr.num_entries * sq_attr.entry_size);
+		ctx->data.open(ofi_domain, proxy_info, gda_ops);
 
 		/*
-		 * rdma-core mmaps the doorbell MMIO region with
-		 * sysconf(_SC_PAGESIZE) (see providers/efa/verbs.c). Use the
-		 * plugin's cached system_page_size so our GPU-side mapping
-		 * covers the same region rdma-core opened.
-		 */
-		ctx->sq_doorbell.map(sq_attr.doorbell, system_page_size);
-
-		/*
-		 * Step 5: Build GPU-resident QP and CQ descriptors.
-		 */
-		ctx->gpu_qp.build(sq_attr, rq_attr, ctx->sq_buffer.dev,
-				  ctx->sq_doorbell.dev);
-		ctx->gpu_cq.build(efa_cq_attr);
-
-		/*
-		 * Step 6: Exchange endpoint addresses and populate per-peer
-		 * addressing tables in GPU memory.
+		 * Step 4: Exchange endpoint addresses across the team, then
+		 * complete the data endpoint's GPU-side build.
 		 */
 		constexpr size_t ep_addr_len = MAX_EP_ADDR;
-		std::vector<uint8_t> all_addrs(nranks * ep_addr_len, 0);
-		size_t addrlen = ep_addr_len;
-		ret = fi_getname(&ctx->endpoint.ep->fid,
-				 &all_addrs[rank * ep_addr_len], &addrlen);
-		if (ret != 0) {
-			throw std::runtime_error("fi_getname failed: " +
-						 std::string(fi_strerror(-ret)));
-		}
-		ret = put_comm->get_ag_comm().all_gather(all_addrs.data(), ep_addr_len);
-		if (ret != 0) {
-			throw std::runtime_error("allgather of ep addresses failed");
-		}
-		ctx->peers.populate(ctx->endpoint, all_addrs, ep_addr_len, nranks, gda_ops);
+		std::vector<uint8_t> all_addrs = allgather_ep_addr(
+			ctx->data.base.endpoint.ep, put_comm, nranks, rank, ep_addr_len);
+		ctx->data.populate(gda_ops, all_addrs, ep_addr_len, nranks);
 
 		/*
 		 * Step 7: Populate and upload the device-visible handle.
 		 */
 		ctx->dev_handle.allocate(1);
 		nccl_ofi_gin_gdaki_dev_handle &h = *ctx->dev_handle.host;
-		h.qp = ctx->gpu_qp.dev();
-		h.cq = ctx->gpu_cq.dev();
-		h.address_handles = ctx->peers.ahs.dev;
-		h.remote_qpns = ctx->peers.qpns.dev;
-		h.qkey = ctx->peers.qkeys.dev;
-		h.pending_reqs = 0;
+		h.data.qp = ctx->data.base.gpu_qp.dev();
+		h.data.cq = ctx->data.base.gpu_cq.dev();
+		h.data.address_handles = ctx->data.base.peers.ahs.dev;
+		h.data.remote_qpns = ctx->data.base.peers.qpns.dev;
+		h.data.qkey = ctx->data.base.peers.qkeys.dev;
+		h.data.sq_lock = 0;
+		h.data.local_cntr_value = ctx->data.write_cntr.gpu_ptr();
+		h.data.submitted_count = 0;
+		h.data.sq_size = ctx->data.base.sq_size;
 		h.nranks = nranks;
 		h.rank = rank;
 		ctx->dev_handle.commit();
@@ -258,11 +246,8 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		dev_handle_out->needsProxyProgress = 0;
 
 		NCCL_OFI_INFO(NCCL_NET,
-			      "gin GDAKI: createContext done (nranks=%d rank=%d "
-			      "sq_entries=%u sq_entry_size=%u cq_entries=%u cq_entry_size=%u)",
-			      nranks, rank,
-			      sq_attr.num_entries, sq_attr.entry_size,
-			      efa_cq_attr.num_entries, efa_cq_attr.entry_size);
+			      "gin GDAKI: createContext done (nranks=%d rank=%d)",
+			      nranks, rank);
 
 		*ginCtx = ctx.release();
 		*devHandle = dev_handle_out;
@@ -297,15 +282,12 @@ static ncclResult_t nccl_ofi_gin_gdaki_destroyContext(void *ginCtx)
  *      on the GDAKI endpoint; no second registration is needed.
  *   2. Reach through the plugin mhandle to obtain the underlying fid_mr*.
  *   3. Query the local key via gda_ops->get_mr_lkey().
- *   4. Read the plugin's already-allgathered per-peer (base VA, rkey)
- *      from mhandle->remote_mr[i].address / mr_key[0] — no second MPI
- *      allgather needed.
- *   5. Package lkey + local_addr + peers[nranks] into an
- *      nccl_ofi_gin_gdaki_mr_handle (the layout declared in
- *      nccl_ofi_gin_gdaki_dev.h) and return it via ginHandle. The GPU
- *      kernel reads lkey for local SGEs and peers[peer].remote_addr +
- *      peers[peer].rkey to compute absolute remote VAs for RDMA writes
- *      (FI_MR_VIRT_ADDR mode).
+ *   4. Read the plugin's already-allgathered per-peer rkeys from
+ *      mhandle->remote_mr[i].mr_key[0] — no second MPI allgather needed.
+ *   5. Package lkey + rkeys[nranks] into an nccl_ofi_gin_gdaki_mr_handle
+ *      (the layout declared in nccl_ofi_gin_gdaki_dev.h) and return it via
+ *      ginHandle. The GPU kernel reads lkey for local SGEs and rkeys[peer]
+ *      for remote RDMA writes.
  *
  * The device-visible handle owns no libfabric resources — the underlying
  * fid_mr is owned by the proxy regMrSym path and torn down by its dereg.

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -120,14 +120,6 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		      config->nSignals, config->nCounters,
 		      config->nContexts, config->queueDepth);
 
-	if (config->nSignals > 0 || config->nCounters > 0) {
-		NCCL_OFI_WARN(
-			"gin GDAKI: caller requested nSignals=%d nCounters=%d "
-			"but signal/counter endpoints are not supported",
-			config->nSignals, config->nCounters);
-		return ncclInvalidArgument;
-	}
-
 	auto *put_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	int nranks = put_comm->get_nranks();
 	int rank = put_comm->get_rank();
@@ -208,7 +200,50 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		ctx->data.populate(gda_ops, all_addrs, ep_addr_len, nranks);
 
 		/*
-		 * Step 7: Populate and upload the device-visible handle.
+		 * Step 7: Create signal/counter endpoints if requested.
+		 *
+		 * Each endpoint has its own QP plus two hardware counters
+		 * (FI_WRITE for local completion, FI_REMOTE_WRITE for remote
+		 * notification). Both counter values live in GPU memory
+		 * (DMA-BUF-mapped). We expose them through GPU-resident
+		 * arrays of nccl_ofi_gin_gdaki_dev_counter_handle pointers, one
+		 * per signal and one per counter.
+		 */
+		int n_sc = std::max(config->nSignals, config->nCounters);
+		if (n_sc > 0) {
+			ctx->nSignals = config->nSignals;
+			ctx->nCounters = config->nCounters;
+			ctx->sc_endpoints.reserve(n_sc);
+
+			for (int i = 0; i < n_sc; i++) {
+				ctx->sc_endpoints.push_back(std::make_unique<gdaki_sc_endpoint>());
+				ctx->sc_endpoints[i]->open(ofi_domain, proxy_info, gda_ops);
+
+				std::vector<uint8_t> sc_addrs = allgather_ep_addr(
+					ctx->sc_endpoints[i]->base.endpoint.ep,
+					put_comm, nranks, rank, ep_addr_len);
+
+				ctx->sc_endpoints[i]->populate(gda_ops, sc_addrs, ep_addr_len, nranks);
+			}
+
+			/* Build counter_handles and signal_handles GPU arrays. */
+			auto build_handle_array = [&](gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> &buf,
+						      int count, auto get_dev_handle) {
+				if (count > 0) {
+					buf.allocate(count);
+					for (int i = 0; i < count; i++)
+						buf.host[i] = get_dev_handle(i);
+					buf.commit();
+				}
+			};
+			build_handle_array(ctx->d_counter_handles, config->nCounters,
+				[&](int i) { return ctx->sc_endpoints[i]->counter_dev_handle.dev; });
+			build_handle_array(ctx->d_signal_handles, config->nSignals,
+				[&](int i) { return ctx->sc_endpoints[i]->signal_dev_handle.dev; });
+		}
+
+		/*
+		 * Step 8: Populate and upload the device-visible handle.
 		 */
 		ctx->dev_handle.allocate(1);
 		nccl_ofi_gin_gdaki_dev_handle &h = *ctx->dev_handle.host;
@@ -221,6 +256,10 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		h.data.local_cntr_value = ctx->data.write_cntr.gpu_ptr();
 		h.data.submitted_count = 0;
 		h.data.sq_size = ctx->data.base.sq_size;
+		h.counter_handles = (config->nCounters > 0) ? ctx->d_counter_handles.dev : nullptr;
+		h.signal_handles  = (config->nSignals  > 0) ? ctx->d_signal_handles.dev  : nullptr;
+		h.nCounters = config->nCounters;
+		h.nSignals  = config->nSignals;
 		h.nranks = nranks;
 		h.rank = rank;
 		ctx->dev_handle.commit();
@@ -246,8 +285,10 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		dev_handle_out->needsProxyProgress = 0;
 
 		NCCL_OFI_INFO(NCCL_NET,
-			      "gin GDAKI: createContext done (nranks=%d rank=%d)",
-			      nranks, rank);
+			      "gin GDAKI: createContext done (nranks=%d rank=%d "
+			      "nSignals=%d nCounters=%d)",
+			      nranks, rank,
+			      config->nSignals, config->nCounters);
 
 		*ginCtx = ctx.release();
 		*devHandle = dev_handle_out;

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -20,6 +20,8 @@
 
 #include <algorithm>
 #include <memory>
+#include <mutex>
+#include <unordered_map>
 #include <vector>
 
 #include <rdma/fi_cm.h>
@@ -34,6 +36,77 @@
 #endif
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_param.h"
+
+/*
+ * GDAKI contexts tracked by collComm so we can clean them up at
+ * closeColl time. NCCL's GIN call sequence is supposed to be
+ *   createContext -> destroyContext -> closeColl
+ * but in practice (verified on alltoall_perf shutdown) destroyContext
+ * is sometimes never called, leaving libfabric EPs / hardware counters
+ * / scratch MRs open on the proxy domain. The proxy plugin then closes
+ * its fabric/domain with our resources still alive, producing
+ * "Failed to close fid_domain/fid_fabric: Device or resource busy"
+ * warnings.
+ *
+ * The closeColl wrapper below sweeps any contexts created against this
+ * collComm before delegating to the shared closeColl, ensuring our
+ * resources are released before the proxy domain goes away.
+ *
+ * The map + mutex are bundled into a class so callers don't have to
+ * remember to take the lock when manipulating the map.
+ */
+class gdaki_context_registry {
+public:
+	/** Register a newly-created context against its collComm. */
+	void add(void *collComm, nccl_ofi_gin_gdaki_context *ctx)
+	{
+		std::lock_guard<std::mutex> lock(mu);
+		map[collComm].push_back(ctx);
+	}
+
+	/**
+	 * Deregister a context from whichever collComm bucket it lives in.
+	 * Called from destroyContext, which is invoked either by NCCL or
+	 * by our own closeColl sweep — both paths must remove the entry
+	 * to avoid a double-free.
+	 */
+	void remove(nccl_ofi_gin_gdaki_context *ctx)
+	{
+		std::lock_guard<std::mutex> lock(mu);
+		for (auto it = map.begin(); it != map.end(); ) {
+			auto &vec = it->second;
+			vec.erase(std::remove(vec.begin(), vec.end(), ctx), vec.end());
+			if (vec.empty()) {
+				it = map.erase(it);
+			} else {
+				++it;
+			}
+		}
+	}
+
+	/**
+	 * Atomically take and remove all contexts for a given collComm.
+	 * Used by closeColl to sweep any contexts that NCCL forgot to
+	 * destroyContext.
+	 */
+	std::vector<nccl_ofi_gin_gdaki_context *> take_all(void *collComm)
+	{
+		std::lock_guard<std::mutex> lock(mu);
+		auto it = map.find(collComm);
+		if (it == map.end()) {
+			return {};
+		}
+		auto leftover = std::move(it->second);
+		map.erase(it);
+		return leftover;
+	}
+
+private:
+	std::mutex mu;
+	std::unordered_map<void *, std::vector<nccl_ofi_gin_gdaki_context *>> map;
+};
+
+static gdaki_context_registry gdaki_contexts;
 
 static ncclResult_t nccl_ofi_gin_gdaki_get_properties(int dev, ncclNetProperties_v12_t *props)
 {
@@ -394,6 +467,10 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 
 		*ginCtx = ctx.release();
 		*devHandle = dev_handle_out;
+
+		gdaki_contexts.add(collComm,
+				   static_cast<nccl_ofi_gin_gdaki_context *>(*ginCtx));
+
 		return ncclSuccess;
 
 	} catch (const std::exception &e) {
@@ -412,8 +489,32 @@ static ncclResult_t nccl_ofi_gin_gdaki_destroyContext(void *ginCtx)
 	 * GPU QP/CQ first, then the MMIO BAR mappings, finally the
 	 * libfabric endpoint (after the BAR mappings are gone, as
 	 * required). */
-	delete static_cast<nccl_ofi_gin_gdaki_context *>(ginCtx);
+	auto *ctx = static_cast<nccl_ofi_gin_gdaki_context *>(ginCtx);
+
+	/* Deregister from the per-collComm tracking map (if present).
+	 * destroyContext may be called by NCCL or by our own closeColl
+	 * sweep — either path needs to remove the entry to avoid a
+	 * double-free. */
+	gdaki_contexts.remove(ctx);
+
+	delete ctx;
 	return ncclSuccess;
+}
+
+/*
+ * GDAKI closeColl: sweep any GDAKI contexts that NCCL forgot to
+ * destroyContext for this collComm, then delegate to the shared
+ * closeColl. See gdaki_contexts comment above for rationale.
+ */
+static ncclResult_t nccl_ofi_gin_gdaki_closeColl(void *collComm)
+{
+	auto leftover = gdaki_contexts.take_all(collComm);
+
+	for (auto *ctx : leftover) {
+		nccl_ofi_gin_gdaki_destroyContext(ctx);
+	}
+
+	return nccl_ofi_gin_closeColl(collComm);
 }
 
 /*
@@ -539,7 +640,7 @@ ncclGin_v13_t nccl_ofi_gin_gdaki_plugin = {
 	.regMrSymDmaBuf = nccl_ofi_gin_regMrSymDmaBuf,
 	.deregMrSym = nccl_ofi_gin_gdaki_deregMrSym,
 	.destroyContext = nccl_ofi_gin_gdaki_destroyContext,
-	.closeColl = nccl_ofi_gin_closeColl,
+	.closeColl = nccl_ofi_gin_gdaki_closeColl,
 	.closeListen = nccl_ofi_gin_closeListen,
 	.iput = nullptr,
 	.iputSignal = nullptr,

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -127,8 +127,11 @@ void gdaki_fi_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info
 		throw std::runtime_error("fi_ep_bind AV failed: " +
 					 std::string(fi_strerror(-ret)));
 	}
+}
 
-	ret = fi_enable(ep);
+void gdaki_fi_endpoint::enable()
+{
+	int ret = fi_enable(ep);
 	if (ret != 0) {
 		throw std::runtime_error("fi_enable failed: " +
 					 std::string(fi_strerror(-ret)));
@@ -215,5 +218,77 @@ void gdaki_peer_addressing::populate(gdaki_fi_endpoint &endpoint,
 	ahs.commit();
 	qpns.commit();
 	qkeys.commit();
+}
+
+void gdaki_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
+			  size_t cq_size)
+{
+	endpoint.open(domain, ref_info, cq_size);
+	endpoint.enable();
+}
+
+void gdaki_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
+			      const std::vector<uint8_t> &peer_addrs,
+			      size_t ep_addr_len, int nranks)
+{
+	/* Query QP and map SQ MMIO for GPU access. */
+	struct fi_efa_wq_attr sq_attr = {}, rq_attr = {};
+	int ret = gda_ops->query_qp_wqs(endpoint.ep, &sq_attr, &rq_attr);
+	if (ret != 0)
+		throw std::runtime_error("gdaki_endpoint query_qp_wqs failed: " +
+					 std::string(fi_strerror(-ret)));
+
+	sq_buffer.map(sq_attr.buffer,
+		      (size_t)sq_attr.num_entries * sq_attr.entry_size);
+
+	/* rdma-core mmaps the doorbell MMIO region with sysconf(_SC_PAGESIZE)
+	 * (see providers/efa/verbs.c). Use the plugin's cached system_page_size
+	 * so our GPU-side mapping covers the same region rdma-core opened. */
+	sq_doorbell.map(sq_attr.doorbell, system_page_size);
+
+	gpu_qp.build(sq_attr, rq_attr, sq_buffer.dev, sq_doorbell.dev);
+
+	/* Stash SQ ring depth for the device-side SQ-overflow backpressure
+	 * check. gdaki_data_endpoint reads this via base.sq_size. */
+	sq_size = sq_attr.num_entries;
+
+	/* Query CQ and build GPU descriptor. */
+	struct fi_efa_cq_attr efa_cq_attr = {};
+	ret = gda_ops->query_cq(endpoint.cq, &efa_cq_attr);
+	if (ret != 0)
+		throw std::runtime_error("gdaki_endpoint query_cq failed: " +
+					 std::string(fi_strerror(-ret)));
+
+	gpu_cq.build(efa_cq_attr);
+
+	/* Populate per-peer addressing tables in GPU memory. */
+	peers.populate(endpoint, peer_addrs, ep_addr_len, nranks, gda_ops);
+}
+
+void gdaki_data_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
+			       struct fi_efa_ops_gda *gda_ops)
+{
+	/* Create the FI_WRITE counter first; it will be bound to the inner
+	 * endpoint between open() and enable(). */
+	write_cntr.create(gda_ops, domain);
+
+	/* Open the inner endpoint without enable. */
+	base.endpoint.open(domain, ref_info, ofi_nccl_cq_size());
+
+	int ret = fi_ep_bind(base.endpoint.ep, &write_cntr.get()->fid, FI_WRITE);
+	if (ret != 0)
+		throw std::runtime_error("data_endpoint fi_ep_bind FI_WRITE counter failed: " +
+					 std::string(fi_strerror(-ret)));
+
+	base.endpoint.enable();
+}
+
+void gdaki_data_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
+				   const std::vector<uint8_t> &peer_addrs,
+				   size_t ep_addr_len, int nranks)
+{
+	/* Delegate the shared work (QP/CQ query, MMIO map, GPU descriptors,
+	 * per-peer addressing, sq_size stash) to the inner endpoint. */
+	base.populate(gda_ops, peer_addrs, ep_addr_len, nranks);
 }
 

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -138,6 +138,15 @@ void gdaki_fi_endpoint::enable()
 	}
 }
 
+void gdaki_fi_endpoint::bind(struct fid *fid, uint64_t flags)
+{
+	int ret = fi_ep_bind(ep, fid, flags);
+	if (ret != 0) {
+		throw std::runtime_error("fi_ep_bind failed: " +
+					 std::string(fi_strerror(-ret)));
+	}
+}
+
 void gdaki_gpu_qp::build(const struct fi_efa_wq_attr &sq_attr,
 			 const struct fi_efa_wq_attr &rq_attr,
 			 void *sq_buf_dev, void *sq_db_dev)
@@ -249,7 +258,8 @@ void gdaki_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 	gpu_qp.build(sq_attr, rq_attr, sq_buffer.dev, sq_doorbell.dev);
 
 	/* Stash SQ ring depth for the device-side SQ-overflow backpressure
-	 * check. gdaki_data_endpoint reads this via base.sq_size. */
+	 * check. Both gdaki_data_endpoint and gdaki_sc_endpoint read this
+	 * via base.sq_size. */
 	sq_size = sq_attr.num_entries;
 
 	/* Query CQ and build GPU descriptor. */
@@ -275,10 +285,7 @@ void gdaki_data_endpoint::open(struct fid_domain *domain, struct fi_info *ref_in
 	/* Open the inner endpoint without enable. */
 	base.endpoint.open(domain, ref_info, ofi_nccl_cq_size());
 
-	int ret = fi_ep_bind(base.endpoint.ep, &write_cntr.get()->fid, FI_WRITE);
-	if (ret != 0)
-		throw std::runtime_error("data_endpoint fi_ep_bind FI_WRITE counter failed: " +
-					 std::string(fi_strerror(-ret)));
+	base.endpoint.bind(&write_cntr.get()->fid, FI_WRITE);
 
 	base.endpoint.enable();
 }
@@ -290,5 +297,72 @@ void gdaki_data_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 	/* Delegate the shared work (QP/CQ query, MMIO map, GPU descriptors,
 	 * per-peer addressing, sq_size stash) to the inner endpoint. */
 	base.populate(gda_ops, peer_addrs, ep_addr_len, nranks);
+}
+
+void gdaki_sc_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
+			     struct fi_efa_ops_gda *gda_ops)
+{
+	/* Create hardware counters first; they will be bound to the inner
+	 * endpoint between open() and enable(). */
+	write_cntr.create(gda_ops, domain);
+	remote_write_cntr.create(gda_ops, domain);
+
+	/* Open the inner endpoint without enable. Use the same CQ sizing as
+	 * the data endpoint so callers get consistent capacity per env config. */
+	base.endpoint.open(domain, ref_info, ofi_nccl_cq_size());
+
+	/* Bind counters before enabling. */
+	base.endpoint.bind(&write_cntr.get()->fid, FI_WRITE);
+	base.endpoint.bind(&remote_write_cntr.get()->fid, FI_REMOTE_WRITE);
+
+	base.endpoint.enable();
+}
+
+void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
+				 const std::vector<uint8_t> &peer_addrs,
+				 size_t ep_addr_len, int nranks)
+{
+	/* Delegate the shared work (QP/CQ query, MMIO map, GPU descriptors,
+	 * per-peer addressing) to the inner endpoint. */
+	base.populate(gda_ops, peer_addrs, ep_addr_len, nranks);
+
+	/*
+	 * Build the two device handles. They share QP / CQ / per-peer
+	 * addressing / sq_lock / sq_size / submitted_count layout — only
+	 * the (cntr_value, local_cntr_value) pair differs.
+	 *
+	 * - counter_dev_handle exposes the WRITE counter via cntr_value
+	 *   (FI_WRITE — local completion). Returned to the kernel through
+	 *   counter_handles[].
+	 * - signal_dev_handle exposes the REMOTE_WRITE counter via cntr_value
+	 *   (FI_REMOTE_WRITE — signal arrival), and the WRITE counter via
+	 *   local_cntr_value (used by the device for backpressure / Flush).
+	 *   Returned to the kernel through signal_handles[].
+	 *
+	 * Both `cntr_value` and `local_cntr_value` are set on the host before
+	 * commit() pushes the struct to GPU memory.
+	 */
+	auto fill_common = [&](nccl_ofi_gin_gdaki_dev_counter_handle &h) {
+		h.base.qp = base.gpu_qp.dev();
+		h.base.cq = base.gpu_cq.dev();
+		h.base.address_handles = base.peers.ahs.dev;
+		h.base.remote_qpns = base.peers.qpns.dev;
+		h.base.qkey = base.peers.qkeys.dev;
+		h.base.sq_lock = 0;
+		h.base.submitted_count = 0;
+		h.base.sq_size = base.sq_size;
+	};
+
+	counter_dev_handle.allocate(1);
+	fill_common(counter_dev_handle.host[0]);
+	counter_dev_handle.host[0].cntr_value = write_cntr.gpu_ptr();
+	counter_dev_handle.host[0].base.local_cntr_value = nullptr; /* unused on counter handles */
+	counter_dev_handle.commit();
+
+	signal_dev_handle.allocate(1);
+	fill_common(signal_dev_handle.host[0]);
+	signal_dev_handle.host[0].cntr_value = remote_write_cntr.gpu_ptr();
+	signal_dev_handle.host[0].base.local_cntr_value = write_cntr.gpu_ptr();
+	signal_dev_handle.commit();
 }
 

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -12,6 +12,7 @@
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
 #endif
+#include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_ofiutils.h"
 #include "nccl_ofi_mr.h"
 #include "nccl_ofi_param.h"
@@ -334,10 +335,37 @@ static inline struct fi_info *get_gin_info(struct fi_info *info)
 	ofi_info_ptr gin_hints = ofi_info_ptr(fi_allocinfo());
 	get_gin_hints(*gin_hints.get(), info);
 
+	/*
+	 * Select libfabric API version.
+	 *   - GDAKI: hard requirements — CUDA, DMA-BUF, libfabric 2.5+ (the
+	 *     hardware-counter ABI). Fail loudly if any prerequisite is
+	 *     missing rather than silently degrading.
+	 *   - Proxy: works on any libfabric >= 1.18; the GIN endpoint hints
+	 *     (FI_RX_CQ_DATA, cq_data_size = 4) don't use any 1.20+ features,
+	 *     so 1.18 is sufficient and avoids requesting a contract we don't
+	 *     consume.
+	 */
+	uint32_t api_version;
+	if (ofi_nccl_gin_type.get() == GIN_TYPE::GDAKI) {
+#if !HAVE_CUDA
+		throw std::runtime_error(
+			"OFI_NCCL_GIN_TYPE=GDAKI set but plugin built without CUDA");
+#endif
+		if (!nccl_ofi_dmabuf_viable()) {
+			throw std::runtime_error(
+				"OFI_NCCL_GIN_TYPE=GDAKI set but DMA-BUF is not viable");
+		}
+		api_version = FI_VERSION(2, 5);
+	} else {
+		api_version = FI_VERSION(1, 18);
+	}
+
 	struct fi_info *results = nullptr;
-	int ret = fi_getinfo(FI_VERSION(1, 18), nullptr, nullptr, 0ULL, gin_hints.get(), &results);
+	int ret = fi_getinfo(api_version, nullptr, nullptr, 0ULL, gin_hints.get(), &results);
 	if (ret != 0) {
-		throw std::runtime_error("Failed to get gin_info");
+		throw std::runtime_error(
+			"fi_getinfo for GIN failed: " +
+			std::string(fi_strerror(-ret)));
 	};
 
 	/* There should only be exactly one result, that supports everything we asked for */

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -8,3 +8,4 @@ grouped_recv
 gin_gdaki_misconfig_probe
 eager_multirecv
 gin_put_gdaki_gpu
+gin_signal_gdaki_gpu

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -36,7 +36,7 @@ noinst_HEADERS = functional_test.h
 bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin grouped_recv gin_gdaki_misconfig_probe eager_multirecv
 if ENABLE_GDAKI
 if HAVE_NVCC
-bin_PROGRAMS += gin_put_gdaki_gpu
+bin_PROGRAMS += gin_put_gdaki_gpu gin_signal_gdaki_gpu
 endif
 endif
 
@@ -63,6 +63,9 @@ SUFFIXES = .cu
 
 gin_put_gdaki_gpu_SOURCES = $(base_sources) gin_put_gdaki_gpu.cu
 gin_put_gdaki_gpu_LDADD = $(LDADD) -lcuda
+
+gin_signal_gdaki_gpu_SOURCES = $(base_sources) gin_signal_gdaki_gpu.cu
+gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 
 .cu.o:
 	$(NVCC) -std=c++17 $(NVCC_GENCODE) \

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -186,7 +186,7 @@ int main(int argc, char *argv[])
 	auto *dst_gin_mr = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(dst_ginhandle);
 	uint32_t src_lkey = src_gin_mr->lkey;
 	std::vector<uint32_t> all_rkeys(nranks);
-	for (int i = 0; i < nranks; i++) all_rkeys[i] = dst_gin_mr->rkeys[i];
+	for (int i = 0; i < nranks; i++) all_rkeys[i] = dst_gin_mr->peers[i].rkey;
 
 	/* Allgather destination buffer GPU addresses out-of-band over MPI so
 	 * rank 0 knows rank 1's RDMA-write target without reaching into any

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -58,16 +58,16 @@ __global__ void gin_put_gpu_kernel(nccl_ofi_gin_gdaki_dev_handle *dev,
 {
 	if (threadIdx.x != 0 || blockIdx.x != 0) return;
 
-	auto *qp = reinterpret_cast<efa_cuda_qp *>(dev->qp);
-	auto *cq = reinterpret_cast<efa_cuda_cq *>(dev->cq);
+	auto *qp = reinterpret_cast<efa_cuda_qp *>(dev->data.qp);
+	auto *cq = reinterpret_cast<efa_cuda_cq *>(dev->data.cq);
 
 	efa_io_tx_wqe wr;
 	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);
 	efa_cuda_wr_set_sge(&wr, src_lkey, src_addr, bytes);
 	efa_cuda_wr_set_remote(&wr,
-			       dev->address_handles[peer],
-			       (uint32_t)dev->remote_qpns[peer],
-			       dev->qkey[peer]);
+			       dev->data.address_handles[peer],
+			       (uint32_t)dev->data.remote_qpns[peer],
+			       dev->data.qkey[peer]);
 
 	efa_cuda_start_sq_batch(qp, 1);
 	efa_cuda_sq_batch_place_wr(qp, 0, &wr);

--- a/tests/functional/gin_signal_gdaki_gpu.cu
+++ b/tests/functional/gin_signal_gdaki_gpu.cu
@@ -1,0 +1,321 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * GDAKI signal-endpoint validation via a GPU-issued RDMA write.
+ *
+ * GPU counterpart of the CPU gin_signal_gdaki test this commit replaces.
+ * Exercises the per-request signal endpoint path: createContext with
+ * nSignals=1 allocates a gdaki_sc_endpoint with FI_WRITE +
+ * FI_REMOTE_WRITE hardware counters in GPU memory; the kernel posts an
+ * RDMA write on that signal endpoint's QP; both counters are then
+ * checked from the host via cudaMemcpy.
+ *
+ * No plugin-internal mhandle / sc_endpoint reach-through: everything is
+ * driven through the public dev->signal_handles[] contract that the
+ * kernel uses in production. dev->signal_handles[i]->cntr_value is the
+ * FI_REMOTE_WRITE counter (the receiver sees this increment);
+ * dev->signal_handles[i]->base.local_cntr_value is the FI_WRITE counter
+ * (the sender sees this increment).
+ *
+ * Built only when configure finds nvcc (HAVE_NVCC) and --enable-gdaki.
+ * Run with at least 2 MPI ranks and OFI_NCCL_GIN_TYPE=GDAKI.
+ */
+
+#include "functional_test.h"
+#include "rdma/gin/nccl_ofi_gin_gdaki_dev.h"
+
+#include "efa_cuda_dp.cuh"
+#include "efa_cuda_dp_impl.cuh"
+
+struct proc_handle {
+	char handle[NCCL_NET_HANDLE_MAXSIZE];
+};
+
+/*
+ * GPU kernel: build, post, and poll a single RDMA_WRITE WQE through the
+ * signal endpoint's QP/CQ that the plugin populated in GPU memory.
+ *
+ * Single-thread (gridDim=1, blockDim=1). All other lanes early-return.
+ */
+__global__ void gin_signal_gpu_kernel(nccl_ofi_gin_gdaki_dev_counter_handle *sig,
+				      int peer,
+				      uint64_t dst_addr,
+				      uint32_t dst_rkey,
+				      uint64_t src_addr,
+				      uint32_t src_lkey,
+				      uint32_t bytes,
+				      int max_iters,
+				      uint8_t *out_status,
+				      uint8_t *out_q_type,
+				      uint8_t *out_op_type,
+				      uint16_t *out_req_id,
+				      uint32_t *out_done)
+{
+	if (threadIdx.x != 0 || blockIdx.x != 0) return;
+
+	auto *qp = reinterpret_cast<efa_cuda_qp *>(sig->base.qp);
+	auto *cq = reinterpret_cast<efa_cuda_cq *>(sig->base.cq);
+
+	efa_io_tx_wqe wr;
+	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);
+	efa_cuda_wr_set_sge(&wr, src_lkey, src_addr, bytes);
+	efa_cuda_wr_set_remote(&wr,
+			       sig->base.address_handles[peer],
+			       (uint32_t)sig->base.remote_qpns[peer],
+			       sig->base.qkey[peer]);
+
+	efa_cuda_start_sq_batch(qp, 1);
+	efa_cuda_sq_batch_place_wr(qp, 0, &wr);
+	efa_cuda_flush_sq_wrs(qp);
+
+	*out_done = 0;
+	for (int i = 0; i < max_iters; i++) {
+		void *wc = efa_cuda_cq_poll(cq, /*position=*/0);
+		if (wc != nullptr) {
+			auto *cqe = reinterpret_cast<efa_io_cdesc_common *>(wc);
+			*out_status = cqe->status;
+			/* q_type lives in bits [2:1] of cqe->flags. */
+			*out_q_type = (uint8_t)((cqe->flags >> 1) & 0x3);
+			*out_op_type = efa_cuda_wc_read_opcode(wc);
+			*out_req_id = efa_cuda_wc_read_req_id(wc);
+			efa_cuda_cq_pop(cq, 1);
+			*out_done = 1;
+			return;
+		}
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	int rank, nranks, proc_name_len, local_rank = 0;
+
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+	if (nranks < 2) {
+		NCCL_OFI_WARN("Need at least 2 ranks");
+		MPI_Finalize();
+		return ncclInvalidArgument;
+	}
+
+	std::vector<char> all_proc_name(nranks * MPI_MAX_PROCESSOR_NAME);
+	MPI_Get_processor_name(&all_proc_name[PROC_NAME_IDX(rank)], &proc_name_len);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, all_proc_name.data(),
+		      MPI_MAX_PROCESSOR_NAME, MPI_BYTE, MPI_COMM_WORLD);
+	for (int i = 0; i < nranks; i++) {
+		if (!strcmp(&all_proc_name[PROC_NAME_IDX(rank)],
+			    &all_proc_name[PROC_NAME_IDX(i)])) {
+			if (i < rank) ++local_rank;
+		}
+	}
+	CUDACHECK(cudaSetDevice(local_rank));
+
+	set_system_page_size();
+	auto *net_plugin_handle = load_netPlugin();
+	auto *extNet = get_netPlugin_symbol(net_plugin_handle);
+	auto *extGin = get_ginPlugin_symbol(net_plugin_handle);
+	if (!extNet || !extGin) { MPI_Finalize(); return ncclInternalError; }
+
+	void *netCtx = nullptr;
+	ncclNetCommConfig_v11_t netConfig = {};
+	OFINCCLCHECK(extNet->init(&netCtx, 0, &netConfig, &functional_test_logger, nullptr));
+
+	void *ginCtx = nullptr;
+	OFINCCLCHECK(extGin->init(&ginCtx, 0, &functional_test_logger));
+
+	int ndev;
+	OFINCCLCHECK(extGin->devices(&ndev));
+	int dev = local_rank % ndev;
+
+	std::vector<proc_handle> handles(nranks);
+	std::vector<void *> handles_ptrs(nranks);
+	void *listenComm = nullptr;
+	OFINCCLCHECK(extGin->listen(ginCtx, dev, handles[rank].handle, &listenComm));
+
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, handles.data(),
+		      NCCL_NET_HANDLE_MAXSIZE, MPI_CHAR, MPI_COMM_WORLD);
+	for (int i = 0; i < nranks; i++) handles_ptrs[i] = &handles[i];
+
+	void *collComm = nullptr;
+	OFINCCLCHECK(extGin->connect(ginCtx, handles_ptrs.data(), nranks, rank,
+				     listenComm, &collComm));
+
+	/* Request 1 signal endpoint. */
+	ncclGinConfig_v13_t ginConfig = {};
+	ginConfig.nSignals = 1;
+	ginConfig.nContexts = 1;
+	ginConfig.queueDepth = 64;
+	ginConfig.trafficClass = -1;
+
+	void *proxyCtx = nullptr;
+	ncclNetDeviceHandle_v11_t *devHandle = nullptr;
+	OFINCCLCHECK(extGin->createContext(collComm, &ginConfig, &proxyCtx, &devHandle));
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: createContext done (nSignals=1)", rank);
+
+	/* The signal endpoint payload only has to land in registered memory
+	 * for the receiver's NIC to bump FI_REMOTE_WRITE. Use a small
+	 * GPU-resident buffer registered through regMrSym (works on both
+	 * sides as src and dst). */
+	const size_t SIG_BUF_SIZE = 64;
+	void *sig_buf_gpu = nullptr;
+	CUDACHECK(cudaMalloc(&sig_buf_gpu, SIG_BUF_SIZE));
+	CUDACHECK(cudaMemset(sig_buf_gpu, 0, SIG_BUF_SIZE));
+
+	void *sig_mhandle = nullptr, *sig_ginhandle = nullptr;
+	OFINCCLCHECK(extGin->regMrSym(collComm, sig_buf_gpu, SIG_BUF_SIZE,
+				      NCCL_PTR_CUDA, 0,
+				      &sig_mhandle, &sig_ginhandle));
+	if (!sig_ginhandle) {
+		NCCL_OFI_WARN("regMrSym returned null ginHandle");
+		MPI_Finalize();
+		return ncclInternalError;
+	}
+	auto *sig_mr = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(sig_ginhandle);
+	uint32_t sig_lkey = sig_mr->lkey;
+	std::vector<uint32_t> all_rkeys(nranks);
+	for (int i = 0; i < nranks; i++) all_rkeys[i] = sig_mr->peers[i].rkey;
+
+	/* Allgather destination buffer GPU addresses out-of-band over MPI so
+	 * rank 0 knows rank 1's RDMA-write target without reaching into any
+	 * plugin-internal mhandle. */
+	std::vector<uint64_t> all_dst_addrs(nranks, 0);
+	uint64_t my_dst_addr = (uint64_t)sig_buf_gpu;
+	MPI_Allgather(&my_dst_addr, 1, MPI_UINT64_T, all_dst_addrs.data(), 1,
+		      MPI_UINT64_T, MPI_COMM_WORLD);
+
+	/* The dev_handle gives us GPU pointers to the per-rank
+	 * signal_handles array. Pull host-side copies of:
+	 *   - the signal_handles[0] device handle pointer (for kernel arg)
+	 *   - cntr_value         = FI_REMOTE_WRITE counter (receiver sees++)
+	 *   - base.local_cntr_value = FI_WRITE counter    (sender sees++) */
+	auto *dev_h_gpu =
+		reinterpret_cast<nccl_ofi_gin_gdaki_dev_handle *>(devHandle->handle);
+	nccl_ofi_gin_gdaki_dev_handle h_dev = {};
+	CUDACHECK(cudaMemcpy(&h_dev, dev_h_gpu, sizeof(h_dev), cudaMemcpyDeviceToHost));
+
+	if (h_dev.nSignals < 1 || h_dev.signal_handles == nullptr) {
+		NCCL_OFI_WARN("dev_handle reports no signal endpoints");
+		MPI_Finalize();
+		return ncclInternalError;
+	}
+
+	nccl_ofi_gin_gdaki_dev_counter_handle *sig_dev_gpu = nullptr;
+	CUDACHECK(cudaMemcpy(&sig_dev_gpu, h_dev.signal_handles,
+			     sizeof(sig_dev_gpu), cudaMemcpyDeviceToHost));
+
+	nccl_ofi_gin_gdaki_dev_counter_handle h_sig = {};
+	CUDACHECK(cudaMemcpy(&h_sig, sig_dev_gpu, sizeof(h_sig), cudaMemcpyDeviceToHost));
+
+	uint64_t rw_cntr_before = 0, w_cntr_before = 0;
+	CUDACHECK(cudaMemcpy(&rw_cntr_before, (void *)h_sig.cntr_value,
+			     sizeof(uint64_t), cudaMemcpyDeviceToHost));
+	CUDACHECK(cudaMemcpy(&w_cntr_before, (void *)h_sig.base.local_cntr_value,
+			     sizeof(uint64_t), cudaMemcpyDeviceToHost));
+	NCCL_OFI_INFO(NCCL_NET,
+		      "Rank %d: before -- remote_write_cntr=%lu write_cntr=%lu",
+		      rank, rw_cntr_before, w_cntr_before);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	/* Rank 0: post a single RDMA write on the signal endpoint to rank 1. */
+	if (rank == 0) {
+		const int tgt = 1;
+		NCCL_OFI_INFO(NCCL_NET,
+			      "R0: GPU signal write to R%d lkey=0x%x rkey=0x%x addr=0x%lx",
+			      tgt, sig_lkey, all_rkeys[tgt], all_dst_addrs[tgt]);
+
+		struct kernel_result {
+			uint8_t  status;
+			uint8_t  q_type;
+			uint8_t  op_type;
+			uint8_t  pad0;
+			uint16_t req_id;
+			uint16_t pad1;
+			uint32_t done;
+		};
+		kernel_result *d_result = nullptr;
+		CUDACHECK(cudaMalloc(&d_result, sizeof(kernel_result)));
+		CUDACHECK(cudaMemset(d_result, 0, sizeof(kernel_result)));
+
+		gin_signal_gpu_kernel<<<1, 1>>>(
+			sig_dev_gpu, tgt,
+			all_dst_addrs[tgt], all_rkeys[tgt],
+			(uint64_t)sig_buf_gpu, sig_lkey,
+			(uint32_t)SIG_BUF_SIZE,
+			/*max_iters=*/100000000,
+			&d_result->status, &d_result->q_type, &d_result->op_type,
+			&d_result->req_id, &d_result->done);
+		CUDACHECK(cudaDeviceSynchronize());
+
+		kernel_result h_result = {};
+		CUDACHECK(cudaMemcpy(&h_result, d_result, sizeof(h_result),
+				     cudaMemcpyDeviceToHost));
+		CUDACHECK(cudaFree(d_result));
+
+		if (!h_result.done) {
+			NCCL_OFI_WARN("R0: signal CQ poll timeout");
+		} else {
+			NCCL_OFI_INFO(NCCL_NET,
+				      "R0: signal CQ completion status=%u op_type=%u q_type=%u req_id=%u",
+				      h_result.status, h_result.op_type,
+				      h_result.q_type, h_result.req_id);
+		}
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	/* Rank 1: poll remote_write_cntr until the signal arrives. */
+	if (rank == 1) {
+		uint64_t rw = rw_cntr_before;
+		for (int i = 0; i < 100000000; i++) {
+			CUDACHECK(cudaMemcpy(&rw, (void *)h_sig.cntr_value,
+					     sizeof(uint64_t), cudaMemcpyDeviceToHost));
+			if (rw != rw_cntr_before) break;
+		}
+	}
+
+	/* Both ranks: re-read counters and validate. */
+	uint64_t rw_cntr_after = 0, w_cntr_after = 0;
+	CUDACHECK(cudaMemcpy(&rw_cntr_after, (void *)h_sig.cntr_value,
+			     sizeof(uint64_t), cudaMemcpyDeviceToHost));
+	CUDACHECK(cudaMemcpy(&w_cntr_after, (void *)h_sig.base.local_cntr_value,
+			     sizeof(uint64_t), cudaMemcpyDeviceToHost));
+	NCCL_OFI_INFO(NCCL_NET,
+		      "Rank %d: after  -- remote_write_cntr=%lu write_cntr=%lu",
+		      rank, rw_cntr_after, w_cntr_after);
+
+	int local_pass = 1;
+	if (rank == 0) {
+		bool ok = (w_cntr_after == w_cntr_before + 1);
+		NCCL_OFI_INFO(NCCL_NET, "R0: write_cntr delta=%lu (%s)",
+			      w_cntr_after - w_cntr_before,
+			      ok ? "PASS" : "FAIL");
+		if (!ok) local_pass = 0;
+	} else if (rank == 1) {
+		bool ok = (rw_cntr_after == rw_cntr_before + 1);
+		NCCL_OFI_INFO(NCCL_NET, "R1: remote_write_cntr delta=%lu (%s)",
+			      rw_cntr_after - rw_cntr_before,
+			      ok ? "PASS" : "FAIL");
+		if (!ok) local_pass = 0;
+	}
+
+	OFINCCLCHECK(extGin->deregMrSym(collComm, sig_mhandle));
+	CUDACHECK(cudaFree(sig_buf_gpu));
+
+	OFINCCLCHECK(extGin->destroyContext(proxyCtx));
+	OFINCCLCHECK(extGin->closeColl(collComm));
+	OFINCCLCHECK(extGin->closeListen(listenComm));
+	OFINCCLCHECK(extGin->finalize(ginCtx));
+	OFINCCLCHECK(extNet->finalize(netCtx));
+	dlclose(net_plugin_handle);
+
+	int global_pass = 0;
+	MPI_Allreduce(&local_pass, &global_pass, 1, MPI_INT, MPI_MIN, MPI_COMM_WORLD);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Finalize();
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: test completed (%s)",
+		      rank, global_pass ? "PASS" : "FAIL");
+	return global_pass ? ncclSuccess : ncclSystemError;
+}


### PR DESCRIPTION
### Summary
  Adds GPU-driven signal and counter delivery to the GDAKI plugin path. Each
  createContext request for nSignals or nCounters allocates dedicated efa-direct
  endpoints with hardware completion counters whose values live in GPU-accessible
  memory. The downstream NCCL kernel polls those counters directly — no host
  round-trip — to observe Put-with-signal arrivals (FI_REMOTE_WRITE on the
  receiver) and Put local completion (FI_WRITE on the sender).
  
 ### Commits
  
  1. gin/gdaki: absolute-address MR handle (peers[])
     Replaces the per-MR rkeys[] flex array with a peers[] array of (remote_addr, rkey) pairs and adds local_addr, so the kernel can compute absolute remote VAs for FI_MR_VIRT_ADDR-mode WQEs.
  
  2. nccl_ofi_cuda: Add CUDA VMM API
     Adds nccl_net_ofi_gpu_vmm_alloc/free using cuMemCreate with gpuDirectRDMACapable, required to back GPU-resident hardware-counter values with DMA-BUF–exportable memory.
  
  3. gin: select libfabric version based on GDAKI mode in get_gin_info
     Makes get_gin_info() ask FI_VERSION(2,5) when OFI_NCCL_GIN_TYPE=GDAKI (and throw on missing CUDA / DMA-BUF) and FI_VERSION(1,18) otherwise. Avoids breaking proxy-only users on libfabric < 2.5 while letting the GDAKI follow-up commits use the 2.5 hardware-counter ABI.
  
  4. gin/gdaki: hardware-counter completion on the data endpoint
     Wraps the data EP in gdaki_data_endpoint with a FI_WRITE hardware counter and exposes local_cntr_value / submitted_count / sq_size on dev_handle.data so the kernel can poll local completion instead of the CQ. Adds the configure-time HAVE_FI_EFA_COMP_CNTR probe and extends --enable-gdaki to require it, making the counter ABI a configure-time invariant.
  
  5. gin/gdaki: per-request signal/counter endpoints
     Adds gdaki_sc_endpoint (FI_WRITE + FI_REMOTE_WRITE counters per EP) and the counter_handles[] / signal_handles[] GPU arrays so the kernel can issue Put-with-signal on a dedicated EP and observe arrivals via the FI_REMOTE_WRITE counter.
  
  6. gin/gdaki: add gin_signal_gdaki_gpu functional test
     GPU-driven functional test that creates a context with nSignals=1, launches a CUDA kernel posting an RDMA write on the signal endpoint via efa-dp-direct, and validates both the sender's FI_WRITE counter and the receiver's FI_REMOTE_WRITE counter increment by 1. Reads everything through the public dev->signal_handles[] API — no plugin-internal reach-through.
  
  7. gin/gdaki: per-context signal-only scratch buffer
     Allocates a small per-rank buffer, registers it on the proxy domain, and allgathers (addr, rkey) so the kernel can deliver net.signal()-style writes (hasWins=false, bytes=0) — required for ncclBarrierSession::sync. EFA still needs a registered remote address to bump the receiver's FI_REMOTE_WRITE counter.
  
  8. gin/gdaki: sweep contexts at closeColl to release proxy domain resources
     Tracks GDAKI contexts per collComm and frees them in a closeColl wrapper, since NCCL doesn't always invoke destroyContext; otherwise EPs / counters / MRs leak and the proxy plugin's fabric/domain close emits "Device or resource busy".