### PR TITLE
Fix closeColl deadlock in GIN single-process teardown

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -195,8 +195,8 @@
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_write_completion_func_end, dev, comm, rail_id, peer_rank, msg_seq_num, ret); \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, consumed) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, num_segments, consumed); \
+#define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(dev, comm, rail_id, peer_rank, msg_seq_num, num_segments) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, gin_handle_signal_metadata_completion_func_start, dev, comm, rail_id, peer_rank, msg_seq_num, num_segments); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(dev, comm, rail_id, peer_rank, msg_seq_num, ret) do { \

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -80,9 +80,8 @@ struct nccl_ofi_gin_resource_releaser {
  *
  *   tx_head     - sender: ops produced (advances on every iputSignal)
  *   tx_tail     - sender's local view of "ops the receiver has consumed"
- *                 (advances when an ACK -- bundled or standalone -- arrives)
+ *                 (advances when a standalone ACK arrives)
  *   rx_consumed - receiver: ops delivered upstream in seq order
- *   rx_acked    - receiver: last value of rx_consumed it sent back
  *
  * Wrap-safe forward delta is computed as
  *     ((b - a) & GIN_RX_CONSUMED_MASK)
@@ -112,12 +111,9 @@ struct nccl_ofi_gin_peer_rank_info {
 	uint32_t tx_head = 0;
 	uint32_t tx_tail = 0;
 
-	/* Receiver-side cursors. rx_consumed advances every time we retire
-	   an op in seq order (signal delivered upstream). rx_acked is the
-	   latest value of rx_consumed we transmitted back to the peer either
-	   via metadata piggyback or a standalone ACK. */
+	/* Receiver-side cursor. rx_consumed advances every time we retire
+	   an op in seq order (signal delivered upstream). */
 	uint32_t rx_consumed = 0;
-	uint32_t rx_acked = 0;
 
 	/* Hysteresis counter for the sender-side ack-request gate. Once
 	   outstanding crosses GIN_ACK_REQ_THRESHOLD this counts ops; only
@@ -125,6 +121,13 @@ struct nccl_ofi_gin_peer_rank_info {
 	   this, every op above threshold would request an ACK and we'd
 	   flood the receiver with standalone ACK packets. */
 	uint32_t consecutive_puts_without_ack = 0;
+
+	/* Sequence-number tracking for close-time drain.
+	   last_ack_requested_seq records tx_head at the time the most
+	   recent is_ack_requested was set on the wire.
+	   closeColl waits until a standalone ACK covers this sequence. */
+	uint32_t last_ack_requested_seq = 0;
+	bool has_pending_ack_request = false;
 
 	/**
 	 * Next-to-be-delivered sequence number, stored at target, from
@@ -267,11 +270,15 @@ public:
 	{
 		outstanding_ack_counter--;
 	}
+	bool has_outstanding_ack_sends() const
+	{
+		return outstanding_ack_counter > 0;
+	}
 
 	/**
-	 * Apply an inbound rx_consumed cursor from the peer (bundled on
-	 * metadata or on a standalone ACK). Wrap-safe: only advances tx_tail
-	 * when the cursor represents forward progress.
+	 * Apply an inbound rx_consumed cursor from the peer (from a standalone
+	 * ACK). Wrap-safe: only advances tx_tail when the cursor represents
+	 * forward progress.
 	 *
 	 * The wire value is already at the cursor width (GIN_RX_CONSUMED_BITS)
 	 * thanks to the bitfield bring-in. We compute the modular forward
@@ -289,8 +296,8 @@ public:
 	}
 
 	/* Wait for any outstanding requests as necessary. Should be called before
-	   the GIN comm is destructed. Caller must hold resources.get_ep().ep_lock. */
-	int await_pending_requests() REQUIRES(get_ep_lock()) override;
+	   the GIN comm is destructed. Acquires/releases ep_lock internally. */
+	int await_pending_requests() EXCLUDES(get_ep_lock()) override;
 
 	/**
 	 * iputSignal API. Transfers some user data (determined by memory registrations

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -109,7 +109,6 @@ static_assert(GIN_ACK_INTERVAL <= (GIN_IMM_SEQ_MASK >> 1),
 
 /* Reserved bit computation for Metadata message header */
 #define GIN_MSG_HEADER_RESERVED_BITS (64 - GIN_MSG_TYPE_BITS - GIN_IMM_COMM_BITS \
-                                      - GIN_RX_CONSUMED_BITS                    \
                                       - GIN_IMM_SEQ_BITS - GIN_IMM_SEG_CNT_BITS \
                                       - 1 /* ack_req */)
 
@@ -126,10 +125,6 @@ struct nccl_net_ofi_gin_msg_header_t {
 	uint64_t msg_type        : GIN_MSG_TYPE_BITS;
 	/* Comm identifier on the receiver side */
 	uint64_t remote_comm_id  : GIN_IMM_COMM_BITS;
-	/* Receiver's rx_consumed cursor at the time this packet was queued.
-	   Wraps at 2x the seq window. The sender uses a wrap-safe forward
-	   delta against tx_tail (see apply_rx_consumed) to advance its tail. */
-	uint64_t rx_consumed     : GIN_RX_CONSUMED_BITS;
 	/* Message sequence number and count */
 	uint64_t seq_num         : GIN_IMM_SEQ_BITS;
 	uint64_t seq_seg_cnt     : GIN_IMM_SEG_CNT_BITS;
@@ -193,7 +188,7 @@ static_assert(offsetof(nccl_net_ofi_gin_signal_metadata_msg_t, header) == 0,
 #if !defined(__clang__) && defined(__GNUC__) && (__GNUC__ >= 9)
 static_assert(
 	__builtin_bit_cast(uint64_t,
-		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0, 0})
+		nccl_net_ofi_gin_msg_header_t{GIN_MSG_TYPE_MAX, 0, 0, 0, 0, 0})
 		== (uint64_t)GIN_MSG_TYPE_MAX,
 	"msg_type must be at LSB of nccl_net_ofi_gin_msg_header_t");
 static_assert(
@@ -205,9 +200,7 @@ static_assert(
 
 /* Sender requests an ACK once the outstanding window is at least half full
    (i.e. tx_head - tx_tail >= GIN_ACK_REQ_THRESHOLD). The receiver answers
-   either by piggybacking its `consumed` cursor on the next outbound
-   metadata to this peer, or via a standalone ACK packet when no metadata
-   is in flight back to us. */
+   via a standalone ACK packet carrying its rx_consumed cursor. */
 #define GIN_ACK_REQ_THRESHOLD ((GIN_IMM_SEQ_MASK + 1) / 2)
 
 #endif

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -745,8 +745,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             uint16_t, rail_id,
             uint32_t, peer_rank,
             uint16_t, msg_seq_num,
-            uint16_t, num_segments,
-            uint32_t, consumed
+            uint16_t, num_segments
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
@@ -755,7 +754,6 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(uint32_t, peer_rank, peer_rank)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
             lttng_ust_field_integer(uint16_t, num_segments, num_segments)
-            lttng_ust_field_integer(uint32_t, consumed, consumed)
     )
 )
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -4,6 +4,9 @@
 
 #include "config.h"
 
+#include <mutex>
+#include <thread>
+
 #include "rdma/gin/nccl_ofi_gin.h"
 
 #include "nccl_ofi_assert.h"
@@ -390,52 +393,43 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 {
 	int ret = 0;
+	auto &ep_lock = resources.get_ep().ep_lock;
 
 	NCCL_OFI_TRACE(NCCL_NET, "GIN communicator: awaiting pending acks");
 
-	/* Flush any deferred bundled acks so remote senders can complete
-	   their outstanding requests. Walk all peers; if our rx_consumed has
-	   advanced past rx_acked (or there's no metadata going back to this
-	   peer to piggyback on), emit a standalone ACK. */
-	for (uint32_t peer = 0; peer < rank_comms.size(); peer++) {
-		auto &rank_comm = rank_comms[peer];
-		if (gin_cursor_delta(rank_comm.rx_consumed, rank_comm.rx_acked) > 0) {
-			ret = send_ack(*this, peer, rank_comm.rx_consumed);
-			if (OFI_UNLIKELY(ret != 0)) {
-				return ret;
-			}
-			rank_comm.rx_acked = rank_comm.rx_consumed;
-		}
-	}
+	/* Wait until all ACKs we requested have been received. Only ops
+	   that set is_ack_requested on the wire will generate a standalone
+	   ACK from the receiver. We track the sequence number of the last
+	   request and compare against the last received ACK's rx_consumed.
+	   If we never requested any ACKs, this loop is a no-op.
 
-	while (outstanding_ack_counter > 0) {
-		ret = resources.progress();
-		if (OFI_UNLIKELY(ret != 0)) {
-			return ret;
-		}
-	}
-
-	/* Drain inbound ACKs we are still waiting on. The NCCL proxy may
-	   have already stopped polling test() by the time we get here, so
-	   closeColl()/the destructor would otherwise tear the EP down with
-	   peers' inflight ACKs still bound for our QP. Pump the CQ until
-	   tx_tail == tx_head on every peer, i.e. every op we ever sent has
-	   been retired by its receiver. */
+	   This intentionally replaces the former outstanding_ack_counter
+	   progress loop: per-peer has_pending_ack_request gives precise
+	   drain semantics without requiring a global counter, avoiding the
+	   deadlock where sequential comm teardown within a single process
+	   would stall waiting for a peer whose progress cannot run. */
 	while (true) {
-		bool any_outstanding = false;
-		for (auto &rank_comm : rank_comms) {
-			if (gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail) != 0) {
-				any_outstanding = true;
-				break;
+		bool any_pending = false;
+		{
+			std::lock_guard<std::mutex> lock(ep_lock);
+			for (auto &rank_comm : rank_comms) {
+				if (rank_comm.has_pending_ack_request) {
+					any_pending = true;
+					break;
+				}
+			}
+			if (any_pending) {
+				ret = resources.progress();
+				if (OFI_UNLIKELY(ret != 0)) {
+					return ret;
+				}
 			}
 		}
-		if (!any_outstanding) {
+		if (!any_pending) {
 			break;
 		}
-		ret = resources.progress();
-		if (OFI_UNLIKELY(ret != 0)) {
-			return ret;
-		}
+		/* Let peer's progress thread run (single-process case shares EP). */
+		std::this_thread::yield();
 	}
 
 	return ret;
@@ -508,6 +502,12 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	}
 
 	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
+	if (is_ack_requested) {
+		rank_comm.last_ack_requested_seq = rank_comm.tx_head;
+		rank_comm.has_pending_ack_request = true;
+	}
+
 	/* Determine how many segments to send */
 	uint16_t nseg = 0;
 	if (has_signal) {
@@ -635,12 +635,6 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		} else {
 			metadata_send->signal_value = 0;
 		}
-
-		/* Piggyback our latest rx_consumed cursor for this peer. The
-		   peer reads it via apply_rx_consumed() to advance its tx_tail
-		   without needing a separate ACK round-trip. */
-		metadata_send->header.rx_consumed = rank_comm.rx_consumed;
-		rank_comm.rx_acked = rank_comm.rx_consumed;
 
 		/* This send flushes the QP work queue on the first rail,
 		   issuing a doorbell that includes the coalesced writedata
@@ -930,10 +924,7 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 
    Emits a standalone ACK only when the sender explicitly requested one
    (the ack_req bit was set in either the data immediate or the metadata
-   header for any of this peer's in-flight ops). When the sender did not
-   request an ACK, rx_consumed gets piggybacked on outbound metadata in
-   the next iputSignal() to this peer; we never emit a standalone ACK
-   on the receiver's own initiative. */
+   header for any of this peer's in-flight ops). */
 int nccl_ofi_rdma_gin_put_comm::maybe_send_ack(uint32_t peer_rank, bool sender_requested)
 {
 	if (!sender_requested) {
@@ -945,7 +936,6 @@ int nccl_ofi_rdma_gin_put_comm::maybe_send_ack(uint32_t peer_rank, bool sender_r
 	if (OFI_UNLIKELY(ret != 0)) {
 		return ret;
 	}
-	rank_comm.rx_acked = rank_comm.rx_consumed;
 	return 0;
 }
 
@@ -955,9 +945,8 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 	bool ack_requested = false;
 
 	/* Walk in-order delivered ops, advancing rx_consumed as we go. The
-	   sender's flow-control window opens up as soon as we ack progress
-	   either via piggyback on outbound metadata (in iputSignal) or via
-	   a standalone ACK (maybe_send_ack at the end of this function). */
+	   sender's flow-control window opens once we send back a standalone
+	   ACK (maybe_send_ack at the end of this function). */
 	while (true) {
 		auto &rank_comm = this->rank_comms[peer_rank];
 		uint16_t next_seq_num = rank_comm.next_delivered_signal_seq_num;
@@ -985,9 +974,7 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 		this->resources.return_req_to_pool(req);
 	}
 
-	/* If the sender requested an ACK.
-	   emit a standalone ACK now. Otherwise rx_consumed will go out on
-	   the next outbound metadata to this peer via piggyback. */
+	/* If the sender requested an ACK, emit a standalone ACK now. */
 	return maybe_send_ack(peer_rank, ack_requested);
 }
 
@@ -1003,16 +990,7 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 	uint32_t peer_rank = get_peer_rank(src_addr, rank_map[rail_id]);
 
 	NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_START(
-		dev, this, rail_id, peer_rank, msg_seq_num, num_segments,
-		metadata_msg->header.rx_consumed);
-
-	/* Apply piggybacked rx_consumed cursor from the peer. The peer's
-	   metadata is in essence a bundled ACK: it tells us how many of our
-	   ops the peer has already delivered to its application, so we can
-	   advance tx_tail and free up window slots. apply_rx_consumed() is
-	   wrap-safe and a no-op if the cursor doesn't represent forward
-	   progress (e.g. because metadata arrived out of order). */
-	apply_rx_consumed(peer_rank, metadata_msg->header.rx_consumed);
+		dev, this, rail_id, peer_rank, msg_seq_num, num_segments);
 
 	uint64_t map_key = get_req_map_key(peer_rank, msg_seq_num);
 
@@ -1078,6 +1056,14 @@ int nccl_ofi_rdma_gin_put_comm::handle_ack_completion(const gin_ack_msg_t *ack_m
 	   arriving after newer ones are no-ops because they don't move
 	   tx_tail forward. */
 	apply_rx_consumed(peer_rank, rx_consumed);
+	auto &rank_comm = rank_comms[peer_rank];
+	if (rank_comm.has_pending_ack_request) {
+		uint32_t delta = gin_cursor_delta(rx_consumed,
+						  rank_comm.last_ack_requested_seq);
+		if (delta <= GIN_RX_CONSUMED_HALF) {
+			rank_comm.has_pending_ack_request = false;
+		}
+	}
 
 	NCCL_OFI_TRACE_GIN_HANDLE_ACK_COMPLETION_FUNC_END(dev, this, rail_id, peer_rank,
 						  rx_consumed, 0);

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -295,15 +295,29 @@ ncclResult_t nccl_ofi_gin_ginProgress(void *collComm)
 ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
 
 	int ret = gin_comm->await_pending_requests();
 	if (OFI_UNLIKELY(ret != 0)) {
 		return nccl_net_ofi_retval_translate(ret);
 	}
 
-	gin_comm->get_resources().remove_comm(gin_comm->get_local_comm_id());
-	delete gin_comm;
+	/* Under ep_lock: drain any outbound ACK sends (their CQ handler
+	   references this comm), then atomically remove + delete so no new
+	   work can be dispatched to this comm in between. */
+	auto &ep_lock = gin_comm->get_ep_lock();
+	while (true) {
+		std::lock_guard<std::mutex> lock(ep_lock);
+		if (gin_comm->has_outstanding_ack_sends()) {
+			ret = gin_comm->get_resources().progress();
+			if (OFI_UNLIKELY(ret != 0)) {
+				return nccl_net_ofi_retval_translate(ret);
+			}
+			continue;
+		}
+		gin_comm->get_resources().remove_comm(gin_comm->get_local_comm_id());
+		delete gin_comm;
+		break;
+	}
 
 	return ncclSuccess;
 }


### PR DESCRIPTION
`closeColl` now only waits for ACKs that were explicitly requested on the wire (tracked via per-peer sequence numbers), removes rx_consumed piggybacking on metadata, and narrows ep_lock to only protect the final remove_comm/delete. This prevents a deadlock from occurring when we have a single process with multiple communicators cleaning up.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
