### PR TITLE
gin: drain inbound ACK handshake before close tears EP down

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -411,6 +411,29 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 		}
 	}
 
+	/* Drain inbound ACKs we are still waiting on. The NCCL proxy may
+	   have already stopped polling test() by the time we get here, so
+	   closeColl()/the destructor would otherwise tear the EP down with
+	   peers' inflight ACKs still bound for our QP. Pump the CQ until
+	   tx_tail == tx_head on every peer, i.e. every op we ever sent has
+	   been retired by its receiver. */
+	while (true) {
+		bool any_outstanding = false;
+		for (auto &rank_comm : rank_comms) {
+			if (gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail) != 0) {
+				any_outstanding = true;
+				break;
+			}
+		}
+		if (!any_outstanding) {
+			break;
+		}
+		ret = resources.progress();
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
+	}
+
 	return ret;
 }
 


### PR DESCRIPTION
Closing a comm can race with peers' standalone ACKs still in flight bound for our QP. The receiver-side completion path then surfaces those late ACKs against an already-freed QP, cascading into teardown failures and a collective-operation hang on the lone survivor.

Fix: on the close path, after the existing outbound-ACK drain, pump the CQ until every op we ever sent has been retired by its receiver. Bounded by a 5s deadline so a hung peer cannot deadlock close.

Note: this race was theoretically reachable before the recent ACK refactor too. It stayed dormant for two reasons:

  1. The old fixed-cadence ACK policy provided long quiet windows between bursts during which inflight ACKs naturally drained before close.
  2. The pre-refactor GIN test() API did not return completion for an ACK-requested op until the ACK had landed. That doubled as an implicit barrier: as long as the application drained all its requests via test(), it could not reach close while ACKs were still in flight.

Both safeguards were incidental, not by design. The current ACK policy fires at much finer granularity, so the race went from "never observed" to deterministic on close. The right fix has always been to drain explicitly on the close path; we just had not had to.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
