### PR TITLE
rdma: Fix eager hang from sequence-number wrap

### DIFF
--- a/doc/multi-recv.md
+++ b/doc/multi-recv.md
@@ -110,14 +110,22 @@ Each eager message prepends an 8-byte header to the bounce buffer data:
 ```
 struct nccl_ofi_eager_msg_header {
     uint8_t  eager_offset;       // position within the eager batch
-    uint8_t  prev_batch_count;   // count of previous batch (when offset == 0)
-    uint16_t prev_msg_seq_num;   // seq of previous batch (when offset == 0)
+    uint8_t  prev_batch_count;   // size of the previous batch (when offset == 0)
+    uint16_t eager_seq;          // per-batch eager sequence number (chain identity)
     int32_t  tag;                // NCCL tag for multi-recv routing
 };
 ```
 
 The sender transmits this via `fi_sendmsg` with two iovecs: the header (from a
 registered freelist buffer) and the payload (from the user buffer).
+
+`eager_seq` is a dedicated per-batch counter that is the **sole identity** used
+to chain eager batches on the receiver. Unlike `msg_seq_num` (which counts every
+message, eager and rendezvous, and is masked to 10 bits), `eager_seq` advances
+only for eager batches. This makes the chain wrap-safe; see
+[Eager Sequence Numbers and Wrap Safety](#eager-sequence-numbers-and-wrap-safety).
+Note that the recv-side target resolution still uses `msg_seq_num` (carried in
+the RDMA write/eager immediate data), not `eager_seq`.
 
 ### Sender-Side Eager Queue
 
@@ -137,6 +145,14 @@ outstanding eager sends. Key behaviors:
   `eager_offset_next` increments (0, 1, 2, ...). All eager sends in a batch
   share the same `msg_seq_num`.
 
+- **Per-batch eager sequence**: At the start of each eager batch (the
+  `eager_offset == 0` send), the sender assigns `cur_eager_seq` from a
+  monotonically increasing `eager_seq_next` counter (a 16-bit value that wraps
+  naturally). Every send in the batch carries this `cur_eager_seq` in its
+  header. `eager_seq_next` is incremented once per batch, so consecutive eager
+  batches get consecutive eager sequence numbers regardless of how much
+  rendezvous traffic flows in between.
+
 - **Drain**: When a ctrl msg arrives (detected in `send()` or `test()`), the
   drain function matches queued eager sends against ctrl msg entries:
   - **Single recv**: Pop the front entry, mark the send as having received its
@@ -145,23 +161,26 @@ outstanding eager sends. Key behaviors:
     consumed (`entry_used = 1`). Unmatched entries are pushed back. If all N
     sub-recvs are satisfied, advance `next_msg_seq_num`.
 
-- **Batch boundary tracking**: When `next_msg_seq_num` advances (in the drain
-  or in the non-eager send path) and `eager_offset_next > 0`, the sender
-  records `prev_eager_msg_seq_num` and `prev_eager_batch_count` from the
-  current state, then resets `eager_offset_next` to 0. These values are
-  stamped into the next batch's `offset == 0` header so the receiver can
-  verify batch boundaries. The sender initializes `prev_eager_msg_seq_num`
-  to `0xFFFF` (sentinel) so the receiver can distinguish the very first
-  eager batch from a later batch that arrives out of order.
+- **Batch boundary tracking**: When a batch closes (its `msg_seq_num` advances,
+  in the drain or in the non-eager send path) and `eager_offset_next > 0`, the
+  sender records `prev_eager_batch_count` (the size of the just-closed batch)
+  and resets `eager_offset_next` to 0. The next batch stamps that
+  `prev_batch_count` into its `offset == 0` header so the receiver can confirm
+  the previous batch was fully processed before starting the new one. Batch
+  ordering is established purely by the contiguity of `eager_seq` (see below), so
+  no first-batch sentinel is needed either (the first batch is simply
+  `eager_seq == 0`).
 
 ### Receiver-Side Eager Queue
 
 The receiver maintains a **sorted doubly-linked list** of pending eager messages,
-ordered by `(msg_seq_num, eager_offset)`. A pre-allocated pool of
-`NCCL_OFI_CTRL_MAILBOX_SIZE` entries avoids dynamic allocation.
+ordered by `(eager_seq, eager_offset)` using wrap-aware 16-bit comparison. A
+pre-allocated pool of `NCCL_OFI_CTRL_MAILBOX_SIZE` entries avoids dynamic
+allocation.
 
 When an eager message arrives (`handle_eager_recv`):
-1. Parse the 8-byte header to extract `eager_offset`, `tag`, and batch info.
+1. Parse the 8-byte header to extract `eager_offset`, `tag`, `prev_batch_count`,
+   and `eager_seq`.
 2. Subtract 8 from `recv_len` (the header is not part of the payload).
 3. Insert into the sorted list.
 4. Call `drain_recv_eager_queue()`.
@@ -180,26 +199,58 @@ drain matches by tag, ensuring each eager send is paired with the correct
 sub-receive.
 
 **Receiver ordering**: The drain processes entries in strict
-`(msg_seq_num, eager_offset)` order. Before processing an entry, it verifies
-continuity:
+`(eager_seq, eager_offset)` order. Before processing an entry, it verifies
+continuity (`eager_entry_can_process()`):
 
 - **First-ever batch** (`has_processed_eager == false`): The entry must have
-  `eager_offset == 0` and `prev_msg_seq_num == 0xFFFF` (the sentinel value).
-  This ensures that if a later batch arrives before the first batch (due to
-  out-of-order delivery), it is not mistakenly processed as the first batch.
+  `eager_offset == 0` and `eager_seq == 0`. This ensures that if a later batch
+  arrives before the first batch (due to out-of-order delivery), it is not
+  mistakenly processed as the first batch.
 
-- **offset == 0 (new batch)**: The previous batch must be complete. This is
-  verified by checking that `last_eager_msg_seq_num == prev_msg_seq_num` and
-  `last_eager_offset == prev_batch_count - 1`.
+- **offset == 0 (new batch)**: The new batch must be the contiguous successor of
+  the last processed batch, and the previous batch must be complete. This is
+  verified by `entry.eager_seq == (uint16_t)(last_eager_seq + 1)` (wrap-aware)
+  and `last_eager_offset == prev_batch_count - 1`.
 
-- **offset > 0 (same batch)**: Must be consecutive with the last processed
-  entry: `last_eager_msg_seq_num == entry.msg_seq_num` and
-  `last_eager_offset == entry.eager_offset - 1`.
+- **offset > 0 (same batch)**: Must be the next offset of the same batch:
+  `entry.eager_seq == last_eager_seq` and
+  `last_eager_offset == entry.eager_offset - 1`. The `eager_seq` match is what
+  rejects a *new* batch's `offset > 0` entry that arrives (out of order) before
+  that batch's `offset == 0` — without it, a stale `(last_seq, last_offset)`
+  could spuriously accept it and strand the queue.
 
+On success the drain advances its tracking to the entry's `(eager_seq, offset)`.
 If the check fails (e.g., an earlier offset hasn't arrived yet), the drain stops
 and retries later.
 
-### Target Recv Resolution
+### Eager Sequence Numbers and Wrap Safety
+
+Eager batches are chained by `eager_seq` rather than by `msg_seq_num`. This is
+required for correctness, not just convenience.
+
+`msg_seq_num` is a per-comm counter advanced by **every** message (eager and
+rendezvous) and masked to `NCCL_OFI_RDMA_SEQ_BITS` (10 bits), so it wraps every
+1024 messages. The eager chain trackers are persistent scalars updated only by
+eager activity. If the chain were keyed on `msg_seq_num`, a long run of
+rendezvous traffic (common in a size sweep that mixes small and large messages)
+could advance `msg_seq_num` through a full 1024-message wrap while no eager
+batch updated the trackers. Two eager batches landing on the same masked
+`msg_seq_num` — a wrap apart — then became indistinguishable: the receiver could
+mis-accept an out-of-order `offset > 0` entry of the new batch as a continuation
+of the old batch, or reject the new `offset == 0`, permanently stranding
+`drain_recv_eager_queue()` and hanging the collective.
+
+`eager_seq` removes this hazard by construction. Because it advances **only**
+for eager batches, it cannot be overrun by rendezvous traffic. The number of
+eager batches that can be "in play" at once is bounded by the eager inflight
+limit (`NCCL_OFI_MAX_EAGER_PENDING`) and the receiver's queue/window — far below
+the 16-bit `eager_seq` range. Therefore two *live* batches can never share an
+`eager_seq`, and the wrap-aware contiguity check (`eager_seq == last + 1`,
+`eager_seq == last` for continuations) remains unambiguous across the 16-bit
+wrap. This is the standard "sequence-number range exceeds the outstanding
+window" guarantee, applied to eager batches in isolation.
+
+
 
 Once an entry passes the continuity check, the drain resolves which recv it
 targets using `eager_drain_recv_seq`:

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -213,8 +213,12 @@ public:
  */
 typedef struct nccl_ofi_eager_msg_header {
 	uint8_t eager_offset;
-	uint8_t prev_batch_count;     /* only meaningful when eager_offset == 0 */
-	uint16_t prev_msg_seq_num;    /* only meaningful when eager_offset == 0 */
+	uint8_t prev_batch_count;     /* previous batch's size (only meaningful when eager_offset == 0) */
+	/* Per-batch eager sequence number. This counts only eager batches (never
+	 * advanced by rendezvous traffic), so combined with the bounded number of
+	 * in-flight eager messages it is wrap-safe: two live batches can never
+	 * share an eager_seq. It is the sole identity used to chain eager batches. */
+	uint16_t eager_seq;
 	int32_t tag;
 } nccl_ofi_eager_msg_header_t;
 static_assert(sizeof(nccl_ofi_eager_msg_header_t) == NCCL_OFI_EAGER_HEADER_SIZE,
@@ -407,9 +411,10 @@ typedef struct {
 	nccl_ofi_freelist::fl_entry *eager_hdr_fl_entry;
 	/* Sub-receive index from ctrl msg entry (for RDMA write immediate data) */
 	uint8_t recv_idx;
-	/* Previous batch info */
+	/* Previous batch's size (written to the header for an off==0 send) */
 	uint8_t prev_batch_count;
-	uint16_t prev_msg_seq_num;
+	/* This batch's eager sequence number (chain identity) */
+	uint16_t eager_seq;
 	/* Schedule used to transfer this request. We save the pointer to
 	 * reference it when transferring the request over network. */
 	nccl_net_ofi_schedule_t *schedule;
@@ -713,9 +718,15 @@ public:
 	uint8_t eager_queue_count;
 	/* Next eager offset to assign */
 	uint8_t eager_offset_next;
-	/* Previous batch info (set when drain resets eager_offset_next) */
-	uint16_t prev_eager_msg_seq_num;
+	/* Size of the previous (closed) eager batch, written to the header of the
+	 * next batch's off==0 send so the receiver can confirm batch completion. */
 	uint8_t prev_eager_batch_count;
+	/* Per-batch eager sequence number. cur_eager_seq is the batch currently
+	 * being assembled; eager_seq_next is the value for the next new batch.
+	 * Counts only eager batches, so it is never overrun by rendezvous traffic;
+	 * combined with the bounded eager inflight it is wrap-safe. */
+	uint16_t cur_eager_seq{};
+	uint16_t eager_seq_next{};
 	/* Freelist of eager header buffers */
 	nccl_ofi_freelist *eager_hdr_fl;
 	/* Registration context for eager_hdr_fl. Freed in send_comm_destroy(). */
@@ -794,10 +805,10 @@ typedef struct nccl_net_ofi_rdma_flush_buffer {
 typedef struct nccl_ofi_recv_eager_entry {
 	nccl_ofi_dlist_node link;  /* intrusive list node */
 	nccl_net_ofi_rdma_req *rx_buff_req;
-	uint16_t msg_seq_num;
+	uint16_t msg_seq_num;         /* recv target seq (immediate data), for msgbuff lookup */
 	uint8_t eager_offset;
 	uint8_t prev_batch_count;     /* from header, only meaningful when eager_offset == 0 */
-	uint16_t prev_msg_seq_num;    /* from header, only meaningful when eager_offset == 0 */
+	uint16_t eager_seq;           /* from header: this batch's eager sequence (chain identity) */
 	int32_t tag;
 	size_t recv_len;  /* payload length (excluding header) */
 	bool handled;     /* true = data copied, awaiting removal at front */
@@ -813,12 +824,60 @@ inline bool seq_before(uint16_t a, uint16_t b)
 	uint16_t diff = (a - b) & MSG_SEQ_NUM_MASK; return diff > (MSG_SEQ_NUM_MASK >> 1);
 }
 
+/* Wrap-aware "a precedes b" for the 16-bit eager sequence. Correct as long as
+ * the number of in-flight eager batches stays below 2^15, which is guaranteed
+ * by NCCL's inflight limit (<= NCCL_OFI_MAX_EAGER_PENDING). */
+inline bool eager_seq_before(uint16_t a, uint16_t b)
+{
+	return (int16_t)(a - b) < 0;
+}
+
 inline bool eager_entry_less(const nccl_ofi_recv_eager_entry_t *a,
 			    const nccl_ofi_recv_eager_entry_t *b)
 {
-	if (a->msg_seq_num != b->msg_seq_num)
-		return seq_before(a->msg_seq_num, b->msg_seq_num);
+	if (a->eager_seq != b->eager_seq)
+		return eager_seq_before(a->eager_seq, b->eager_seq);
 	return a->eager_offset < b->eager_offset;
+}
+
+/*
+ * @brief	Decide whether an eager entry is the next in sequence and can be
+ *		processed by the receiver eager drain.
+ *
+ * Eager batches are chained by a dedicated per-batch eager sequence number
+ * (eager_seq) that advances only for eager batches. Because the number of
+ * in-flight eager messages is bounded (NCCL inflight limit /
+ * NCCL_OFI_MAX_EAGER_PENDING) and that bound is far below the 16-bit eager_seq
+ * range, two live batches can never share an eager_seq -- so the chain is
+ * wrap-safe regardless of how much rendezvous traffic flows in between.
+ * Factored out as a pure function so it can be unit tested without a comm.
+ *
+ * @param	has_processed	whether any eager batch has been processed yet
+ * @param	last_eager_seq	eager_seq of the last processed batch
+ * @param	last_offset	eager_offset of the last processed entry
+ * @param	entry		candidate entry at the front of the chain
+ */
+inline bool eager_entry_can_process(bool has_processed,
+				    uint16_t last_eager_seq,
+				    uint8_t last_offset,
+				    const nccl_ofi_recv_eager_entry_t *entry)
+{
+	if (!has_processed) {
+		/* First eager batch on this comm: eager_seq starts at 0. */
+		return (entry->eager_offset == 0) && (entry->eager_seq == 0);
+	} else if (entry->eager_offset == 0) {
+		/* New batch start: must be the next eager_seq (contiguous, wrap-safe),
+		 * and the previous batch must be complete (its last offset ==
+		 * prev_batch_count - 1). */
+		return (entry->eager_seq == (uint16_t)(last_eager_seq + 1))
+		    && (last_offset == entry->prev_batch_count - 1);
+	} else {
+		/* Continuation: the next offset of the same (eager_seq) batch. The
+		 * eager_seq match is what rejects a new batch's offset>0 that arrives
+		 * before its offset==0. */
+		return (entry->eager_seq == last_eager_seq)
+		    && (last_offset == entry->eager_offset - 1);
+	}
 }
 
 inline void recv_eager_sorted_insert(nccl_ofi_dlist *list,
@@ -907,8 +966,8 @@ public:
 	nccl_ofi_dlist recv_eager_list;
 	nccl_ofi_recv_eager_entry_t recv_eager_pool[NCCL_OFI_CTRL_MAILBOX_SIZE];
 	nccl_ofi_dlist recv_eager_free;
-	/* Last processed eager entry's coordinates */
-	uint16_t last_eager_msg_seq_num;
+	/* Last processed eager batch's coordinates (chain identity) */
+	uint16_t last_eager_seq{};
 	uint8_t last_eager_offset;
 	bool has_processed_eager;
 	/* Current recv seq being filled by the drain */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -956,7 +956,7 @@ int nccl_net_ofi_rdma_recv_comm::eager_copy_to_sub_recv(
 int nccl_net_ofi_rdma_recv_comm::drain_recv_eager_queue()
 {
 	bool skipping = false;
-	uint16_t tmp_last_msg_seq_num = this->last_eager_msg_seq_num;
+	uint16_t tmp_last_eager_seq = this->last_eager_seq;
 	uint8_t tmp_last_offset = this->last_eager_offset;
 	bool tmp_has_processed = this->has_processed_eager;
 	uint16_t tmp_drain_recv_seq = this->eager_drain_recv_seq;
@@ -966,23 +966,15 @@ int nccl_net_ofi_rdma_recv_comm::drain_recv_eager_queue()
 		nccl_ofi_recv_eager_entry_t *entry =
 			nccl_ofi_dlist_entry(node, &nccl_ofi_recv_eager_entry_t::link);
 
-		/* Check if this entry is the next in sequence */
-		bool can_process;
-		if (!tmp_has_processed) {
-			can_process = ((entry->eager_offset == 0) && (entry->prev_msg_seq_num == 0xFFFF));
-		} else if (entry->eager_offset == 0) {
-			can_process = (tmp_last_msg_seq_num == entry->prev_msg_seq_num
-				    && tmp_last_offset == entry->prev_batch_count - 1);
-		} else {
-			can_process = (tmp_last_msg_seq_num == entry->msg_seq_num
-				    && tmp_last_offset == entry->eager_offset - 1);
-		}
+		/* Check if this entry is the next in sequence (wrap-safe via eager_seq) */
+		bool can_process = eager_entry_can_process(tmp_has_processed, tmp_last_eager_seq,
+							   tmp_last_offset, entry);
 
 		if (!can_process)
 			break;
 
 		/* Advance temp tracking */
-		tmp_last_msg_seq_num = entry->msg_seq_num;
+		tmp_last_eager_seq = entry->eager_seq;
 		tmp_last_offset = entry->eager_offset;
 		tmp_has_processed = true;
 
@@ -991,7 +983,7 @@ int nccl_net_ofi_rdma_recv_comm::drain_recv_eager_queue()
 			if (!skipping) {
 				node->remove();
 				this->recv_eager_free.push_back(&entry->link);
-				this->last_eager_msg_seq_num = entry->msg_seq_num;
+				this->last_eager_seq = entry->eager_seq;
 				this->last_eager_offset = entry->eager_offset;
 				this->has_processed_eager = true;
 				this->eager_drain_recv_seq = tmp_drain_recv_seq;
@@ -1054,7 +1046,7 @@ int nccl_net_ofi_rdma_recv_comm::drain_recv_eager_queue()
 		if (!skipping) {
 			node->remove();
 			this->recv_eager_free.push_back(&entry->link);
-			this->last_eager_msg_seq_num = entry->msg_seq_num;
+			this->last_eager_seq = entry->eager_seq;
 			this->last_eager_offset = entry->eager_offset;
 			this->has_processed_eager = true;
 			this->eager_drain_recv_seq = tmp_drain_recv_seq;
@@ -1086,7 +1078,7 @@ int nccl_net_ofi_rdma_recv_comm::handle_eager_recv(
 	uint8_t eager_offset = eager_hdr->eager_offset;
 	int32_t eager_tag = eager_hdr->tag;
 	uint8_t prev_batch_count = eager_hdr->prev_batch_count;
-	uint16_t prev_msg_seq_num = eager_hdr->prev_msg_seq_num;
+	uint16_t eager_seq = eager_hdr->eager_seq;
 	/* Adjust recv_len to exclude header */
 	rx_data->recv_len -= NCCL_OFI_EAGER_HEADER_SIZE;
 
@@ -1104,7 +1096,7 @@ int nccl_net_ofi_rdma_recv_comm::handle_eager_recv(
 	new_entry->eager_offset = eager_offset;
 	new_entry->tag = eager_tag;
 	new_entry->prev_batch_count = prev_batch_count;
-	new_entry->prev_msg_seq_num = prev_msg_seq_num;
+	new_entry->eager_seq = eager_seq;
 	new_entry->recv_len = rx_data->recv_len;
 	new_entry->handled = false;
 	recv_eager_sorted_insert(&this->recv_eager_list, new_entry);
@@ -4384,7 +4376,7 @@ nccl_net_ofi_rdma_recv_comm::nccl_net_ofi_rdma_recv_comm()
 		recv_eager_free.push_back(&recv_eager_pool[i].link);
 	}
 	has_processed_eager = false;
-	last_eager_msg_seq_num = 0;
+	last_eager_seq = 0;
 	last_eager_offset = 0;
 	eager_drain_recv_seq = NCCL_OFI_RDMA_MSG_SEQ_NUM_START;
 	last_completed_seq = NCCL_OFI_RDMA_MSG_SEQ_NUM_START - 1;
@@ -5359,7 +5351,7 @@ static int post_rdma_eager_send(nccl_net_ofi_rdma_req *req,
 	hdr->eager_offset = send_data->eager_offset;
 	hdr->tag = send_data->tag;
 	hdr->prev_batch_count = send_data->prev_batch_count;
-	hdr->prev_msg_seq_num = send_data->prev_msg_seq_num;
+	hdr->eager_seq = send_data->eager_seq;
 
 	/* Build 2-iovec message: [header][payload] */
 	struct iovec iov[2];
@@ -5864,7 +5856,6 @@ bool nccl_net_ofi_rdma_send_comm::drain_sender_eager_queue()
 			this->next_msg_seq_num = (seq + 1) & MSG_SEQ_NUM_MASK;
 			/* Reset eager offset counter and prev parameters when advancing msg_seq_num if sent eager since last time */
 			if (this->eager_offset_next > 0) {
-				this->prev_eager_msg_seq_num = seq;
 				this->prev_eager_batch_count = this->eager_offset_next;
 				this->eager_offset_next = 0;
 			}
@@ -5905,7 +5896,6 @@ bool nccl_net_ofi_rdma_send_comm::drain_sender_eager_queue()
 			this->group_num_recvs = 0;
 			/* Reset eager offset counter and prev parameters when advancing msg_seq_num if sent eager since last time */
 			if (this->eager_offset_next > 0) {
-				this->prev_eager_msg_seq_num = seq;
 				this->prev_eager_batch_count = this->eager_offset_next;
 				this->eager_offset_next = 0;
 			}
@@ -6055,10 +6045,18 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 	if (eager) {
 		/* Set eager offset and enqueue */
 		rdma_req_send_data_t *eager_send_data = get_send_data(req);
+		/* At a batch start, assign this batch's eager sequence number. It
+		 * counts only eager batches, so it is never advanced by rendezvous
+		 * traffic; with the bounded eager inflight it is wrap-safe. All entries
+		 * of the batch carry the same cur_eager_seq. */
+		if (s_comm->eager_offset_next == 0) {
+			s_comm->cur_eager_seq = s_comm->eager_seq_next;
+			s_comm->eager_seq_next++;  /* uint16 wraps naturally */
+		}
 		eager_send_data->eager_offset = s_comm->eager_offset_next;
 		eager_send_data->eager_ctrl_msg_received = false;
 		eager_send_data->prev_batch_count = s_comm->prev_eager_batch_count;
-		eager_send_data->prev_msg_seq_num = s_comm->prev_eager_msg_seq_num;
+		eager_send_data->eager_seq = s_comm->cur_eager_seq;
 
 		uint8_t idx = s_comm->eager_queue_tail;
 		s_comm->eager_queue[idx].req = req;
@@ -6126,9 +6124,9 @@ int nccl_net_ofi_rdma_send_comm::send(void *data, size_t size, int tag,
 		} else {
 			s_comm->next_msg_seq_num = (s_comm->next_msg_seq_num + 1) & MSG_SEQ_NUM_MASK;
 		}
-		/* Reset eager offset counter and prev parameters when advancing msg_seq_num if sent eager since last time */
+		/* A rendezvous send that advances the sequence closes any pending eager
+		 * batch; record its size for the next batch's prev_batch_count. */
 		if ((s_comm->eager_offset_next > 0) && (orig_seq != s_comm->next_msg_seq_num)) {
-			s_comm->prev_eager_msg_seq_num = orig_seq;
 			s_comm->prev_eager_batch_count = s_comm->eager_offset_next;
 			s_comm->eager_offset_next = 0;
 		}
@@ -6595,7 +6593,7 @@ int nccl_net_ofi_rdma_ep_t::create_send_comm(nccl_net_ofi_rdma_send_comm **s_com
 	ret_s_comm->eager_queue_tail = 0;
 	ret_s_comm->eager_queue_count = 0;
 	ret_s_comm->eager_offset_next = 0;
-	ret_s_comm->prev_eager_msg_seq_num = 0xFFFF;
+	ret_s_comm->eager_seq_next = 0;
 	ret_s_comm->prev_eager_batch_count = 0;
 
 	/* The connect() API function acquired the endpoint we are using via

--- a/tests/unit/ctrl_msg.cpp
+++ b/tests/unit/ctrl_msg.cpp
@@ -196,10 +196,10 @@ static int test_eager_sorted_insert()
 	nccl_ofi_dlist list;
 	nccl_ofi_recv_eager_entry_t entries[8] = {};
 
-	/* Test 1: Insert in order */
-	entries[0].msg_seq_num = 1; entries[0].eager_offset = 0;
-	entries[1].msg_seq_num = 1; entries[1].eager_offset = 1;
-	entries[2].msg_seq_num = 2; entries[2].eager_offset = 0;
+	/* Test 1: Insert in order (sorted by eager_seq, then eager_offset) */
+	entries[0].eager_seq = 1; entries[0].eager_offset = 0;
+	entries[1].eager_seq = 1; entries[1].eager_offset = 1;
+	entries[2].eager_seq = 2; entries[2].eager_offset = 0;
 	recv_eager_sorted_insert(&list, &entries[0]);
 	recv_eager_sorted_insert(&list, &entries[1]);
 	recv_eager_sorted_insert(&list, &entries[2]);
@@ -224,11 +224,11 @@ static int test_eager_sorted_insert()
 	}
 	while (!list.empty()) list.pop_front();
 
-	/* Test 3: Same seq, different offsets interleaved */
-	entries[3].msg_seq_num = 1; entries[3].eager_offset = 3;
-	entries[4].msg_seq_num = 1; entries[4].eager_offset = 1;
-	entries[5].msg_seq_num = 1; entries[5].eager_offset = 2;
-	entries[6].msg_seq_num = 1; entries[6].eager_offset = 0;
+	/* Test 3: Same eager_seq, different offsets interleaved */
+	entries[3].eager_seq = 1; entries[3].eager_offset = 3;
+	entries[4].eager_seq = 1; entries[4].eager_offset = 1;
+	entries[5].eager_seq = 1; entries[5].eager_offset = 2;
+	entries[6].eager_seq = 1; entries[6].eager_offset = 0;
 	recv_eager_sorted_insert(&list, &entries[3]);
 	recv_eager_sorted_insert(&list, &entries[4]);
 	recv_eager_sorted_insert(&list, &entries[5]);
@@ -242,24 +242,27 @@ static int test_eager_sorted_insert()
 	}
 	while (!list.empty()) list.pop_front();
 
-	/* Test 4: Seq wraparound (1023 before 0 in 10-bit space) */
-	entries[0].msg_seq_num = 1023; entries[0].eager_offset = 0;
-	entries[1].msg_seq_num = 0;    entries[1].eager_offset = 0;
-	entries[2].msg_seq_num = 1;    entries[2].eager_offset = 0;
+	/* Test 4: eager_seq wraparound. The eager sequence is a 16-bit counter;
+	 * sorting must be wrap-aware so a batch at eager_seq 65535 precedes 0, 1. */
+	entries[0].eager_seq = 65535; entries[0].eager_offset = 0;
+	entries[1].eager_seq = 0;     entries[1].eager_offset = 0;
+	entries[2].eager_seq = 1;     entries[2].eager_offset = 0;
 	recv_eager_sorted_insert(&list, &entries[2]);
 	recv_eager_sorted_insert(&list, &entries[0]);
 	recv_eager_sorted_insert(&list, &entries[1]);
 
 	n = collect_list(&list, out, 8);
-	if (n != 3 || out[0]->msg_seq_num != 1023 || out[1]->msg_seq_num != 0 || out[2]->msg_seq_num != 1) {
-		NCCL_OFI_WARN("wraparound insert failed: got seq %d, %d, %d",
-			out[0]->msg_seq_num, out[1]->msg_seq_num, out[2]->msg_seq_num);
+	if (n != 3 || out[0]->eager_seq != 65535 || out[1]->eager_seq != 0 || out[2]->eager_seq != 1) {
+		NCCL_OFI_WARN("wraparound insert failed: got eager_seq %u, %u, %u",
+			out[0]->eager_seq, out[1]->eager_seq, out[2]->eager_seq);
 		return 1;
 	}
+	/* Reset eager_seq so later tests (which use eager_seq 0) are unaffected. */
+	entries[0].eager_seq = 0; entries[1].eager_seq = 0; entries[2].eager_seq = 0;
 	while (!list.empty()) list.pop_front();
 
 	/* Test 5: Single element */
-	entries[0].msg_seq_num = 5; entries[0].eager_offset = 2;
+	entries[0].eager_seq = 5; entries[0].eager_offset = 2;
 	recv_eager_sorted_insert(&list, &entries[0]);
 	n = collect_list(&list, out, 8);
 	if (n != 1 || out[0] != &entries[0]) {
@@ -269,8 +272,8 @@ static int test_eager_sorted_insert()
 	while (!list.empty()) list.pop_front();
 
 	/* Test 6: Duplicate key — both should be in list */
-	entries[0].msg_seq_num = 3; entries[0].eager_offset = 1; entries[0].tag = 10;
-	entries[1].msg_seq_num = 3; entries[1].eager_offset = 1; entries[1].tag = 20;
+	entries[0].eager_seq = 3; entries[0].eager_offset = 1; entries[0].tag = 10;
+	entries[1].eager_seq = 3; entries[1].eager_offset = 1; entries[1].tag = 20;
 	recv_eager_sorted_insert(&list, &entries[0]);
 	recv_eager_sorted_insert(&list, &entries[1]);
 	n = collect_list(&list, out, 8);
@@ -280,11 +283,11 @@ static int test_eager_sorted_insert()
 	}
 	while (!list.empty()) list.pop_front();
 
-	/* Test 7: Multiple seq batches interleaved */
-	entries[0].msg_seq_num = 2; entries[0].eager_offset = 1;
-	entries[1].msg_seq_num = 1; entries[1].eager_offset = 0;
-	entries[2].msg_seq_num = 2; entries[2].eager_offset = 0;
-	entries[3].msg_seq_num = 1; entries[3].eager_offset = 1;
+	/* Test 7: Multiple eager_seq batches interleaved */
+	entries[0].eager_seq = 2; entries[0].eager_offset = 1;
+	entries[1].eager_seq = 1; entries[1].eager_offset = 0;
+	entries[2].eager_seq = 2; entries[2].eager_offset = 0;
+	entries[3].eager_seq = 1; entries[3].eager_offset = 1;
 	recv_eager_sorted_insert(&list, &entries[0]);
 	recv_eager_sorted_insert(&list, &entries[1]);
 	recv_eager_sorted_insert(&list, &entries[2]);
@@ -292,16 +295,134 @@ static int test_eager_sorted_insert()
 
 	n = collect_list(&list, out, 8);
 	if (n != 4 ||
-	    !(out[0]->msg_seq_num == 1 && out[0]->eager_offset == 0) ||
-	    !(out[1]->msg_seq_num == 1 && out[1]->eager_offset == 1) ||
-	    !(out[2]->msg_seq_num == 2 && out[2]->eager_offset == 0) ||
-	    !(out[3]->msg_seq_num == 2 && out[3]->eager_offset == 1)) {
+	    !(out[0]->eager_seq == 1 && out[0]->eager_offset == 0) ||
+	    !(out[1]->eager_seq == 1 && out[1]->eager_offset == 1) ||
+	    !(out[2]->eager_seq == 2 && out[2]->eager_offset == 0) ||
+	    !(out[3]->eager_seq == 2 && out[3]->eager_offset == 1)) {
 		NCCL_OFI_WARN("multi-batch interleaved insert failed");
 		return 1;
 	}
 	while (!list.empty()) list.pop_front();
 
 	printf("PASS: eager sorted insert\n");
+	return 0;
+}
+
+/*
+ * Exercises eager_entry_can_process() -- the wrap-safe chain decision used by
+ * drain_recv_eager_queue(). Signature:
+ *   eager_entry_can_process(has_processed, last_eager_seq, last_offset, entry)
+ */
+static int test_eager_drain_chain()
+{
+	nccl_ofi_recv_eager_entry_t e = {};
+
+	/* First batch (nothing processed yet): eager_seq starts at 0 */
+	e = {}; e.eager_offset = 0; e.eager_seq = 0;
+	if (!eager_entry_can_process(false, 0, 0, &e)) {
+		NCCL_OFI_WARN("first-batch: valid eager_seq==0 start rejected");
+		return 1;
+	}
+	e = {}; e.eager_offset = 0; e.eager_seq = 5;   /* not the first batch */
+	if (eager_entry_can_process(false, 0, 0, &e)) {
+		NCCL_OFI_WARN("first-batch: non-zero eager_seq start accepted");
+		return 1;
+	}
+	e = {}; e.eager_offset = 1; e.eager_seq = 0;   /* offset>0 first */
+	if (eager_entry_can_process(false, 0, 0, &e)) {
+		NCCL_OFI_WARN("first-batch: offset>0 start accepted");
+		return 1;
+	}
+
+	/* Continuation within a batch: last processed = (eager_seq 5, off 2) */
+	e = {}; e.eager_seq = 5; e.eager_offset = 3;
+	if (!eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("continuation: in-order next offset rejected");
+		return 1;
+	}
+	e.eager_offset = 4;  /* gap */
+	if (eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("continuation: gapped offset accepted");
+		return 1;
+	}
+	/* Different eager_seq must NOT be a continuation -- rejects a new batch's
+	 * offset>0 arriving before its offset==0. */
+	e = {}; e.eager_seq = 6; e.eager_offset = 3;
+	if (eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("continuation: wrong eager_seq accepted");
+		return 1;
+	}
+
+	/* Batch boundary: previous batch was eager_seq 5 with 3 msgs -> last (5,2) */
+	e = {}; e.eager_offset = 0; e.eager_seq = 6; e.prev_batch_count = 3;
+	if (!eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("boundary: valid next-batch start rejected");
+		return 1;
+	}
+	e.prev_batch_count = 1;  /* previous batch not actually complete at off 2 */
+	if (eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("boundary: mismatched prev_batch_count accepted");
+		return 1;
+	}
+	e = {}; e.eager_offset = 0; e.eager_seq = 7; e.prev_batch_count = 3;  /* skips a batch */
+	if (eager_entry_can_process(true, 5, 2, &e)) {
+		NCCL_OFI_WARN("boundary: non-contiguous eager_seq accepted");
+		return 1;
+	}
+
+	/* eager_seq wrap at the batch boundary (65535 -> 0) is handled */
+	e = {}; e.eager_offset = 0; e.eager_seq = 0; e.prev_batch_count = 2;
+	if (!eager_entry_can_process(true, 65535, 1, &e)) {
+		NCCL_OFI_WARN("boundary: eager_seq wrap 65535->0 rejected");
+		return 1;
+	}
+
+	printf("PASS: eager drain chain decision\n");
+	return 0;
+}
+
+/*
+ * Regression test for the sequence-number-wrap hang.
+ *
+ * A previous eager batch (eager_seq E, size 1) has been processed; a new batch
+ * (eager_seq E+1) arrives and its offset>0 entry arrives before its offset==0
+ * entry. The eager_seq identity must reject the out-of-order offset>0 as a
+ * continuation, and offset==0 must anchor cleanly. Because eager_seq counts
+ * only eager batches and the eager inflight is bounded, this holds even across
+ * the 16-bit eager_seq wrap.
+ */
+static int test_eager_wrap_collision()
+{
+	const bool has_processed = true;
+	uint16_t last_eager_seq = 65535;   /* previous batch (size 1, off 0) */
+	uint8_t  last_off = 0;
+
+	/* New batch (eager_seq 0 after wrap) offset=1 arrives FIRST (reorder). */
+	nccl_ofi_recv_eager_entry_t off1 = {};
+	off1.eager_seq = 0; off1.eager_offset = 1;
+	if (eager_entry_can_process(has_processed, last_eager_seq, last_off, &off1)) {
+		NCCL_OFI_WARN("wrap: new-batch offset=1 mis-accepted before its offset=0");
+		return 1;
+	}
+
+	/* New batch offset=0 arrives: contiguous eager_seq (65535+1==0), prev size 1. */
+	nccl_ofi_recv_eager_entry_t off0 = {};
+	off0.eager_seq = 0; off0.eager_offset = 0; off0.prev_batch_count = 1;
+	if (!eager_entry_can_process(has_processed, last_eager_seq, last_off, &off0)) {
+		NCCL_OFI_WARN("wrap: new-batch offset=0 failed to anchor across wrap");
+		return 1;
+	}
+
+	/* Simulate processing offset=0: tracker advances to (eager_seq 0, off 0). */
+	last_eager_seq = off0.eager_seq; last_off = off0.eager_offset;
+
+	/* Now offset=1 of the new batch is a valid continuation. */
+	if (!eager_entry_can_process(has_processed, last_eager_seq, last_off, &off1)) {
+		NCCL_OFI_WARN("wrap: new-batch offset=1 rejected after offset=0 anchored");
+		return 1;
+	}
+
+	printf("PASS: eager wrap collision regression\n");
 	return 0;
 }
 
@@ -314,6 +435,8 @@ int main(int argc, char *argv[])
 	rc |= test_ready_bit();
 	rc |= test_max_recvs_entries();
 	rc |= test_eager_sorted_insert();
+	rc |= test_eager_drain_chain();
+	rc |= test_eager_wrap_collision();
 
 	if (rc == 0)
 		printf("All ctrl_msg tests passed\n");


### PR DESCRIPTION
The eager batch-chaining metadata linked consecutive eager batches using the shared per-comm message sequence number (msg_seq_num), which is 10-bit and wraps every 1024 messages. Because that counter is advanced by *all* messages, a long run of rendezvous traffic could advance it through a full wrap while no eager activity updated the chain trackers. Two eager batches that then landed on the same masked sequence number (a wrap apart) became indistinguishable: the new batch's offset-0 referenced itself, and the receiver either mis-accepted an out-of-order continuation of the new batch as a continuation of the old one or rejected the new offset-0, wedging drain_recv_eager_queue() and hanging the collective.

Fix: chain eager batches by a dedicated per-batch eager sequence number (eager_seq) carried in the eager header, instead of by msg_seq_num. eager_seq advances only for eager batches, so it is never overrun by rendezvous traffic. Combined with the bounded number of in-flight eager messages (NCCL inflight limit / NCCL_OFI_MAX_EAGER_PENDING, far below the 16-bit eager_seq range), two live batches can never share an eager_seq, so the chain is wrap-safe by construction regardless of intervening rendezvous volume. msg_seq_num is still used (unchanged) for the recv-side msgbuff lookup, which is already window-bounded.

Update unit test for eager sequence number + a test for eager_seq wrap.

Update multi-recv document to reflect these changes.


(cherry picked from commit 1a7055884d0e90f601c44747847a9d31dabce2a8)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
