### PR TITLE
doc: Fix broken coding standards link in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ Contributions via pull requests are much appreciated. Before sending us a pull r
 1. You are working against the latest source on the *master* branch.
 2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
 3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
-4. Please ensure that any contribution follows the project's [coding standards](https://github.com/doc/coding-standards.md).
+4. Please ensure that any contribution follows the project's [coding standards](doc/coding-standards.md).
 
 To send us a pull request, please:
 


### PR DESCRIPTION
The coding-standards link added in 8c2784c1 (`doc: Move coding standards into git`) points at https://github.com/doc/coding-standards.md, which 404s. Replace it with a repo-relative path so the link resolves both on GitHub and on local clones.