### PR TITLE
gin: Add NET plugin initialization requirement for GIN

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -41,6 +41,15 @@ ncclResult_t nccl_ofi_gin_init(void **ctx, uint64_t commId, ncclDebugLogger_t lo
 
 	NCCL_OFI_INFO(NCCL_NET | NCCL_INIT, "gin: Initializing");
 
+	/* GIN requires the OFI NET plugin to be initialized first. If NCCL
+	   selected a different NET transport (e.g. NCCL_NET=Socket), the
+	   plugin will be NULL and GIN cannot operate. */
+	if (nccl_net_ofi_get_plugin() == NULL) {
+		NCCL_OFI_WARN("gin: OFI NET plugin has not been initialized. "
+		              "GIN requires the OFI NET plugin to be active.");
+		return ncclInternalError;
+	}
+
 	/* GIN only supports RDMA transport protocol */
 	if (ofi_nccl_protocol.get() != PROTOCOL::RDMA) {
 		NCCL_OFI_WARN("GIN only supports RDMA transport protocol.");


### PR DESCRIPTION
Currently GIN has a dependency on plugin initialization for environment variables and topology. Adding a check to enforce this till we refactor to code to eliminate this requirement.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
