### PR TITLE
Backport rdma fixes to v1.20.x: invalid-peer segfault + ECANCELLED removal

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -1613,20 +1613,7 @@ int nccl_net_ofi_rdma_context::handle_error_entry(struct fid_cq *cq,
 						  struct fi_cq_err_entry *err_entry,
 						  uint16_t rail_id)
 {
-	int ret = 0;
 	nccl_net_ofi_rdma_req *req = NULL;
-
-	if (err_entry->err == FI_ECANCELED) {
-		/* Closing an EP with posted receives will (erroneously) generate
-		   cancellation events for the posted receives with the EFA provider
-		   in Libfabric versions prior to 1.22. These events are harmless
-		   and can be ignored.
-
-		   With Libfabric 1.22 and later, we shouldn't get these cancel
-		   events at all. The plugin does not explicitly call fi_cancel. */
-		ret = -(err_entry->err);
-		goto exit;
-	}
 
 	req = this->get_req(rail_id);
 	assert(req);
@@ -1653,9 +1640,7 @@ int nccl_net_ofi_rdma_context::handle_error_entry(struct fid_cq *cq,
 	 * how to deal with these, so it is safe to pass up the err as-is.
 	 * However, any special-handling for prov_errno should be handled here.
 	 */
-	ret = -(err_entry->err);
-exit:
-	return ret;
+	return -(err_entry->err);
 }
 
 
@@ -1822,14 +1807,7 @@ static inline int rdma_process_error_entry(struct fi_cq_err_entry *err_entry, st
 	nccl_net_ofi_context *ctx = cpp_container_of(op_ctx,
 						     &nccl_net_ofi_context::ofi_ctx);
 
-	int ret = ctx->handle_error_entry(cq, err_entry, rail_id);
-	if (ret == -FI_ECANCELED) {
-		/* Non-fatal cancellation event -- see comment in
-		   nccl_net_ofi_rdma_context::handle_error_entry. Ignore. */
-		return 0;
-	} else {
-		return ret;
-	}
+	return ctx->handle_error_entry(cq, err_entry, rail_id);
 }
 
 

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6717,14 +6717,19 @@ int nccl_net_ofi_rdma_ep_t::connect(nccl_net_ofi_conn_handle_t *handle,
 		if (OFI_UNLIKELY(s_comm == nullptr)) {
 			return -ENOMEM;
 		}
-		comm_state->comm = s_comm;
 
 		nccl_ofi_rdma_connection_info_t conn_msg;
 
 		this->prepare_send_connect_message(s_comm->local_comm_id, s_comm->ctrl_mailbox, s_comm->ctrl_mr_handle, &conn_msg);
 
 		/* Create connector */
-		s_comm->connector = this->cm->connect(*handle, &conn_msg, sizeof(conn_msg));
+		try {
+			s_comm->connector = this->cm->connect(*handle, &conn_msg, sizeof(conn_msg));
+		} catch (const std::exception &e) {
+			NCCL_OFI_WARN("CM connect failed: %s", e.what());
+			goto error;
+		}
+		comm_state->comm = s_comm;
 	}
 
 	/* Progress our engine to get completions */


### PR DESCRIPTION
## Summary

Backports two `rdma` bugfixes from `master` to `v1.20.x` via cherry-pick (`-x`).

| Backported | Upstream (master) | Subject |
|---|---|---|
| `4723207` | `ecc05c0` | rdma: fix segfault when connecting to a peer with invalid address |
| `d007970` | `6c68479` | rdma: Remove ECANCELLED handling |

Both touch only `src/nccl_ofi_rdma.cpp` and cherry-picked cleanly onto `v1.20.x`.

### ecc05c0 — invalid-peer segfault
When a peer loses EFA (e.g. UAR exhaustion) its address becomes garbage. The CM connector
constructor throws on `fi_av_insert` failure, bypassing the `error:` cleanup and leaving a
half-built `send_comm` in `comm_state`. On retry, NCCL dereferences the dangling pointer and
crashes. Fix catches the exception (routing to the existing `error:` label) and moves the
`comm_state->comm` assignment to after connector creation.

### 6c68479 — remove ECANCELLED handling
Removes the now-unnecessary special handling of `FI_ECANCELED` error completions. This became
unnecessary once the CQ moved to the endpoint structure (destroying an endpoint always destroys
its CQ). Side effect: firmware-cancelled operations (MR/AH closing) now propagate to NCCL so
error-handling can fire.