### PR TITLE
gin: Move signal gdrcopy to a worker thread

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -47,6 +47,7 @@ noinst_HEADERS = \
 	nccl_ofi_scheduler.h \
 	nccl_ofi_sendrecv.h \
 	nccl_ofi_spinlock.h \
+	nccl_ofi_spsc_ring.h \
 	nccl_ofi_system.h \
 	nccl_ofi_topo.h \
 	nccl_ofi_tracepoint.h \

--- a/include/nccl_ofi_spsc_ring.h
+++ b/include/nccl_ofi_spsc_ring.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_SPSC_RING_H_
+#define NCCL_OFI_SPSC_RING_H_
+
+#include <atomic>
+#include <cstdint>
+
+/**
+ * Single-producer / single-consumer lock-free ring buffer.
+ *
+ * One thread calls push(), a different thread calls pop(). There are no
+ * locks: the producer releases head, the consumer releases tail, and each
+ * side acquires the other's index so it observes the slot the other handed
+ * off. push()/pop() return false (rather than blocking) when the ring is
+ * full / empty, leaving the caller to decide whether to spin, back off, or
+ * do other work.
+ *
+ * FIFO ordering holds, so a producer that needs in-order delivery can rely
+ * on the consumer seeing entries in push order.
+ *
+ * CAPACITY is the compile-time slot count. One slot is always kept empty to
+ * tell full apart from empty, so the ring holds at most CAPACITY - 1 entries.
+ *
+ * T is copied by value into and out of the ring, so keep it trivially
+ * copyable and cheap.
+ */
+template <typename T, uint32_t CAPACITY = 1024>
+class nccl_ofi_spsc_ring {
+	T ring[CAPACITY];
+	/* head and tail sit on separate cache lines so the producer and
+	   consumer don't false-share the index the other is spinning on. */
+	alignas(64) std::atomic<uint32_t> head{0};
+	alignas(64) std::atomic<uint32_t> tail{0};
+
+public:
+	bool push(const T &entry)
+	{
+		uint32_t h = head.load(std::memory_order_relaxed);
+		uint32_t next = (h + 1) % CAPACITY;
+		if (next == tail.load(std::memory_order_acquire)) {
+			return false;
+		}
+		ring[h] = entry;
+		head.store(next, std::memory_order_release);
+		return true;
+	}
+
+	bool pop(T &entry)
+	{
+		uint32_t t = tail.load(std::memory_order_relaxed);
+		if (t == head.load(std::memory_order_acquire)) {
+			return false;
+		}
+		entry = ring[t];
+		tail.store((t + 1) % CAPACITY, std::memory_order_release);
+		return true;
+	}
+};
+
+#endif

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -9,12 +9,16 @@
 #include "rdma/gin/nccl_ofi_gin_resources.h"
 #include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi_dlist.h"
+#include "nccl_ofi_spsc_ring.h"
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_gdrcopy.h"
 #include "nccl_ofi_tracepoint.h"
 
 #include <bitset>
+#include <atomic>
+#include <cstdint>
+#include <thread>
 
 /**
  * Get singleton instance of the device copy context shared across all GIN communicators.
@@ -197,6 +201,33 @@ struct nccl_ofi_rdma_gin_symm_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 	 * does not pass ginHandle to deregMrSym. Plain heap memory, no
 	 * libfabric resources. Null when the proxy path is used. */
 	void *gin_device_handle = nullptr;
+};
+
+/**
+ * Work descriptor enqueued by the proxy CQ-drain thread for the gdrcopy
+ * worker. The signal metadata is captured by value so the recv buffer
+ * can be re-armed without waiting for the worker to consume.
+ */
+struct gin_signal_work_entry {
+	nccl_net_ofi_gin_signal_metadata_msg_t metadata;
+	nccl_net_ofi_gin_iputsignal_recv_req *req;
+	uint32_t peer_rank;
+};
+
+/**
+ * Done descriptor pushed by the worker thread back to the proxy. The
+ * worker only does the gdrcopy read-modify-write; libfabric-side
+ * bookkeeping (rx_consumed advance, next_delivered_signal_seq_num,
+ * map erase, return_req_to_pool, ACK emission) stays on the proxy because
+ * libfabric EP affinity requires it. The proxy completes that bookkeeping
+ * when it drains the done queue, ensuring ACK and request reuse never race
+ * ahead of the gdrcopy that made the signal visible.
+ */
+struct gin_signal_done_entry {
+	nccl_net_ofi_gin_iputsignal_recv_req *req;
+	uint32_t peer_rank;
+	uint16_t seq_num;
+	int status;
 };
 
 /**
@@ -486,10 +517,10 @@ private:
 	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
 
 	int do_gin_signal_and_trace(uint32_t peer_rank,
-				    nccl_net_ofi_gin_iputsignal_recv_req *req);
+				    nccl_net_ofi_gin_iputsignal_recv_req *req) REQUIRES(get_ep_lock());
 
 	int iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
-					    nccl_net_ofi_gin_iputsignal_recv_req *req);
+					    nccl_net_ofi_gin_iputsignal_recv_req *req) REQUIRES(get_ep_lock());
 
 	/**
 	 * Receiver-side: emit a standalone ACK if we have unsent rx_consumed
@@ -500,9 +531,32 @@ private:
 
 	int retire_completed_peer_iput_ops(uint32_t peer_rank) REQUIRES(get_ep_lock());
 
+	/* --- gdrcopy worker thread (signal delivery off proxy) ---
+	 * The proxy CQ-drain thread pushes completed signal recv reqs into
+	 * gdrcopy_work_queue; the worker pops, runs do_gin_signal (the gdrcopy
+	 * read-modify-write to/from device memory), and pushes results to
+	 * gdrcopy_done_queue. The proxy drains the done queue every progress
+	 * tick. The SPSC ring's FIFO guarantee preserves seq-num delivery
+	 * order under strong_signal_ordering. */
+	std::atomic<int> gdrcopy_thread_stop{0};
+	std::atomic<int> gdrcopy_thread_exited{0};
+	nccl_ofi_spsc_ring<gin_signal_work_entry> gdrcopy_work_queue;
+	nccl_ofi_spsc_ring<gin_signal_done_entry> gdrcopy_done_queue;
+	std::thread gdrcopy_thread;
+
+	void run_gdrcopy_worker_loop();
+	int enqueue_gdrcopy_work(uint32_t peer_rank,
+				 nccl_net_ofi_gin_iputsignal_recv_req *req) REQUIRES(get_ep_lock());
+
 	friend class nccl_ofi_rdma_gin_listen_comm;
 
 public:
+	/* Reap completed signal-delivery work from the gdrcopy worker. Called
+	 * from ginProgress every progress tick and from the destructor while
+	 * joining the worker; both hold the ep lock, which is why we advance
+	 * retire_completed_peer_iput_ops (and thus emit ACKs) from here. */
+	int drain_gdrcopy_done_queue() REQUIRES(get_ep_lock());
+
 	/* NVTX tracing support - public for macro access (parallel to RDMA struct pattern) */
 #if HAVE_NVTX_TRACING
 	nvtxDomainHandle_t nvtx_domain[NCCL_OFI_N_NVTX_DOMAIN_PER_COMM];

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -339,6 +339,20 @@ private:
 	 */
 	nccl_net_ofi_gin_signal_metadata_msg_t metadata;
 
+	/**
+	 * True once the signal has been handed to the gdrcopy worker. Cleared
+	 * when the worker reports completion via the done queue. Retire skips
+	 * a req while this is set so ACK and pool return cannot run ahead of
+	 * the actual signal becoming visible to the local GPU.
+	 */
+	bool gdrcopy_in_flight = false;
+
+	/**
+	 * Final status from the gdrcopy worker. Only valid once
+	 * gdrcopy_in_flight transitions back to false.
+	 */
+	int gdrcopy_status = 0;
+
 	/* This request structure doesn't have any use outside of gin_comm.
 	   So, instead of adding a bunch of getters/setters, just add a
 	   friend class. */

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -15,6 +15,9 @@
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_tracepoint.h"
 
+#include <system_error>
+#include <vector>
+
 struct gin_connect_handle {
 	/* Number of rails */
 	uint16_t num_rails;
@@ -68,10 +71,44 @@ nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &r
 
 	resources.set_comm(local_comm_id, *this);
 	resources.increment_ref_cnt();
+
+	/* Spawn the gdrcopy worker thread that runs the signal-delivery
+	 * read-modify-write off the proxy CQ-drain thread. A spawn failure is
+	 * unexpected (thread/FD exhaustion); rather than silently fall back to
+	 * running gdrcopy on the proxy thread, fail comm creation so we never
+	 * run in that degraded configuration. Undo the comm registration before
+	 * rethrowing so resources teardown does not see a dangling comm. */
+	try {
+		gdrcopy_thread = std::thread(
+			&nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop, this);
+	} catch (const std::system_error &err) {
+		NCCL_OFI_WARN("Failed to spawn GIN gdrcopy worker thread: %s",
+			      err.what());
+		resources.remove_comm(local_comm_id);
+		throw;
+	}
 }
 
-nccl_ofi_rdma_gin_put_comm::~nccl_ofi_rdma_gin_put_comm()
+/* closeColl() holds the ep lock across `delete gin_comm`, so the drain calls
+ * below run with the lock held. Clang TSA does not track the held lock across
+ * the implicit destructor invocation, so suppress analysis here rather than
+ * weakening drain_gdrcopy_done_queue()'s REQUIRES(get_ep_lock()). */
+nccl_ofi_rdma_gin_put_comm::~nccl_ofi_rdma_gin_put_comm() NO_THREAD_SAFETY_ANALYSIS
 {
+	/* Stop and join the gdrcopy worker thread. The proxy is the only
+	 * consumer of gdrcopy_done_queue, so it must keep draining while the
+	 * worker is shutting down — otherwise a worker that finds the done
+	 * queue full spins forever on push and we self-deadlock on join. */
+	if (gdrcopy_thread.joinable()) {
+		gdrcopy_thread_stop.store(1, std::memory_order_release);
+		while (!gdrcopy_thread_exited.load(std::memory_order_acquire)) {
+			drain_gdrcopy_done_queue();
+		}
+		gdrcopy_thread.join();
+	}
+	/* Drain any leftover done-queue entries (best effort). */
+	drain_gdrcopy_done_queue();
+
 #if HAVE_NVTX_TRACING
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) {
 		for (int i = 0; i < NCCL_OFI_N_NVTX_DOMAIN_PER_COMM; ++i) {
@@ -887,14 +924,121 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal_and_trace(uint32_t peer_rank,
 {
 	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
 						 req->metadata.header.seq_num, req);
-	int ret = do_gin_signal(req->metadata);
-	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, peer_rank,
-					       req->metadata.header.seq_num, req);
-	if (OFI_UNLIKELY(ret != 0)) {
-		NCCL_OFI_WARN("Failed to complete signal seq_num %lu",
-			      (unsigned long)req->metadata.header.seq_num);
+
+	/* Hand the gdrcopy work off to the worker thread. The proxy reaps via
+	 * drain_gdrcopy_done_queue() each progress tick, which emits the
+	 * matching DELIVERY_END trace once the gdrcopy has actually landed. The
+	 * worker is spawned at comm construction (a spawn failure aborts comm
+	 * creation), so it is always running here. */
+	return enqueue_gdrcopy_work(peer_rank, req);
+}
+
+/* Push a signal-delivery work item to the gdrcopy worker. On a full work
+ * ring the proxy must not fall back to running gdrcopy itself: the worker
+ * is the sole owner of that read-modify-write, and two concurrent r-m-w
+ * sequences against a PCIe-mapped counter can race and lose increments. We
+ * spin instead, draining the worker's done ring while we wait so it keeps
+ * making room. The ring holds nearly its full CAPACITY of entries, so under
+ * normal load this loop never iterates; if it does, a recv burst genuinely
+ * outpaced gdrcopy and throttling the proxy until the worker catches up is
+ * the behavior we want.
+ *
+ * The req is marked in_flight before the push so retire_completed_peer_iput_ops
+ * will not advance past it, return it to the pool, or stash an ACK while
+ * the gdrcopy is outstanding. */
+int nccl_ofi_rdma_gin_put_comm::enqueue_gdrcopy_work(uint32_t peer_rank,
+						nccl_net_ofi_gin_iputsignal_recv_req *req)
+{
+	gin_signal_work_entry work;
+	work.metadata = req->metadata;
+	work.req = req;
+	work.peer_rank = peer_rank;
+
+	req->gdrcopy_in_flight = true;
+	req->gdrcopy_status = 0;
+
+	while (!gdrcopy_work_queue.push(work)) {
+		int drain_ret = drain_gdrcopy_done_queue();
+		if (OFI_UNLIKELY(drain_ret != 0)) {
+			return drain_ret;
+		}
+		asm volatile("" ::: "memory");
+	}
+	return 0;
+}
+
+/* Drain the worker's done queue. Each entry is a signal whose gdrcopy
+ * has already been applied. Clearing gdrcopy_in_flight here is what
+ * unblocks retire_completed_peer_iput_ops for this seq num: ACK stash,
+ * map erase and request pool return all run after this point. Returns
+ * the first nonzero worker status so callers can propagate failures. */
+int nccl_ofi_rdma_gin_put_comm::drain_gdrcopy_done_queue()
+{
+	gin_signal_done_entry done;
+	int ret = 0;
+	while (gdrcopy_done_queue.pop(done)) {
+		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, done.peer_rank,
+						       done.seq_num, done.req);
+
+		auto *req = done.req;
+		req->gdrcopy_status = done.status;
+		/* Release so the proxy thread observes gdrcopy_status before
+		 * it sees in_flight cleared. */
+		std::atomic_thread_fence(std::memory_order_release);
+		req->gdrcopy_in_flight = false;
+
+		if (OFI_UNLIKELY(done.status != 0)) {
+			NCCL_OFI_WARN("gdrcopy worker failed for signal seq_num %hu (rc=%d)",
+				      done.seq_num, done.status);
+			if (ret == 0) {
+				ret = done.status;
+			}
+		}
+
+		int retire_ret = retire_completed_peer_iput_ops(done.peer_rank);
+		if (OFI_UNLIKELY(retire_ret != 0) && ret == 0) {
+			ret = retire_ret;
+		}
 	}
 	return ret;
+}
+
+void nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop()
+{
+	gin_signal_work_entry work;
+	while (true) {
+		if (!gdrcopy_work_queue.pop(work)) {
+			/* Empty queue. After stop is set, draining to empty
+			 * means we're done; otherwise busy-poll. We deliberately
+			 * busy-poll rather than block on a condition variable:
+			 * signal delivery is latency-critical and a wakeup
+			 * syscall round-trip would show up directly in the
+			 * critical path, so the worker pegs one core instead. */
+			if (gdrcopy_thread_stop.load(std::memory_order_acquire)) {
+				break;
+			}
+			asm volatile("" ::: "memory");
+			continue;
+		}
+
+		int status = do_gin_signal(work.metadata);
+
+		gin_signal_done_entry done;
+		done.req = work.req;
+		done.peer_rank = work.peer_rank;
+		done.seq_num = work.metadata.header.seq_num;
+		done.status = status;
+		while (!gdrcopy_done_queue.push(done)) {
+			/* Done queue full: brief pause, proxy will drain on its
+			 * next tick. Both rings share the same CAPACITY, so this
+			 * is unlikely under normal operation. */
+			asm volatile("" ::: "memory");
+		}
+	}
+
+	/* Signal the destructor that we have exited so it stops draining
+	 * the done queue and joins. */
+	gdrcopy_thread_exited.store(1, std::memory_order_release);
 }
 
 int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
@@ -961,6 +1105,18 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 		if (req->num_seg_completions != req->total_segments) {
 			/* No more signals to deliver */
 			break;
+		}
+
+		if (req->gdrcopy_in_flight) {
+			/* Hand-off to worker hasn't completed; cannot ACK
+			 * or recycle this seq num yet. Strict ordering means
+			 * later seq nums also have to wait. */
+			break;
+		}
+
+		if (OFI_UNLIKELY(req->gdrcopy_status != 0)) {
+			ret = req->gdrcopy_status;
+			return ret;
 		}
 
 		ack_requested = ack_requested || req->is_ack_requested;

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -289,6 +289,13 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
 	int ret = gin_comm->get_resources().progress();
+	if (OFI_UNLIKELY(ret != 0)) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
+
+	/* Reap signal-delivery completions from the gdrcopy worker every
+	   progress tick so gdrcopy_in_flight clears and retire can advance. */
+	ret = gin_comm->drain_gdrcopy_done_queue();
 	return nccl_net_ofi_retval_translate(ret);
 }
 

--- a/tests/unit/.gitignore
+++ b/tests/unit/.gitignore
@@ -16,4 +16,5 @@ param
 platform_manager
 gdrcopy
 spinlock
+spsc_ring
 ctrl_msg

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -28,7 +28,8 @@ noinst_PROGRAMS = \
 	dlopen_c_test \
 	param \
 	platform_manager \
-	spinlock
+	spinlock \
+	spsc_ring
 
 if WANT_PLATFORM_AWS
 noinst_PROGRAMS += aws_platform_mapper
@@ -67,6 +68,7 @@ dlopen_c_test_SOURCES = $(base_sources) dlopen_c_test.c
 param_SOURCES = $(base_sources) param.cpp
 platform_manager_SOURCES = $(base_sources) platform_manager.cpp
 spinlock_SOURCES = $(base_sources) spinlock.cpp
+spsc_ring_SOURCES = $(base_sources) spsc_ring.cpp
 
 TESTS = $(noinst_PROGRAMS)
 endif

--- a/tests/unit/spsc_ring.cpp
+++ b/tests/unit/spsc_ring.cpp
@@ -1,0 +1,143 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <cstdio>
+#include <atomic>
+#include <thread>
+
+#include "unit_test.h"
+#include "nccl_ofi_assert.h"
+#include "nccl_ofi_spsc_ring.h"
+
+static void test_empty_pop()
+{
+	nccl_ofi_spsc_ring<uint32_t, 4> ring;
+	uint32_t val = 0;
+	assert_always(!ring.pop(val));
+}
+
+static void test_push_pop_fifo()
+{
+	nccl_ofi_spsc_ring<uint32_t, 8> ring;
+
+	for (uint32_t i = 0; i < 5; ++i) {
+		assert_always(ring.push(i));
+	}
+
+	for (uint32_t i = 0; i < 5; ++i) {
+		uint32_t val = 0;
+		assert_always(ring.pop(val));
+		assert_always(val == i);
+	}
+
+	uint32_t val = 0;
+	assert_always(!ring.pop(val));
+}
+
+/* A ring of CAPACITY slots holds at most CAPACITY - 1 entries: one slot is
+   reserved to disambiguate full from empty. */
+static void test_full_keeps_one_slot()
+{
+	nccl_ofi_spsc_ring<uint32_t, 4> ring;
+
+	assert_always(ring.push(10));
+	assert_always(ring.push(11));
+	assert_always(ring.push(12));
+	/* Fourth push would collide head with tail -- reject. */
+	assert_always(!ring.push(13));
+
+	uint32_t val = 0;
+	assert_always(ring.pop(val));
+	assert_always(val == 10);
+	/* A freed slot lets exactly one more push through. */
+	assert_always(ring.push(13));
+	assert_always(!ring.push(14));
+}
+
+/* Push and pop many times so head/tail wrap past CAPACITY repeatedly. */
+static void test_wraparound()
+{
+	nccl_ofi_spsc_ring<uint32_t, 4> ring;
+
+	for (uint32_t i = 0; i < 100; ++i) {
+		assert_always(ring.push(i));
+		uint32_t val = 0;
+		assert_always(ring.pop(val));
+		assert_always(val == i);
+		assert_always(!ring.pop(val));
+	}
+}
+
+/* Interleave so the ring sits partially full while indices wrap. */
+static void test_interleaved()
+{
+	nccl_ofi_spsc_ring<uint32_t, 4> ring;
+
+	assert_always(ring.push(1));
+	assert_always(ring.push(2));
+
+	uint32_t val = 0;
+	assert_always(ring.pop(val));
+	assert_always(val == 1);
+
+	assert_always(ring.push(3));
+	assert_always(ring.push(4));
+	/* Holding 2, 3, 4 -- one short of CAPACITY, so full. */
+	assert_always(!ring.push(5));
+
+	assert_always(ring.pop(val));
+	assert_always(val == 2);
+	assert_always(ring.pop(val));
+	assert_always(val == 3);
+	assert_always(ring.pop(val));
+	assert_always(val == 4);
+	assert_always(!ring.pop(val));
+}
+
+/* One producer thread, one consumer thread: every value pushed must be
+   popped exactly once and in order. Exercises the acquire/release handoff. */
+static void test_spsc_threaded()
+{
+	constexpr uint32_t num_items = 1000000;
+	nccl_ofi_spsc_ring<uint32_t, 1024> ring;
+
+	std::thread producer([&ring]() {
+		uint32_t i = 0;
+		while (i < num_items) {
+			if (ring.push(i)) {
+				++i;
+			}
+		}
+	});
+
+	uint32_t expected = 0;
+	while (expected < num_items) {
+		uint32_t val = 0;
+		if (ring.pop(val)) {
+			assert_always(val == expected);
+			++expected;
+		}
+	}
+
+	producer.join();
+	assert_always(expected == num_items);
+}
+
+int main(int argc, char *argv[])
+{
+	unit_test_init();
+
+	test_empty_pop();
+	test_push_pop_fifo();
+	test_full_keeps_one_slot();
+	test_wraparound();
+	test_interleaved();
+	test_spsc_threaded();
+
+	printf("Test completed successfully!\n");
+
+	return 0;
+}


### PR DESCRIPTION
Moves the GIN signal-delivery gdrcopy read-modify-write off the proxy CQ-drain thread onto a per-comm worker.

Currently each gdrcopy crosses PCIe to device memory, and that latency shows up as reduced new-CQE poll rate and reduced post throughput on the same proxy thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.