### PR TITLE
gin: Create separate endpoints for GIN and RMA init

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -331,6 +331,13 @@ public:
 	int await_pending_requests() EXCLUDES(get_ep_lock()) override;
 
 	/**
+	 * Spin-wait until the per-peer outstanding window has at least one free
+	 * slot. Drives CQ progress and gdrcopy drain each iteration so that
+	 * ACKs from the receiver advance tx_tail.
+	 */
+	int await_tx_window(nccl_ofi_gin_peer_rank_info &rank_comm) EXCLUDES(get_ep_lock());
+
+	/**
 	 * iputSignal API. Transfers some user data (determined by memory registrations
 	 * and offsets) via RDMA write. When the data transfer is complete, a signal
 	 * operation is performed at the destination, at location given by

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -488,6 +488,27 @@ int nccl_ofi_rdma_gin_put_comm::await_pending_requests()
 	return ret;
 }
 
+int nccl_ofi_rdma_gin_put_comm::await_tx_window(nccl_ofi_gin_peer_rank_info &rank_comm)
+{
+	uint32_t outstanding = gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail);
+	while (OFI_UNLIKELY(outstanding >= (uint32_t)(GIN_IMM_SEQ_MASK + 1))) {
+		{
+			std::lock_guard<std::mutex> lock(get_ep_lock());
+			int ret = resources.progress();
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+			ret = drain_gdrcopy_done_queue();
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+		}
+		std::this_thread::yield();
+		outstanding = gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail);
+	}
+	return 0;
+}
+
 static inline void clear_write_reqs_pending_back_pointers(
 	std::array<nccl_net_ofi_gin_write_req_t *, MAX_NUM_RAILS> &write_reqs)
 {
@@ -525,14 +546,11 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	   get_next_rail() when there is no data to coalesce with. */
 	uint16_t rail_id = 0;
 
-	/* Outstanding window. Cursors live on the GIN_RX_CONSUMED_MASK ring,
-	   so all comparisons mask the modular subtraction. */
-	const uint32_t outstanding = gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail);
-	if (OFI_UNLIKELY(outstanding >= (uint32_t)(GIN_IMM_SEQ_MASK + 1))) {
-		NCCL_OFI_WARN("Outstanding window full (head=%u tail=%u)",
-			      rank_comm.tx_head, rank_comm.tx_tail);
-		assert(false);
-		return -EBUSY;
+	/* Wait for a free slot in the TX window if full. */
+	{
+		int ret = await_tx_window(rank_comm);
+		if (OFI_UNLIKELY(ret != 0))
+			return ret;
 	}
 
 	/* Determine if this message needs an ACK.
@@ -546,6 +564,7 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	 * below the threshold, resetting the gate. */
 	bool has_signal = (signalOp != 0);
 	bool is_ack_requested = false;
+	const uint32_t outstanding = gin_cursor_delta(rank_comm.tx_head, rank_comm.tx_tail);
 
 	if (OFI_UNLIKELY(outstanding >= GIN_ACK_REQ_THRESHOLD)) {
 		if (OFI_UNLIKELY(rank_comm.consecutive_puts_without_ack++ >= GIN_ACK_INTERVAL)) {

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include <atomic>
 #include <cstring>
 
 #include "rdma/gin/nccl_ofi_gin.h"
@@ -19,18 +20,12 @@
 /* Forward declaration — defined at bottom of this file */
 extern ncclGin_v13_t ncclGinPlugin_v13;
 
-/**
- * Structure to hold GIN context data.
- * This is created once per NCCL communicator and passed to all listen() calls
- * for that communicator. It stores the comm_id which is used as the endpoint
- * key, ensuring different communicators get different endpoints even when
- * created on the same thread.
- */
 struct nccl_ofi_gin_context {
-	uint64_t comm_id; // Unique communicator identifier (from commHash)
-	
-	// Constructor to initialize comm_id
-	explicit nccl_ofi_gin_context(uint64_t id) : comm_id(id) {}
+	/* Per-init() sequence number used as endpoint cache key so that the
+	 * RMA and GIN proxy layers get separate endpoints. */
+	static inline std::atomic<uint64_t> next_seq{0};
+
+	uint64_t seq = next_seq.fetch_add(1, std::memory_order_relaxed);
 };
 
 ncclResult_t nccl_ofi_gin_init(void **ctx, uint64_t commId, ncclDebugLogger_t logFunction)
@@ -75,12 +70,9 @@ ncclResult_t nccl_ofi_gin_init(void **ctx, uint64_t commId, ncclDebugLogger_t lo
 		return ncclInternalError;
 	}
 
-	/* Create per-communicator context to store the comm_id.
-	   This allows listen() to use comm_id as the endpoint key for
-	   endpoint lookup, giving each NCCL communicator its own
-	   endpoint instead of sharing one per thread. */
+	/* Create per-communicator context with a unique endpoint key. */
 	try {
-		nccl_ofi_gin_context *context = new nccl_ofi_gin_context(commId);
+		nccl_ofi_gin_context *context = new nccl_ofi_gin_context();
 		*ctx = context;
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Failed to allocate GIN context: %s", e.what());
@@ -173,7 +165,7 @@ ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void **listen
 		return ncclInternalError;
 	}
 
-	uint64_t comm_id = context->comm_id;
+	long endpoint_key = static_cast<long>(context->seq);
 
 	auto plugin = nccl_net_ofi_get_plugin();
 	if (plugin == nullptr) {
@@ -188,17 +180,9 @@ ncclResult_t nccl_ofi_gin_listen(void *ctx, int dev, void *handle, void **listen
 	}
 
 	try {
-		/* Note: although the GIN plugin uses its own endpoint type, we still need
-		the transport endpoint to set up the bootstrap AG ring.
-
-		Use comm_id as endpoint_key to ensure all GIN contexts within the same
-		communicator share the same endpoint. This creates one endpoint per
-		communicator instead of one per thread.
-		
-		domain_key=0 uses the default domain, endpoint_key=comm_id caches endpoints
-		by communicator ID instead of thread ID. */
-
-		auto ep = device->get_ep(0, static_cast<long>(comm_id));
+		/* Use seq as endpoint key so that the RMA and GIN layers
+		   don't share one endpoint/lock. */
+		auto ep = device->get_ep(0, endpoint_key);
 
 		nccl_net_ofi_listen_comm *l_comm = nullptr;
 		int ret = ep->listen(static_cast<nccl_net_ofi_conn_handle_t *>(handle), &l_comm);


### PR DESCRIPTION
NCCL calls init() twice per communicator—once for the RMA backend and once for the GIN proxy—both with the same commHash.Replace comm_id-based endpoint keying with a gin_context_seq so each init() layer gets its own endpoint.
Additionally, replace the hard EBUSY in iputSignal when the TX window is full with a new await_tx_window() helper that spins on CQ progress until ACKs free a slot.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
