### PR TITLE
rdma: Disable eager temporarily

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -223,8 +223,9 @@ OFI_NCCL_PARAM(float, net_latency, "NET_LATENCY", 0.0);
 /*
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly.
+ * Temporarily disabling EAGER to obtain performance data
  */
-OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", -1);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
We are disabling eager temporarily to obtain performance data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
