### PR TITLE
.ci/aws: Rename CI cluster names to contain hyphen instead of underscore

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -72,7 +72,7 @@ def download_all_testing_packages() {
 
 def get_persistent_cluster_name(build_tag, os, instance_type) {
     def instance_type_prefix = instance_type.split("\\.")[0]
-    return "PluginPRCI_PersistentManualCluster_${instance_type_prefix}"
+    return "PluginPRCI-PersistentManualCluster-${instance_type_prefix}"
 }
 
 def get_persistent_cluster_region(cluster_name) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Rename CI cluster names to contain hyphen instead of underscore to map running clusters' names appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
