### PR TITLE
gin: hold `ep_lock` around `flush_stale_acks` in `ginProgress`

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -268,7 +268,14 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 		return nccl_net_ofi_retval_translate(ret);
 	}
 
-	ret = gin_comm->flush_stale_acks();
+	{
+		/* flush_stale_acks calls send_ack which touches freelist and
+		 * request pool. Must hold ep_lock since there an be multiple
+		 * NCCL threads calling ginProgress() concurrently */
+		auto &gin_ep = gin_comm->get_resources().get_ep();
+		std::lock_guard<std::mutex> lock(gin_ep.ep_lock);
+		ret = gin_comm->flush_stale_acks();
+	}
 	return nccl_net_ofi_retval_translate(ret);
 }
 


### PR DESCRIPTION
`flush_stale_acks()` calls `send_ack()` which allocates from the request freelist and posts fi_send without holding ep_lock. When multiple NCCL threads call `ginProgress()` concurrently (e.g. GIN proxy and RMA proxy progress thread both invoke ginProgress on the same endpoint), this races with `process_cq()` in the other thread, leading to potential segmentation fault / memory corruption in NCCL v2.30u1.

Wrap `flush_stale_acks()` in ep_lock to serialize it against concurrent request pool operations. 

This PR serves as an interim workaround for NCCL v2.30u1 while PR #1249, which also refactors `flush_stale_acks()`, may still need some time to complete review.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
