### PR TITLE
gin: Add flags param to v13 iput/iputSignal

### DIFF
--- a/3rd-party/nccl/cuda/include/nccl/gin_v13.h
+++ b/3rd-party/nccl/cuda/include/nccl/gin_v13.h
@@ -46,11 +46,11 @@ typedef struct {
 
   // Put operations
   ncclResult_t (*iput)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size,
-      uint64_t dstOff, void* dstMhandle, uint32_t rank, void** request);
+      uint64_t dstOff, void* dstMhandle, uint32_t rank, uint32_t flags, void** request);
   ncclResult_t (*iputSignal)(void* ginCtx, int context, uint64_t srcOff, void* srcMhandle,
       size_t size, uint64_t dstOff, void* dstMhandle,
       uint32_t rank, uint64_t signalOff, void *signalMhandle,
-      uint64_t signalValue, uint32_t signalOp, void** request);
+      uint64_t signalValue, uint32_t signalOp, uint32_t flags, void** request);
   ncclResult_t (*iget)(void* ginCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
       uint64_t localOff, void* localMhandle, uint32_t rank, void** request);
 

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -456,8 +456,10 @@ static ncclResult_t nccl_ofi_gin_destroyContext_v13(void *ginCtx)
 
 static ncclResult_t nccl_ofi_gin_iput_v13(void *ginCtx, int context, uint64_t srcOff,
 					  void *srcMhandle, size_t size, uint64_t dstOff,
-					  void *dstMhandle, uint32_t rank, void **request)
+					  void *dstMhandle, uint32_t rank, uint32_t flags,
+					  void **request)
 {
+	(void)flags;
 	return nccl_ofi_gin_iput(ginCtx, srcOff, srcMhandle, size,
 				 dstOff, dstMhandle, rank, request);
 }
@@ -466,8 +468,9 @@ static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint6
 						void *srcMhandle, size_t size, uint64_t dstOff,
 						void *dstMhandle, uint32_t rank, uint64_t signalOff,
 						void *signalMhandle, uint64_t signalValue,
-						uint32_t signalOp, void **request)
+						uint32_t signalOp, uint32_t flags, void **request)
 {
+	(void)flags;
 	return nccl_ofi_gin_iputSignal(ginCtx, srcOff, srcMhandle, size,
 				       dstOff, dstMhandle, rank, signalOff, signalMhandle,
 				       signalValue, signalOp, request);

--- a/tests/functional/gin.cpp
+++ b/tests/functional/gin.cpp
@@ -232,7 +232,7 @@ int main(int argc, char *argv[])
 			for (int i = 0; i < NUM_REQS_PER_PEER; ++i) {
 				void *request = nullptr;
 				OFINCCLCHECK(extGin->iput(proxyCtx, 0, 0, put_mhandle, SEND_SIZE, 0,
-							  put_mhandle, dst_rank, &request));
+							  put_mhandle, dst_rank, 0, &request));
 				assert(request != nullptr);
 				request_deque.push_back(request);
 			}
@@ -246,7 +246,7 @@ int main(int argc, char *argv[])
 								put_signal_mhandle, SEND_SIZE,
 								0, put_signal_mhandle,
 								dst_rank, 0, signal_mhandle, 1,
-								NCCL_NET_SIGNAL_OP_INC, &request));
+								NCCL_NET_SIGNAL_OP_INC, 0, &request));
 				assert(request != nullptr);
 				request_deque.push_back(request);
 			}


### PR DESCRIPTION
NCCL's v13 GIN API carries a uint32_t flags argument on iput() and iputSignal(), immediately before the request out-pointer. The bundled gin_v13.h and the proxy's iput_v13/iputSignal_v13 entry points still had the older flag-less prototype, so at runtime NCCL passed one more argument than the function declared. The flags value landed in the request parameter and *request = req then wrote the completion pointer through it, faulting on the first dispatch when DeepEP drives the GIN proxy.

Take the flags argument and ignore it (the proxy path has no use for it yet); the point is to match the ABI NCCL actually calls with.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
