### PR TITLE
gin: Set maxRecvs to 1

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -140,7 +140,10 @@ static ncclResult_t nccl_ofi_gin_getProperties(int dev, ncclNetProperties_v11_t 
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = NCCL_GIN_MAX_COMMS;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* This should be set to ofi_properties.max_group_receives once
+	* the perf regression is resolved
+	*/
+	props->maxRecvs = 1;
 	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 	props->vProps.ndevs = 1;
@@ -401,7 +404,10 @@ static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v1
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = NCCL_GIN_MAX_COMMS;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* This should be set to ofi_properties.max_group_receives once
+	* the perf regression is resolved.
+	*/
+	props->maxRecvs = 1;
 	props->netDeviceType = NCCL_NET_DEVICE_GIN_PROXY;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 	props->vProps.ndevs = 1;

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -59,7 +59,11 @@ static ncclResult_t nccl_ofi_gin_gdaki_get_properties(int dev, ncclNetProperties
 	props->port = ofi_properties.port_number;
 	props->latency = ofi_properties.latency;
 	props->maxComms = ofi_properties.max_communicators;
-	props->maxRecvs = ofi_properties.max_group_receives;
+	/* This should not matter for GDAKI, but for completeness it should be set to
+	* ofi_properties.max_group_receives once the perf regression in proxy mode
+	* is resolved
+	*/
+	props->maxRecvs = 1;
 	props->netDeviceType = NCCL_NET_DEVICE_GIN_EFA_GDA;
 	props->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
 	props->vProps.ndevs = 1;


### PR DESCRIPTION
With the introduction of multi-recv in the plugin, the number of max receives supported by the net plugin is 8. This is causing a perf regression for GIN and we should set maxRecvs to 1 as a workaround.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
