### PR TITLE
gin/gdaki: target-indexed signal addressing with asymmetric counts

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -151,9 +151,10 @@ struct nccl_ofi_gin_gdaki_cq {
 
 /**
  * Common per-endpoint state shared by the data, counter, and signal
- * device handles. Holds the GPU-resident QP/CQ, per-peer addressing,
- * the per-QP spinlock that serializes the device-side WQE-post
- * sequence, and the counter-based completion tracking fields.
+ * device handles. Holds the GPU-resident QP/CQ, the target
+ * addressing table, the per-QP spinlock that serializes the
+ * device-side WQE-post sequence, and the counter-based completion
+ * tracking fields.
  * Used directly as the `data` member of nccl_ofi_gin_gdaki_dev_handle,
  * and embedded as a `base` member in nccl_ofi_gin_gdaki_dev_counter_handle.
  *
@@ -167,10 +168,35 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
 	/* GPU-resident CQ for this endpoint. */
 	struct nccl_ofi_gin_gdaki_cq *cq;
 
-	/* Per-peer addressing for this endpoint's QP. [nranks] in GPU mem. */
-	uint16_t *address_handles;
-	uint16_t *remote_qpns;
-	uint32_t *qkey;
+	/* Target addressing for this (poster) endpoint's QP.
+	 *
+	 * One GPU-resident table, sized [total_slots * nranks] and laid out
+	 * targetSlot-major: idx = targetSlot * nranks + peer, where
+	 *     targetSlot 0       -> peer's DATA endpoint
+	 *     targetSlot 1 + s   -> peer's sc endpoint s (signal id s)
+	 * and total_slots = 1 + (max over peers of their sc-endpoint count).
+	 *
+	 * The device side selects the slot per write:
+	 *     plain put / counter-only write -> slot 0 (peer data EP, which
+	 *       binds no FI_REMOTE_WRITE, so the write ticks the local
+	 *       FI_WRITE counter without firing a signal on the receiver)
+	 *     signalling write (signal id s) -> slot 1 + s (peer sc EP s,
+	 *       whose FI_REMOTE_WRITE counter the GIN waitSignal observes)
+	 * The local poster QP is chosen by counterId (which endpoint owns
+	 * this handle); the remote target QP is chosen by the slot.
+	 *
+	 * Every (slot, peer) tuple is resolved through THIS endpoint's own
+	 * AV (an address handle is AV-local), so the data endpoint and every
+	 * sc endpoint each carry their own table. A (slot, peer) a peer does
+	 * not expose (asymmetric counts) is a zero entry, never addressed (a
+	 * correct caller never directs a signalId at a peer that did not
+	 * create it).
+	 *
+	 * Layout is shared with the NCCL mirror in
+	 * nccl_device/gin/efa_gda/gin_efa_gda_dev.h — keep them in sync. */
+	uint16_t *target_address_handles;   /* [total_slots * nranks] */
+	uint16_t *target_remote_qpns;       /* [total_slots * nranks] */
+	uint32_t *target_qkey;              /* [total_slots * nranks] */
 
 	/* Per-QP spinlock used by the device-side WQE post path. efa-dp-direct's
 	 * start_sq_batch / sq_batch_place_wr / flush_sq_wrs sequence must be
@@ -229,8 +255,8 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
  * counter value lives in GPU memory and is updated by the NIC directly.
  *
  * For signals: the GPU kernel reads *cntr_value to detect remote writes
- *              (FI_REMOTE_WRITE counter). The per-peer arrays let the
- *              sender target this QP on the remote rank.
+ *              (FI_REMOTE_WRITE counter). The target table lets
+ *              the sender target this QP on the remote rank.
  *
  * For counters: the GPU kernel reads *cntr_value to track local write
  *               completions (FI_WRITE counter). The QP is used by the

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -210,32 +210,59 @@ public:
 };
 
 /**
- * Per-peer addressing tables.
+ * Target addressing table.
  *
- * Three GPU-resident arrays indexed by rank, each populated by
- * fi_av_insert + gda_ops->query_addr during createContext. The kernel
+ * One GPU-resident table per poster endpoint, sized [total_slots * nranks]
+ * and laid out targetSlot-major: idx = targetSlot * nranks + peer.
+ *
+ * A "target slot" names which of the peer's endpoints a write addresses:
+ *     targetSlot 0          -> peer's DATA endpoint
+ *     targetSlot 1 + s      -> peer's sc endpoint s (signal id s)
+ * with total_slots = 1 + global_n_sc. The device side selects a slot per
+ * write:
+ *     - plain put / counter-only write  -> slot 0 (peer data EP, no
+ *       FI_REMOTE_WRITE bound, so it never fires a signal)
+ *     - signalling write (signal id s)  -> slot 1 + s (peer sc EP s,
+ *       whose FI_REMOTE_WRITE counter the GIN waitSignal observes)
+ *
+ * Every (slot, peer) tuple is resolved through THIS endpoint's own AV
+ * (an address handle is AV-local), so the data endpoint and every sc
+ * endpoint each build their own table. The plugin (createContext) writes
+ * this layout; NCCL's device code reads it — both must agree on the
+ * targetSlot-major convention and on slot 0 = data EP (see the dev-handle
+ * mirror).
+ *
+ * Three GPU-resident arrays indexed by (targetSlot, peer), each populated
+ * by fi_av_insert + gda_ops->query_addr during createContext. The kernel
  * dereferences them via the device-visible handle.
  */
-class gdaki_peer_addressing {
+class gdaki_target_addressing {
 public:
-	gdaki_gpu_buf<uint16_t> ahs;      /* address handle numbers */
-	gdaki_gpu_buf<uint16_t> qpns;     /* remote QP numbers */
-	gdaki_gpu_buf<uint32_t> qkeys;    /* remote QKeys */
+	gdaki_gpu_buf<uint16_t> ahs;      /* [total_slots*nranks] address handle numbers */
+	gdaki_gpu_buf<uint16_t> qpns;     /* [total_slots*nranks] remote QP numbers */
+	gdaki_gpu_buf<uint32_t> qkeys;    /* [total_slots*nranks] remote QKeys */
 
-	gdaki_peer_addressing() = default;
-	gdaki_peer_addressing(const gdaki_peer_addressing &) = delete;
-	gdaki_peer_addressing &operator=(const gdaki_peer_addressing &) = delete;
+	gdaki_target_addressing() = default;
+	gdaki_target_addressing(const gdaki_target_addressing &) = delete;
+	gdaki_target_addressing &operator=(const gdaki_target_addressing &) = delete;
 
 	/*
-	 * Insert each peer's EP address from `peer_addrs` into the AV,
-	 * query the (ahn, qpn, qkey) tuple, and commit the three tables
-	 * to GPU memory.
+	 * Build the [total_slots * nranks] target table for THIS endpoint.
 	 *
-	 * peer_addrs is a flat buffer of nranks * MAX_EP_ADDR bytes.
+	 * `all_addrs` is the batched-allgather buffer, peer-major:
+	 *     addr(peer, slot) = &all_addrs[(peer * total_slots + slot) * ep_addr_len]
+	 * with slot 0 = peer's data EP and slots 1..global_n_sc = peer's sc
+	 * EPs. For each (slot, peer) this inserts the address into THIS
+	 * endpoint's AV, queries the (ahn, qpn, qkey) tuple, and stores it
+	 * targetSlot-major at [slot * nranks + peer]. Absent slots (a peer
+	 * with fewer sc EPs leaves a zero address) are skipped; the entry
+	 * stays 0 and is never addressed (a correct caller never directs a
+	 * signalId at a peer that did not create it). Commits the three
+	 * tables to GPU memory.
 	 */
 	void populate(gdaki_fi_endpoint &endpoint,
-		      const std::vector<uint8_t> &peer_addrs,
-		      size_t ep_addr_len, int nranks,
+		      const std::vector<uint8_t> &all_addrs,
+		      size_t ep_addr_len, int total_slots, int nranks,
 		      struct fi_efa_ops_gda *gda_ops);
 };
 
@@ -380,16 +407,17 @@ private:
 
 /**
  * Host-side state for a libfabric endpoint plus its GPU-side queue
- * descriptors and per-peer addressing.
+ * descriptors and target addressing table.
  *
  * Used directly for the data (main) endpoint, and composed inside
  * gdaki_sc_endpoint for the signal/counter endpoints.
  *
  * Owns: fid_ep + fid_cq + fid_av (via gdaki_fi_endpoint), GPU-mapped
  * SQ buffer + doorbell BAR regions, GPU-resident QP and CQ descriptors,
- * per-peer ahn/qpn/qkey arrays in GPU memory.
+ * and the [total_slots*nranks] target ahn/qpn/qkey table in GPU
+ * memory.
  *
- * Destruction order (reverse declaration): peers, gpu_cq, gpu_qp,
+ * Destruction order (reverse declaration): targets, gpu_cq, gpu_qp,
  * sq_doorbell, sq_buffer, endpoint. The libfabric EP closes last so any
  * GPU mappings of its BAR regions are torn down before the EP itself.
  * When this class is composed inside gdaki_sc_endpoint AFTER the
@@ -398,13 +426,13 @@ private:
  */
 class gdaki_endpoint {
 public:
-	gdaki_fi_endpoint     endpoint;
-	gdaki_mmio_region     sq_buffer;
-	gdaki_mmio_region     sq_doorbell;
-	gdaki_gpu_qp          gpu_qp;
-	gdaki_gpu_cq          gpu_cq;
-	gdaki_peer_addressing peers;
-	uint32_t              sq_size = 0;       /* SQ ring depth, populated by populate() */
+	gdaki_fi_endpoint       endpoint;
+	gdaki_mmio_region       sq_buffer;
+	gdaki_mmio_region       sq_doorbell;
+	gdaki_gpu_qp            gpu_qp;
+	gdaki_gpu_cq            gpu_cq;
+	gdaki_target_addressing targets;   /* [total_slots*nranks] target table */
+	uint32_t                sq_size = 0;       /* SQ ring depth, populated by populate() */
 
 	gdaki_endpoint() = default;
 	/* Implicit dtor: members destroy in reverse declaration order. */
@@ -418,13 +446,13 @@ public:
 
 	/**
 	 * Query EFA QP/CQ attributes, map the SQ MMIO regions for GPU
-	 * access, build the GPU-resident QP/CQ descriptors, and populate
-	 * per-peer addressing from the allgathered peer addresses.
-	 * Must be called after open().
+	 * access, build the GPU-resident QP/CQ descriptors, and build the
+	 * [total_slots*nranks] target table from the batched
+	 * allgather buffer. Must be called after open().
 	 */
 	void populate(struct fi_efa_ops_gda *gda_ops,
-		      const std::vector<uint8_t> &peer_addrs,
-		      size_t ep_addr_len, int nranks);
+		      const std::vector<uint8_t> &all_addrs,
+		      size_t ep_addr_len, int total_slots, int nranks);
 };
 
 /**
@@ -464,12 +492,13 @@ public:
 
 	/**
 	 * Populate the inner endpoint's GPU descriptors (QP/CQ attrs,
-	 * SQ MMIO BAR mapping, GPU-resident QP/CQ, per-peer addressing).
-	 * Must be called after open().
+	 * SQ MMIO BAR mapping, GPU-resident QP/CQ) and build the
+	 * [total_slots*nranks] target table from the batched allgather
+	 * buffer. Must be called after open().
 	 */
 	void populate(struct fi_efa_ops_gda *gda_ops,
-		      const std::vector<uint8_t> &peer_addrs,
-		      size_t ep_addr_len, int nranks);
+		      const std::vector<uint8_t> &all_addrs,
+		      size_t ep_addr_len, int total_slots, int nranks);
 
 	/**
 	 * Stash the PutValue slot pool slice base for this endpoint.
@@ -526,12 +555,14 @@ public:
 		  struct fi_efa_ops_gda *gda_ops);
 
 	/**
-	 * Populate the inner endpoint's GPU descriptors and build the
-	 * per-EP device handles. Must be called after open().
+	 * Populate the inner endpoint's GPU descriptors, build the
+	 * [total_slots*nranks] target table (from the batched allgather
+	 * buffer), and build the per-EP device handles. Must be called
+	 * after open().
 	 */
 	void populate(struct fi_efa_ops_gda *gda_ops,
-		      const std::vector<uint8_t> &peer_addrs,
-		      size_t ep_addr_len, int nranks);
+		      const std::vector<uint8_t> &all_addrs,
+		      size_t ep_addr_len, int total_slots, int nranks);
 
 	/**
 	 * Set the PutValue slot pool slice base on both
@@ -549,20 +580,32 @@ public:
  * All members are lifecycle-managed objects; the destructor is
  * implicit. Declaration order is creation order; C++ destroys members
  * in reverse declaration order, which matches the required teardown
- * order (GPU mappings and per-peer arrays before MMIO mappings before
- * the endpoint).
+ * order (GPU mappings and the target addressing table before MMIO
+ * mappings before the endpoint).
  */
 struct nccl_ofi_gin_gdaki_context {
 	/* Set first (stateless). */
 	int nContexts = 0;
 	int nranks = 0;
 	int rank = 0;
-	int nSignals = 0;
-	int nCounters = 0;
+	int nSignals = 0;   /* this rank's local signal count  */
+	int nCounters = 0;  /* this rank's local counter count */
+
+	/* Asymmetric-count support. Ranks are NOT required to request the
+	 * same nSignals/nCounters for a context, so createContext allgathers
+	 * each rank's counts and derives:
+	 *   global_n_sc = max over ranks of max(nSignals, nCounters)
+	 *               = number of sc-endpoint slots every rank's batched
+	 *                 endpoint-address allgather must cover (a rank with
+	 *                 fewer sc EPs contributes a zero address in the
+	 *                 surplus slots), and the sc-endpoint span of every
+	 *                 poster's target table (total_slots =
+	 *                 1 + global_n_sc). */
+	int global_n_sc = 0;
 
 	/* Per-ctx data (main) endpoint: libfabric EP on the reused proxy
 	 * domain plus its GPU-side SQ buffer/doorbell mappings, GPU-
-	 * resident QP/CQ descriptors, per-peer addressing, and a
+	 * resident QP/CQ descriptors, target addressing, and a
 	 * FI_WRITE hardware counter for completion tracking. One per
 	 * logical context. unique_ptr because gdaki_data_endpoint owns
 	 * non-movable members (libfabric/CUDA handles). */

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -153,30 +153,82 @@ static ncclResult_t nccl_ofi_gin_gdaki_get_properties(int dev, ncclNetProperties
 }
 
 /*
- * Read this rank's libfabric EP address into a per-rank slot of an
- * allgather buffer, then allgather across the team. Returns the buffer.
+ * Allgather every endpoint address of one context in a SINGLE collective.
  *
- * Used by createContext for both the data endpoint and each
- * signal/counter endpoint.
+ * `eps` lists this rank's endpoints for the context in slot order
+ * (slot 0 = data EP, slots 1..global_n_sc = sc EPs). A nullptr slot is an
+ * endpoint this rank does not have (asymmetric counts): it contributes a
+ * zero-filled address so peers that DO have an endpoint at that slot still
+ * exchange correctly. The collective is called once with a per-rank record
+ * of all slots, instead of one allgather per endpoint.
+ *
+ * Returns a buffer of nranks * total_slots * ep_addr_len bytes laid out
+ * rank-major then slot-major:
+ *   addr(peer, slot) = &buf[(peer * total_slots + slot) * ep_addr_len]
+ * Each poster endpoint's gdaki_target_addressing::populate() consumes this
+ * buffer directly to build its [total_slots * nranks] target table.
  *
  * Throws std::runtime_error on fi_getname / allgather failure.
  */
-static std::vector<uint8_t> allgather_ep_addr(struct fid_ep *ep,
-					      nccl_ofi_rdma_gin_put_comm *put_comm,
-					      int nranks, int rank,
-					      size_t ep_addr_len)
+static std::vector<uint8_t> allgather_ep_addrs_batched(
+	const std::vector<struct fid_ep *> &eps,
+	nccl_ofi_rdma_gin_put_comm *put_comm,
+	int nranks, int rank, size_t ep_addr_len)
 {
-	std::vector<uint8_t> all_addrs(nranks * ep_addr_len, 0);
-	size_t addrlen = ep_addr_len;
-	int ret = fi_getname(&ep->fid, &all_addrs[rank * ep_addr_len], &addrlen);
-	if (ret != 0) {
-		throw std::runtime_error("fi_getname failed: " +
-					 std::string(fi_strerror(-ret)));
+	const size_t total_slots = eps.size();
+	const size_t rec_len = total_slots * ep_addr_len;
+	std::vector<uint8_t> all(nranks * rec_len, 0);
+
+	uint8_t *my_rec = all.data() + (size_t)rank * rec_len;
+	for (size_t s = 0; s < total_slots; s++) {
+		if (eps[s] == nullptr) {
+			continue; /* absent slot stays zero-filled */
+		}
+		size_t addrlen = ep_addr_len;
+		int ret = fi_getname(&eps[s]->fid, my_rec + s * ep_addr_len, &addrlen);
+		if (ret != 0) {
+			throw std::runtime_error("fi_getname failed: " +
+						 std::string(fi_strerror(-ret)));
+		}
 	}
-	if (put_comm->get_ag_comm().all_gather(all_addrs.data(), ep_addr_len) != 0) {
-		throw std::runtime_error("allgather of ep addresses failed");
+
+	if (put_comm->get_ag_comm().all_gather(all.data(), rec_len) != 0) {
+		throw std::runtime_error("batched allgather of ep addresses failed");
 	}
-	return all_addrs;
+	return all;
+}
+
+/*
+ * Exchange each rank's (nSignals, nCounters) for this context across the
+ * team and derive the asymmetric-count quantities the rest of
+ * createContext needs. Ranks are NOT required to request the same counts.
+ *
+ * Fills ctx->global_n_sc = max over ranks of max(nSignals, nCounters),
+ * which sizes the per-poster target table (total_slots = 1 +
+ * global_n_sc) and the per-context endpoint-address allgather.
+ *
+ * Throws std::runtime_error on allgather failure.
+ */
+static void exchange_signal_counter_counts(nccl_ofi_gin_gdaki_context *ctx,
+					    nccl_ofi_rdma_gin_put_comm *put_comm,
+					    int nranks, int rank)
+{
+	/* allGather a 2-int record {nSignals, nCounters} per rank. Each rank
+	 * fills its own slot; the collective fills the rest. */
+	std::vector<int32_t> counts(nranks * 2, 0);
+	counts[rank * 2 + 0] = ctx->nSignals;
+	counts[rank * 2 + 1] = ctx->nCounters;
+	if (put_comm->get_ag_comm().all_gather(counts.data(), 2 * sizeof(int32_t)) != 0) {
+		throw std::runtime_error("allgather of signal/counter counts failed");
+	}
+
+	ctx->global_n_sc = 0;
+	for (int p = 0; p < nranks; p++) {
+		const int p_nSignals = counts[p * 2 + 0];
+		const int p_nCounters = counts[p * 2 + 1];
+		ctx->global_n_sc = std::max(ctx->global_n_sc,
+					    std::max(p_nSignals, p_nCounters));
+	}
 }
 
 /*
@@ -389,9 +441,9 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 {
 	h.data.qp = ctx->data[ctx_id]->base.gpu_qp.dev();
 	h.data.cq = ctx->data[ctx_id]->base.gpu_cq.dev();
-	h.data.address_handles = ctx->data[ctx_id]->base.peers.ahs.dev;
-	h.data.remote_qpns = ctx->data[ctx_id]->base.peers.qpns.dev;
-	h.data.qkey = ctx->data[ctx_id]->base.peers.qkeys.dev;
+	h.data.target_address_handles = ctx->data[ctx_id]->base.targets.ahs.dev;
+	h.data.target_remote_qpns     = ctx->data[ctx_id]->base.targets.qpns.dev;
+	h.data.target_qkey            = ctx->data[ctx_id]->base.targets.qkeys.dev;
 	h.data.sq_lock = 0;
 	h.data.local_cntr_value = ctx->data[ctx_id]->write_cntr.gpu_ptr();
 	h.data.submitted_count = 0;
@@ -562,66 +614,116 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		setup_scratch_buffer(ctx.get(), ofi_domain, put_comm, nranks, rank);
 
 		/*
+		 * Step 3b: Exchange each rank's (nSignals, nCounters) so we can
+		 * support asymmetric counts. Derives global_n_sc (max over ranks
+		 * of max(nSignals, nCounters)).
+		 */
+		exchange_signal_counter_counts(ctx.get(), put_comm, nranks, rank);
+
+		/*
 		 * Per-context loop: build (data EP + sc EPs + counter/signal
 		 * handle arrays) for each logical context. The dev_handles[]
 		 * slots are filled in a second loop below, after the PutValue
 		 * pool is allocated and slice bases are assigned.
+		 *
+		 * local_n_sc  = this rank's sc-endpoint count.
+		 * global_n_sc = max over ranks; every rank must run this many
+		 *               collective allgather rounds (a surplus round
+		 *               contributes a zero address), and it is the
+		 *               sc-endpoint span of every poster's target
+		 *               target table.
 		 */
 		constexpr size_t ep_addr_len = MAX_EP_ADDR;
-		const int n_sc = std::max(config->nSignals, config->nCounters);
+		const int local_n_sc = std::max(config->nSignals, config->nCounters);
+		const int global_n_sc = ctx->global_n_sc;
+		/* Endpoint slot layout within one context's batched allgather:
+		 * slot 0 = data EP, slots [1, 1+global_n_sc) = sc EPs. A rank
+		 * with fewer than global_n_sc sc EPs leaves the surplus slots
+		 * as nullptr (zero address). This is also the target-slot layout
+		 * of each poster's target addressing table. */
+		const size_t total_slots = 1 + (size_t)global_n_sc;
 		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++) {
 			/*
-			 * Step 4: Open this ctx's data endpoint on the reused
-			 * domain.
+			 * Step 4: Open this ctx's endpoints — data EP (slot 0) and
+			 * this rank's local sc EPs (slots 1..local_n_sc). Surplus sc
+			 * slots have no local endpoint.
 			 */
 			ctx->data[ctx_id]->open(ofi_domain, proxy_info, gda_ops);
-
-			/*
-			 * Step 5: Exchange this ctx's data-EP address across the
-			 * team, then complete the data EP's GPU-side build.
-			 * Each ctx's data EP is its own libfabric EP, so each
-			 * needs its own allgather — ctx ctx_id on rank A pairs with
-			 * ctx ctx_id on rank B for cross-rank symmetric communication.
-			 */
-			std::vector<uint8_t> all_addrs = allgather_ep_addr(
-				ctx->data[ctx_id]->base.endpoint.ep, put_comm, nranks, rank, ep_addr_len);
-			ctx->data[ctx_id]->populate(gda_ops, all_addrs, ep_addr_len, nranks);
-
-			/*
-			 * Step 6: Create this ctx's signal/counter endpoints
-			 * (one per max(nSignals, nCounters)) and build the GPU
-			 * pointer arrays the kernel reads as
-			 * dev[ctx.contextId].counter_handles[] /
-			 * .signal_handles[].
-			 */
-			if (n_sc > 0) {
-				ctx->sc_endpoints[ctx_id].reserve(n_sc);
-				for (int i = 0; i < n_sc; i++) {
-					ctx->sc_endpoints[ctx_id].push_back(std::make_unique<gdaki_sc_endpoint>());
-					ctx->sc_endpoints[ctx_id][i]->open(ofi_domain, proxy_info, gda_ops);
-
-					std::vector<uint8_t> sc_addrs = allgather_ep_addr(
-						ctx->sc_endpoints[ctx_id][i]->base.endpoint.ep,
-						put_comm, nranks, rank, ep_addr_len);
-
-					ctx->sc_endpoints[ctx_id][i]->populate(gda_ops, sc_addrs,
-									  ep_addr_len, nranks);
-				}
-
-				auto build_handle_array = [&](gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> &buf,
-							      int count, auto get_dev_handle) {
-					if (count > 0) {
-						buf.allocate(count);
-						for (int i = 0; i < count; i++)
-							buf.host[i] = get_dev_handle(i);
-						buf.commit();
-					}
-				};
-				build_handle_array(*ctx->d_counter_handles[ctx_id], config->nCounters,
-					[&](int i) { return ctx->sc_endpoints[ctx_id][i]->counter_dev_handle.dev; });
-				build_handle_array(*ctx->d_signal_handles[ctx_id], config->nSignals,
-					[&](int i) { return ctx->sc_endpoints[ctx_id][i]->signal_dev_handle.dev; });
+			if (local_n_sc > 0) {
+				ctx->sc_endpoints[ctx_id].reserve(local_n_sc);
 			}
+			for (int i = 0; i < local_n_sc; i++) {
+				ctx->sc_endpoints[ctx_id].push_back(std::make_unique<gdaki_sc_endpoint>());
+				ctx->sc_endpoints[ctx_id][i]->open(ofi_domain, proxy_info, gda_ops);
+			}
+
+			/*
+			 * Step 5: Exchange ALL of this ctx's endpoint addresses in a
+			 * SINGLE collective (data EP + every sc slot), instead of one
+			 * allgather per endpoint. The allgather is collective, so the
+			 * per-rank record covers global_n_sc sc slots even when this
+			 * rank created fewer; surplus slots are nullptr (zero address)
+			 * and peers skip them. ctx ctx_id on rank A pairs with ctx
+			 * ctx_id on rank B for cross-rank symmetric communication.
+			 */
+			std::vector<struct fid_ep *> eps;
+			eps.reserve(total_slots);
+			eps.push_back(ctx->data[ctx_id]->base.endpoint.ep); /* slot 0 = data EP */
+			for (int i = 0; i < global_n_sc; i++) {
+				/* slots 1..global_n_sc: this rank's sc EP if it has one
+				 * at this index, else nullptr (surplus / absent slot). */
+				eps.push_back(i < local_n_sc
+					? ctx->sc_endpoints[ctx_id][i]->base.endpoint.ep
+					: nullptr);
+			}
+			std::vector<uint8_t> all_addrs = allgather_ep_addrs_batched(
+				eps, put_comm, nranks, rank, ep_addr_len);
+
+			/*
+			 * Step 6: Target addressing. Every poster endpoint
+			 * (the data EP and all local sc EPs — any may post a
+			 * Put/PutValue) builds one [total_slots * nranks] table that
+			 * resolves, through its OWN AV, every peer endpoint slot:
+			 *     slot 0       -> peer's data EP (plain put / counter-only
+			 *                     "quiet sink" target — no FI_REMOTE_WRITE)
+			 *     slot 1 + s   -> peer's sc EP s (signal id s target,
+			 *                     whose FI_REMOTE_WRITE the GIN waitSignal
+			 *                     observes)
+			 * The device side selects the slot per write: 0 for a plain
+			 * or counter-only put, 1+signalId for a signalling put. A
+			 * (slot, peer) a peer doesn't expose (asymmetric counts) is a
+			 * zero address, skipped by populate(); a correct caller never
+			 * directs a signalId at a peer that did not create it.
+			 *
+			 * populate() consumes the peer-major all_addrs buffer
+			 * directly (addr(peer, slot) = all_addrs[(peer*total_slots +
+			 * slot)...]) and transposes it into the targetSlot-major
+			 * device table.
+			 */
+			ctx->data[ctx_id]->populate(gda_ops, all_addrs, ep_addr_len,
+						    (int)total_slots, nranks);
+			for (int i = 0; i < local_n_sc; i++) {
+				ctx->sc_endpoints[ctx_id][i]->populate(
+					gda_ops, all_addrs, ep_addr_len,
+					(int)total_slots, nranks);
+			}
+
+			/* Build this rank's own counter/signal handle arrays from
+			 * its LOCAL counts (these are the endpoints this rank
+			 * exposes as targets / uses as counters). */
+			auto build_handle_array = [&](gdaki_gpu_buf<nccl_ofi_gin_gdaki_dev_counter_handle *> &buf,
+						      int count, auto get_dev_handle) {
+				if (count > 0) {
+					buf.allocate(count);
+					for (int i = 0; i < count; i++)
+						buf.host[i] = get_dev_handle(i);
+					buf.commit();
+				}
+			};
+			build_handle_array(*ctx->d_counter_handles[ctx_id], config->nCounters,
+				[&](int i) { return ctx->sc_endpoints[ctx_id][i]->counter_dev_handle.dev; });
+			build_handle_array(*ctx->d_signal_handles[ctx_id], config->nSignals,
+				[&](int i) { return ctx->sc_endpoints[ctx_id][i]->signal_dev_handle.dev; });
 		}
 
 		/*
@@ -692,8 +794,8 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 static ncclResult_t nccl_ofi_gin_gdaki_destroyContext(void *ginCtx)
 {
 	/* The ctx's member destructors tear down every owned resource in
-	 * reverse construction order: device handle + per-peer tables +
-	 * GPU QP/CQ first, then the MMIO BAR mappings, finally the
+	 * reverse construction order: device handle + target addressing
+	 * table + GPU QP/CQ first, then the MMIO BAR mappings, finally the
 	 * libfabric endpoint (after the BAR mappings are gone, as
 	 * required). */
 	auto *ctx = static_cast<nccl_ofi_gin_gdaki_context *>(ginCtx);

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -189,39 +189,87 @@ void gdaki_gpu_cq::build(const struct fi_efa_cq_attr &cq_attr)
 	buf.commit();
 }
 
-void gdaki_peer_addressing::populate(gdaki_fi_endpoint &endpoint,
-				     const std::vector<uint8_t> &peer_addrs,
-				     size_t ep_addr_len, int nranks,
-				     struct fi_efa_ops_gda *gda_ops)
+/*
+ * Sentinel for "this peer has no endpoint at this slot". A rank that did
+ * not create an endpoint for a given (collective) allgather round leaves
+ * its slot zero-filled; ranks are NOT required to request the same number
+ * of signal/counter endpoints, so some (slot, peer) pairs have no remote
+ * endpoint. A real EFA address (FI_ADDR_EFA: AH + QPN + QKEY-derived bytes)
+ * is never all-zero, so an all-zero slot unambiguously means "absent" and
+ * is skipped during addressing — the corresponding table entry stays 0 and
+ * is never used by a correct caller (the kernel bounds each post by the
+ * target's advertised count).
+ */
+static bool gdaki_ep_addr_is_absent(const uint8_t *addr, size_t len)
 {
-	ahs.allocate(nranks);
-	qpns.allocate(nranks);
-	qkeys.allocate(nranks);
-
-	for (int i = 0; i < nranks; i++) {
-		fi_addr_t fi_addr;
-		int ret = fi_av_insert(endpoint.av,
-				       peer_addrs.data() + i * ep_addr_len,
-				       1, &fi_addr, 0, nullptr);
-		if (ret != 1) {
-			throw std::runtime_error(
-				"fi_av_insert failed for rank " +
-				std::to_string(i));
+	for (size_t i = 0; i < len; i++) {
+		if (addr[i] != 0) {
+			return false;
 		}
+	}
+	return true;
+}
 
-		uint16_t ahn = 0, remote_qpn = 0;
-		uint32_t remote_qkey = 0;
-		ret = gda_ops->query_addr(endpoint.ep, fi_addr, &ahn,
-					  &remote_qpn, &remote_qkey);
-		if (ret != 0) {
-			throw std::runtime_error(
-				"query_addr failed for rank " +
-				std::to_string(i));
+void gdaki_target_addressing::populate(gdaki_fi_endpoint &endpoint,
+				       const std::vector<uint8_t> &all_addrs,
+				       size_t ep_addr_len, int total_slots, int nranks,
+				       struct fi_efa_ops_gda *gda_ops)
+{
+	if (total_slots <= 0 || nranks <= 0) {
+		return;
+	}
+
+	const size_t n = (size_t)total_slots * (size_t)nranks;
+	ahs.allocate(n);
+	qpns.allocate(n);
+	qkeys.allocate(n);
+
+	/* Build the targetSlot-major table: idx = slot * nranks + peer.
+	 *
+	 * `all_addrs` is the batched-allgather buffer, peer-major:
+	 *     addr(peer, slot) = &all_addrs[(peer * total_slots + slot) * ep_addr_len]
+	 * with slot 0 = peer's data EP and slots 1..(total_slots-1) = peer's
+	 * sc EPs. We resolve every (slot, peer) through THIS endpoint's own AV
+	 * (an address handle is AV-local) and store it at [slot * nranks + peer].
+	 *
+	 * A (slot, peer) whose peer has no endpoint at that slot (asymmetric
+	 * counts leave a zero address) is skipped; the entry stays 0 and is
+	 * never addressed — the kernel bounds each signalling post by the
+	 * target peer's advertised signal count. */
+	for (int slot = 0; slot < total_slots; slot++) {
+		for (int peer = 0; peer < nranks; peer++) {
+			const size_t dst_idx = (size_t)slot * (size_t)nranks + (size_t)peer;
+			const size_t src_idx = (size_t)peer * (size_t)total_slots + (size_t)slot;
+			const uint8_t *addr = all_addrs.data() + src_idx * ep_addr_len;
+
+			if (gdaki_ep_addr_is_absent(addr, ep_addr_len)) {
+				continue;
+			}
+
+			fi_addr_t fi_addr;
+			int ret = fi_av_insert(endpoint.av, addr, 1, &fi_addr, 0, nullptr);
+			if (ret != 1) {
+				throw std::runtime_error(
+					"target fi_av_insert failed (slot " +
+					std::to_string(slot) + ", rank " +
+					std::to_string(peer) + ")");
+			}
+
+			uint16_t ahn = 0, remote_qpn = 0;
+			uint32_t remote_qkey = 0;
+			ret = gda_ops->query_addr(endpoint.ep, fi_addr, &ahn,
+						  &remote_qpn, &remote_qkey);
+			if (ret != 0) {
+				throw std::runtime_error(
+					"target query_addr failed (slot " +
+					std::to_string(slot) + ", rank " +
+					std::to_string(peer) + ")");
+			}
+
+			ahs.host[dst_idx] = ahn;
+			qpns.host[dst_idx] = remote_qpn;
+			qkeys.host[dst_idx] = remote_qkey;
 		}
-
-		ahs.host[i] = ahn;
-		qpns.host[i] = remote_qpn;
-		qkeys.host[i] = remote_qkey;
 	}
 
 	ahs.commit();
@@ -237,8 +285,8 @@ void gdaki_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
 }
 
 void gdaki_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
-			      const std::vector<uint8_t> &peer_addrs,
-			      size_t ep_addr_len, int nranks)
+			      const std::vector<uint8_t> &all_addrs,
+			      size_t ep_addr_len, int total_slots, int nranks)
 {
 	/* Query QP and map SQ MMIO for GPU access. */
 	struct fi_efa_wq_attr sq_attr = {}, rq_attr = {};
@@ -271,8 +319,8 @@ void gdaki_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 
 	gpu_cq.build(efa_cq_attr);
 
-	/* Populate per-peer addressing tables in GPU memory. */
-	peers.populate(endpoint, peer_addrs, ep_addr_len, nranks, gda_ops);
+	/* Build the [total_slots*nranks] target table in GPU memory. */
+	targets.populate(endpoint, all_addrs, ep_addr_len, total_slots, nranks, gda_ops);
 }
 
 void gdaki_data_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
@@ -291,12 +339,12 @@ void gdaki_data_endpoint::open(struct fid_domain *domain, struct fi_info *ref_in
 }
 
 void gdaki_data_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
-				   const std::vector<uint8_t> &peer_addrs,
-				   size_t ep_addr_len, int nranks)
+				   const std::vector<uint8_t> &all_addrs,
+				   size_t ep_addr_len, int total_slots, int nranks)
 {
 	/* Delegate the shared work (QP/CQ query, MMIO map, GPU descriptors,
-	 * per-peer addressing, sq_size stash) to the inner endpoint. */
-	base.populate(gda_ops, peer_addrs, ep_addr_len, nranks);
+	 * target table, sq_size stash) to the inner endpoint. */
+	base.populate(gda_ops, all_addrs, ep_addr_len, total_slots, nranks);
 }
 
 void gdaki_sc_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
@@ -319,15 +367,15 @@ void gdaki_sc_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info
 }
 
 void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
-				 const std::vector<uint8_t> &peer_addrs,
-				 size_t ep_addr_len, int nranks)
+				 const std::vector<uint8_t> &all_addrs,
+				 size_t ep_addr_len, int total_slots, int nranks)
 {
 	/* Delegate the shared work (QP/CQ query, MMIO map, GPU descriptors,
-	 * per-peer addressing) to the inner endpoint. */
-	base.populate(gda_ops, peer_addrs, ep_addr_len, nranks);
+	 * target table) to the inner endpoint. */
+	base.populate(gda_ops, all_addrs, ep_addr_len, total_slots, nranks);
 
 	/*
-	 * Build the two device handles. They share QP / CQ / per-peer
+	 * Build the two device handles. They share QP / CQ / target
 	 * addressing / sq_lock / sq_size / submitted_count layout — only
 	 * the (cntr_value, local_cntr_value) pair differs.
 	 *
@@ -345,9 +393,9 @@ void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 	auto fill_common = [&](nccl_ofi_gin_gdaki_dev_counter_handle &h) {
 		h.base.qp = base.gpu_qp.dev();
 		h.base.cq = base.gpu_cq.dev();
-		h.base.address_handles = base.peers.ahs.dev;
-		h.base.remote_qpns = base.peers.qpns.dev;
-		h.base.qkey = base.peers.qkeys.dev;
+		h.base.target_address_handles = base.targets.ahs.dev;
+		h.base.target_remote_qpns = base.targets.qpns.dev;
+		h.base.target_qkey = base.targets.qkeys.dev;
 		h.base.sq_lock = 0;
 		h.base.submitted_count = 0;
 		h.base.sq_size = base.sq_size;

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -65,9 +65,10 @@ __global__ void gin_put_gpu_kernel(nccl_ofi_gin_gdaki_dev_handle *dev,
 	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);
 	efa_cuda_wr_set_sge(&wr, src_lkey, src_addr, bytes);
 	efa_cuda_wr_set_remote(&wr,
-			       dev->data.address_handles[peer],
-			       (uint32_t)dev->data.remote_qpns[peer],
-			       dev->data.qkey[peer]);
+			       /* slot 0 = peer's data EP: target idx = 0*nranks + peer */
+			       dev->data.target_address_handles[peer],
+			       (uint32_t)dev->data.target_remote_qpns[peer],
+			       dev->data.target_qkey[peer]);
 
 	efa_cuda_start_sq_batch(qp, 1);
 	efa_cuda_sq_batch_place_wr(qp, 0, &wr);

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -182,8 +182,21 @@ int main(int argc, char *argv[])
 		return ncclInternalError;
 	}
 
-	auto *src_gin_mr = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(src_ginhandle);
-	auto *dst_gin_mr = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(dst_ginhandle);
+	/* regMrSym returns a GPU-resident MR handle (the device-side Put
+	 * kernel dereferences it). Copy each handle to a host staging buffer
+	 * before reading lkey / peers[] on the host — dereferencing the GPU
+	 * pointer directly on the host faults. The handle is a flex-array
+	 * struct: header + peers[nranks]. */
+	const size_t mr_handle_bytes =
+		sizeof(nccl_ofi_gin_gdaki_mr_handle) +
+		(size_t)nranks * sizeof(nccl_ofi_gin_gdaki_mr_peer);
+	std::vector<uint8_t> src_mr_host(mr_handle_bytes), dst_mr_host(mr_handle_bytes);
+	CUDACHECK(cudaMemcpy(src_mr_host.data(), src_ginhandle, mr_handle_bytes,
+			     cudaMemcpyDeviceToHost));
+	CUDACHECK(cudaMemcpy(dst_mr_host.data(), dst_ginhandle, mr_handle_bytes,
+			     cudaMemcpyDeviceToHost));
+	auto *src_gin_mr = reinterpret_cast<nccl_ofi_gin_gdaki_mr_handle *>(src_mr_host.data());
+	auto *dst_gin_mr = reinterpret_cast<nccl_ofi_gin_gdaki_mr_handle *>(dst_mr_host.data());
 	uint32_t src_lkey = src_gin_mr->lkey;
 	std::vector<uint32_t> all_rkeys(nranks);
 	for (int i = 0; i < nranks; i++) all_rkeys[i] = dst_gin_mr->peers[i].rkey;

--- a/tests/functional/gin_signal_gdaki_gpu.cu
+++ b/tests/functional/gin_signal_gdaki_gpu.cu
@@ -39,6 +39,7 @@ struct proc_handle {
  */
 __global__ void gin_signal_gpu_kernel(nccl_ofi_gin_gdaki_dev_counter_handle *sig,
 				      int peer,
+				      int nranks,
 				      uint64_t dst_addr,
 				      uint32_t dst_rkey,
 				      uint64_t src_addr,
@@ -59,10 +60,14 @@ __global__ void gin_signal_gpu_kernel(nccl_ofi_gin_gdaki_dev_counter_handle *sig
 	efa_io_tx_wqe wr;
 	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);
 	efa_cuda_wr_set_sge(&wr, src_lkey, src_addr, bytes);
+	/* Target peer's signal endpoint 0. In the unified target table,
+	 * signal id s lives at slot (1 + s); this test uses signal 0, so
+	 * slot 1 -> target idx = 1*nranks + peer. (Slot 0 is the peer data EP.) */
+	const uint32_t targetIdx = (uint32_t)nranks + (uint32_t)peer;
 	efa_cuda_wr_set_remote(&wr,
-			       sig->base.address_handles[peer],
-			       (uint32_t)sig->base.remote_qpns[peer],
-			       sig->base.qkey[peer]);
+			       sig->base.target_address_handles[targetIdx],
+			       (uint32_t)sig->base.target_remote_qpns[targetIdx],
+			       sig->base.target_qkey[targetIdx]);
 
 	efa_cuda_start_sq_batch(qp, 1);
 	efa_cuda_sq_batch_place_wr(qp, 0, &wr);
@@ -249,7 +254,7 @@ int main(int argc, char *argv[])
 		CUDACHECK(cudaMemset(d_result, 0, sizeof(kernel_result)));
 
 		gin_signal_gpu_kernel<<<1, 1>>>(
-			sig_dev_gpu, tgt,
+			sig_dev_gpu, tgt, nranks,
 			all_dst_addrs[tgt], all_rkeys[tgt],
 			(uint64_t)sig_buf_gpu, sig_lkey,
 			(uint32_t)SIG_BUF_SIZE,

--- a/tests/functional/gin_signal_gdaki_gpu.cu
+++ b/tests/functional/gin_signal_gdaki_gpu.cu
@@ -171,7 +171,17 @@ int main(int argc, char *argv[])
 		MPI_Finalize();
 		return ncclInternalError;
 	}
-	auto *sig_mr = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(sig_ginhandle);
+	/* regMrSym returns a GPU-resident MR handle; copy it to a host
+	 * staging buffer before reading lkey / peers[] on the host
+	 * (dereferencing the GPU pointer on the host faults). Flex-array
+	 * struct: header + peers[nranks]. */
+	const size_t mr_handle_bytes =
+		sizeof(nccl_ofi_gin_gdaki_mr_handle) +
+		(size_t)nranks * sizeof(nccl_ofi_gin_gdaki_mr_peer);
+	std::vector<uint8_t> sig_mr_host(mr_handle_bytes);
+	CUDACHECK(cudaMemcpy(sig_mr_host.data(), sig_ginhandle, mr_handle_bytes,
+			     cudaMemcpyDeviceToHost));
+	auto *sig_mr = reinterpret_cast<nccl_ofi_gin_gdaki_mr_handle *>(sig_mr_host.data());
 	uint32_t sig_lkey = sig_mr->lkey;
 	std::vector<uint32_t> all_rkeys(nranks);
 	for (int i = 0; i < nranks; i++) all_rkeys[i] = sig_mr->peers[i].rkey;


### PR DESCRIPTION
Make the GIN `signalId` a property of the target endpoint and support ranks requesting different `nSignals` for a context.

Signal-target addressing:
- New `gdaki_signal_addressing`: per-poster-endpoint signal-target table of (`ahn`, `qpn`, `qkey`), signalId-major (`idx = signalId*nranks + peer`).
- Built for the data endpoint and every sc endpoint: any of them may post a signal-bearing `Put`/`PutValue` if its counter is unused.

Asymmetric counts:
- Allgather each rank's (`nSignals`, `nCounters`); derive `peer_n_sc[]`, `peer_nSignals[]` (uploaded to GPU), `global_n_sc` and `global_nSignals`.
- New ABI field `peer_nSignals[nranks]` on the dev handle: lets the device bounds-check the target `signalId` per peer without assuming uniformity. Mirrored in NCCL's `gin_efa_gda_dev.h`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
