### PR TITLE
Customize error message for bad SG

### DIFF
--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -9,6 +9,7 @@
 #include <map>
 
 #include <rdma/fabric.h>
+#include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
 
 #include "nccl_ofi_param.h"
@@ -105,6 +106,27 @@ public:
 	 * @param	device	Network device to set GUID for
 	 */
 	virtual uint64_t device_get_guid(struct fi_info *info, int dev_id) = 0;
+
+	/**
+	 * @brief	Platform-specific hook to print a custom CQ error warning
+	 *
+	 *              Translate Libfabric error to a warn-level log print.
+	 *              The base class prints the simple translation code, but
+	 *              some NICs have custom error messages (such as EFA's
+	 *              Security Group-related errors.
+	 *
+	 * @param	cq		Completion queue that reported the error
+	 * @param	err_entry	Error entry from the completion queue
+	 */
+	virtual void log_cq_error(void *req_p, struct fid_cq *cq, struct fi_cq_err_entry *err_entry,
+				  const char *req_type)
+	{
+		NCCL_OFI_WARN("Request %p (%s) completed with error: err: %d, flags: %ld, prov_errno: %d, strerror: %s, len: %ld",
+			      req_p, req_type,
+			      err_entry->err, err_entry->flags, err_entry->prov_errno,
+			      fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
+			      (long)err_entry->len);
+	}
 };
 
 using PlatformPtr = std::unique_ptr<Platform>;

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -36,6 +36,8 @@ public:
 	int config_endpoint(struct fi_info *info, struct fid_ep *ep) override;
 	void sort_rails(struct fi_info **info_list, size_t num_rails, size_t num_groups) override;
 	uint64_t device_get_guid(struct fi_info *info, int dev_id) override;
+	void log_cq_error(void *req_p, struct fid_cq *cq, struct fi_cq_err_entry *err_entry,
+			  const char *req_type) override;
 
 protected:
 	struct ec2_platform_data {

--- a/src/cm/nccl_ofi_cm_reqs.cpp
+++ b/src/cm/nccl_ofi_cm_reqs.cpp
@@ -6,6 +6,7 @@
 #include <stdexcept>
 
 #include "nccl_ofi.h"
+#include "nccl_ofi_platform.h"
 
 #include "cm/nccl_ofi_cm_reqs.h"
 #include "cm/nccl_ofi_cm.h"
@@ -39,12 +40,7 @@ int nccl_net_ofi_cm_context::handle_error_entry(struct fid_cq *cq,
 	}
 
 	nccl_ofi_cm_req *req = cpp_container_of(this, &nccl_ofi_cm_req::ctx);
-
-	NCCL_OFI_WARN("Request %p completed with error. RC: %d. Flags: %ld. Error: %d (%s). Completed length: %ld",
-		req, err_entry->err,
-		err_entry->flags, err_entry->prov_errno,
-		fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
-		(long)err_entry->len);
+	PlatformManager::get_global().get_platform().log_cq_error(req, cq, err_entry, "cm");
 
 	/*
 	 * Libfabric error codes directly map to ISO C errno values for standard

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -32,6 +32,7 @@
 #include "nccl_ofi_topo.h"
 #include "nccl_ofi_memcheck.h"
 #include "nccl_ofi_ofiutils.h"
+#include "nccl_ofi_platform.h"
 #include "nccl_ofi_pthread.h"
 #include "nccl_ofi_dmabuf.h"
 #include "nccl_ofi_mr.h"
@@ -1618,11 +1619,8 @@ int nccl_net_ofi_rdma_context::handle_error_entry(struct fid_cq *cq,
 	req = this->get_req(rail_id);
 	assert(req);
 
-	NCCL_OFI_WARN("Request %p seq %d completed with error. RC: %d. Flags: %ld. Error: %d (%s). Completed length: %ld, Request: %s",
-		      req, req->msg_seq_num, err_entry->err,
-		      err_entry->flags, err_entry->prov_errno,
-		      fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
-		      (long)err_entry->len, nccl_net_ofi_req_str(req));
+	PlatformManager::get_global().get_platform().log_cq_error(req, cq, err_entry,
+								  nccl_net_ofi_req_str(req));
 
 	if ((req->type == NCCL_OFI_RDMA_CTRL_RX_BUFF) ||
 		(req->type == NCCL_OFI_RDMA_EAGER_RX_BUFF)) {

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -30,6 +30,7 @@
 #include "nccl_ofi_sendrecv.h"
 #include "nccl_ofi_freelist.h"
 #include "nccl_ofi_ofiutils.h"
+#include "nccl_ofi_platform.h"
 #include "nccl_ofi_tracepoint.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_pthread.h"
@@ -212,16 +213,8 @@ int nccl_net_ofi_sendrecv_context::handle_error_entry(struct fid_cq *cq,
 	(void)rail_id;
 	nccl_net_ofi_sendrecv_req *req = cpp_container_of(this, &nccl_net_ofi_sendrecv_req::ctx);
 
-	NCCL_OFI_WARN("Request %p completed with error. RC: %d. Flags: %ld. Error: %d (%s). Completed length: %ld, Request: %s",
-		      req,
-		      err_entry->err,
-		      err_entry->flags,
-		      err_entry->prov_errno,
-		      fi_cq_strerror(cq,
-				     err_entry->prov_errno,
-				     err_entry->err_data, NULL, 0),
-		      (long)err_entry->len,
-		      nccl_net_ofi_req_str(req));
+	PlatformManager::get_global().get_platform().log_cq_error(req, cq, err_entry,
+								  nccl_net_ofi_req_str(req));
 
         sendrecv_req_update(req, NCCL_OFI_SENDRECV_REQ_ERROR, err_entry->len);
 

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -958,6 +958,31 @@ uint64_t PlatformAWS::device_get_guid(struct fi_info *info, int dev_id)
 	return guid;
 }
 
+
+void PlatformAWS::log_cq_error(void *req_p, struct fid_cq *cq, struct fi_cq_err_entry *err_entry,
+			       const char *req_type)
+{
+	if (err_entry->err == FI_EHOSTUNREACH) {
+		// FI_EHOSTUNREACH is only returned by EFA if packets are
+		// dropped due to security groups.  It would be better if there
+		// was a prov_errno that was more explicit, but the current
+		// prov_errno is not a constant exposed by the efa provider
+		NCCL_OFI_WARN("Request %p (%s) completed with error: err: %d, flags: %ld, prov_errno: %d, strerror: %s, len: %ld\n\n"
+			      "**********************************************************************\n"
+			      "* This error indicates that the security group on either this instance or the peer instance\n"
+			      "* is not setup correctly.  For more information, please see the AWS documentation at\n"
+			      "* https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa-start-nccl.html#nccl-start-base-setup\n"
+			      "**********************************************************************",
+			      req_p, req_type,
+			      err_entry->err, err_entry->flags, err_entry->prov_errno,
+			      fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
+			      (long)err_entry->len);
+
+	} else {
+		Platform::log_cq_error(req_p, cq, err_entry, req_type);
+	}
+}
+
 /*
  * On P5/P5e, there are up to 32 EFA devices.  Each pair of EFA
  * devices shares some Nitro card resources, and there is a marginal


### PR DESCRIPTION
Provide hook in the platform infrastructure to provide custom error messages when an error completion event is generated.  At the same time unify the three logs for error completions so that they always have the same format.

Add a hook for AWS that prints a warning about Security Groups when the error entry indicates a Security Group problem, because we get too many tickets about that.

Testing:

Tested success case, caused bad SG change mid-job (which doesn't cause EHOSTUNREACH) and verified that the normal error print happens.  Tried mis-matched SGs, bad egress rule (All Traffic to 0.0.0.0), and bad ingress rule (All TCP from SG), and each case printed the SG error message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
