### PR TITLE
Add histogram collection and printing API.

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -59,6 +59,7 @@ src/gin/nccl_ofi_gin_allgather.cpp
 src/gin/nccl_ofi_gin_api.cpp
 src/gin/nccl_ofi_gin_reqs.cpp
 src/gin/nccl_ofi_gin_resources.cpp
+src/stats/histogram.cpp
 src/nccl_ofi_api.cpp
 src/nccl_ofi_assert.cpp
 src/nccl_ofi_compat.cpp

--- a/configure.ac
+++ b/configure.ac
@@ -163,6 +163,7 @@ AS_IF([test "${have_device_interface}" = "no"],
 
 CHECK_PKG_LTTNG()
 CHECK_PKG_NVTX()
+CHECK_ENABLE_HISTOGRAM()
 
 do_cuda=0
 do_rocm=0

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -57,7 +57,12 @@ noinst_HEADERS = \
 	platform-aws.h \
 	internal/tuner/nccl_defaults.h \
 	stats/histogram.h \
+	stats/histogram_impl.h \
 	stats/histogram_binner.h \
+	stats/histogram_bin.h \
+	stats/histogram_def.h \
+	stats/histogram_formatter.h \
+	stats/histogram_formatter_impl.h \
 	tracing_impl/lttng.h \
 	tracing_impl/nvtx.h \
 	tuner/nccl_ofi_tuner_common.h \

--- a/include/stats/histogram.h
+++ b/include/stats/histogram.h
@@ -5,118 +5,459 @@
 #ifndef NCCL_OFI_STATS_HISTOGRAM
 #define NCCL_OFI_STATS_HISTOGRAM
 
+#include <atomic>
 #include <cassert>
 #include <chrono>
 #include <cstddef>
 #include <string>
 #include <sstream>
 #include <vector>
+#include <mutex>
+#include <unordered_set>
+#include <unordered_map>
 
-#include "nccl_ofi_log.h"
 #include "histogram_binner.h"
+#include "histogram_bin.h"
+#include "histogram_def.h"
+#include "histogram_formatter.h"
 
+#include "nccl_ofi_config_bottom.h"
+#include "nccl_ofi_log.h"
 
-//
-// Base histogram class.  Histograms are a lightweight mechanism for tracking
-// events occurances in code and are used for instrumenting the plugin code.
-//
-// T is the type of the data that will be inserted into the histogram.  Any POD
-//  will work, and little effort has been put into making the interface safe for
-//  non-Pods.
-//
-template <typename T, typename Binner>
-class histogram {
+// entire operation of histograms is controlled by this global API
+// by default it is set to true if plugin was built with --enable-histogram
+// user can still set it to true if needed (as in unit tests)
+extern bool histograms_enabled();
+extern void enable_histograms(bool enable);
+
+// forward declarations
+template <typename T> class histogram_formatter;
+template <typename T> class base_histogram;
+
+/**
+ * @brief A base interface for all histogram aggregator types (abstract away the sample type).
+ *
+ * @note Histogram aggregation allows collecting the same histogram from multiple threads
+ * concurrently. During plugin tear-down the data from all histograms is aggregated into one grand
+ * total and printed.
+ */
+class base_histogram_aggregator {
 public:
-	histogram(const std::string& description_arg, Binner binner_arg)
-		: description(description_arg), binner(binner_arg),
-		bins(binner.get_num_bins()), num_samples(0), first_insert(true)
+	base_histogram_aggregator() = default;
+
+	/** @brief Prints all histograms aggregated by this aggregator. */
+	virtual void print_histograms(PrintFormat print_format, bool skip_empty_bins) = 0;
+
+protected:
+	virtual ~base_histogram_aggregator() = default;
+};
+
+/** @brief A global manager of all histogram aggregators of all types. */
+class global_histogram_aggregator {
+public:
+	static global_histogram_aggregator &get_instance();
+
+	inline void register_histogram_aggregator(base_histogram_aggregator *aggregator)
+	{
+		std::lock_guard<std::mutex> guard(lock);
+		aggregators.push_back(aggregator);
+	}
+
+	/** @brief Prints all histograms from all aggregators. */
+	inline void print_all_histograms(PrintFormat print_format, bool skip_empty_bins)
+	{
+		load_env_override(print_format, skip_empty_bins);
+		std::lock_guard<std::mutex> guard(lock);
+		for (auto aggregator : aggregators) {
+			aggregator->print_histograms(print_format, skip_empty_bins);
+		}
+	}
+
+private:
+	std::mutex lock;
+	std::vector<base_histogram_aggregator *> aggregators;
+
+	global_histogram_aggregator() = default;
+	~global_histogram_aggregator() = default;
+
+	void load_env_override(PrintFormat &print_format, bool &skip_empty_bins);
+};
+
+/**
+ * @brief Aggregator of all histograms by name for a given sample type.
+ *
+ * @note Histograms with same name but different type will not be aggregated into the same
+ * grand-total, but rather each will have its own separate summary print.
+ */
+template <typename T> class histogram_aggregator : public base_histogram_aggregator {
+public:
+	static histogram_aggregator<T> &get_instance()
+	{
+		static histogram_aggregator<T> instance;
+		return instance;
+	}
+
+	/**
+	 * @brief Register histogram for auto-aggregation during plugin tear-down.
+	 *
+	 * @note This is for supporting the use case of global-scope histograms that have not been
+	 * aggregated by the time the plugin needs to shut down.
+	 */
+	void register_histogram(base_histogram<T> *hist);
+
+	/**
+	 * @brief Explicitly aggregates a histogram now.
+	 *
+	 * @note This is for supporting the case of local scope histograms that are about to be
+	 * destroyed and need to be added to the total aggregation of histograms sharing the same
+	 * name. This ensures it will be aggregaed now, and will not be aggregated again during
+	 * plugin tear-down.
+	 *
+	 * @note Calling this method several times for the same histogram will have effect only for
+	 * the first call, and the rest of the calls wil be ignored.
+	 */
+	void aggregate_histogram(base_histogram<T> *hist);
+
+	/** @brief Prints all histograms aggregated by this aggregator. */
+	void print_histograms(PrintFormat print_format, bool skip_empty_bins) override;
+
+private:
+	using histogram_set_type = std::unordered_set<base_histogram<T> *>;
+	using histogram_aggregation_type = std::pair<base_histogram<T> *, histogram_set_type>;
+	using histogram_map_type = std::unordered_map<std::string, histogram_aggregation_type>;
+	histogram_map_type histogram_map;
+
+	std::mutex histogram_map_lock;
+
+	histogram_aggregator()
+	{
+		global_histogram_aggregator::get_instance().register_histogram_aggregator(this);
+	}
+	~histogram_aggregator() = default;
+
+	bool aggregate_single_histogram(histogram_aggregation_type &histogram_agg,
+					const base_histogram<T> *hist,
+					bool print_warning = true);
+};
+
+/**
+ * @brief Base histogram class, for common aggregation and printing.
+ */
+template <typename T> class base_histogram {
+public:
+	virtual ~base_histogram()
+	{
+		// aggregate this histogram
+		// the following call has no effect if the histogram has already been finalized
+		if (auto_aggregate) {
+			histogram_aggregator<T>::get_instance().aggregate_histogram(this);
+		}
+	}
+
+	inline const char *get_description() const
+	{
+		return description.c_str();
+	}
+
+	inline const std::string &get_units() const
+	{
+		return units;
+	}
+
+	inline uint64_t get_factor() const
+	{
+		return factor;
+	}
+
+	inline size_t get_num_bins() const
+	{
+		return bins.size();
+	}
+
+	inline const bin<T> &get_bin(size_t index) const
+	{
+		return bins[index];
+	}
+
+	/** @brief Retrieves the upper bound for the required bin (not inclusive). */
+	inline const T &get_bin_upper_bound(size_t index) const
+	{
+		return bins[index].get_upper_bound();
+	}
+
+	/** @brief Retrieves the lower bound for the required bin. */
+	inline const T &get_bin_lower_bound(size_t index) const
+	{
+		return bins[index].get_lower_bound();
+	}
+
+	/** @brief Aggregates another histogram into this one. */
+	void aggregate(const base_histogram<T> &h)
+	{
+		assert(bins.size() == h.bins.size());
+		for (size_t i = 0; i < bins.size(); ++i) {
+			bins[i].aggregate(h.bins[i]);
+		}
+	}
+
+	/**
+	 * @brief Cancels auto aggregation.
+	 *
+	 * @note This is used by the histogram aggregator to designate that the histogram was
+	 * already aggregated (and should avoid additional aggregation during destruction when
+	 * auto-aggregation was scheduled).
+	 */
+	void cancel_auto_aggregate()
+	{
+		auto_aggregate = false;
+	}
+
+	/** @brief Clone this base histogram (required for aggregation). */
+	virtual base_histogram<T> *clone() const = 0;
+
+	/**
+	 * @brief Prints the histogram.
+	 * @param print_format The output print format.
+	 * @param skip_empty_bins Optioanlly specify whether empty bins should be printed or not (by
+	 * default yes).
+	 * @param formatter Optional custom user-provided print formatter. Used when printFormat is
+	 * set to PF_CUSTOM.
+	 */
+	void print_stats(PrintFormat print_format = PrintFormat::PF_TEXT,
+			 bool skip_empty_bins = false,
+			 histogram_formatter<T> *formatter = nullptr) const;
+
+protected:
+	std::string description;
+	std::string units;
+	uint64_t factor;
+	std::vector<bin<T>> bins;
+	bool enabled;
+	bool auto_aggregate;
+
+	base_histogram(const std::string &description_arg,
+		       const char *units_arg = "",
+		       uint64_t factor_arg = 1)
+	    : description(description_arg), units(units_arg), factor(factor_arg),
+	      enabled(histograms_enabled()), auto_aggregate(false)
 	{
 	}
 
-	void insert(const T& input_val)
+	base_histogram(const base_histogram<T> &h)
+	    : description(h.description), units(h.units), factor(h.factor), bins(h.bins),
+	      enabled(h.enabled), auto_aggregate(false)
 	{
-		if (OFI_UNLIKELY(first_insert)) {
-			max_val = min_val = input_val;
-			first_insert = false;
-		}
-
-		if (input_val > max_val) {
-			max_val = input_val;
-		} else if (input_val < min_val) {
-			min_val = input_val;
-		}
-
-		bins[binner.get_bin(input_val)]++;
-		num_samples++;
+		// NOTE: copy constructor sets auto-aggregate to false
 	}
 
-	void print_stats(void) {
-		auto range_labels = binner.get_bin_ranges();
+	/**
+	 * @brief registers this histogram for auto-finalization/aggregation (in case it gets out of
+	 * scope early).
+	 *
+	 * @note Derived classes should call this for enabling auto-aggregation, but be careful to
+	 * make the call only from the bottom-most class in the class hierarchy.
+	 *
+	 * @see timer_histogram constructor for an example how this should be done.
+	 */
+	inline void schedule_auto_aggregate()
+	{
+		if (enabled) {
+			histogram_aggregator<T>::get_instance().register_histogram(this);
+			auto_aggregate = true;
+		}
+	}
+};
 
-		NCCL_OFI_INFO(NCCL_NET, "histogram %s", description.c_str());
-		NCCL_OFI_INFO(NCCL_NET, "  min: %ld, max: %ld, num_samples: %lu",
-					(long int)min_val, (long int)max_val, num_samples);
-		for (size_t i = 0 ; i < bins.size() ; ++i) {
-			std::stringstream ss;
-			ss << "    " << range_labels[i] << " - ";
-			if (i + 1 != bins.size()) {
-				ss << range_labels[i + 1] - 1;
-			} else {
-				ss << "    ";
+/**
+ * @brief A histogram for measuring data distribution.
+ * @tparam BinGenerator The binner type.
+ * @tparam ClockType The clock type to use (not restricted to std::chrono clocks,
+ * so we can further optimize with direct TSC clock).
+ *
+ * @note Since we are measure only non-negative integer values, there is no motivation in using
+ * a template data type, and it is fixed as uint64_t.
+ */
+template <typename T, typename Binner> class histogram : public base_histogram<T> {
+public:
+	histogram(const std::string &description_arg,
+		  const Binner &binner_arg,
+		  const char *units_arg = "",
+		  uint64_t factor_arg = 1,
+		  bool enable_auto_aggregate = true)
+	    : base_histogram<T>(description_arg, units_arg, factor_arg), binner(binner_arg)
+	{
+		if (base_histogram<T>::enabled) {
+			init_bins();
+			if (enable_auto_aggregate) {
+				base_histogram<T>::schedule_auto_aggregate();
 			}
-			ss  << "    " << bins[i];
-			NCCL_OFI_INFO(NCCL_NET, "%s", ss.str().c_str());
+		}
+	}
+
+	histogram(const histogram<T, Binner> &h) : base_histogram<T>(h), binner(h.binner)
+	{
+		// NOTE: bins already initialized and copied data
+		// NOTE: copy constructor does not schedule auto-aggregation
+	}
+	~histogram() override
+	{
+	}
+
+	base_histogram<T> *clone() const override
+	{
+		return new (std::nothrow) histogram<T, Binner>(*this);
+	}
+
+	inline void insert(const T &input_val)
+	{
+		if (base_histogram<T>::enabled) {
+			uint64_t bin_index = binner.get_bin(input_val);
+			base_histogram<T>::bins[bin_index].add_sample(input_val);
 		}
 	}
 
 protected:
-	std::string description;
 	Binner binner;
-	std::vector<std::size_t> bins;
-	T max_val;
-	T min_val;
-	std::size_t num_samples;
-	bool first_insert;
+
+	void init_bins()
+	{
+		// NOTE: bin ranges each denote the lower bound of each bin
+		base_histogram<T>::bins.resize(binner.get_num_bins());
+		for (size_t i = 0; i < base_histogram<T>::bins.size(); ++i) {
+			base_histogram<T>::bins[i].set_lower_bound(binner.get_bin_ranges()[i]);
+			if (i + 1 < binner.get_num_bins()) {
+				base_histogram<T>::bins[i].set_upper_bound(
+					binner.get_bin_ranges()[i + 1]);
+			} else {
+				// put zero to denote no upper bound (last bin only), this affects
+				// printing only
+				base_histogram<T>::bins[i].set_upper_bound(get_zero_elem<T>());
+			}
+		}
+	}
 };
 
-
-//
-// Histogram class for tracking intervals.  A timer_histogram class can only
-// track one interval at a time, and will auto-insert the result when
-// stop_timer() is called.  Times are recorded in microseconds.
-//
-// T is the type of the data that will be inserted into the histogram.  Any POD
-//  will work, and little effort has been put into making the interface safe for
-//  non-Pods.
-template <typename Binner, typename clock = std::chrono::steady_clock, typename T  = std::size_t>
+/**
+ * @brief A histogram for measuring latency distribution.
+ * @tparam BinGenerator The binner type.
+ * @tparam ClockType The clock type to use (not restricted to std::chrono clocks,
+ * so we can further optimize with direct TSC clock).
+ *
+ * @note Since we are measure only non-negative integer values, there is no motivation in using
+ * a template data type, and it is fixed as uint64_t.
+ */
+template <typename Binner, typename clock = std::chrono::steady_clock, typename T = std::size_t>
 class timer_histogram : public histogram<T, Binner> {
 public:
 	using rep = T;
-	using histogram<T, Binner>::insert;
 
-	timer_histogram(const std::string &description_arg, Binner binner_arg)
-		: histogram<T, Binner>(description_arg, binner_arg)
+	timer_histogram(const std::string &description_arg,
+			const Binner &binner_arg,
+			const char *units_arg = "",
+			uint64_t factor_arg = 1,
+			bool enable_auto_aggregate = true)
+	    : histogram<T, Binner>(description_arg, binner_arg, units_arg, factor_arg, false)
+	{
+		// NOTE: this is a bit tricky, since auto-registration takes place at constructor,
+		// but the histogram aggregator needs to call a virtual function, so only the
+		// bottom-most clas in the class hierarchy can call the reigstration function (when
+		// the virtual function table is ready), otherwise we get pure virtual function call
+		// exception.
+		// For this reason, false was passed to parent class for enable_auto_aggregate, to
+		// avoid registration before the virtual function table is ready.
+		if (enable_auto_aggregate) {
+			base_histogram<T>::schedule_auto_aggregate();
+		}
+	}
+
+	timer_histogram(const timer_histogram<Binner, clock, T> &h) : histogram<T, Binner>(h)
+	{
+	}
+	~timer_histogram() override
 	{
 	}
 
-	void start_timer(void)
+	base_histogram<T> *clone() const override
 	{
-		start_time = clock::now();
-		asm volatile ("" : : : "memory");
+		return new (std::nothrow) timer_histogram<Binner, clock, T>(*this);
 	}
 
-	rep stop_timer(void)
+	/** @brief Marks start of latency measurement. */
+	inline void start_timer()
 	{
-		asm volatile ("" : : : "memory");
-		auto now = clock::now();
-		auto duration = std::chrono::duration_cast<std::chrono::microseconds>(now - start_time);
-		insert(duration.count());
-		return duration.count();
+		if (base_histogram<T>::enabled) {
+			start_time = clock::now();
+			// add compiler fence to ensure start timestamp is taken before measured
+			// activity
+			std::atomic_signal_fence(std::memory_order_seq_cst);
+		}
 	}
 
+	/** @brief Marks end of latency measurement. */
+	inline uint64_t stop_timer()
+	{
+		if (base_histogram<T>::enabled) {
+			// add compiler fence to ensure end timestamp is taken after measured
+			// activity
+			std::atomic_signal_fence(std::memory_order_seq_cst);
+			auto now = clock::now();
+			auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(
+				now - start_time);
+			histogram<T, Binner>::insert(duration.count());
+
+			// NOTE: this is returned only for sake of unit tests, so we return it in
+			// microseconds as the unit tests expect, but note that the sample was added
+			// as nanoseconds
+			return std::chrono::duration_cast<std::chrono::microseconds>(now -
+										     start_time)
+				.count();
+		}
+		return 0;
+	}
 
 protected:
 	typename clock::time_point start_time;
 };
 
+/**
+ * @brief Prints all histograms. Should be normally called during shutdown.
+ * @param print_format The histogram print format.
+ * @param skip_empty_bins Specifies whether empty bins should be printed or not.
+ *
+ * @note These values are overridable by the following environment variables:
+ * - OFI_HISTOGRAM_PRINT_FORMAT (string): text, table, csv, json
+ * - OFI_HISTOGRAM_SKIP_EMPTY_BINS (boolean)
+ */
+inline void print_all_histograms(PrintFormat print_format = PrintFormat::PF_TABLE,
+				 bool skip_empty_bins = false)
+{
+	if (histograms_enabled()) {
+		global_histogram_aggregator::get_instance().print_all_histograms(print_format,
+										 skip_empty_bins);
+	}
+}
+
+/**
+ * @brief A scoped histogram object RAII wrapper.
+ * @tparam A pointer type to the histogram.
+ */
+template <typename T> class scoped_histogram {
+public:
+	scoped_histogram(T &histogram) : m_histogram(histogram)
+	{
+		m_histogram.start_timer();
+	}
+	~scoped_histogram()
+	{
+		m_histogram.stop_timer();
+	}
+
+private:
+	T &m_histogram;
+};
+
 #endif
+
+// include inline histogram implementation
+#include "histogram_formatter_impl.h"
+#include "histogram_impl.h"

--- a/include/stats/histogram_bin.h
+++ b/include/stats/histogram_bin.h
@@ -1,0 +1,180 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_BIN
+#define NCCL_OFI_STATS_HISTOGRAM_BIN
+
+#include <cstdint>
+#include <vector>
+
+#include "nccl_ofi_config_bottom.h"
+
+/**
+ * @brief Helper for UDTs to get the "zero" element (so bin can have a default constructor required
+ * for std::vector). UDTs can specialize as required. Default implementation converts zero to the
+ * target type.
+ */
+template <typename T> inline const T &get_zero_elem()
+{
+	static T zero = 0;
+	return zero;
+}
+
+/**
+ * @brief A histogram bin that supports safe (without overflow) average.
+ * @tparam The aggregated sample type. Normally is a primitive type. UDT with overloaded arithmetic
+ * and integer conversion operators would work as well.
+ */
+template <typename T = uint64_t> class bin {
+public:
+	bin(const T &lower_bound_arg = get_zero_elem<T>(),
+	    const T &upper_bound_arg = get_zero_elem<T>())
+	    : lower_bound(lower_bound_arg), upper_bound(upper_bound_arg), sum(0), count(0),
+	      min_sample(0), max_sample(0), first_insert(true)
+	{
+	}
+
+	bin(const bin &) = default;
+	~bin() = default;
+
+	/** @brief Sets the bin's lower bound (inclusive). */
+	inline void set_lower_bound(const T &lower_bound_arg)
+	{
+		lower_bound = lower_bound_arg;
+	}
+
+	/** @brief Sets the bin's upper bound (not inclusive). */
+	inline void set_upper_bound(const T &upper_bound_arg)
+	{
+		upper_bound = upper_bound_arg;
+	}
+
+	/** @brief Adds a sample to the bin. */
+	void add_sample(const T &sample_value)
+	{
+		// despite this slight optimization, there is no way avoiding two if-statements here
+		if (OFI_UNLIKELY(first_insert)) {
+			max_sample = min_sample = sample_value;
+			first_insert = false;
+		} else if (sample_value > max_sample) {
+			max_sample = sample_value;
+		} else if (sample_value < min_sample) {
+			min_sample = sample_value;
+		}
+
+		// guard against overflow
+		T new_sum = sum + sample_value;
+		if (new_sum < sum || count == UINT64_MAX) {
+			prev_sums.push_back({ sum, count });
+			sum = sample_value;
+			count = 1;
+		} else {
+			sum = new_sum;
+			count++;
+		}
+	}
+
+	/** @brief Aggregates another bin into this bin. */
+	void aggregate(const bin<T> &b)
+	{
+		// return early if bin is empty
+		if (b.get_sample_count() == 0) {
+			return;
+		}
+		prev_sums.insert(prev_sums.end(), b.prev_sums.begin(), b.prev_sums.end());
+		// be careful of overflow
+		T new_sum = sum + b.sum;
+		uint64_t new_count = count + b.count;
+		if (new_sum < sum || new_count < count) {
+			prev_sums.push_back({ sum, count });
+			sum = b.sum;
+			count = b.count;
+		} else {
+			sum = new_sum;
+			count = new_count;
+		}
+
+		if (first_insert) {
+			min_sample = b.min_sample;
+			max_sample = b.max_sample;
+			first_insert = false;
+		} else {
+			if (b.min_sample < min_sample) {
+				min_sample = b.min_sample;
+			}
+			if (b.max_sample > max_sample) {
+				max_sample = b.max_sample;
+			}
+		}
+	}
+
+	/** @brief Retrieves the bin's lower bound. */
+	inline const T &get_lower_bound() const
+	{
+		return lower_bound;
+	}
+
+	/** @brief Retrieves the bin's upper bound. */
+	inline const T &get_upper_bound() const
+	{
+		return upper_bound;
+	}
+
+	/** @brief Retrieves the number of samples in this bin. */
+	uint64_t get_sample_count() const
+	{
+		uint64_t total_sample_count = count;
+		for (auto itr : prev_sums) {
+			uint64_t curr_count = itr.second;
+			total_sample_count += curr_count;
+		}
+		return total_sample_count;
+	}
+
+	/** @brief Retrieves the average of the samples in this bin. */
+	double get_avg() const
+	{
+		// do this carefully, we compute the avg in each sum/count pair seprately, then do a
+		// weighted avg so we don't overflow
+		double avg = 0.0f;
+		double total_sample_count = count;
+		for (auto itr : prev_sums) {
+			uint64_t curr_count = itr.second;
+			total_sample_count += curr_count;
+		}
+		for (auto itr : prev_sums) {
+			double curr_sum = (double)itr.first;
+			avg += curr_sum / total_sample_count;
+		}
+		// last part
+		if (count > 0) {
+			avg += ((double)sum) / total_sample_count;
+		}
+		return avg;
+	}
+
+	/** @brief Retrieves the minimum sample value in this bin. */
+	inline const T &get_min_sample() const
+	{
+		return min_sample;
+	}
+
+	/** @brief Retrieves the maximum sample value in this bin. */
+	inline const T &get_max_sample() const
+	{
+		return max_sample;
+	}
+
+private:
+	T lower_bound;
+	T upper_bound;
+	T sum;
+	uint64_t count;
+	T min_sample;
+	T max_sample;
+	std::vector<std::pair<T, uint64_t>> prev_sums;
+	bool first_insert;
+};
+
+#endif

--- a/include/stats/histogram_def.h
+++ b/include/stats/histogram_def.h
@@ -1,0 +1,31 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_DEF
+#define NCCL_OFI_STATS_HISTOGRAM_DEF
+
+// common definitions for histogram support
+
+/** @enum Histogram print format */
+enum class PrintFormat {
+	/** @brief Textual format (each bin in a line). */
+	PF_TEXT,
+
+	/** @brief Tabular format. */
+	PF_TABLE,
+
+	/** @brief CSV format (header row and data rows) */
+	PF_CSV,
+
+	/** @brief Json format. */
+	PF_JSON,
+
+	/** @brief Custom user format. */
+	PF_CUSTOM
+};
+
+// column justification constants for table printing
+enum class Justify { JUSTIFY_LEFT, JUSTIFY_CENTER, JUSTIFY_RIGHT };
+
+#endif // NCCL_OFI_STATS_HISTOGRAM_DEF

--- a/include/stats/histogram_formatter.h
+++ b/include/stats/histogram_formatter.h
@@ -1,0 +1,137 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_FORMATTER
+#define NCCL_OFI_STATS_HISTOGRAM_FORMATTER
+
+#include <iostream>
+
+#include "histogram_def.h"
+
+// forward declaration
+template <typename T> class base_histogram;
+
+/**
+ * @brief Helper for printing data into an output stream in a tabular form.
+ * @param title Table title.
+ * @param rows Data rows.
+ * @param col_justify Justification for each column.
+ * @param os The target output stream.
+ */
+extern void print_table(const std::string &title,
+			const std::vector<std::vector<std::string>> &rows,
+			const std::vector<Justify> &col_justify,
+			std::ostream &os);
+
+/** @brief Allow user to customize how histogram are formatted for printing. */
+template <typename T> class histogram_formatter {
+public:
+	virtual ~histogram_formatter() = default;
+
+	/**
+	 * @brief Format and print a histogram to the given output stream.
+	 * @param h The histogram to format.
+	 * @param skip_empty_bins Specifies whether empty bins should be printed or not.
+	 * @param os The output stream used to print the histogram.
+	 */
+	virtual void
+	format_histogram(const base_histogram<T> &h, bool skip_empty_bins, std::ostream &os) = 0;
+
+protected:
+	histogram_formatter() = default;
+};
+
+/** @brief Format histogram data as plain text. */
+template <typename T> class text_formatter : public histogram_formatter<T> {
+public:
+	static text_formatter<T> *get_instance()
+	{
+		static text_formatter<T> instance;
+		return &instance;
+	}
+
+	void format_histogram(const base_histogram<T> &h,
+			      bool skip_empty_bins,
+			      std::ostream &os) override;
+
+private:
+	text_formatter() = default;
+	~text_formatter() override = default;
+};
+
+/** @brief Format histogram data as a table. */
+template <typename T> class table_formatter : public histogram_formatter<T> {
+public:
+	static table_formatter<T> *get_instance()
+	{
+		static table_formatter<T> instance;
+		return &instance;
+	}
+
+	void format_histogram(const base_histogram<T> &h,
+			      bool skip_empty_bins,
+			      std::ostream &os) override;
+
+private:
+	table_formatter() = default;
+	~table_formatter() override = default;
+};
+
+/** @brief Format histogram data as CSV text. */
+template <typename T> class csv_formatter : public histogram_formatter<T> {
+public:
+	static csv_formatter<T> *get_instance()
+	{
+		static csv_formatter<T> instance;
+		return &instance;
+	}
+
+	void format_histogram(const base_histogram<T> &h,
+			      bool skip_empty_bins,
+			      std::ostream &os) override;
+
+private:
+	csv_formatter() = default;
+	~csv_formatter() override = default;
+};
+
+/** @brief Format histogram data as Json text. */
+template <typename T> class json_formatter : public histogram_formatter<T> {
+public:
+	static json_formatter<T> *get_instance()
+	{
+		static json_formatter<T> instance;
+		return &instance;
+	}
+
+	void format_histogram(const base_histogram<T> &h,
+			      bool skip_empty_bins,
+			      std::ostream &os) override;
+
+private:
+	json_formatter() = default;
+	~json_formatter() override = default;
+};
+
+template <typename T> inline histogram_formatter<T> *get_predefined_formatter(PrintFormat format)
+{
+	switch (format) {
+	case PrintFormat::PF_TEXT:
+		return text_formatter<T>::get_instance();
+
+	case PrintFormat::PF_TABLE:
+		return table_formatter<T>::get_instance();
+
+	case PrintFormat::PF_CSV:
+		return csv_formatter<T>::get_instance();
+
+	case PrintFormat::PF_JSON:
+		return json_formatter<T>::get_instance();
+
+	default:
+		return nullptr;
+	}
+}
+
+#endif

--- a/include/stats/histogram_formatter_impl.h
+++ b/include/stats/histogram_formatter_impl.h
@@ -1,0 +1,175 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_FORMATTER_IMPL
+#define NCCL_OFI_STATS_HISTOGRAM_FORMATTER_IMPL
+
+#include <iomanip>
+
+template <typename T>
+void text_formatter<T>::format_histogram(const base_histogram<T> &h,
+					 bool skip_empty_bins,
+					 std::ostream &os)
+{
+	for (size_t i = 0; i < h.get_num_bins(); ++i) {
+		const bin<T> &b = h.get_bin(i);
+		if (skip_empty_bins && b.get_sample_count() == 0) {
+			continue;
+		}
+		os << "Bin " << i << " [" << h.get_bin_lower_bound(i) << " - ";
+		if (i + 1 < h.get_num_bins()) {
+			os << h.get_bin_upper_bound(i);
+		} else {
+			os << "inf";
+		}
+		if (!h.get_units().empty()) {
+			os << " " << h.get_units();
+		}
+		os << "]: ";
+
+		if (b.get_sample_count() == 0) {
+			os << "no data" << std::endl;
+			continue;
+		}
+
+		double avg = b.get_avg() / h.get_factor();
+		os << "avg: " << std::setprecision(2) << std::fixed << avg
+		   << ", min: " << b.get_min_sample() / h.get_factor()
+		   << ", max: " << b.get_max_sample() / h.get_factor()
+		   << ", samples: " << b.get_sample_count() << std::endl;
+	}
+}
+
+template <typename T>
+void table_formatter<T>::format_histogram(const base_histogram<T> &h,
+					  bool skip_empty_bins,
+					  std::ostream &os)
+{
+	// prepare table data
+	std::string title = std::string(h.get_description()) + " histogram";
+	std::vector<std::vector<std::string>> bins;
+	bins.push_back({ "Range", "Average", "Min", "Max", "Sample Count" });
+	for (size_t i = 0; i < h.get_num_bins(); ++i) {
+		const bin<T> &b = h.get_bin(i);
+		if (skip_empty_bins && b.get_sample_count() == 0) {
+			continue;
+		}
+		std::stringstream ss;
+		ss << h.get_bin_lower_bound(i) << " - ";
+		if (i + 1 < h.get_num_bins()) {
+			ss << h.get_bin_upper_bound(i);
+		} else {
+			ss << "inf";
+		}
+		if (!h.get_units().empty()) {
+			ss << " " << h.get_units();
+		}
+		std::string time_range = ss.str();
+
+		ss.str(""); // clear stream
+		ss << std::setprecision(2) << std::fixed << (b.get_avg() / h.get_factor());
+		std::string avg =
+			b.get_sample_count() > 0 ? (ss.str() + " " + h.get_units()) : "N/A";
+		std::string min_val =
+			b.get_sample_count() > 0
+				? (std::to_string(b.get_min_sample() / h.get_factor()) + " " +
+				   h.get_units())
+				: "N/A";
+		std::string max_val =
+			b.get_sample_count() > 0
+				? (std::to_string(b.get_max_sample() / h.get_factor()) + " " +
+				   h.get_units())
+				: "N/A";
+		bins.push_back({ time_range,
+				 avg,
+				 min_val,
+				 max_val,
+				 std::to_string(b.get_sample_count()) });
+	}
+
+	// now print table to output stream
+	std::vector<Justify> justify = { Justify::JUSTIFY_CENTER,
+					 Justify::JUSTIFY_RIGHT,
+					 Justify::JUSTIFY_RIGHT,
+					 Justify::JUSTIFY_RIGHT,
+					 Justify::JUSTIFY_RIGHT };
+	print_table(title, bins, justify, os);
+}
+
+template <typename T>
+void csv_formatter<T>::format_histogram(const base_histogram<T> &h,
+					bool skip_empty_bins,
+					std::ostream &os)
+{
+	os << "bin-index,low-bound,high-bound,avg,min,max,count" << std::endl;
+	for (size_t i = 0; i < h.get_num_bins(); ++i) {
+		const bin<T> &b = h.get_bin(i);
+		if (skip_empty_bins && b.get_sample_count() == 0) {
+			continue;
+		}
+		os << i << "," << h.get_bin_lower_bound(i) << ",";
+		if (i + 1 < h.get_num_bins()) {
+			os << h.get_bin_upper_bound(i);
+		} else {
+			os << "inf";
+		}
+		// NOTE: units are not printed in CSV format
+		os << ",";
+
+		if (b.get_sample_count() == 0) {
+			os << "0,0,0,0" << std::endl;
+			continue;
+		}
+
+		double avg = b.get_avg() / h.get_factor();
+		os << std::setprecision(2) << std::fixed << avg << ","
+		   << b.get_min_sample() / h.get_factor() << ","
+		   << b.get_max_sample() / h.get_factor() << "," << b.get_sample_count()
+		   << std::endl;
+	}
+}
+
+template <typename T>
+void json_formatter<T>::format_histogram(const base_histogram<T> &h,
+					 bool skip_empty_bins,
+					 std::ostream &os)
+{
+	os << "{" << std::endl;
+	os << "  \"name\": \"" << h.get_description() << "\"," << std::endl;
+	os << "  \"bins\": [" << std::endl;
+	for (size_t i = 0; i < h.get_num_bins(); ++i) {
+		const bin<T> &b = h.get_bin(i);
+		if (skip_empty_bins && b.get_sample_count() == 0) {
+			continue;
+		}
+
+		os << "    { \"start\": " << h.get_bin_lower_bound(i) << ", \"end\": ";
+		if (i + 1 < h.get_num_bins()) {
+			os << h.get_bin_upper_bound(i);
+		} else {
+			// NOTE: putting here "inf" string value
+			os << "\"inf\"";
+		}
+
+		if (b.get_sample_count() == 0) {
+			os << ", \"avg\": \"N/A\", \"min\": \"N/A\", \"max\": \"N/A\", \"count\": "
+			      "0 }";
+		} else {
+			double avg = b.get_avg() / h.get_factor();
+			os << ", \"avg\": " << std::setprecision(2) << std::fixed << avg
+			   << ", \"min\": " << b.get_min_sample() / h.get_factor()
+			   << ", \"max\": " << b.get_max_sample() / h.get_factor()
+			   << ", \"count\": " << b.get_sample_count() << " }";
+		}
+
+		if (i + 1 < h.get_num_bins()) {
+			os << ",";
+		}
+		os << std::endl;
+	}
+	os << "  ]" << std::endl;
+	os << "}";
+}
+
+#endif

--- a/include/stats/histogram_impl.h
+++ b/include/stats/histogram_impl.h
@@ -1,0 +1,161 @@
+//
+// Copyright (c) 2025 Amazon.com, Inc. or its affiliates. All rights reserved.
+//
+
+#ifndef NCCL_OFI_STATS_HISTOGRAM_IMPL
+#define NCCL_OFI_STATS_HISTOGRAM_IMPL
+
+#include "histogram.h"
+
+template <typename T> void histogram_aggregator<T>::register_histogram(base_histogram<T> *hist)
+{
+	std::lock_guard<std::mutex> guard(histogram_map_lock);
+
+	auto pairib = histogram_map.insert(
+		{ hist->get_description(), { nullptr, histogram_set_type() } });
+	auto &histogram_agg = pairib.first->second;
+	auto &histogram_set = histogram_agg.second;
+	if (!histogram_set.insert(hist).second) {
+		NCCL_OFI_WARN("Cannot register histogram %s: already registered",
+			      hist->get_description());
+	}
+	if (histogram_agg.first == nullptr) {
+		// NOTE: at time of clone the histogram has no sample data
+		histogram_agg.first = hist->clone();
+		if (histogram_agg.first == nullptr) {
+			NCCL_OFI_WARN("Cannot register histogram %s: failed to clone histogram for "
+				      "aggregation",
+				      hist->get_description());
+		}
+	}
+}
+
+template <typename T> void histogram_aggregator<T>::aggregate_histogram(base_histogram<T> *hist)
+{
+	std::lock_guard<std::mutex> guard(histogram_map_lock);
+
+	// get the histogram set
+	auto itr = histogram_map.find(hist->get_description());
+	if (itr == histogram_map.end()) {
+		NCCL_OFI_WARN("Cannot aggregate histogram %s: name group unrecognized",
+			      hist->get_description());
+		return;
+	}
+	auto &histogram_agg = itr->second;
+
+	// make sure it was registered
+	auto itr2 = histogram_agg.second.find(hist);
+	if (itr2 == histogram_agg.second.end()) {
+		NCCL_OFI_WARN("Cannot aggregate histogram %s: not registered in set",
+			      hist->get_description());
+		return;
+	}
+
+	// now aggregate
+	aggregate_single_histogram(histogram_agg, hist);
+
+	// in any case it must be removed from the set now, since it might go out of scope (e.g.
+	// local variable)
+	histogram_agg.second.erase(itr2);
+
+	// NOTE: for global scope objects (whose destructor will be called later, during CRT
+	// shutdown sequence), we would like to avoid a second call to aggregate the object (from
+	// within its destructor)
+	hist->cancel_auto_aggregate();
+}
+
+template <typename T>
+void histogram_aggregator<T>::print_histograms(PrintFormat print_format, bool skip_empty_bins)
+{
+	NCCL_OFI_TRACE(NCCL_ALL, "Aggregating all histograms");
+	// go over all groups, and for each group aggregate remaining histogram, and finally print
+	for (auto &kv : histogram_map) {
+		auto &histogram_agg = kv.second;
+		auto &histogram_set = histogram_agg.second;
+		bool warn_printed = false; // print warning only once per histogram set
+		while (!histogram_set.empty()) {
+			auto itr = histogram_set.begin();
+			auto hist = *itr;
+			bool print_warning = !warn_printed;
+			bool res = aggregate_single_histogram(histogram_agg, hist, print_warning);
+			if (!res && !warn_printed) {
+				warn_printed = true;
+			}
+			// remove histogram from set after being aggregated into grand-total
+			// NOTE: caller is responsible for managing histogram memory/life-cycle
+			histogram_set.erase(itr);
+
+			// NOTE: for global scope objects (whose destructor will be called later,
+			// during CRT shutdown sequence), we would like to avoid a second call to
+			// aggregate the object (from within its destructor)
+			hist->cancel_auto_aggregate();
+		}
+	}
+
+	// now print aggregated histograms and release memory of aggregate histogram
+	NCCL_OFI_TRACE(NCCL_ALL, "Printing all histograms");
+	for (auto &kv : histogram_map) {
+		auto &histogram_agg = kv.second;
+		if (histogram_agg.first != nullptr) {
+			histogram_agg.first->print_stats(print_format, skip_empty_bins);
+			delete histogram_agg.first;
+			histogram_agg.first = nullptr;
+		}
+	}
+	histogram_map.clear();
+}
+
+
+template <typename T>
+bool histogram_aggregator<T>::aggregate_single_histogram(histogram_aggregation_type &histogram_agg,
+							 const base_histogram<T> *hist,
+							 bool print_warning /* = true */)
+{
+	bool res = true;
+	if (histogram_agg.first == nullptr) {
+		// allocate aggregate histogram on-demand
+		histogram_agg.first = hist->clone();
+		if (histogram_agg.first == nullptr) {
+			if (print_warning) {
+				NCCL_OFI_WARN("Cannot aggregate histogram %s: failed to clone "
+					      "first histogram for aggregation",
+					      hist->get_description());
+			}
+			res = false;
+		}
+	} else {
+		histogram_agg.first->aggregate(*hist);
+	}
+	return res;
+}
+
+/**
+ * @brief Prints the histogram.
+ * @param print_format The output print format.
+ * @param skip_empty_bins Optioanlly specify whether empty bins should be printed or not (by
+ * default yes).
+ */
+template <typename T>
+void base_histogram<T>::print_stats(PrintFormat print_format /* = PrintFormat::TEXT */,
+				    bool skip_empty_bins /* = false */,
+				    histogram_formatter<T> *formatter /* = nullptr */) const
+{
+	// however we format the output, we must avoid printing to stdout line by line,
+	// since in multi-rank use cases (as in SLURM), the output of multiple histograms
+	// from different ranks will be printed together, all mixed up
+	std::ostringstream oss;
+	if (print_format != PrintFormat::PF_CUSTOM) {
+		formatter = get_predefined_formatter<T>(print_format);
+	}
+	if (formatter == nullptr) {
+		// deny request
+		NCCL_OFI_WARN("Cannot print histograms, invalid print format or internal error");
+		return;
+	}
+	formatter->format_histogram(*this, skip_empty_bins, oss);
+
+	// now print histogram
+	NCCL_OFI_INFO(NCCL_ALL, "Histogram [%s] data: \n%s", get_description(), oss.str().c_str());
+}
+
+#endif

--- a/m4/check_enable_histogram.m4
+++ b/m4/check_enable_histogram.m4
@@ -1,0 +1,24 @@
+# -*- Autoconf -*-
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+
+# Check for --enable-histogram flag in configure.
+#
+# This configure option is used to enable histogram data collection and printing.
+#
+# With this option enabled, all OFI_HISTOGRAM_XXX() macros are enabled, and histogram
+# data will be collected.
+#
+# See include/nccl_ofi_prof.h for the histogram API.
+#
+AC_DEFUN([CHECK_ENABLE_HISTOGRAM],[
+  AC_ARG_ENABLE([histogram],
+     [AS_HELP_STRING([--enable-histogram],
+         [Enable histogram data collection and printing. (default: Disabled)])])
+
+  AS_IF([test "${enable_histogram}" = "yes"], [histogram_define=1], [histogram_define=0])
+  AC_DEFINE_UNQUOTED([ENABLE_HISTOGRAM], [${histogram_define}], [Defined to 1 if histogram data collection is enabled, 0 otherwise])])
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -35,7 +35,8 @@ sources = \
 	nccl_ofi_ep_addr_list.cpp \
 	nccl_ofi_param.cpp \
 	nccl_ofi_platform.cpp \
-	tracepoint.cpp
+	tracepoint.cpp \
+	stats/histogram.cpp
 
 if WANT_PLATFORM_AWS
 sources += platform-aws.cpp

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -10,6 +10,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 #include "nccl_ofi_param.h"
+#include "stats/histogram.h"
 
 
 static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
@@ -95,6 +96,7 @@ ncclResult_t nccl_net_ofi_fini()
 		NCCL_OFI_WARN("Finalizing already finalized plugin");
 		ret = check_return(ncclSystemError);
 	} else {
+		print_all_histograms();
 		delete plugin;
 		plugin = NULL;
 	}

--- a/src/stats/histogram.cpp
+++ b/src/stats/histogram.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "stats/histogram.h"
+
+#include <cstring>
+
+#include "config.h"
+#include "nccl_ofi_log.h"
+
+#if ENABLE_HISTOGRAM == 1
+static bool histograms_enabled_cfg = true;
+#else
+static bool histograms_enabled_cfg = false;
+#endif
+
+bool histograms_enabled()
+{
+	return histograms_enabled_cfg;
+}
+
+void enable_histograms(bool enable)
+{
+	histograms_enabled_cfg = enable;
+}
+
+global_histogram_aggregator &global_histogram_aggregator::get_instance()
+{
+	static global_histogram_aggregator instance;
+	return instance;
+}
+
+static void parse_print_format(const char *print_format_str, PrintFormat &print_format)
+{
+	if (strcasecmp(print_format_str, "TEXT") == 0) {
+		print_format = PrintFormat::PF_TEXT;
+	} else if (strcasecmp(print_format_str, "TABLE") == 0) {
+		print_format = PrintFormat::PF_TABLE;
+	} else if (strcasecmp(print_format_str, "CSV") == 0) {
+		print_format = PrintFormat::PF_CSV;
+	} else if (strcasecmp(print_format_str, "JSON") == 0) {
+		print_format = PrintFormat::PF_JSON;
+	} else {
+		NCCL_OFI_WARN("Unrecognized histogram print format: %s, ignoring",
+			      print_format_str);
+	}
+}
+
+static void parse_bool(const char *bool_str, bool &bool_value, const char *var_name)
+{
+	if (strcasecmp(bool_str, "true") == 0 || strcasecmp(bool_str, "yes") == 0 ||
+	    strcasecmp(bool_str, "on") == 0) {
+		bool_value = true;
+	} else if (strcasecmp(bool_str, "false") == 0 || strcasecmp(bool_str, "no") == 0 ||
+		   strcasecmp(bool_str, "off") == 0) {
+		bool_value = false;
+	} else {
+		NCCL_OFI_WARN("Unrecognized histogram %s flag: %s, ignoring", var_name, bool_str);
+	}
+}
+
+static void parse_skip_empty_bins(char *skip_empty_binsStr, bool &skip_empty_bins)
+{
+	parse_bool(skip_empty_binsStr, skip_empty_bins, "skip-empty-bins");
+}
+
+void global_histogram_aggregator::load_env_override(PrintFormat &print_format,
+						    bool &skip_empty_bins)
+{
+	char *print_format_str = getenv("OFI_HISTOGRAM_PRINT_FORMAT");
+	if (print_format_str != nullptr) {
+		parse_print_format(print_format_str, print_format);
+	}
+	char *skip_empty_binsStr = getenv("OFI_HISTOGRAM_SKIP_EMPTY_BINS");
+	if (skip_empty_binsStr != nullptr) {
+		parse_skip_empty_bins(skip_empty_binsStr, skip_empty_bins);
+	}
+}
+
+static size_t get_total_column_width(const std::vector<size_t> &col_width)
+{
+	size_t total = 0;
+	for (size_t w : col_width) total += w;
+	total += col_width.size() - 1;
+	return total;
+}
+
+static void print_table_border(std::ostream &os, const std::vector<size_t> &col_width)
+{
+	os << "+" << std::string(get_total_column_width(col_width), '-') << "+" << std::endl;
+}
+
+static void print_row_border(std::ostream &os, const std::vector<size_t> &col_width)
+{
+	os << "+";
+	for (size_t w : col_width) {
+		os << std::string(w, '-') << "+";
+	}
+	os << std::endl;
+}
+
+static void
+print_column(std::ostream &os, const std::string &value, size_t col_width, Justify justify)
+{
+	size_t padding = col_width - value.length();
+	size_t left = 0;
+	if (justify == Justify::JUSTIFY_LEFT)
+		left = 1;
+	else if (justify == Justify::JUSTIFY_CENTER)
+		left = padding / 2;
+	else if (justify == Justify::JUSTIFY_RIGHT)
+		left = padding - 1;
+	size_t right = padding - left;
+	os << std::string(left, ' ') << value << std::string(right, ' ');
+}
+
+static void
+print_title(std::ostream &os, const std::string &title, const std::vector<size_t> &col_width)
+{
+	os << "|";
+	print_column(os, title, get_total_column_width(col_width), Justify::JUSTIFY_CENTER);
+	os << "|" << std::endl;
+}
+
+static void print_row(std::ostream &os,
+		      const std::vector<std::string> &row,
+		      const std::vector<size_t> &col_width,
+		      const std::vector<Justify> &col_justify)
+{
+	os << "|";
+	for (size_t i = 0; i < row.size(); ++i) {
+		print_column(os, row[i], col_width[i], col_justify[i]);
+		os << "|";
+	}
+	os << std::endl;
+}
+
+void print_table(const std::string &title,
+		 const std::vector<std::vector<std::string>> &rows,
+		 const std::vector<Justify> &col_justify,
+		 std::ostream &os)
+{
+	if (rows.empty()) {
+		// no data, silently ignore request
+		return;
+	}
+
+	std::vector<size_t> col_width(rows[0].size(), 0);
+	for (auto &row : rows) {
+		for (size_t i = 0; i < row.size(); ++i) {
+			// reserve space on both sides
+			col_width[i] = std::max(col_width[i], row[i].length() + 2);
+		}
+	}
+	// if the title width is larger than table width, expand each column width evenly, if not
+	// divisible, then last column gets excess space
+	if (title.length() + 2 > get_total_column_width(col_width)) {
+		size_t extra = title.length() + 2 - get_total_column_width(col_width);
+		size_t inc = extra / col_width.size();
+		size_t remainder = extra % col_width.size();
+		for (size_t i = 0; i < col_width.size(); ++i)
+			col_width[i] += inc + (i == col_width.size() - 1 ? remainder : 0);
+	}
+
+	if (!title.empty()) {
+		print_table_border(os, col_width);
+		print_title(os, title, col_width);
+	}
+	// first row should have all center justify
+	std::vector<Justify> colTitleJustify(col_width.size(), Justify::JUSTIFY_CENTER);
+	for (size_t i = 0; i < rows.size(); ++i) {
+		print_row_border(os, col_width);
+		print_row(os, rows[i], col_width, i == 0 ? colTitleJustify : col_justify);
+	}
+	print_table_border(os, col_width);
+}

--- a/tests/unit/histogram.cpp
+++ b/tests/unit/histogram.cpp
@@ -17,6 +17,8 @@
 		exit(1);				      \
 	}
 
+
+
 // wrapper around histogram to get access to the results to verify
 template <typename T, class Binner>
 class test_histogram : public histogram<T, Binner> {
@@ -26,7 +28,7 @@ public:
 	{
 	}
 
-	const std::vector<std::size_t> & get_results(void)
+	const std::vector<bin<T>> & get_results(void)
 	{
 		return this->bins;
 	}
@@ -35,6 +37,9 @@ public:
 
 static void check_histogram(void)
 {
+	// NOTE: this is required for testing in case --enable-histogram was not specified in build
+	enable_histograms(true);
+
 	using Binner = histogram_linear_binner<int>;
 
 	test_histogram<int, Binner> histogram("testing!",
@@ -55,11 +60,11 @@ static void check_histogram(void)
 
 	auto results = histogram.get_results();
 	CHECK_AND_EXIT(results.size() == 5);
-	CHECK_AND_EXIT(results[0] == 3);
-	CHECK_AND_EXIT(results[1] == 2);
-	CHECK_AND_EXIT(results[2] == 2);
-	CHECK_AND_EXIT(results[3] == 2);
-	CHECK_AND_EXIT(results[4] == 3);
+	CHECK_AND_EXIT(results[0].get_sample_count() == 3);
+	CHECK_AND_EXIT(results[1].get_sample_count() == 2);
+	CHECK_AND_EXIT(results[2].get_sample_count() == 2);
+	CHECK_AND_EXIT(results[3].get_sample_count() == 2);
+	CHECK_AND_EXIT(results[4].get_sample_count() == 3);
 
 	histogram.print_stats();
 }


### PR DESCRIPTION
Histogram macros are enabled with "--enable-histogram" build option,
without which all macros are compiled as empty macros (no code compiled).

This API was added to standardize the usage of statistic histogram data collection and printing in the plugin.

*Issue #, if available:* None

*Description of changes:*

Added build option "--enable-histogram" to enable feature.
Histogram data can now be collected via macros as described in include/nccl_ofi_prof.h.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
