### PR TITLE
gin: Add proxy dispatch batch as property

### DIFF
--- a/3rd-party/nccl/cuda/include/nccl/net_v12.h
+++ b/3rd-party/nccl/cuda/include/nccl/net_v12.h
@@ -45,6 +45,7 @@ typedef struct {
   int maxMultiRequestSize;         // Maximum number of requests supported in a single multi-request.
   int16_t railId;                  // rail ID associated with the netdev
   int16_t planeId;                 // plane ID associated with the netdev
+  int ginProxyDispatchBatch;       // GFDs GIN proxy may drain per peer per tick (<=1 means 1)
 } ncclNetProperties_v12_t;
 
 #define NCCL_NET_ATTR_UNDEF -1

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -406,4 +406,21 @@ OFI_NCCL_PARAM(GIN_TYPE, gin_type, "GIN_TYPE", GIN_TYPE::PROXY)
  */
 OFI_NCCL_PARAM(bool, gin_strong_signal, "GIN_STRONG_SIGNAL", true);
 
+/*
+ * Number of GFDs the GIN proxy progress loop may drain per
+ * (context, peer) per tick. Advertised to NCCL through the
+ * getProperties() field ginProxyDispatchBatch; the proxy honors it
+ * instead of carrying an EFA-specific knob in its own tree.
+ *
+ * The proxy thread pays a fixed per-tick cost (completion drain, queue
+ * walks, yield) regardless of how many posts it makes. On a deep GIN
+ * workload such as DeepEP dispatch the GFD queue is rarely empty, so
+ * draining several GFDs per tick amortizes that cost across more posts.
+ *
+ * Default: 1, which keeps the single-pull behavior NCCL had before the
+ * property existed. Larger values trade a touch of fairness across peers
+ * for throughput.
+ */
+OFI_NCCL_PARAM(int, gin_proxy_dispatch_batch, "GIN_PROXY_DISPATCH_BATCH", 1);
+
 #endif // End NCCL_OFI_PARAM_H_

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -447,6 +447,7 @@ static ncclResult_t nccl_ofi_gin_getProperties_v13(int dev, ncclNetProperties_v1
 	props->maxMultiRequestSize = 1;
 	props->railId = -1;
 	props->planeId = -1;
+	props->ginProxyDispatchBatch = (int)ofi_nccl_gin_proxy_dispatch_batch();
 
 	return ncclSuccess;
 }

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -147,6 +147,7 @@ static ncclResult_t nccl_ofi_gin_gdaki_get_properties(int dev, ncclNetProperties
 	props->maxMultiRequestSize = 1;
 	props->railId = -1;
 	props->planeId = -1;
+	props->ginProxyDispatchBatch = (int)ofi_nccl_gin_proxy_dispatch_batch();
 
 	return ncclSuccess;
 }


### PR DESCRIPTION
The GIN proxy progress loop in NCCL pulls at most one GFD per (context, peer) before falling through to its per-tick fixed cost (completion drain, queue walks, yield). On a deep workload the GFD queue is rarely empty, so that fixed cost dominates and throughput suffers.

Draining several GFDs per tick amortizes the cost, but the knob that controls it belongs on the plugin side, not baked into NCCL's tree as an EFA-specific env var. Advertise the count through the existing getProperties() path so NCCL can set it the same way it already derives the proxy queue size from maxRecvs. Default 1 preserves the single-pull behavior; OFI_NCCL_GIN_PROXY_DISPATCH_BATCH tunes it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
