### PR TITLE
gin/gdaki: allocate one endpoint set per requested ctx (honor nContexts)

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -532,35 +532,50 @@ public:
  */
 struct nccl_ofi_gin_gdaki_context {
 	/* Set first (stateless). */
+	int nContexts = 0;
 	int nranks = 0;
 	int rank = 0;
-
-	/* Data (main) endpoint: libfabric EP on the reused proxy domain plus
-	 * its GPU-side SQ buffer/doorbell mappings, GPU-resident QP/CQ
-	 * descriptors, per-peer addressing, and a FI_WRITE hardware counter
-	 * for completion tracking. The kernel polls the counter rather than
-	 * the CQ for data-EP Flush. */
-	gdaki_data_endpoint data;
-
-	/* Signal/counter endpoints. Empty when nSignals == 0 && nCounters == 0. */
 	int nSignals = 0;
 	int nCounters = 0;
-	std::vector<std::unique_ptr<gdaki_sc_endpoint>> sc_endpoints;
 
-	/* GPU-resident arrays of device handle pointers for counter/signal. */
-	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_counter_handles;
-	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> d_signal_handles;
+	/* Per-ctx data (main) endpoint: libfabric EP on the reused proxy
+	 * domain plus its GPU-side SQ buffer/doorbell mappings, GPU-
+	 * resident QP/CQ descriptors, per-peer addressing, and a
+	 * FI_WRITE hardware counter for completion tracking. One per
+	 * logical context. unique_ptr because gdaki_data_endpoint owns
+	 * non-movable members (libfabric/CUDA handles). */
+	std::vector<std::unique_ptr<gdaki_data_endpoint>> data;                            /* [nContexts]      */
 
-	/* Signal-only scratch buffer.
+	/* Per-ctx signal/counter endpoints. data[c]'s sibling: each
+	 * logical ctx c owns max(nSignals, nCounters) sc endpoints,
+	 * accessed as sc_endpoints[c][i]. */
+	std::vector<std::vector<std::unique_ptr<gdaki_sc_endpoint>>> sc_endpoints;        /* [nContexts][n_sc]*/
+
+	/* Per-ctx GPU-resident pointer arrays for the kernel's
+	 * dev->counter_handles[] and dev->signal_handles[]. unique_ptr
+	 * for the same reason as `data` — gdaki_gpu_buf<T> is
+	 * non-movable. */
+	std::vector<std::unique_ptr<gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *>>> d_counter_handles; /* [nContexts] */
+	std::vector<std::unique_ptr<gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *>>> d_signal_handles;  /* [nContexts] */
+
+	/* Shared signal-only scratch buffer.
 	 *
 	 * `net.signal(team, peer, ...)` (the path used by ncclBarrierSession)
-	 * routes through ncclGinApi_Put with hasWins=false, bytes=0. EFA needs
-	 * a real remote address to bump the receiver's FI_REMOTE_WRITE counter,
-	 * so we register a small per-rank buffer on the proxy domain and
-	 * allgather the (addr, rkey) pair across all ranks. The GPU kernel
-	 * issues a 4-byte RDMA write to the peer's scratch on the signal
-	 * endpoint when it needs a signal-only delivery. Cleanup is automatic:
-	 * fi_close on the MR before free of the host buffer.
+	 * routes through ncclGinApi_Put with hasWins=false, bytes=0. EFA
+	 * requires a registered remote address to bump the receiver's
+	 * FI_REMOTE_WRITE counter even for a 0-byte write, so we allocate
+	 * a small buffer per rank and allgather (addr, rkey) across the
+	 * team.
+	 *
+	 * One scratch buffer is shared by all nContexts on this rank,
+	 * because:
+	 *   - 0-byte RDMA writes never read or write buffer contents —
+	 *     only the per-EP FI_REMOTE_WRITE counter ticks on the
+	 *     receiver. The buffer is purely a registered destination
+	 *     address.
+	 *   - Each ctx has its own signal endpoint (with its own
+	 *     counter), so per-ctx isolation of "what got signalled" is
+	 *     preserved even though the destination address is shared.
 	 */
 	void *scratch_buf = nullptr;
 	struct fid_mr *scratch_mr = nullptr;
@@ -568,6 +583,13 @@ struct nccl_ofi_gin_gdaki_context {
 	uint64_t scratch_local_addr = 0;
 	gdaki_gpu_buf<uint64_t> scratch_remote_addrs_buf;
 	gdaki_gpu_buf<uint32_t> scratch_remote_rkeys_buf;
+
+	/* Contiguous GPU-resident array of device handles, one entry per
+	 * logical context. The kernel reads
+	 *   &((nccl_ofi_gin_gdaki_dev_handle*)ctx.handle)[ctx.contextId]
+	 * to pick its entry. Populated last, after every per-ctx
+	 * endpoint is built, then committed once. */
+	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_handle> dev_handles;
 
 	~nccl_ofi_gin_gdaki_context()
 	{
@@ -580,10 +602,6 @@ struct nccl_ofi_gin_gdaki_context {
 			scratch_buf = nullptr;
 		}
 	}
-
-	/* GPU-resident device handle. Populated last; points into the
-	 * GPU buffers owned by the members above. */
-	gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_handle> dev_handle;
 };
 
 #endif /* NCCL_OFI_GIN_GDAKI_RESOURCES_H_ */

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -19,6 +19,7 @@
 #include "nccl_ofi_api.h"
 
 #include <algorithm>
+#include <cstdlib>
 #include <memory>
 #include <mutex>
 #include <unordered_map>
@@ -245,28 +246,29 @@ static void setup_scratch_buffer(nccl_ofi_gin_gdaki_context *ctx,
 }
 
 /*
- * Populate the GPU-resident device handle from the built context and
- * upload it to GPU memory via commit().
+ * Fill one entry of the contiguous dev_handles[] GPU array for logical
+ * context `ctx_id`. Caller (createContext) owns the GPU buffer; this function
+ * only writes the host-side copy. The whole array is committed to GPU
+ * memory once after every entry is filled.
  */
-static void populate_dev_handle(nccl_ofi_gin_gdaki_context *ctx,
-				const ncclGinConfig_v13_t *config,
+static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
+				const nccl_ofi_gin_gdaki_context *ctx,
+				int ctx_id,
 				int nranks, int rank)
 {
-	ctx->dev_handle.allocate(1);
-	nccl_ofi_gin_gdaki_dev_handle &h = *ctx->dev_handle.host;
-	h.data.qp = ctx->data.base.gpu_qp.dev();
-	h.data.cq = ctx->data.base.gpu_cq.dev();
-	h.data.address_handles = ctx->data.base.peers.ahs.dev;
-	h.data.remote_qpns = ctx->data.base.peers.qpns.dev;
-	h.data.qkey = ctx->data.base.peers.qkeys.dev;
+	h.data.qp = ctx->data[ctx_id]->base.gpu_qp.dev();
+	h.data.cq = ctx->data[ctx_id]->base.gpu_cq.dev();
+	h.data.address_handles = ctx->data[ctx_id]->base.peers.ahs.dev;
+	h.data.remote_qpns = ctx->data[ctx_id]->base.peers.qpns.dev;
+	h.data.qkey = ctx->data[ctx_id]->base.peers.qkeys.dev;
 	h.data.sq_lock = 0;
-	h.data.local_cntr_value = ctx->data.write_cntr.gpu_ptr();
+	h.data.local_cntr_value = ctx->data[ctx_id]->write_cntr.gpu_ptr();
 	h.data.submitted_count = 0;
-	h.data.sq_size = ctx->data.base.sq_size;
-	h.counter_handles = (config->nCounters > 0) ? ctx->d_counter_handles.dev : nullptr;
-	h.signal_handles  = (config->nSignals  > 0) ? ctx->d_signal_handles.dev  : nullptr;
-	h.nCounters = config->nCounters;
-	h.nSignals  = config->nSignals;
+	h.data.sq_size = ctx->data[ctx_id]->base.sq_size;
+	h.counter_handles = (ctx->nCounters > 0) ? ctx->d_counter_handles[ctx_id]->dev : nullptr;
+	h.signal_handles  = (ctx->nSignals  > 0) ? ctx->d_signal_handles[ctx_id]->dev  : nullptr;
+	h.nCounters = ctx->nCounters;
+	h.nSignals  = ctx->nSignals;
 	h.nranks = nranks;
 	h.rank = rank;
 	h.scratch_lkey         = ctx->scratch_lkey;
@@ -274,8 +276,6 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_context *ctx,
 	h.scratch_local_addr   = ctx->scratch_local_addr;
 	h.scratch_remote_addrs = ctx->scratch_remote_addrs_buf.dev;
 	h.scratch_remote_rkeys = ctx->scratch_remote_rkeys_buf.dev;
-	/* Upload the populated host-side struct to GPU memory. */
-	ctx->dev_handle.commit();
 }
 
 static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConfig_v13_t *config,
@@ -297,21 +297,50 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 	int nranks = put_comm->get_nranks();
 	int rank = put_comm->get_rank();
 
+	/* Honor config->nContexts (NCCL's GIN API contract: createContext
+	 * returns one ncclNetDeviceHandle whose .handle points at an array
+	 * of nContexts per-context dev handles, indexed by ctx.contextId
+	 * from the kernel). Defend against pathological zero/negative
+	 * values by clamping to 1. */
+	int nContexts = (config->nContexts > 0) ? config->nContexts : 1;
+
 	/*
-	 * The ctx holds every lifecycle-managed resource as a member;
-	 * its destructor unwinds them in reverse construction order. If
-	 * any step below throws, unique_ptr's reset in the catch handler
-	 * drives the destructor chain and partially-built state is
-	 * cleaned up automatically.
+	 * TODO: Upfront EFA hardware-counter capacity check.
+	 *
+	 * Each ctx allocates 1 FI_WRITE counter on the data EP plus
+	 * (FI_WRITE + FI_REMOTE_WRITE) on each of its
+	 * max(nSignals, nCounters) sc EPs. When the total request exceeds
+	 * the per-NIC counter budget, cntr_open_ext returns -FI_ENOMEM
+	 * mid-loop and we tear down a partially-built ctx via the
+	 * exception path with a generic error.
+	 *
+	 * Today libfabric reports domain_attr->cntr_cnt = 0 on EFA because
+	 * the EFA driver does not populate ibv_query_device_ex's
+	 * max_comp_cntr field. Once it does, add an upfront check here so
+	 * we can reject early with an actionable error instead of failing
+	 * partway through the per-context loop.
+	 */
+
+	/*
+	 * The ctx holds every lifecycle-managed resource. Per-logical-context
+	 * state is held in vectors of size nContexts; the device-visible
+	 * dev_handles[] array is contiguous so the kernel can index by
+	 * ctx.contextId.
+	 *
+	 * RAII unwinds members in reverse declaration order if anything
+	 * throws below.
 	 */
 	auto ctx = std::unique_ptr<nccl_ofi_gin_gdaki_context>(
 		new (std::nothrow) nccl_ofi_gin_gdaki_context());
 	if (ctx == nullptr) {
-		NCCL_OFI_WARN("gin GDAKI: createContext failed to allocate context");
+		NCCL_OFI_WARN("gin GDAKI: createContext failed to allocate ctx");
 		return ncclSystemError;
 	}
+	ctx->nContexts = nContexts;
 	ctx->nranks = nranks;
 	ctx->rank = rank;
+	ctx->nSignals = config->nSignals;
+	ctx->nCounters = config->nCounters;
 
 	ncclNetDeviceHandle_v11_t *dev_handle_out = nullptr;
 
@@ -324,7 +353,7 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		 * prov_filter_by_match against the first entry, which is
 		 * efa-direct). That domain exposes FI_EFA_GDA_OPS. Reusing it
 		 * ensures MR keys registered via extGin->regMrSym are valid on
-		 * the endpoint we open here.
+		 * the endpoints we open here.
 		 */
 		auto &proxy_domain_ptr =
 			put_comm->get_resources().get_ep().get_domain().get_ofi_domain(0);
@@ -345,7 +374,7 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 
 		/*
 		 * Step 2: Open FI_EFA_GDA_OPS on the reused domain. Used by
-		 * data.open() (to bind the FI_WRITE counter), data.populate(),
+		 * data EPs (to bind the FI_WRITE counter), data.populate(),
 		 * and the sc_endpoint loop below.
 		 */
 		struct fi_efa_ops_gda *gda_ops = nullptr;
@@ -358,95 +387,114 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				std::string(ret ? fi_strerror(-ret) : "no ops table"));
 		}
 
-		/*
-		 * Step 3: Open the data endpoint on the reused domain.
-		 */
-		ctx->data.open(ofi_domain, proxy_info, gda_ops);
-
-		/*
-		 * Step 4: Exchange endpoint addresses across the team, then
-		 * complete the data endpoint's GPU-side build.
-		 */
-		constexpr size_t ep_addr_len = MAX_EP_ADDR;
-		std::vector<uint8_t> all_addrs = allgather_ep_addr(
-			ctx->data.base.endpoint.ep, put_comm, nranks, rank, ep_addr_len);
-		ctx->data.populate(gda_ops, all_addrs, ep_addr_len, nranks);
-
-		/*
-		 * Step 5: Create signal/counter endpoints if requested.
-		 *
-		 * Each endpoint has its own QP plus two hardware counters
-		 * (FI_WRITE for local completion, FI_REMOTE_WRITE for remote
-		 * notification). Both counter values live in GPU memory
-		 * (DMA-BUF-mapped). We expose them through GPU-resident
-		 * arrays of nccl_ofi_gin_gdaki_dev_counter_handle pointers, one
-		 * per signal and one per counter.
-		 */
-		int n_sc = std::max(config->nSignals, config->nCounters);
-		if (n_sc > 0) {
-			ctx->nSignals = config->nSignals;
-			ctx->nCounters = config->nCounters;
-			ctx->sc_endpoints.reserve(n_sc);
-
-			for (int i = 0; i < n_sc; i++) {
-				ctx->sc_endpoints.push_back(std::make_unique<gdaki_sc_endpoint>());
-				ctx->sc_endpoints[i]->open(ofi_domain, proxy_info, gda_ops);
-
-				std::vector<uint8_t> sc_addrs = allgather_ep_addr(
-					ctx->sc_endpoints[i]->base.endpoint.ep,
-					put_comm, nranks, rank, ep_addr_len);
-
-				ctx->sc_endpoints[i]->populate(gda_ops, sc_addrs, ep_addr_len, nranks);
-			}
-
-			/* Build counter_handles and signal_handles GPU arrays. */
-			auto build_handle_array = [&](gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> &buf,
-						      int count, auto get_dev_handle) {
-				if (count > 0) {
-					buf.allocate(count);
-					for (int i = 0; i < count; i++)
-						buf.host[i] = get_dev_handle(i);
-					buf.commit();
-				}
-			};
-			build_handle_array(ctx->d_counter_handles, config->nCounters,
-				[&](int i) { return ctx->sc_endpoints[i]->counter_dev_handle.dev; });
-			build_handle_array(ctx->d_signal_handles, config->nSignals,
-				[&](int i) { return ctx->sc_endpoints[i]->signal_dev_handle.dev; });
+		/* Pre-size all per-ctx vectors and the contiguous dev_handles[]
+		 * GPU array. data / d_counter_handles / d_signal_handles hold
+		 * unique_ptrs whose targets are constructed inside the per-ctx
+		 * loop below; sc_endpoints holds vectors-of-unique_ptr too.
+		 * Resizing here just creates the slots (default-initialized
+		 * empty unique_ptrs); endpoints / GPU buffers are allocated
+		 * later only after we successfully open them. */
+		ctx->data.resize(nContexts);
+		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++)
+			ctx->data[ctx_id] = std::make_unique<gdaki_data_endpoint>();
+		ctx->sc_endpoints.resize(nContexts);
+		ctx->d_counter_handles.resize(nContexts);
+		ctx->d_signal_handles.resize(nContexts);
+		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++) {
+			ctx->d_counter_handles[ctx_id] =
+			    std::make_unique<gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *>>();
+			ctx->d_signal_handles[ctx_id] =
+			    std::make_unique<gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *>>();
 		}
+		ctx->dev_handles.allocate(nContexts);
 
 		/*
-		 * Step 6: Allocate signal-only scratch buffer and allgather
-		 * (addr, rkey) per rank.
-		 *
-		 * net.signal(team, peer) (the path used by ncclBarrierSession)
-		 * routes through ncclGinApi_Put with hasWins=false, bytes=0. EFA
-		 * still requires a registered remote address to bump the
-		 * receiver's FI_REMOTE_WRITE counter — even for a 0-byte write —
-		 * so we register a small per-rank buffer on the proxy domain and
-		 * allgather (addr, rkey) across ranks.
-		 *
-		 * Allocated unconditionally (not gated on n_sc > 0) so any
-		 * caller that creates a context — even one that doesn't request
-		 * signal/counter endpoints today but later issues a signal-only
-		 * Put — has a valid scratch destination. The cost is ~8 bytes
-		 * of host memory + one small MR registration; negligible.
+		 * Step 3: Allocate the signal-only scratch buffer once per
+		 * createContext (not per logical ctx). Shared across all
+		 * ctxs on this rank because the buffer's contents are never
+		 * read or written — 0-byte RDMA writes only tick the per-EP
+		 * FI_REMOTE_WRITE counter on the receiver, and the buffer is
+		 * just a registered destination address.
 		 */
 		setup_scratch_buffer(ctx.get(), ofi_domain, put_comm, nranks, rank);
 
 		/*
-		 * Step 7: Populate and upload the device-visible handle.
+		 * Per-context loop: build (data EP + sc EPs + counter/signal
+		 * handle arrays) for each logical context, then fill that
+		 * context's slot in dev_handles[].
 		 */
-		populate_dev_handle(ctx.get(), config, nranks, rank);
+		constexpr size_t ep_addr_len = MAX_EP_ADDR;
+		const int n_sc = std::max(config->nSignals, config->nCounters);
+		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++) {
+			/*
+			 * Step 4: Open this ctx's data endpoint on the reused
+			 * domain.
+			 */
+			ctx->data[ctx_id]->open(ofi_domain, proxy_info, gda_ops);
+
+			/*
+			 * Step 5: Exchange this ctx's data-EP address across the
+			 * team, then complete the data EP's GPU-side build.
+			 * Each ctx's data EP is its own libfabric EP, so each
+			 * needs its own allgather — ctx ctx_id on rank A pairs with
+			 * ctx ctx_id on rank B for cross-rank symmetric communication.
+			 */
+			std::vector<uint8_t> all_addrs = allgather_ep_addr(
+				ctx->data[ctx_id]->base.endpoint.ep, put_comm, nranks, rank, ep_addr_len);
+			ctx->data[ctx_id]->populate(gda_ops, all_addrs, ep_addr_len, nranks);
+
+			/*
+			 * Step 6: Create this ctx's signal/counter endpoints
+			 * (one per max(nSignals, nCounters)) and build the GPU
+			 * pointer arrays the kernel reads as
+			 * dev[ctx.contextId].counter_handles[] /
+			 * .signal_handles[].
+			 */
+			if (n_sc > 0) {
+				ctx->sc_endpoints[ctx_id].reserve(n_sc);
+				for (int i = 0; i < n_sc; i++) {
+					ctx->sc_endpoints[ctx_id].push_back(std::make_unique<gdaki_sc_endpoint>());
+					ctx->sc_endpoints[ctx_id][i]->open(ofi_domain, proxy_info, gda_ops);
+
+					std::vector<uint8_t> sc_addrs = allgather_ep_addr(
+						ctx->sc_endpoints[ctx_id][i]->base.endpoint.ep,
+						put_comm, nranks, rank, ep_addr_len);
+
+					ctx->sc_endpoints[ctx_id][i]->populate(gda_ops, sc_addrs,
+									  ep_addr_len, nranks);
+				}
+
+				auto build_handle_array = [&](gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> &buf,
+							      int count, auto get_dev_handle) {
+					if (count > 0) {
+						buf.allocate(count);
+						for (int i = 0; i < count; i++)
+							buf.host[i] = get_dev_handle(i);
+						buf.commit();
+					}
+				};
+				build_handle_array(*ctx->d_counter_handles[ctx_id], config->nCounters,
+					[&](int i) { return ctx->sc_endpoints[ctx_id][i]->counter_dev_handle.dev; });
+				build_handle_array(*ctx->d_signal_handles[ctx_id], config->nSignals,
+					[&](int i) { return ctx->sc_endpoints[ctx_id][i]->signal_dev_handle.dev; });
+			}
+
+			/*
+			 * Step 7: Fill this ctx's slot in dev_handles[]. Don't
+			 * commit yet — whole array committed once at end.
+			 */
+			populate_dev_handle(ctx->dev_handles.host[ctx_id], ctx.get(),
+					    ctx_id, nranks, rank);
+		}
+
+		/* Commit the whole dev_handles[] array (host → GPU) once. */
+		ctx->dev_handles.commit();
 
 		/*
 		 * Step 8: Publish the host-side ncclNetDeviceHandle_v11_t.
-		 *
-		 * On EFA, FI_EFA_GDA_OPS exposes MMIO-mappable SQ / CQ /
-		 * doorbell regions (query_qp_wqs, query_cq), so the GPU kernel
-		 * posts WQEs, rings the doorbell, and polls the CQ directly.
-		 * CQ polling is exclusively GPU-side; ginProgress has no CQ to
-		 * drain, so NCCL should not call it on this context.
+		 * The kernel indexes dev_handles[ctx.contextId] to pick the
+		 * per-ctx state. .size is the size of one entry, per the
+		 * NCCL GIN device-handle contract.
 		 */
 		dev_handle_out = static_cast<ncclNetDeviceHandle_v11_t *>(
 			calloc(1, sizeof(ncclNetDeviceHandle_v11_t)));
@@ -455,15 +503,15 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		}
 		dev_handle_out->netDeviceType = NCCL_NET_DEVICE_GIN_EFA_GDA;
 		dev_handle_out->netDeviceVersion = NCCL_NET_DEVICE_INVALID_VERSION;
-		dev_handle_out->handle = ctx->dev_handle.dev;
+		dev_handle_out->handle = ctx->dev_handles.dev;
 		dev_handle_out->size = sizeof(nccl_ofi_gin_gdaki_dev_handle);
 		dev_handle_out->needsProxyProgress = 0;
 
 		NCCL_OFI_INFO(NCCL_NET,
 			      "gin GDAKI: createContext done (nranks=%d rank=%d "
-			      "nSignals=%d nCounters=%d)",
+			      "nSignals=%d nCounters=%d nContexts=%d)",
 			      nranks, rank,
-			      config->nSignals, config->nCounters);
+			      config->nSignals, config->nCounters, nContexts);
 
 		*ginCtx = ctx.release();
 		*devHandle = dev_handle_out;


### PR DESCRIPTION
## Why
  
NCCL's GIN device API exposes ctx.contextId so the kernel picks its per-ctx state via blockIdx.x % comm.ginContextCount, and ctx.resourceSharingMode chooses GPU-scope or CTA-scope synchronization on that state. CTA mode uses block-scope atomics, which is correct only if each contextId maps to QPs touched by one CTA.
  
The plugin previously ignored config->nContexts and always allocated one (data EP + sc EPs) set per createContext, regardless of how many contexts NCCL requested. NCCL would hand out N logical context handles all backed by the same physical QPs. Distinct contextIds would still hit the same sq_lock, so CTA-mode block-scope atomics would race across CTAs. CTA mode was structurally unsafe in any workload with more than one CTA per ginCtx.
  
This PR makes the plugin honor nContexts so each contextId maps to its own endpoint set. With that, CTA mode is safe and the perf benefit (block-scope atomics, sharded sq_lock contention) becomes available.
  
## Validation
  
Validated on 2x p6.b200, GDAKI mode, NCCL 2.30.4. Multiple alltoall configurations covering the under-budget range run end-to-end with 0 wrong on every size; over-budget configurations are rejected by the capacity check with a clear diagnostic.