### PR TITLE
GIN: Fix thread-safety in closeColl(), deregMrSym(), and add TSA annotations for send_ack() path

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -211,6 +211,11 @@ public:
 		return resources;
 	}
 
+	std::mutex &get_ep_lock() RETURN_CAPABILITY(resources.get_ep().ep_lock)
+	{
+		return resources.get_ep().ep_lock;
+	}
+
 	uint32_t get_local_comm_id() const
 	{
 		return local_comm_id;
@@ -284,8 +289,8 @@ public:
 	}
 
 	/* Wait for any outstanding requests as necessary. Should be called before
-	   the GIN comm is destructed. */
-	int await_pending_requests() override;
+	   the GIN comm is destructed. Caller must hold resources.get_ep().ep_lock. */
+	int await_pending_requests() REQUIRES(get_ep_lock()) override;
 
 	/**
 	 * iputSignal API. Transfers some user data (determined by memory registrations
@@ -344,7 +349,7 @@ public:
 	 */
 	int handle_signal_metadata_completion(
 		const nccl_net_ofi_gin_signal_metadata_msg_t *metadata_msg,
-		fi_addr_t src_addr, uint16_t rail_id);
+		fi_addr_t src_addr, uint16_t rail_id) REQUIRES(get_ep_lock());
 
 	/**
 	 * Callback for write completion (data signals only).
@@ -354,7 +359,7 @@ public:
 	 * @param rail_id: rail ID of the signal
 	 */
 	int handle_signal_write_completion(struct fi_cq_data_entry * cq_entry,
-					   fi_addr_t src_addr, uint16_t rail_id);
+					   fi_addr_t src_addr, uint16_t rail_id) REQUIRES(get_ep_lock());
 
 	/**
 	 * Callback for ACK message received via fi_recv.
@@ -469,7 +474,7 @@ private:
 	 * @param rx_consumed receiver's rx_consumed cursor at this moment
 	 */
 	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
-		     uint32_t rx_consumed);
+		     uint32_t rx_consumed) REQUIRES(get_ep_lock());
 
 	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
 
@@ -484,9 +489,9 @@ private:
 	 * progress and either the sender requested it or we've crossed the
 	 * flush threshold. Idempotent and cheap when there's nothing to do.
 	 */
-	int maybe_send_ack(uint32_t peer_rank, bool sender_requested);
+	int maybe_send_ack(uint32_t peer_rank, bool sender_requested) REQUIRES(get_ep_lock());
 
-	int retire_completed_peer_iput_ops(uint32_t peer_rank);
+	int retire_completed_peer_iput_ops(uint32_t peer_rank) REQUIRES(get_ep_lock());
 
 	friend class nccl_ofi_rdma_gin_listen_comm;
 

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -211,6 +211,11 @@ public:
 		return resources;
 	}
 
+	uint32_t get_local_comm_id() const
+	{
+		return local_comm_id;
+	}
+
 	int get_rank() const
 	{
 		return rank;

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -243,7 +243,7 @@ public:
 
 	/**
 	 * Set a GIN communicator with given comm_id in map. Throw exception if
-	 * comm_id already exists.
+	 * comm_id already exists. Caller must hold ep_lock.
 	 */
 	void set_comm(uint16_t comm_id, nccl_ofi_rdma_gin_put_comm &comm)
 	{
@@ -252,6 +252,19 @@ public:
 			throw std::runtime_error("Failed to insert comm_id");
 		}
 		gin_comms[comm_id] = &comm;
+	}
+
+	/**
+	 * Remove a GIN communicator with given comm_id from map. Throw exception if
+	 * comm_id does not exist. Caller must hold ep_lock.
+	 */
+	void remove_comm(uint16_t comm_id)
+	{
+		if (OFI_UNLIKELY(comm_id >= NCCL_GIN_MAX_COMMS || gin_comms[comm_id] == nullptr)) {
+			NCCL_OFI_WARN("Failed to remove comm_id %d (not found or out of range)", comm_id);
+			throw std::runtime_error("Failed to remove comm_id");
+		}
+		gin_comms[comm_id] = nullptr;
 	}
 
 	nccl_ofi_rdma_gin_ep_t &get_ep()
@@ -354,7 +367,8 @@ public:
 	}
 
 	/**
-	 * Progress completion queue and retry any pending requests
+	 * Progress completion queue and retry any pending requests.
+	 * Caller must hold ep_lock.
 	 */
 	int progress();
 

--- a/include/rdma/gin/nccl_ofi_gin_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_resources.h
@@ -19,6 +19,7 @@
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_rdma.h"
 #include "nccl_ofi_scheduler.h"
+#include "nccl_ofi_tsa.h"
 
 static inline void freelist_deleter(nccl_ofi_freelist *fl)
 {

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -362,6 +362,10 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 {
 	auto *mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mr_handle_base);
 	NCCL_OFI_TRACE(NCCL_NET, "deregMrSym handle %p", mr_handle);
+
+	auto &gin_ep = resources.get_ep();
+	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		int ret = get_device_copy().deregister_region(mr_handle->gdr_handle);
 		if (ret != 0) {

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -275,6 +275,7 @@ ncclResult_t nccl_ofi_gin_deregMrSym(void *collComm, void *mhandle)
 ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
 	int ret = gin_comm->get_resources().progress();
 	return nccl_net_ofi_retval_translate(ret);
 }
@@ -282,12 +283,18 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+	auto &gin_ep = gin_comm->get_resources().get_ep();
+	std::lock_guard<std::mutex> lock(gin_ep.ep_lock);
 
 	int ret = gin_comm->await_pending_requests();
+	if (OFI_UNLIKELY(ret != 0)) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
 
+	gin_comm->get_resources().remove_comm(gin_comm->get_local_comm_id());
 	delete gin_comm;
 
-	return nccl_net_ofi_retval_translate(ret);
+	return ncclSuccess;
 }
 
 ncclResult_t nccl_ofi_gin_closeListen(void *listenComm)

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -283,8 +283,7 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	auto &gin_ep = gin_comm->get_resources().get_ep();
-	std::lock_guard<std::mutex> lock(gin_ep.ep_lock);
+	std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
 
 	int ret = gin_comm->await_pending_requests();
 	if (OFI_UNLIKELY(ret != 0)) {

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -72,6 +72,18 @@ nccl_net_ofi_gin_recv_req_t::~nccl_net_ofi_gin_recv_req_t()
 
 int nccl_net_ofi_gin_recv_req_t::handle_cq_entry(struct fi_cq_entry *cq_entry_base,
 						 fi_addr_t src_addr, uint16_t rail_id_arg)
+	/* ep_lock is held by the process_cq() caller, but TSA cannot verify
+	   this for two reasons:
+	   1. Virtual dispatch: the base class handle_cq_entry() has no
+	      REQUIRES annotation (would need a mutex ref in the base context).
+	   2. Lock alias: this function accesses ep_lock as
+	      resources.get_ep().ep_lock, while callees (e.g.
+	      handle_signal_write_completion) require it as
+	      gin_comm.resources.get_ep().ep_lock. These are the same mutex
+	      at runtime (all comms on an endpoint share one resources object),
+	      but TSA does syntactic expression matching and cannot prove the
+	      alias through the dynamic get_comm() lookup. */
+	NO_THREAD_SAFETY_ANALYSIS
 {
 	assert(this->rail.rail_id == rail_id_arg);
 

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -553,7 +553,6 @@ nccl_ofi_gin_resources::~nccl_ofi_gin_resources()
 
 int nccl_ofi_gin_resources::progress()
 {
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
 	int ret = gin_ep.process_cq();
 	if (OFI_UNLIKELY(ret != 0)) {
 		return ret;


### PR DESCRIPTION
When `NCCL_GIN_TYPE=2` (GIN CPU Proxy), both the GIN progress thread and the RMA proxy progress thread call `ginProgress()` on the same endpoint concurrently in NCCL v2.30u1. Three issues were identified:
                                                    
1. `await_pending_requests()` called `send_ack()` and `progress()` without holding `ep_lock`, racing with concurrent CQ processing.
2. `closeColl()` deleted the comm without removing it from the resources lookup table. Any in-flight ACK completion processed after the delete would dereference freed memory via `get_comm()`, causing `SIGSEGV` in `handle_ack_completion`. (Note the delayed in-flight ACK issue is addressed by #1268 .)
3. `deregMrSym()` called `fi_close()` on MR handles without `ep_lock`, racing with concurrent libfabric endpoint operations.

This PR fixes above issues by:
- Moving `ep_lock` acquisition out of `progress()` and into its callers (`ginProgress()` and `closeColl()`), so the lock is held for the entire operation scope.
- Having `closeColl()` hold `ep_lock` for the entire teardown: drain pending requests, remove comm from lookup table, then delete.
- Having `deregMrSym()` acquire `ep_lock` before closing MR handles.

In addition, to address [@bwbarrett 's review comment](https://github.com/aws/aws-ofi-nccl/pull/1259#discussion_r3289267790) in #1259 :
> Either way, please add TSA annotations to codify this requirement.

this PR adds Clang Thread Safety Analysis (TSA) annotations for `send_ack` path:

1. Annotate send_ack and its callers in GIN put_comm with TSA annotations to enable compile-time verification of the ep_lock discipline:
- `send_ack()`, `maybe_send_ack()`, `retire_completed_peer_iput_ops()`
- `await_pending_requests()`
- `handle_signal_metadata_completion()`, `handle_signal_write_completion()`
2. Add `RETURN_CAPABILITY` on `get_ep_lock()` accessor to allow TSA to match the lock capability across put_comm method boundaries.
3. This is because TSA cannot verify the lock is held in this context for two reasons:
  (1) The base class virtual `handle_cq_entry()` has no `REQUIRES` annotation and adding one requires invasive changes to the interface.
  (2) The same mutex at runtime is named differently as `resources.get_ep().ep_lock` and `gin_comm.resources.get_ep().ep_lock`. TSA does syntactic expression matching on lock names and cannot
   prove the alias through the dynamic `get_comm()` lookup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
