### PR TITLE
Changes for NGC installer fixes

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -181,6 +181,8 @@ AC_SUBST([DEVICE_INTERFACE])
 NCCL_OFI_PLATFORM="none"
 AS_IF([test "${NCCL_OFI_PLATFORM}" = "none"], [AX_CHECK_PLATFORM_AWS()])
 
+CHECK_ENABLE_NGC()
+
 AS_IF([test "${valgrind_enabled}" = "1" -a "${enable_asan}" = "yes"],
       [AC_MSG_ERROR([Enabling ASAN and valgrind at the same time is not permitted])])
 

--- a/contrib/debian-template/rules
+++ b/contrib/debian-template/rules
@@ -47,7 +47,8 @@ override_dh_auto_configure:
 		--without-lttng \
 		--without-valgrind \
 		--disable-werror \
-		--disable-nccl-net-library
+		--disable-nccl-net-library \
+		--enable-ngc
 	dh_auto_configure \
 		--builddirectory=build/libnccl-ofi-ngc-v2 -- \
 		--with-libfabric=/opt/amazon/efa \
@@ -87,10 +88,6 @@ override_dh_auto_install:
 	dh_auto_install --builddirectory=build/libnccl-ofi-ngc-v2 --destdir=debian/tmp-ngc-v2
 	dh_auto_install --builddirectory=build/libnccl-ofi-ngc-v3 --destdir=debian/tmp-ngc-v3
 	mkdir -p debian/tmp/etc/ld.so.conf.d && echo "${OFI_NCCL_PREFIX}/lib" >> debian/tmp/etc/ld.so.conf.d/100_ofinccl.conf
-	mv $(CURDIR)/debian/tmp-ngc-v1/opt/amazon/aws-ofi-nccl/lib/libnccl-net-ofi.so \
-		$(CURDIR)/debian/tmp-ngc-v1/opt/amazon/aws-ofi-nccl/lib/libnccl-net-aws-ofi.so
-	mv $(CURDIR)/debian/tmp-ngc-v1/opt/amazon/aws-ofi-nccl/lib/libnccl-tuner-ofi.so \
-		$(CURDIR)/debian/tmp-ngc-v1/opt/amazon/aws-ofi-nccl/lib/libnccl-tuner-aws-ofi.so
 	find debian/tmp -name *.la -delete
 	find debian/tmp-ngc-v1 -name *.la -delete
 	find debian/tmp-ngc-v2 -name *.la -delete

--- a/m4/check_enable_ngc.m4
+++ b/m4/check_enable_ngc.m4
@@ -1,0 +1,33 @@
+# -*- Autoconf -*-
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+# Check for --enable-ngc flag in configure.
+#
+# This configure option is used only during Debian package building
+# for supporting NGC images with library name libnccl-net-aws-ofi.so (aka NGC v1).
+#
+# With this option enabled we get another artifact by the name libnccl-net-aws-ofi.so
+# which also has the same SONAME embedded in the ELF image.
+# Thus, we are able to build correctly the nccl-ofi-ngc-v1 package,
+# and avoid any unwanted symlinks in /opt/amazon/aws-ofi-nccl/lib/ due
+# to ldconfig seeing SONAME that is different than the library name,
+# as previously the target libnccl-net-ofi.so was renamed to libnccl-net-aws-ofi.so,
+# during Debian package building.
+#
+# The same is true also for libnccl-tuner-aws-ofi.so.
+#
+# See contrib/debian-template/rules for sole usage of this option.
+AC_DEFUN([CHECK_ENABLE_NGC],[
+  AC_ARG_ENABLE([ngc],
+     [AS_HELP_STRING([--enable-ngc],
+         [Enable NGC container specific packaging. Creates additional plugin libraries to conform to older NGC container conventions. (default: Disabled)])])
+
+  AM_CONDITIONAL([ENABLE_NGC], [test "${enable_ngc}" = "yes"])
+  AS_IF([test "${enable_ngc}" = "yes"],
+        [AC_DEFINE([ENABLE_NGC], [1], [Define to 1 if NGC container specific packaging is enabled])
+         NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS="$NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS --enable-ngc=${enable_ngc}"])])
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -134,6 +134,25 @@ endif
   libnccl_net_ofi_la_LIBTOOLFLAGS = --tag=CXX
   libnccl_net_ofi_la_LDFLAGS = -module -avoid-version
 
+if ENABLE_NGC
+# NOTE: For NGC older images (aka ngc-v1), where the NGC image uses libnccl-net-aws-ofi.so
+# library name, we are adding here another target for libnccl-net-aws-ofi.so so that we
+# could have the right name embedded in the SONAME of the target library, otherwise ldconfig
+# will add unwaned symlinks during EFA install.
+# This option is enabled by "configure --enable-ngc"
+  lib_LTLIBRARIES += libnccl-net-aws-ofi.la
+  libnccl_net_aws_ofi_la_SOURCES =
+  libnccl_net_aws_ofi_la_LIBADD = libinternal_plugin.la
+  libnccl_net_aws_ofi_la_LIBTOOLFLAGS = --tag=CXX
+  libnccl_net_aws_ofi_la_LDFLAGS = -module -avoid-version
+
+  lib_LTLIBRARIES += libnccl-tuner-aws-ofi.la
+  libnccl_tuner_aws_ofi_la_SOURCES =
+  libnccl_tuner_aws_ofi_la_LIBADD = libinternal_plugin.la
+  libnccl_tuner_aws_ofi_la_LIBTOOLFLAGS = --tag=CXX
+  libnccl_tuner_aws_ofi_la_LDFLAGS = -module -avoid-version
+endif
+
 
 if WANT_PLATFORM_AWS
 # The tuner is normally built into the net plugin shared library, supporting


### PR DESCRIPTION
Add option to build NGC-v1-compatible libraries.

This change is required for NGC installer fixes.

Currently, when building Debian packages for NGC v1 images, that require target library name libnccl-net-aws-ofi.so,
we get the wrong SONAME in the library, because mv file is used during override_dh_auto_install phase in contrib/debina-template/rules.

The impact of that is that after EFA install on NGC of v1 type, if the user runs ldconfig, additional wrong symlinks are added in /opt/amazon/aws-ofi-nccl/lib.

In order to have the right SONAME embedded in libnccl-net-aws-ofi.so, we need to have autotools build the same target name we need.

For this purpose a configure option --enable-ngc was added, which builds an additional target by the name
libnccl-net-aws-ofi.so which has the correct SONAME.

This is required only during the build of NGC v1 Debian package.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
