### PR TITLE
gin/gdaki: return GPU-accessible ginHandle from regMrSym

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -196,11 +196,18 @@ struct nccl_ofi_rdma_gin_symm_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 	std::vector<gin_remote_mr> remote_mr;
 
 	/* Optional device-visible handle owned by the GDAKI plugin wrapper
-	 * (nccl_ofi_gin_gdaki_mr_handle *). Stored here so deregMrSym can
-	 * free it with only the mhandle in hand — NCCL's ncclGinDeregister
-	 * does not pass ginHandle to deregMrSym. Plain heap memory, no
-	 * libfabric resources. Null when the proxy path is used. */
+	 * (nccl_ofi_gin_gdaki_mr_handle *). This is GPU-accessible memory
+	 * (allocated via nccl_net_ofi_gpu_mem_alloc) — it is the pointer
+	 * returned to NCCL as ginHandle and dereferenced by the device-side
+	 * Put kernel, so it MUST be device-readable. Stored here so
+	 * deregMrSym can free it with only the mhandle in hand — NCCL's
+	 * ncclGinDeregister does not pass ginHandle to deregMrSym. Null when
+	 * the proxy path is used. */
 	void *gin_device_handle = nullptr;
+	/* Host staging copy of the above (plain heap). The handle is built
+	 * on the host here, then copied to gin_device_handle. Freed by
+	 * deregMrSym. Null when the proxy path is used. */
+	void *gin_device_handle_host = nullptr;
 };
 
 /**

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -782,7 +782,18 @@ static ncclResult_t nccl_ofi_gin_gdaki_regMrSym(void *collComm, void *data, size
 	uint32_t lkey = (uint32_t)gda_ops->get_mr_lkey(mr);
 
 	/* Step 4/5: allocate and populate the device-visible handle.
-	 * Layout: base struct + flex peers[nranks]. */
+	 * Layout: base struct + flex peers[nranks].
+	 *
+	 * The returned ginHandle is dereferenced by the device-side Put
+	 * kernel (ncclGinApi_Put<EFA_GDA>: srcMh->local_addr,
+	 * dstMh->peers[peer]...). It therefore MUST live in GPU-accessible
+	 * memory. Build the handle on a host staging buffer, then copy it
+	 * into a device allocation and return the DEVICE pointer.
+	 *
+	 * (Previously this returned a plain calloc() host pointer, which the
+	 * GPU could only read when the page happened to be mapped/cached —
+	 * causing intermittent illegal-address faults in the Put kernel and
+	 * the resulting waitSignal hangs.) */
 	size_t handle_size = sizeof(nccl_ofi_gin_gdaki_mr_handle) +
 			     (size_t)nranks * sizeof(nccl_ofi_gin_gdaki_mr_peer);
 	auto *gdaki_handle = static_cast<nccl_ofi_gin_gdaki_mr_handle *>(
@@ -803,23 +814,43 @@ static ncclResult_t nccl_ofi_gin_gdaki_regMrSym(void *collComm, void *data, size
 		gdaki_handle->peers[i].rkey        = (uint32_t)sym->remote_mr[i].mr_key[0];
 	}
 
-	/* Stash on the mhandle so deregMrSym can free it. The mhandle and
-	 * the gdaki_handle share a lifetime by construction. */
-	sym->gin_device_handle = gdaki_handle;
+	/* Allocate the GPU-accessible copy and stage the host handle into it. */
+	void *gdaki_handle_dev = nullptr;
+	if (nccl_net_ofi_gpu_mem_alloc(&gdaki_handle_dev, handle_size) != 0) {
+		NCCL_OFI_WARN("gin GDAKI: gpu_mem_alloc for gdaki_mr_handle failed");
+		free(gdaki_handle);
+		return ncclSystemError;
+	}
+	if (nccl_net_ofi_gpu_mem_copy_host_to_device(gdaki_handle_dev, gdaki_handle,
+						     handle_size) != 0) {
+		NCCL_OFI_WARN("gin GDAKI: h2d copy of gdaki_mr_handle failed");
+		nccl_net_ofi_gpu_mem_free(gdaki_handle_dev);
+		free(gdaki_handle);
+		return ncclSystemError;
+	}
 
-	*ginHandle = gdaki_handle;
+	/* Stash on the mhandle so deregMrSym can free both. The mhandle and
+	 * the gdaki_handle share a lifetime by construction. */
+	sym->gin_device_handle      = gdaki_handle_dev;  /* GPU-visible */
+	sym->gin_device_handle_host = gdaki_handle;      /* host staging */
+
+	*ginHandle = gdaki_handle_dev;
 	return ncclSuccess;
 }
 
 static ncclResult_t nccl_ofi_gin_gdaki_deregMrSym(void *collComm, void *mhandle)
 {
-	/* Free the device-visible handle first. The mhandle's
-	 * gin_device_handle points at plain heap memory owned by the
-	 * GDAKI regMrSym above; the underlying fid_mr is torn down by
-	 * the shared deregMrSym call that follows. */
+	/* Free the GDAKI device-visible handle and its host staging copy.
+	 * gin_device_handle is GPU memory (nccl_net_ofi_gpu_mem_alloc);
+	 * gin_device_handle_host is plain heap. The underlying fid_mr is
+	 * torn down by the shared deregMrSym call that follows. */
 	auto *sym = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mhandle);
-	free(sym->gin_device_handle);
-	sym->gin_device_handle = nullptr;
+	if (sym->gin_device_handle != nullptr) {
+		nccl_net_ofi_gpu_mem_free(sym->gin_device_handle);
+		sym->gin_device_handle = nullptr;
+	}
+	free(sym->gin_device_handle_host);
+	sym->gin_device_handle_host = nullptr;
 
 	return nccl_ofi_gin_deregMrSym(collComm, mhandle);
 }


### PR DESCRIPTION
*Issue #, if available:*

The GDAKI regMrSym built the device-visible MR handle with calloc() (host memory) and returned that host pointer to NCCL as the ginHandle. The device-side Put kernel dereferences it (srcMh->local_addr, dstMh->peers[peer]...), so reading a host pointer from the GPU intermittently faulted with an illegal address. The faulting kernel left the CUDA stream stuck, the put + SignalInc was never posted, and the receiver hung forever in waitSignal (~40% pass rate).

*Description of changes:*

Build the handle on a host staging buffer, copy it into a GPU allocation via nccl_net_ofi_gpu_mem_alloc /
nccl_net_ofi_gpu_mem_copy_host_to_device, and return the device pointer. Track both allocations on the mhandle (gin_device_handle for the GPU copy, gin_device_handle_host for the staging copy) so deregMrSym, which only receives the mhandle, can free both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
