### PR TITLE
tests/gdaki: make efa-dp-direct submodule conditional on GDAKI + tests

### DIFF
--- a/3rd-party/Makefile.am
+++ b/3rd-party/Makefile.am
@@ -6,5 +6,4 @@
 
 EXTRA_DIST = \
 	boost \
-	efa-dp-direct \
 	nccl

--- a/configure.ac
+++ b/configure.ac
@@ -348,6 +348,18 @@ AS_IF([test "${enable_gdaki}" = "yes"],
              [AC_MSG_ERROR([--enable-gdaki requires CUDA support.])])
        AS_IF([test "${have_fi_efa_comp_cntr}" != "1"],
              [AC_MSG_ERROR([--enable-gdaki requires libfabric with the fi_efa_ops_gda hardware-counter ABI (libfabric >= 2.5.0).])])
+       dnl The GDAKI GPU functional tests build against the EFA device-side
+       dnl (CUDA) datapath headers from the amzn/efa-dp-direct submodule. That
+       dnl submodule is the ONLY consumer of efa-dp-direct, so it is not
+       dnl required for a non-GDAKI build and is not bundled in the release
+       dnl tarball. When GDAKI tests will actually be built (func tests on and
+       dnl nvcc present), require the submodule to be checked out and tell the
+       dnl developer how to get it; we deliberately do NOT fetch it ourselves.
+       AS_IF([test "${build_func_tests}" = "yes" -a "${check_nvcc_found}" = "yes" \
+              -a ! -f "${srcdir}/3rd-party/efa-dp-direct/CUDA/src/efa_cuda_dp.cuh"],
+             [AC_MSG_ERROR([--enable-gdaki builds the GDAKI GPU functional tests, which require the
+efa-dp-direct submodule, but 3rd-party/efa-dp-direct is not checked out.
+Run: git submodule update --init 3rd-party/efa-dp-direct])])
        have_gdaki=1],
       [have_gdaki=0])
 AC_DEFINE_UNQUOTED([HAVE_GDAKI], [${have_gdaki}], [Defined to 1 if GDAKI support is enabled])


### PR DESCRIPTION
The efa-dp-direct submodule is only needed to build the GDAKI GPU functional tests. Previously every clone fetched it via the default "git submodule update --init --recursive", and every release tarball bundled it via EXTRA_DIST, forcing the dependency on customers building without GDAKI (the default).

Make the dependency conditional:

- .gitmodules: mark the submodule "update = none" so a default "git submodule update --init [--recursive]" skips it. Non-GDAKI builders never fetch it.

- tests/functional/Makefile.am: initialize the submodule on demand via a BUILT_SOURCES stamp rule, gated inside ENABLE_FUNC_TESTS + ENABLE_GDAKI + HAVE_NVCC, using an explicit "git submodule update --init --checkout -- <path>" (the --checkout is required to override update=none). Errors clearly if a GDAKI test build is attempted from a non-git tree. The nvcc include path now resolves through EFA_DP_DIRECT_SRC.

- 3rd-party/Makefile.am: drop efa-dp-direct from EXTRA_DIST so non-GDAKI release tarballs do not bundle it.

Verified: a default "submodule update --init --recursive" skips the submodule; the gated explicit init populates it; autoreconf is clean.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
