### PR TITLE
tuner: Fix segfault when NCCL_ALGO or NCCL_PROTO is set

### DIFF
--- a/src/tuner/nccl_ofi_tuner.cpp
+++ b/src/tuner/nccl_ofi_tuner.cpp
@@ -143,6 +143,9 @@ static ncclResult_t nccl_ofi_tuner_init_v2(size_t nRanks, size_t nNodes, ncclDeb
 	 * variables and so the internal tuner will be used instead.
 	 */
 	if (getenv("NCCL_ALGO") || getenv("NCCL_PROTO")) {
+		if (ofi_log_function == NULL) {
+			ofi_log_function = logFunction;
+		}
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING, "The tuner plugin can not be loaded when "
 				"explicitly choosing an algorithm or protocol "
 				"with NCCL_ALGO/NCCL_PROTO. "
@@ -188,14 +191,6 @@ static ncclResult_t nccl_ofi_tuner_init_v6(void** ctx, uint64_t commId, size_t n
 					    ncclNvlDomainInfo_v6_t* nvlDomainInfo,
 					    ncclTunerConstants_v6_t* constants)
 {
-	if (getenv("NCCL_ALGO") || getenv("NCCL_PROTO")) {
-		NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING, "The tuner plugin can not be loaded when "
-				"explicitly choosing an algorithm or protocol "
-				"with NCCL_ALGO/NCCL_PROTO. "
-				"Defaulting to internal tuner.");
-		*ctx = nullptr;
-		return ncclSuccess;
-	}
 	return nccl_ofi_tuner_init(nRanks, nNodes, logFunction, ctx);
 }
 


### PR DESCRIPTION
When the tuner plugin is loaded as a separate shared library and the
user sets `NCCL_ALGO` or `NCCL_PROTO`, the tuner init functions (v2 and
v6) attempt to log an informational message before `ofi_log_function`
has been assigned. The `NCCL_OFI_INFO` macro dereferences this NULL
function pointer, causing a segfault at address `(nil)`.

Reported with:
```
NCCL_TUNER_PLUGIN=libnccl-ofi-tuner.so NCCL_ALGO=Ring
```

Fix: set `ofi_log_function` from the NCCL-provided `logFunction`
parameter at the top of each versioned init wrapper, before any logging.
Also adds the `NCCL_ALGO/NCCL_PROTO` early-return guard to v3 (which
previously lacked it) and removes the now-redundant assignment from the
internal `nccl_ofi_tuner_init()`.

Tested on P5en with NCCL 2.30.4: segfault resolved, tuner correctly
falls back to NCCL internal tuner with an INFO log.