### PR TITLE
gin: Support duplicate MR registration via refcounting

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -490,7 +490,11 @@ private:
 
 	   TODO: we could also just pass this in the handle to avoid a map
 	   lookup. Not sure yet if that is the right thing to do. */
-	std::unordered_map<void *, nccl_ofi_rdma_gin_symm_mr_handle *> mr_handle_map;
+	struct nccl_ofi_rdma_gin_mr_map_entry {
+		nccl_ofi_rdma_gin_symm_mr_handle *handle;
+		int refcnt;
+	};
+	std::unordered_map<void *, nccl_ofi_rdma_gin_mr_map_entry> mr_handle_map;
 
 	/* --- TIER 5: setup / teardown only --- */
 	uint32_t local_comm_id;

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -317,18 +317,36 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 {
 	auto &gin_ep = resources.get_ep();
 
+	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
+	/* Check for duplicate registration */
+	auto it = mr_handle_map.find(data_ptr);
+	if (it != mr_handle_map.end()) {
+		if (it->second.handle->size >= size) {
+			/* Existing MR covers the requested region */
+			it->second.refcnt++;
+			*mr_handle_out = it->second.handle;
+			return 0;
+		}
+		/* Existing MR is too small. We do not support upgrading
+		   an existing registration to a larger size. */
+		NCCL_OFI_WARN("regMrSym for ptr %p with size %zu but existing registration "
+			      "has size %zu", data_ptr, size, it->second.handle->size);
+		return -EINVAL;
+	}
+
 	auto *mr_handle = new nccl_ofi_rdma_gin_symm_mr_handle {};
 
 	NCCL_OFI_TRACE(NCCL_NET, "regMrSymDmaBuf ptr %p size %zu type %d flags %lu handle %p",
 		       data_ptr, size, type, mrFlags, mr_handle);
 
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
 	/**
 	 * Local registration with the endpoint
 	 */
 	int ret = gin_ep.reg_mr(ckey, type, &mr_handle->local_handle);
 	if (ret != 0) {
 		NCCL_OFI_WARN("Local endpoint memory registration failed: %d", ret);
+		delete mr_handle;
 		return ret;
 	}
 
@@ -342,15 +360,14 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 	 * Populate this rank's metadata lookup table entry
 	 */
 	my_remote_mr.address = reinterpret_cast<uintptr_t>(mr_handle->input_address);
-
 	if (virt_addr_mr) {
 		my_remote_mr.address_offset = my_remote_mr.address;
 	} else {
 		my_remote_mr.address_offset = 0;
 	}
-
 	my_remote_mr.num_rails = gin_ep.get_num_rails();
 
+	auto *local_handle = mr_handle->local_handle;
 	if (type == NCCL_PTR_CUDA) {
 		/* For CUDA registrations, we also register the memory with
 		   GDRCopy, in case we are asked to do a signal update to this
@@ -359,43 +376,35 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 							mr_handle->gdr_handle);
 		if (ret != 0) {
 			NCCL_OFI_WARN("GDRCopy registration failed: %d", ret);
-			delete mr_handle;
-			return ret;
+			goto err;
 		}
 	}
 
-	auto *local_handle = mr_handle->local_handle;
 	for (unsigned i = 0; i < gin_ep.get_num_rails(); ++i) {
 		my_remote_mr.mr_key[i] = fi_mr_key(local_handle->get_mr(i));
 		if (my_remote_mr.mr_key[i] == FI_KEY_NOTAVAIL) {
 			NCCL_OFI_WARN("Memory registration key is not available");
-			delete mr_handle;
-			return -EIO;
+			ret = -EIO;
+			goto err;
 		}
 	}
 
-	/* Insert the symmetric MR handle into a lookup table for the signal
-	   path */
-	auto insert_res = mr_handle_map.insert(std::make_pair(mr_handle->input_address, mr_handle));
-	if (!insert_res.second) {
-		/* TODO: this is a duplicate registration of the same address. We should
-		   be able to support this, but it doesn't work today. */
-		NCCL_OFI_WARN("Error inserting MR handle to map for ptr %p: entry exists",
-			      mr_handle->input_address);
-		delete mr_handle;
-		return -EEXIST;
-	}
+	mr_handle_map.insert(std::make_pair(data_ptr, nccl_ofi_rdma_gin_mr_map_entry{mr_handle, 1}));
 
 	/* Exchange MR metadata with all ranks using AG ring */
 	ret = ag_comm.all_gather(mr_handle->remote_mr.data(), sizeof(gin_remote_mr));
 	if (ret != 0) {
-		mr_handle_map.erase(mr_handle->input_address);
+		mr_handle_map.erase(data_ptr);
 		delete mr_handle;
 		return ret;
 	}
 
 	*mr_handle_out = mr_handle;
 	return 0;
+
+err:
+	delete mr_handle;
+	return ret;
 }
 
 int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle_base)
@@ -406,6 +415,16 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 	auto &gin_ep = resources.get_ep();
 	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
 
+	auto it = mr_handle_map.find(mr_handle->input_address);
+	if (it == mr_handle_map.end()) {
+		return -ENOENT;
+	}
+
+	if (--it->second.refcnt > 0) {
+		/* Still in use by other registrations */
+		return 0;
+	}
+
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		int ret = get_device_copy().deregister_region(mr_handle->gdr_handle);
 		if (ret != 0) {
@@ -415,10 +434,7 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 		mr_handle->gdr_handle = nullptr;
 	}
 
-	size_t n = mr_handle_map.erase(mr_handle->input_address);
-	if (n != 1) {
-		return -ENOENT;
-	}
+	mr_handle_map.erase(it);
 
 	delete mr_handle->local_handle;
 	mr_handle->local_handle = nullptr;
@@ -875,7 +891,7 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_meta
 		NCCL_OFI_WARN("Signal base address %p not found in MR handle map", signal_base);
 		return -EINVAL;
 	}
-	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = it->second;
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = it->second.handle;
 
 	if (mr_handle->type == NCCL_PTR_CUDA) {
 		uint64_t old_value;

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -4,6 +4,7 @@ nccl_message_transfer
 reuse_listen_comm
 ring
 gin
+gin_duplicate_mr
 grouped_recv
 gin_gdaki_misconfig_probe
 eager_multirecv

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -33,7 +33,7 @@ CXXLINK = OMPI_CXX="$(CXX)" MPICH_CXX="$(CXX)" \
 if ENABLE_FUNC_TESTS
 noinst_HEADERS = functional_test.h
 
-bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin grouped_recv gin_gdaki_misconfig_probe eager_multirecv
+bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin gin_duplicate_mr grouped_recv gin_gdaki_misconfig_probe eager_multirecv
 if ENABLE_GDAKI
 if HAVE_NVCC
 bin_PROGRAMS += gin_put_gdaki_gpu gin_signal_gdaki_gpu
@@ -48,6 +48,7 @@ ring_SOURCES = $(base_sources) ring.cpp
 inflight_close_SOURCES = $(base_sources) inflight_close.cpp
 reuse_listen_comm_SOURCES = $(base_sources) reuse_listen_comm.cpp
 gin_SOURCES = $(base_sources) gin.cpp
+gin_duplicate_mr_SOURCES = $(base_sources) gin_duplicate_mr.cpp
 grouped_recv_SOURCES = $(base_sources) grouped_recv.cpp
 gin_gdaki_misconfig_probe_SOURCES = $(base_sources) gin_gdaki_misconfig_probe.cpp
 

--- a/tests/functional/gin_duplicate_mr.cpp
+++ b/tests/functional/gin_duplicate_mr.cpp
@@ -1,0 +1,257 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include "functional_test.h"
+
+#include <assert.h>
+#include <deque>
+#include <vector>
+
+/**
+ * Functional test for duplicate MR registration in the GIN path.
+ *
+ * Tests that:
+ * 1. Registering the same buffer twice returns the same handle (refcount)
+ * 2. Registering the same buffer with a smaller size is covered by the existing MR
+ * 3. Deregistering with outstanding refs keeps the MR alive
+ * 4. Data transfers work correctly after duplicate registration
+ */
+
+static inline ncclResult_t
+poll_request_completion(ncclGin_v13_t *extGin, std::deque<void *> &request_deque, void *collComm,
+		       void *ginCtx)
+{
+	int done = 0;
+	OFINCCLCHECK(extGin->test(collComm, request_deque.front(), &done));
+	if (done) {
+		request_deque.pop_front();
+	} else {
+		OFINCCLCHECK(extGin->ginProgress(ginCtx));
+	}
+	return ncclSuccess;
+}
+
+struct proc_handle {
+	char handle[NCCL_NET_HANDLE_MAXSIZE];
+};
+
+int main(int argc, char *argv[])
+{
+	ncclResult_t res = ncclSuccess;
+	int rank, nranks, proc_name_len, local_rank = 0;
+	int buffer_type = NCCL_PTR_HOST;
+	int ndev, dev;
+
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+	std::vector<proc_handle> handles(nranks);
+	std::vector<void *> handles_ptrs(nranks);
+
+	if (nranks < 2) {
+		NCCL_OFI_WARN("Expected at least two ranks but got %d.", nranks);
+		res = ncclInvalidArgument;
+		return res;
+	}
+
+	std::vector<char> all_proc_name(nranks * MPI_MAX_PROCESSOR_NAME);
+	MPI_Get_processor_name(&all_proc_name[PROC_NAME_IDX(rank)], &proc_name_len);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, all_proc_name.data(),
+		      MPI_MAX_PROCESSOR_NAME, MPI_BYTE, MPI_COMM_WORLD);
+
+	for (int i = 0; i < nranks; i++) {
+		if (!strcmp(&all_proc_name[PROC_NAME_IDX(rank)],
+			    &all_proc_name[PROC_NAME_IDX(i)])) {
+			if (i < rank) {
+				++local_rank;
+			}
+		}
+	}
+
+	CUDACHECK(cudaSetDevice(local_rank));
+
+	set_system_page_size();
+	auto *net_plugin_handle = load_netPlugin();
+	auto *extNet = get_netPlugin_symbol(net_plugin_handle);
+	auto *extGin = get_ginPlugin_symbol(net_plugin_handle);
+	if (extNet == nullptr || extGin == NULL) {
+		return ncclInternalError;
+	}
+
+	void *netCtx = nullptr;
+	ncclNetCommConfig_v11_t netConfig = {};
+	OFINCCLCHECK(extNet->init(&netCtx, 0, &netConfig, &functional_test_logger, nullptr));
+
+	void *ginCtx = nullptr;
+	OFINCCLCHECK(extGin->init(&ginCtx, 0, &functional_test_logger));
+
+	OFINCCLCHECK(extGin->devices(&ndev));
+
+	std::vector<int> test_support_gdr(ndev);
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v12_t props = {};
+		OFINCCLCHECK(extGin->getProperties(dev, &props));
+		test_support_gdr[dev] = is_gdr_supported_nic(props.ptrSupport);
+	}
+
+	dev = local_rank % ndev;
+
+	if (test_support_gdr[dev] == 1) {
+		buffer_type = NCCL_PTR_CUDA;
+	} else {
+		NCCL_OFI_WARN("Network does not support CUDA buffers. Dev: %d", dev);
+		return 1;
+	}
+
+	void *listenComm = nullptr;
+	OFINCCLCHECK(extGin->listen(ginCtx, dev, handles[rank].handle, &listenComm));
+	assert(listenComm);
+
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, handles.data(), NCCL_NET_HANDLE_MAXSIZE,
+		      MPI_CHAR, MPI_COMM_WORLD);
+
+	for (int i = 0; i < nranks; ++i) {
+		handles_ptrs[i] = &(handles[i]);
+	}
+
+	void *collComm = nullptr;
+	OFINCCLCHECK(
+		extGin->connect(ginCtx, handles_ptrs.data(), nranks, rank, listenComm, &collComm));
+	assert(collComm != nullptr);
+
+	ncclGinConfig_v13_t ginConfig = {};
+	ginConfig.nSignals = 64;
+	ginConfig.nContexts = 1;
+	ginConfig.queueDepth = 64;
+	ginConfig.trafficClass = -1;
+
+	void *proxyCtx = nullptr;
+	ncclNetDeviceHandle_v11_t *devHandle = nullptr;
+	OFINCCLCHECK(extGin->createContext(collComm, &ginConfig, &proxyCtx, &devHandle));
+	assert(proxyCtx != nullptr);
+
+	/*
+	 * Test 1: Register the same buffer twice with the same size.
+	 * Both calls should succeed and return the same handle.
+	 */
+	constexpr uint64_t mrFlags = 0;
+	void *buff = nullptr;
+	OFINCCLCHECK(allocate_buff(&buff, SEND_SIZE, buffer_type));
+	OFINCCLCHECK(initialize_buff(buff, SEND_SIZE, buffer_type, 0));
+
+	void *mhandle1 = nullptr;
+	void *gin_handle1 = nullptr;
+	OFINCCLCHECK(extGin->regMrSym(collComm, buff, SEND_SIZE, buffer_type, mrFlags,
+				      &mhandle1, &gin_handle1));
+	assert(mhandle1 != nullptr);
+
+	void *mhandle2 = nullptr;
+	void *gin_handle2 = nullptr;
+	OFINCCLCHECK(extGin->regMrSym(collComm, buff, SEND_SIZE, buffer_type, mrFlags,
+				      &mhandle2, &gin_handle2));
+	assert(mhandle2 != nullptr);
+
+	if (mhandle1 != mhandle2) {
+		NCCL_OFI_WARN("Test 1 FAILED: duplicate regMrSym should return same handle. "
+			      "Got %p and %p", mhandle1, mhandle2);
+		return 1;
+	}
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 1 PASSED — duplicate regMrSym returns same handle",
+		      rank);
+
+	/*
+	 * Test 2: Register the same buffer with a smaller size.
+	 * Should succeed and return the same handle (existing MR covers it).
+	 */
+	void *mhandle3 = nullptr;
+	void *gin_handle3 = nullptr;
+	OFINCCLCHECK(extGin->regMrSym(collComm, buff, SEND_SIZE / 2, buffer_type, mrFlags,
+				      &mhandle3, &gin_handle3));
+	assert(mhandle3 != nullptr);
+
+	if (mhandle3 != mhandle1) {
+		NCCL_OFI_WARN("Test 2 FAILED: smaller size regMrSym should return same handle. "
+			      "Got %p and %p", mhandle1, mhandle3);
+		return 1;
+	}
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 2 PASSED — smaller size regMrSym returns same handle",
+		      rank);
+
+	/*
+	 * Test 3: Use the duplicate-registered buffer for an iput transfer
+	 * to verify the MR is still functional after refcount operations.
+	 */
+	const int send_val = 55;
+	if (rank == 0) {
+		OFINCCLCHECK(initialize_buff(buff, SEND_SIZE, buffer_type, send_val));
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank == 0) {
+		std::deque<void *> request_deque;
+		for (int dst_rank = 1; dst_rank < nranks; ++dst_rank) {
+			void *request = nullptr;
+			OFINCCLCHECK(extGin->iput(proxyCtx, 0, 0, mhandle1, SEND_SIZE, 0,
+						  mhandle1, dst_rank, &request));
+			assert(request != nullptr);
+			request_deque.push_back(request);
+		}
+
+		while (!request_deque.empty()) {
+			OFINCCLCHECK(poll_request_completion(extGin, request_deque, collComm,
+							    proxyCtx));
+		}
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank != 0) {
+		uint8_t verif_buf[SEND_SIZE];
+		CUDACHECK(cudaMemcpy(verif_buf, buff, SEND_SIZE, cudaMemcpyDefault));
+		for (int i = 0; i < SEND_SIZE; ++i) {
+			if (verif_buf[i] != send_val) {
+				NCCL_OFI_WARN("Test 3 FAILED: rank %d index %d expected %d got %d",
+					      rank, i, send_val, verif_buf[i]);
+				return 1;
+			}
+		}
+	}
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 3 PASSED — iput works with duplicate-registered MR",
+		      rank);
+
+	/*
+	 * Test 4: Deregister one of the duplicate registrations.
+	 * The MR should remain valid (refcount > 0).
+	 * Then deregister the second one to fully release.
+	 */
+	OFINCCLCHECK(extGin->deregMrSym(collComm, mhandle1));
+	/* mhandle1 == mhandle2, so only call deregMrSym once more */
+	OFINCCLCHECK(extGin->deregMrSym(collComm, mhandle2));
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 4 PASSED — double deregMrSym succeeded", rank);
+
+	/* Deregister the third (smaller size) registration */
+	OFINCCLCHECK(extGin->deregMrSym(collComm, mhandle3));
+
+	/* Cleanup */
+	OFINCCLCHECK(extGin->destroyContext(proxyCtx));
+	OFINCCLCHECK(extGin->closeColl(collComm));
+	OFINCCLCHECK(extGin->closeListen(listenComm));
+	OFINCCLCHECK(extGin->finalize(ginCtx));
+	OFINCCLCHECK(extNet->finalize(netCtx));
+
+	dlclose(net_plugin_handle);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Finalize();
+
+	OFINCCLCHECK(deallocate_buffer(buff, buffer_type));
+
+	NCCL_OFI_INFO(NCCL_NET, "Test completed successfully for rank %d", rank);
+
+	return res;
+}


### PR DESCRIPTION
Added refcount to the GIN symmetric MR handle map to allow multiple regMrSym calls for the same base address. On deregistration, resources are only released when the refcount reaches zero.
Registering the same address with a larger size is not supported and returns -EINVAL, as upgrading an existing MR would invalidate remote keys already exchanged via all_gather.
Added gin_duplicate_mr functional test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
