### PR TITLE
Fix crash on healthy peers when connecting to a node with failed network

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6717,14 +6717,19 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 		if (OFI_UNLIKELY(s_comm == nullptr)) {
 			return -ENOMEM;
 		}
-		comm_state->comm = s_comm;
 
 		nccl_ofi_rdma_connection_info_t conn_msg;
 
 		this->prepare_send_connect_message(s_comm->local_comm_id, s_comm->ctrl_mailbox, s_comm->ctrl_mr_handle, &conn_msg);
 
 		/* Create connector */
-		s_comm->connector = this->cm->connect(*handle, &conn_msg, sizeof(conn_msg));
+		try {
+			s_comm->connector = this->cm->connect(*handle, &conn_msg, sizeof(conn_msg));
+		} catch (const std::exception &e) {
+			NCCL_OFI_WARN("CM connect failed: %s", e.what());
+			goto error;
+		}
+		comm_state->comm = s_comm;
 	}
 
 	/* Progress our engine to get completions */


### PR DESCRIPTION
*Description of changes:*

When a node exhausts its UARs, the EFA provider fails to initialize and NCCL falls back to socket transport producing an invalid peer address. Healthy peers receive this address and the plugin's connect function throws an exception when `fi_av_insert` rejects it. The exception skips the cleanup code, leaving a broken pointer behind. Next time NCCL polls, it dereferences that pointer and crashes. The fix catches the exception properly, cleans up, and marks the endpoint as unusable. Healthy peers now get a clean error instead of a segfault.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
