### PR TITLE
gin/gdaki: PutValue source slot pool, shared across endpoints

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -38,6 +38,11 @@ extern "C" {
 #define NCCL_OFI_GDAKI_RQ_INITIAL_PHASE 1
 #define NCCL_OFI_GDAKI_CQ_INITIAL_PHASE 1
 
+/* Per-slot stride (bytes) of the PutValue source pool. PutValue's T
+ * is asserted by the kernel template to be <= 8 bytes; using 8 lets
+ * any T fit in one slot regardless of alignment. */
+#define NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE 8
+
 /**
  * Per-peer MR metadata used by EFA GDA WQE construction.
  *
@@ -199,6 +204,19 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
 	 * kernel spins until (submitted_count - *local_cntr_value + batch_size)
 	 * <= sq_size before reserving slots. */
 	uint32_t sq_size;
+
+	uint32_t putvalue_pad;
+
+	/* Base address of this endpoint's slice of the shared PutValue source
+	 * slot pool. The pool itself is one contiguous GPU-VMM region
+	 * registered as a single FI_HMEM_CUDA / FI_MR_DMABUF MR (see
+	 * dev_handle->putvalue_lkey). Slice size is implied by sq_size; per-call
+	 * slot byte offset is
+	 *     (submitted_count % sq_size) * dev_handle->putvalue_slot_size.
+	 * Set by setup_putvalue_pool; valid for the lifetime of the context.
+	 * Zero on endpoints that don't host PutValue traffic, but every
+	 * endpoint participating in the slot pool gets a unique non-zero base. */
+	uint64_t putvalue_slice_base;
 };
 
 /**
@@ -291,6 +309,42 @@ struct nccl_ofi_gin_gdaki_dev_handle {
 
 	/* Per-peer remote scratch rkeys, indexed by rank. [nranks] in GPU mem. */
 	uint32_t *scratch_remote_rkeys;
+
+	/* PutValue source slot pool, shared across the data endpoint and
+	 * every signal/counter (sc) endpoint.
+	 *
+	 * EFA's RDMA_WRITE WQE cannot use inline data (efa-dp-direct's
+	 * wr_set_inline_data only supports SEND opcode), so PutValue stages
+	 * srcVal through a registered local slot, then posts an RDMA_WRITE
+	 * from the slot to the user's destination. The same WQE arrival on
+	 * the receiver's chosen sc_endpoint bumps that endpoint's
+	 * FI_REMOTE_WRITE counter — i.e. value-and-signal in one WQE.
+	 *
+	 * Routing mirrors Put:
+	 *   signal != NONE  -> sc_endpoints[signalId]
+	 *   signal == NONE  -> data endpoint
+	 *
+	 * Each participating endpoint owns a slice of the pool; the slice
+	 * base lives on its dev_endpoint_handle (see putvalue_slice_base
+	 * above). The pool is one contiguous GPU-VMM region registered as
+	 * a single FI_HMEM_CUDA / FI_MR_DMABUF MR, so a single lkey covers
+	 * every slice. Slot stride is uniform
+	 * (== NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE — the maximum sizeof(T)
+	 * PutValue accepts). Per-endpoint slot reuse uses each endpoint's
+	 * existing (submitted_count - *local_cntr_value) backpressure;
+	 * slot index inside a slice is (ep.submitted_count % ep.sq_size).
+	 *
+	 * That backpressure does double duty for PutValue. For Put it only
+	 * bounds SQ-ring capacity, but PutValue additionally relies on it
+	 * for source-slot lifetime: an RDMA_WRITE's source SGE is DMA-read
+	 * by the NIC before the WR completes, and *local_cntr_value (the
+	 * FI_WRITE counter) ticks on completion. So gating reuse of slot N
+	 * on completion of the WR sq_size posts earlier transitively
+	 * guarantees the NIC has already consumed that slot's prior value
+	 * before we overwrite it — no separate source-buffer fence needed.
+	 */
+	uint32_t putvalue_lkey;
+	uint32_t putvalue_slot_size;
 };
 
 #ifdef __cplusplus

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -470,6 +470,19 @@ public:
 	void populate(struct fi_efa_ops_gda *gda_ops,
 		      const std::vector<uint8_t> &peer_addrs,
 		      size_t ep_addr_len, int nranks);
+
+	/**
+	 * Stash the PutValue slot pool slice base for this endpoint.
+	 * Read by populate_dev_handle() when filling
+	 * dev_handle.data.putvalue_slice_base. No commit here — the data
+	 * endpoint is uploaded as part of the top-level dev_handle.commit()
+	 * at the end of createContext.
+	 */
+	void set_putvalue_slice_base(uint64_t slice_base) { putvalue_slice_base = slice_base; }
+
+	/* Host stash for the slice base; uploaded to GPU memory by
+	 * populate_dev_handle(). */
+	uint64_t putvalue_slice_base = 0;
 };
 
 /**
@@ -519,6 +532,15 @@ public:
 	void populate(struct fi_efa_ops_gda *gda_ops,
 		      const std::vector<uint8_t> &peer_addrs,
 		      size_t ep_addr_len, int nranks);
+
+	/**
+	 * Set the PutValue slot pool slice base on both
+	 * counter_dev_handle and signal_dev_handle (they alias the same
+	 * QP / sq_size / etc., and either may be selected by the kernel).
+	 * Re-commits both handles since populate() already uploaded their
+	 * initial host state.
+	 */
+	void set_putvalue_slice_base(uint64_t slice_base);
 };
 
 /**
@@ -591,8 +613,49 @@ struct nccl_ofi_gin_gdaki_context {
 	 * endpoint is built, then committed once. */
 	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_handle> dev_handles;
 
+	/* PutValue source slot pool, shared across every logical context's
+	 * data endpoint and signal/counter endpoints.
+	 *
+	 * The pool lives in GPU memory allocated via the CUDA VMM API
+	 * (so DMA-BUF export is supported), registered with libfabric as
+	 * FI_HMEM_CUDA / FI_MR_DMABUF. The kernel writes srcVal to the
+	 * staging slot; the NIC DMAs it from GPU HBM directly.
+	 *
+	 * No dedicated PutValue endpoint: the WQE rides on whichever
+	 * endpoint matches the caller's signal request (data endpoint when
+	 * signal == NONE, sc_endpoints[signalId] otherwise). The pool is
+	 * sliced per endpoint, sized to the sum over every context of each
+	 * participating endpoint's sq_size; per-endpoint slice descriptors
+	 * are uploaded to the device via dev_handle->putvalue_slice_base.
+	 *
+	 * putvalue_buf         : GPU pointer (== putvalue_local_addr)
+	 * putvalue_pool_bytes  : VMM-rounded size; pass back to vmm_free
+	 * putvalue_dmabuf_fd   : DMA-BUF fd; close in dtor (-1 = unset)
+	 * putvalue_slot_size   : 8 bytes per slot (T <= 8 bytes)
+	 */
+	void *putvalue_buf = nullptr;
+	struct fid_mr *putvalue_mr = nullptr;
+	int putvalue_dmabuf_fd = -1;
+	uint32_t putvalue_lkey = 0;
+	uint64_t putvalue_local_addr = 0;
+	size_t putvalue_pool_bytes = 0;
+	size_t putvalue_slot_size = NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE;
+
+
 	~nccl_ofi_gin_gdaki_context()
 	{
+		if (putvalue_mr) {
+			fi_close(&putvalue_mr->fid);
+			putvalue_mr = nullptr;
+		}
+		if (putvalue_dmabuf_fd >= 0) {
+			close(putvalue_dmabuf_fd);
+			putvalue_dmabuf_fd = -1;
+		}
+		if (putvalue_buf) {
+			nccl_net_ofi_gpu_vmm_free(putvalue_buf, putvalue_pool_bytes);
+			putvalue_buf = nullptr;
+		}
 		if (scratch_mr) {
 			fi_close(&scratch_mr->fid);
 			scratch_mr = nullptr;

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -246,10 +246,141 @@ static void setup_scratch_buffer(nccl_ofi_gin_gdaki_context *ctx,
 }
 
 /*
+ * Set up the PutValue source slot pool, shared across every logical
+ * context's data endpoint and signal/counter (sc) endpoints.
+ *
+ * EFA's RDMA_WRITE WQE cannot use inline data, so PutValue stages each
+ * value through a registered local source slot then RDMA-writes the
+ * slot to the user's destination. The same WQE arrival on the receiver's
+ * sc_endpoint bumps that endpoint's FI_REMOTE_WRITE counter, giving us
+ * value-and-signal in one WQE; routing matches Put.
+ *
+ * No QP/EP is opened here: the WQE rides on whichever endpoint the
+ * kernel selects (data or sc). The pool is one contiguous GPU-VMM
+ * region registered as a single FI_HMEM_CUDA / FI_MR_DMABUF MR, sized
+ * to the sum over all contexts of (data.sq_size + sum sc_endpoints[i].
+ * sq_size) slots. Per-endpoint slice descriptors are uploaded so the
+ * kernel can locate its slot range without sharing an allocator across
+ * endpoints.
+ *
+ * Must be called after every context's data and sc_endpoints have been
+ * populated so each sq_size is finalized.
+ */
+static void setup_putvalue_pool(nccl_ofi_gin_gdaki_context *ctx,
+				struct fid_domain *ofi_domain)
+{
+	const int nContexts = ctx->nContexts;
+
+	/* Total pool size = sum over all contexts of
+	 *   data[c].sq_size + sum_i(sc_endpoints[c][i].sq_size).
+	 * Per-endpoint slice sizes are implied by each endpoint's sq_size; we
+	 * don't need a separate size array. */
+	uint64_t total_slots = 0;
+	for (int c = 0; c < nContexts; c++) {
+		const uint32_t data_sq_size = ctx->data[c]->base.sq_size;
+		if (data_sq_size == 0) {
+			throw std::runtime_error(
+				"putvalue: data endpoint sq_size is zero (ctx " +
+				std::to_string(c) + ")");
+		}
+		total_slots += data_sq_size;
+		const int nSc = (int)ctx->sc_endpoints[c].size();
+		for (int i = 0; i < nSc; i++) {
+			uint32_t sz = ctx->sc_endpoints[c][i]->base.sq_size;
+			if (sz == 0) {
+				throw std::runtime_error(
+					"putvalue: sc_endpoint sq_size is zero (ctx " +
+					std::to_string(c) + ", sc " + std::to_string(i) + ")");
+			}
+			total_slots += sz;
+		}
+	}
+
+	ctx->putvalue_slot_size = NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE;
+	const size_t requested_bytes = (size_t)total_slots * ctx->putvalue_slot_size;
+
+	/* Allocate GPU memory via VMM (cuMemCreate + cuMemMap with
+	 * gpuDirectRDMACapable) so we can export a DMA-BUF for libfabric
+	 * MR registration. The actual size returned is rounded up to the
+	 * VMM granularity (typically 2 MiB on B200) — store that back so
+	 * vmm_free in the destructor passes the correct size. */
+	void *gpu_pool = nullptr;
+	size_t actual_size = 0;
+	if (nccl_net_ofi_gpu_vmm_alloc(&gpu_pool, requested_bytes, &actual_size) != 0) {
+		throw std::runtime_error("putvalue gpu_vmm_alloc failed");
+	}
+	ctx->putvalue_buf = gpu_pool;
+	ctx->putvalue_pool_bytes = actual_size;
+
+	/* Get DMA-BUF fd. The DMA-BUF must cover the full mapped region
+	 * (rounded to VMM granularity), not just the bytes we use. */
+	int pv_fd = -1;
+	size_t pv_fd_offset = 0;
+	if (nccl_net_ofi_gpu_get_dma_buf_fd(gpu_pool, actual_size, &pv_fd, &pv_fd_offset) != 0) {
+		/* putvalue_buf / putvalue_pool_bytes are already set, so the ctx
+		 * destructor frees the VMM allocation on this throw path, the
+		 * same way it does for the get_gpu_device_for_addr and
+		 * fi_mr_regattr failures below. No manual free here. */
+		throw std::runtime_error("putvalue get_dma_buf_fd failed");
+	}
+	ctx->putvalue_dmabuf_fd = pv_fd;
+
+	/* CUDA device id for FI_HMEM_CUDA */
+	int cuda_dev = 0;
+	if (nccl_net_ofi_get_gpu_device_for_addr(gpu_pool, &cuda_dev) != 0) {
+		throw std::runtime_error("putvalue get_gpu_device_for_addr failed");
+	}
+
+	struct fi_mr_dmabuf pv_dmabuf = {};
+	pv_dmabuf.fd        = pv_fd;
+	pv_dmabuf.offset    = pv_fd_offset;
+	pv_dmabuf.len       = actual_size;
+	pv_dmabuf.base_addr = gpu_pool;
+
+	struct fi_mr_attr pv_mr_attr = {};
+	pv_mr_attr.dmabuf      = &pv_dmabuf;
+	pv_mr_attr.iov_count   = 1;
+	pv_mr_attr.access      = FI_REMOTE_WRITE | FI_WRITE | FI_SEND | FI_RECV;
+	pv_mr_attr.iface       = FI_HMEM_CUDA;
+	pv_mr_attr.device.cuda = cuda_dev;
+	pv_mr_attr.requested_key = 0;
+
+	int ret = fi_mr_regattr(ofi_domain, &pv_mr_attr, FI_MR_DMABUF, &ctx->putvalue_mr);
+	if (ret != 0) {
+		throw std::runtime_error(
+			"putvalue fi_mr_regattr (FI_MR_DMABUF, FI_HMEM_CUDA) failed: " +
+			std::string(fi_strerror(-ret)));
+	}
+	ctx->putvalue_lkey = (uint32_t)fi_mr_key(ctx->putvalue_mr);
+	ctx->putvalue_local_addr = (uint64_t)gpu_pool;
+
+	/* Assign per-endpoint slice bases across every context. Each
+	 * endpoint stores its slice base on its own GPU-resident
+	 * dev_endpoint_handle, so the kernel reads it from the same struct
+	 * it already selects for QP / sq_lock / etc. The data endpoint
+	 * stashes on host (uploaded later by populate_dev_handle); each
+	 * sc_endpoint commits both its counter_dev_handle and
+	 * signal_dev_handle inline. Slices are laid out context-major:
+	 * for each context, the data slice followed by its sc slices. */
+	uint64_t cursor = ctx->putvalue_local_addr;
+	for (int c = 0; c < nContexts; c++) {
+		ctx->data[c]->set_putvalue_slice_base(cursor);
+		cursor += (uint64_t)ctx->data[c]->base.sq_size * ctx->putvalue_slot_size;
+		const int nSc = (int)ctx->sc_endpoints[c].size();
+		for (int i = 0; i < nSc; i++) {
+			ctx->sc_endpoints[c][i]->set_putvalue_slice_base(cursor);
+			cursor += (uint64_t)ctx->sc_endpoints[c][i]->base.sq_size
+				* ctx->putvalue_slot_size;
+		}
+	}
+}
+
+
+/*
  * Fill one entry of the contiguous dev_handles[] GPU array for logical
- * context `ctx_id`. Caller (createContext) owns the GPU buffer; this function
- * only writes the host-side copy. The whole array is committed to GPU
- * memory once after every entry is filled.
+ * context `ctx_id`. Caller (createContext) owns the GPU buffer; this
+ * function only writes the host-side copy. The whole array is committed
+ * to GPU memory once after every entry is filled.
  */
 static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 				const nccl_ofi_gin_gdaki_context *ctx,
@@ -276,6 +407,18 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 	h.scratch_local_addr   = ctx->scratch_local_addr;
 	h.scratch_remote_addrs = ctx->scratch_remote_addrs_buf.dev;
 	h.scratch_remote_rkeys = ctx->scratch_remote_rkeys_buf.dev;
+	/* PutValue slot pool. The pool is allocated unconditionally
+	 * (sized off every context's data.sq_size, which is always
+	 * non-zero), so we always populate these fields. The lkey and
+	 * slot_size are shared across all contexts; the per-context data
+	 * slice base lives on ctx->data[ctx_id]. sc_endpoint slice bases
+	 * live on each sc_endpoint's counter_dev_handle / signal_dev_handle,
+	 * set by gdaki_sc_endpoint::set_putvalue_slice_base in
+	 * setup_putvalue_pool. No commit here — the caller commits the whole
+	 * dev_handles[] array once after every entry is filled. */
+	h.putvalue_lkey            = ctx->putvalue_lkey;
+	h.putvalue_slot_size       = (uint32_t)ctx->putvalue_slot_size;
+	h.data.putvalue_slice_base = ctx->data[ctx_id]->putvalue_slice_base;
 }
 
 static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConfig_v13_t *config,
@@ -420,8 +563,9 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 
 		/*
 		 * Per-context loop: build (data EP + sc EPs + counter/signal
-		 * handle arrays) for each logical context, then fill that
-		 * context's slot in dev_handles[].
+		 * handle arrays) for each logical context. The dev_handles[]
+		 * slots are filled in a second loop below, after the PutValue
+		 * pool is allocated and slice bases are assigned.
 		 */
 		constexpr size_t ep_addr_len = MAX_EP_ADDR;
 		const int n_sc = std::max(config->nSignals, config->nCounters);
@@ -478,11 +622,26 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				build_handle_array(*ctx->d_signal_handles[ctx_id], config->nSignals,
 					[&](int i) { return ctx->sc_endpoints[ctx_id][i]->signal_dev_handle.dev; });
 			}
+		}
 
-			/*
-			 * Step 7: Fill this ctx's slot in dev_handles[]. Don't
-			 * commit yet — whole array committed once at end.
-			 */
+		/*
+		 * Step 7: PutValue source slot pool. Must run after every
+		 * context's data and sc endpoints are populated so their
+		 * sq_sizes are finalized. Allocates the shared GPU-VMM pool
+		 * and assigns each endpoint's slice base (the sc endpoints
+		 * commit their counter/signal dev handles inline; the data
+		 * endpoint's slice base is stashed for populate_dev_handle).
+		 */
+		setup_putvalue_pool(ctx.get(), ofi_domain);
+
+		/*
+		 * Step 8: Fill every context's slot in dev_handles[]. Done in
+		 * a second pass because populate_dev_handle reads the data
+		 * endpoint's putvalue_slice_base, which setup_putvalue_pool
+		 * only assigns once all sq_sizes are known. Don't commit per
+		 * entry — the whole array is committed once below.
+		 */
+		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++) {
 			populate_dev_handle(ctx->dev_handles.host[ctx_id], ctx.get(),
 					    ctx_id, nranks, rank);
 		}

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -366,3 +366,17 @@ void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 	signal_dev_handle.commit();
 }
 
+void gdaki_sc_endpoint::set_putvalue_slice_base(uint64_t slice_base)
+{
+	/* Both counter_dev_handle and signal_dev_handle alias the same QP /
+	 * sq_lock / sq_size / submitted_count layout — only their cntr_value
+	 * differs. Either may be selected by the kernel (counter_handles[]
+	 * for Counter ops, signal_handles[] for Signal ops). PutValue uses
+	 * signal_handles[] when a signal is requested; we write both for
+	 * consistency so a future Counter-only PutValue path would also
+	 * find a valid slice. */
+	counter_dev_handle.host[0].base.putvalue_slice_base = slice_base;
+	signal_dev_handle.host[0].base.putvalue_slice_base = slice_base;
+	counter_dev_handle.commit();
+	signal_dev_handle.commit();
+}


### PR DESCRIPTION
*Description of changes:*
  
  ## What this PR adds

  A real implementation of `ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_EFA_GDA>`
  on top of the in-review GDAKI series in #1250. EFA `RDMA_WRITE` WQEs cannot
  use inline data (`efa-dp-direct`'s `wr_set_inline_data` only supports the
  `SEND` opcode), so PutValue cannot ship the user value directly inside the
  WQE. This PR adds the plumbing the kernel needs to stage the value through
  a registered local source slot, then `RDMA_WRITE` from that slot to the
  user's destination.

  The single new commit is: 

  - **`dd7b2bf` gin/gdaki: PutValue source slot pool, shared across endpoints**
  
  ## How it works

  ### Routing (mirrors `Put`)

  The PutValue WQE rides on the same endpoint that `Put` would use given the
  caller's signal request:
  
    - `signal != NONE`  → `sc_endpoints[signalId]` (via `signal_handles[]`)
    - `signal == NONE`  → data endpoint

  The arrival of the value `RDMA_WRITE` at the receiver bumps the
  `FI_REMOTE_WRITE` counter on the chosen sc_endpoint — i.e. **value and
  signal in a single WQE**. No second WQE, no `ATOMIC_FA`, no inter-WR
  ordering dependency from SRD.
  
  ### Source slot pool plumbing (in `nccl_ofi_gin_gdaki_createContext`)

  After the existing data and signal/counter endpoints are set up:

  1. **Allocate one contiguous source slot pool** in GPU memory via the
     CUDA VMM API (`cuMemCreate` + `cuMemMap` with `gpuDirectRDMACapable`),
     DMA-BUF export the mapping, and register it on the proxy domain with
     `FI_HMEM_CUDA / FI_MR_DMABUF`. Single MR covers the whole pool; a
     single `lkey` suffices.

  2. **Slice the pool per endpoint.** Total slots =
     `data.sq_size + Σ sc_endpoints[i].sq_size`. Each endpoint owns its
     own slice; the slice base lives on the endpoint's GPU-resident
     `nccl_ofi_gin_gdaki_dev_endpoint_handle` (next to `qp` / `cq` /
     `sq_lock` / `sq_size`). The kernel reads `slice_base` from the
     same endpoint struct it already selects for QP / sq_lock / etc. —
     no parallel arrays, no separate index. Slice size is implied by
     `ep.sq_size`.

  3. **Expose `lkey` and uniform slot stride** on
     `nccl_ofi_gin_gdaki_dev_handle` (`putvalue_lkey`,
     `putvalue_slot_size`).

  ### Slot reuse safety

  Each in-flight WQE on endpoint `E` owns one slot at
  `E.submitted_count % E.sq_size` inside `E`'s slice. The existing
  SQ-overflow check on `E`'s FI_WRITE counter (used today by Put on the
  same endpoint) gates new posts until the counter has advanced past the
  about-to-be-claimed slot's prior WR — so the NIC has finished DMAing
  the source bytes for the prior WR before the slot is reused. No
  explicit per-slot lock required.

  ### Existing scratch buffer untouched

  The single-slot `scratch_buf` used by signal-only `Put`
  (`ncclBarrierSession::sync` path: `hasWins=false, bytes=0`) is
  unchanged. It coexists with the PutValue pool because they serve
  different purposes (the scratch buf is for 0-byte writes that just
  bump the receiver's `FI_REMOTE_WRITE` counter; the PutValue pool is
  for actual value delivery).

  ### Companion device-side change (in NCCL, not this PR)

  The kernel-side `ncclGinApi_PutValue<NCCL_NET_DEVICE_GIN_EFA_GDA>`
  specialization that uses these new fields lives in NCCL at
  [`anshumang/upstream-to-nccl@efa_gdaki_putvalue`](https://github.com/anshumang/upstream-to-nccl/tree/efa_gdaki_putvalue)
  (head: [`06c99ff`](https://github.com/anshumang/upstream-to-nccl/commit/06c99ff)
  "tests/efa_gda: add gin_putvalue_gpu standalone GPU test", on top of
  [`f5f70f3`](https://github.com/anshumang/upstream-to-nccl/commit/f5f70f3)
  "nccl_device/efa_gda: implement PutValue via shared sc_endpoint slot pool").

  ## Signal contract

  Mirrors `Put`'s contract on this backend:

    - **INDEXED signals only.** `NCCL_GIN_SIGNAL_TYPE_VA` is asserted out
      on the device side (would require a dedicated VA-signal posting
      path that doesn't exist on EFA today).
    - **Inc-by-1 only.** The FI_REMOTE_WRITE counter ticks once per
      inbound write; `signalOpArg > 1` is asserted out (can be relaxed
      to silently accept later if symmetry with `Put` is preferred).
    - `hasDescriptor` is not supported.

  ## Validation

  Two-phase functional smoke test (`tests/efa_gda/gin_putvalue_gpu` in
  the NCCL companion branch) covers both routing paths:
  
    - **Phase 1 (no-signal):** rank 0 calls
      `gin.putValue<int>(team, peer=1, dstWin, dstOff, value, ncclGin_None{}, ncclCoopThread())`.
      The WQE rides on the data endpoint. Rank 1 polls the destination
      memory directly. **PASS.**
    - **Phase 2 (signal):** rank 0 calls the same with
      `ncclGin_SignalInc{signalId=0}` instead of `ncclGin_None{}`. The
      WQE rides on `signal_handles[0]`'s sc_endpoint. Rank 1 calls
      `gin.waitSignal(coop, signalId=0, least=1)` and verifies the
      destination memory carries the new value. **PASS.**
  
  By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
