### PR TITLE
gin/gdaki: mirror efa_cuda_wq.db_pending in device wq struct

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -103,6 +103,7 @@ struct nccl_ofi_gin_gdaki_wq {
 	int phase;
 	uint8_t *buf;
 	uint32_t *db;
+	uint32_t db_pending;   /* mirror of efa_cuda_wq.db_pending */
 };
 
 /**


### PR DESCRIPTION
Adds `uint32_t db_pending` to the device-visible `nccl_ofi_gin_gdaki_wq`
struct so its byte layout stays matched with the kernel-side `efa_cuda_wq`,
which gains the same field to gate the Flush doorbell ring. This is the
plugin-side companion to the NCCL `ncclGinOptFlagsAggregateRequests` change
(amazon-contributing/upstream-to-nccl#6) where all the doorbell-deferral logic lives; 
the plugin only needs the struct to carry the matching field so
the two layouts stay in sync.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
