### PR TITLE
Fix nvtx compilation and GIN traces

### DIFF
--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -140,7 +140,7 @@
 
 #define NCCL_OFI_TRACE_GIN_WRITE_END(dev, rail_id, comm, rank, msg_seq_num, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_write_end, dev, rail_id, comm, rank, msg_seq_num, request); \
-	NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(request); \
+	NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(comm, msg_seq_num, request); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
@@ -150,7 +150,7 @@
 
 #define NCCL_OFI_TRACE_GIN_METADATA_SEND_END(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_metadata_send_end, dev, rail_id, size, comm, rank, msg_seq_num, request); \
-	NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(request); \
+	NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(comm, msg_seq_num, request); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_RECV_WRITE(dev, rail_id, size, comm, rank, msg_seq_num, request) do { \
@@ -166,7 +166,7 @@
 
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, comm, rank, msg_seq_num, request) do { \
 	lttng_ust_tracepoint(nccl_ofi_plugin, gin_signal_delivery_end, dev, comm, rank, msg_seq_num, request); \
-	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(request); \
+	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(comm, msg_seq_num, request); \
 } while(0)
 
 #define NCCL_OFI_TRACE_GIN_ACK_RECV(dev, rail_id, comm, rank, msg_seq_num) do { \

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -233,9 +233,10 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(request) do { \
+#define NCCL_OFI_TRACE_GIN_WRITE_END_NVTX(comm, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
-		nvtx_end_domain(0, (request)->trace_id); \
+		nvtxDomainHandle_t handle = ((nccl_ofi_rdma_gin_put_comm *)(comm))->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, (request)->trace_id); \
 	} \
 } while(0)
 
@@ -246,9 +247,10 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(request) do { \
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_END_NVTX(comm, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
-		nvtx_end_domain(0, (request)->trace_id); \
+		nvtxDomainHandle_t handle = ((nccl_ofi_rdma_gin_put_comm *)(comm))->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, (request)->trace_id); \
 	} \
 } while(0)
 
@@ -266,9 +268,10 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(request) do { \
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(comm, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
-		nvtx_end_domain(0, (request)->trace_id); \
+		nvtxDomainHandle_t handle = ((nccl_ofi_rdma_gin_put_comm *)(comm))->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_end_domain(handle, (request)->trace_id); \
 	} \
 } while(0)
 

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -261,6 +261,28 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
+/* When NCCL_OFI_TRACE_GIN_SIGNAL_END_MARK_ONLY is 1, signal delivery uses a
+ * lightweight mark at END instead of a start/end range pair. This avoids an
+ * Nsight Systems limitation where nvtxDomainRangeStartEx / nvtxDomainRangeEnd
+ * across different threads causes ~60% of ranges to appear unclosed.
+ * Set to 0 to restore the range-based version (e.g., when the threading model
+ * ensures same-thread BEGIN/END). */
+#define NCCL_OFI_TRACE_GIN_SIGNAL_END_MARK_ONLY (1)
+
+#if NCCL_OFI_TRACE_GIN_SIGNAL_END_MARK_ONLY
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request) do { \
+} while(0)
+
+#define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END_NVTX(comm, msg_seq_num, request) do { \
+	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
+		nvtxDomainHandle_t handle = ((nccl_ofi_rdma_gin_put_comm *)(comm))->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
+		nvtx_mark_domain(handle, "gin_signal_delivery_end", 0x9932CC); \
+	} \
+} while(0)
+
+#else /* Range-based version */
+
 #define NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN_NVTX(comm, rank, msg_seq_num, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
@@ -274,6 +296,8 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_end_domain(handle, (request)->trace_id); \
 	} \
 } while(0)
+
+#endif /* NCCL_OFI_TRACE_GIN_SIGNAL_END_MARK_ONLY */
 
 #define NCCL_OFI_TRACE_GIN_ACK_RECV_NVTX(comm, rail_id, rank, msg_seq_num) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -239,7 +239,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 	} \
 } while(0)
 
-#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, request) do { \
+#define NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN_NVTX(comm, rail_id, rank, msg_seq_num, size, request) do { \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) { \
 		nvtxDomainHandle_t handle = (comm)->nvtx_domain[msg_seq_num % NCCL_OFI_N_NVTX_DOMAIN_PER_COMM]; \
 		(request)->trace_id = nvtx_start_domain(true, handle, "gin_metadata_send", 0x4169E1); \


### PR DESCRIPTION
## trace: Fix GIN NVTX tracing issues

### Summary

This PR fixes several issues with NVTX tracing in the GIN signal delivery path, ensuring traces are correctly captured and visualized in Nsight Systems.

### Changes

1. Fix missing parameter in `GIN_METADATA_SEND_BEGIN_NVTX` — Add missing size parameter to the macro invocation introduced in 681f57b.

2. Use per-comm NVTX domain in GIN END macros — The `GIN_WRITE_END`, `GIN_METADATA_SEND_END`, and `GIN_SIGNAL_DELIVERY_END NVTX` macros were passing 0 as the domain handle instead of resolving the per-comm domain. Add comm and `msg_seq_num` 
parameters and cast to `nccl_ofi_rdma_gin_put_comm*` at the call sites where comm is `void*`.

3. Use mark for GIN signal delivery NVTX end event — Nsight Systems cannot reliably match `nvtxDomainRangeStartEx` / `nvtxDomainRangeEnd` when START and END are emitted from different threads (~60% of ranges appear unclosed). In the GIN path, BEGIN fires on the proxy CQ thread while END fires on whichever NCCL thread next calls `ginProgress` → `drain_gdrcopy_done_queue`. Replace with a lightweight `nvtx_mark_domain` at the END point, guarded by 
`NCCL_OFI_TRACE_GIN_SIGNAL_END_MARK_ONLY` (set to 0 to restore range-based version).

### Testing

- Built and ran ep_bench on 2-node p5en with NVTX tracing enabled
- Verified via nsys sqlite export: all GIN event types now show 100% closure with zero drops
- Confirmed that `gin_signal_delivery_end` has enough visual differentiation from other mark events.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
