### PR TITLE
rdma: Fix memory leak of rx_buff_regmr_ctx in fini_rx_buffers()

### DIFF
--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -6362,6 +6362,8 @@ int nccl_net_ofi_rdma_ep_t::fini_rx_buffers()
 
 	delete this->rx_buff_reqs_fl;
 
+	delete this->rx_buff_regmr_ctx;
+
 	/* Deregister the flush buffer MR (always owned by this endpoint). */
 	if (this->flush_buff_mr_handle != nullptr) {
 		nccl_net_ofi_rdma_domain_t *domain_ptr = this->rdma_endpoint_get_domain();


### PR DESCRIPTION
*Issue #, if available:*
A memory leak is detected by asan.

*Description of changes:*
Delete rx_buff_regmr_ctx in fini_rx_buffers().

Tested with tests/functional/nccl_connection. Can repro before this fix, and verified that's gone after the fix.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
