### PR TITLE
gin/gdaki: add cntr_offset field for offset-based signal/counter reset

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -247,6 +247,14 @@ struct nccl_ofi_gin_gdaki_dev_counter_handle {
 	/* Pointer to the hardware counter value in GPU-accessible memory.
 	 * For signals: FI_REMOTE_WRITE count. For counters: FI_WRITE count. */
 	volatile uint64_t *cntr_value;
+
+	/* Reset baseline for offset-based (reset-without-zeroing) semantics.
+	 * The NIC counter cannot be written by software, so ResetSignal /
+	 * ResetCounter snapshot the current cntr_value into cntr_offset
+	 * instead of zeroing the counter. Reads/waits subtract cntr_offset,
+	 * making the signal/counter appear reset without modifying the
+	 * NIC-visible value. Initialized to 0 at populate() time. */
+	uint64_t cntr_offset;
 };
 
 /**

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -351,6 +351,7 @@ void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 		h.base.sq_lock = 0;
 		h.base.submitted_count = 0;
 		h.base.sq_size = base.sq_size;
+		h.cntr_offset = 0;   /* offset-based reset baseline */
 	};
 
 	counter_dev_handle.allocate(1);


### PR DESCRIPTION
*Issue #, if available:*

The EFA FI_WRITE / FI_REMOTE_WRITE counters are NIC-incremented and cannot be reset by a software store. To support ResetSignal / ResetCounter without writing the NIC counter, add a per-handle reset baseline: cntr_offset is snapshotted from the current counter value on reset, and reads/waits subtract it so the signal/counter appears reset while the NIC-visible value is left untouched.

*Description of changes:*

This commit adds the storage and initialization:

  - Add uint64_t cntr_offset to nccl_ofi_gin_gdaki_dev_counter_handle, alongside cntr_value. The field is mirrored on the NCCL side in gin_efa_gda_dev.h (kept in sync separately).
  - Initialize cntr_offset to 0 in gdaki_sc_endpoint::populate's fill_common, covering both the counter and signal device handles.

The device-side logic that consumes cntr_offset (GetSignalPtr / GetCounterPtr returning the offset, and ResetSignal / ResetCounter snapshotting it) lands in the corresponding NCCL change.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
