### PR TITLE
Add action to verify DCO line

### DIFF
--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,0 +1,15 @@
+name: DCO Check
+
+on:
+  pull_request:
+
+permissions: {}
+
+jobs:
+  check:
+    permissions:
+      contents: read
+
+    runs-on: ubuntu-latest
+    steps:
+      - uses: KineticCafe/actions-dco@v3.1.0


### PR DESCRIPTION
We keep forgetting to DCO sign our commits, so let the computers help us.

This was one of the more popular looking and flexible Marketplace actions, which also looked actively maintained.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
