### PR TITLE
tests: guard efa_direct_wqe x86 sfence/lfence with arch ifdef

### DIFF
--- a/tests/functional/efa_direct_wqe.cpp
+++ b/tests/functional/efa_direct_wqe.cpp
@@ -35,9 +35,20 @@
 #define EFA_IO_CDESC_COMMON_Q_TYPE_MASK     GENMASK(2, 1)
 #define EFA_IO_CDESC_COMMON_OP_TYPE_MASK    GENMASK(6, 4)
 
-/* MMIO helpers */
-#define mmio_flush_writes()      asm volatile("sfence" ::: "memory")
+/* MMIO helpers. Architecture-specific barriers match rdma-core's
+ * util/udma_barrier.h conventions so this test scaffolding builds on
+ * both x86_64 (Intel/AMD EFA hosts) and aarch64 (Grace/Graviton EFA
+ * hosts). */
+#if defined(__x86_64__) || defined(__i386__)
+#define mmio_flush_writes()        asm volatile("sfence" ::: "memory")
 #define udma_from_device_barrier() asm volatile("lfence" ::: "memory")
+#elif defined(__aarch64__)
+#define mmio_flush_writes()        asm volatile("dsb st" ::: "memory")
+#define udma_from_device_barrier() asm volatile("dmb oshld" ::: "memory")
+#else
+#define mmio_flush_writes()        __atomic_thread_fence(__ATOMIC_RELEASE)
+#define udma_from_device_barrier() __atomic_thread_fence(__ATOMIC_ACQUIRE)
+#endif
 
 static inline void mmio_write32(void *addr, uint32_t value)
 {


### PR DESCRIPTION
The CPU-side EFA WQE/CQ test scaffolding added in #1214 used bare `asm volatile("sfence")` / `asm volatile("lfence")` for its MMIO write-flush and udma read barriers. Those mnemonics are `x86`-only and GNU `as` rejects them on `aarch64`, breaking the `master` build on `p6e-gb200`:

    /tmp/cc*.s: Error: unknown mnemonic `sfence`
    /tmp/cc*.s: Error: unknown mnemonic `lfence`
    make[2]: *** [Makefile:612: efa_direct_wqe.o] Error 1

Pick the right barrier per arch, mirroring rdma-core's util/udma_barrier.h conventions:
  * `x86_64` / `i386` - `sfence` + `lfence` (unchanged behavior)
  * `aarch64`       - `dsb st` + `dmb oshld`
  * other         - `C11` thread fences as a portable fallback

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
