### PR TITLE
platform: gate the EFA hardware completion counter on platform support

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -389,6 +389,17 @@ OFI_NCCL_PARAM_VALUE_SET(GIN_TYPE, (PROXY)(GDAKI))
 OFI_NCCL_PARAM(GIN_TYPE, gin_type, "GIN_TYPE", GIN_TYPE::PROXY)
 
 /*
+ * Controls use of the EFA hardware completion counter on the GDAKI GIN
+ * data path, which is only usable on platforms that support it.
+ *
+ *   AUTO: use it where the running platform supports it (the safe default).
+ *   ON:   force enabled, e.g. for development and validation.
+ *   OFF:  force disabled (kill switch).
+ */
+OFI_NCCL_PARAM_VALUE_SET(GDAKI_HW_COUNTER, (AUTO)(ON)(OFF))
+OFI_NCCL_PARAM(GDAKI_HW_COUNTER, gdaki_hw_counter, "GDAKI_HW_COUNTER", GDAKI_HW_COUNTER::AUTO)
+
+/*
  * Enable strong-signal semantics for the GIN plugin.
  *
  * When true, completed requests are delivered to the application in

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -127,6 +127,20 @@ public:
 			      fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
 			      (long)err_entry->len);
 	}
+
+	/**
+	 * @brief	Query whether the running platform supports the EFA
+	 *		hardware completion counter used by the GDAKI GIN data path.
+	 *
+	 *		The base implementation returns false (a platform that does
+	 *		not support the feature); concrete platforms override.
+	 *
+	 * @return	true if the platform supports the feature
+	 */
+	virtual bool platform_has_efa_hw_comp_cntr()
+	{
+		return false;
+	}
 };
 
 using PlatformPtr = std::unique_ptr<Platform>;

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -39,6 +39,17 @@ public:
 	void log_cq_error(void *req_p, struct fid_cq *cq, struct fi_cq_err_entry *err_entry,
 			  const char *req_type) override;
 
+	/*
+	 * Return true if the EFA hardware completion counter should be used on
+	 * the platform this process is running on.
+	 *
+	 * Resolves OFI_NCCL_GDAKI_HW_COUNTER:
+	 *   ON   -> force enabled
+	 *   OFF  -> force disabled (kill switch)
+	 *   AUTO -> whether the matched platform supports it (efa_hw_comp_cntr)
+	 */
+	bool platform_has_efa_hw_comp_cntr() override;
+
 protected:
 	struct ec2_platform_data {
 		const char* name;
@@ -49,6 +60,10 @@ protected:
 		bool gdr_required;
 		PROTOCOL default_protocol;
 		std::map<std::string, std::string> env;
+		/* True on platforms that support the EFA hardware completion
+		 * counter. Consulted only in the AUTO case of
+		 * OFI_NCCL_GDAKI_HW_COUNTER. */
+		bool efa_hw_comp_cntr;
 	};
 
 	struct platform_aws_node_guid {

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -91,6 +91,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p4de.24xlarge",
@@ -104,6 +105,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p3dn.24xlarge",
@@ -114,6 +116,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p5.4xlarge",
@@ -124,6 +127,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p5/p5e",
@@ -140,6 +144,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p5en/p6-b200",
@@ -163,6 +168,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
 			{ "NCCL_NETDEVS_POLICY", "max:1" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "p-series",
@@ -189,6 +195,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "g5.48xlarge",
@@ -199,6 +206,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "g7e.8xlarge",
@@ -212,6 +220,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "g7e",
@@ -225,6 +234,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
 		},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "Trainium Family",
@@ -235,6 +245,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "inf",
@@ -245,6 +256,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 };
 
@@ -342,6 +354,25 @@ const PlatformAWS::ec2_platform_data *PlatformAWS::get_platform_data()
 
 	cached_platform_data_ = get_platform_entry(platform_type, platform_data_list, platform_data_len);
 	return cached_platform_data_;
+}
+
+
+/*
+ * Resolve OFI_NCCL_GDAKI_HW_COUNTER for the running platform:
+ *   ON   -> force enabled
+ *   OFF  -> force disabled (kill switch)
+ *   AUTO -> whether the matched platform supports it (efa_hw_comp_cntr),
+ *           false on an unknown platform.
+ */
+bool PlatformAWS::platform_has_efa_hw_comp_cntr()
+{
+	GDAKI_HW_COUNTER mode = ofi_nccl_gdaki_hw_counter.get();
+	if (mode != GDAKI_HW_COUNTER::AUTO) {
+		return mode == GDAKI_HW_COUNTER::ON;
+	}
+
+	const ec2_platform_data *data = get_platform_data();
+	return data != nullptr && data->efa_hw_comp_cntr;
 }
 
 

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -17,6 +17,7 @@
 #include "rdma/gin/nccl_ofi_gin_gdaki.h"
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
+#include "nccl_ofi_platform.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -455,6 +456,22 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 	if (collComm == nullptr || config == nullptr || ginCtx == nullptr || devHandle == nullptr) {
 		NCCL_OFI_WARN("gin GDAKI: createContext received NULL argument");
 		return ncclInvalidArgument;
+	}
+
+	/*
+	 * Platform-support gate. The GDAKI data path relies on the EFA
+	 * hardware completion counter in GPU memory (fi_efa_ops_gda::
+	 * cntr_open_ext, see gdaki_hw_counter), which is only usable on
+	 * platforms that support it (or when forced via
+	 * OFI_NCCL_GDAKI_HW_COUNTER). Refusing here, before any resources are
+	 * built, gives a clear error instead of failing partway through context
+	 * creation when cntr_open_ext returns an error.
+	 */
+	if (!PlatformManager::get_global().get_platform().platform_has_efa_hw_comp_cntr()) {
+		NCCL_OFI_WARN("gin GDAKI: EFA hardware completion counter not supported "
+			      "on this platform; refusing createContext "
+			      "(set OFI_NCCL_GDAKI_HW_COUNTER=on to override)");
+		return ncclInvalidUsage;
 	}
 
 	NCCL_OFI_INFO(NCCL_NET,

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -19,6 +19,7 @@ public:
 	using PlatformAWS::get_platform_map;
 	using PlatformAWS::get_platform_entry;
 	using PlatformAWS::ec2_platform_data;
+	using PlatformAWS::platform_has_efa_hw_comp_cntr;
 };
 
 /* check that we get the expected response for all our known platforms */
@@ -92,6 +93,40 @@ static int check_known_platforms(void)
 	return ret;
 }
 
+/* GDAKI hardware-completion-counter platform gate.
+ *
+ * platform_has_efa_hw_comp_cntr() answers whether the running platform
+ * supports the EFA hardware completion counter: OFI_NCCL_GDAKI_HW_COUNTER on or
+ * off overrides the platform, and auto defers to whether the platform supports
+ * it. The param is read once and cached, so a single process can only observe
+ * one value; here we cover the base default (off) and the on override forcing
+ * the counter on even where the platform would not support it. */
+static int check_hw_cntr_gate(void)
+{
+	int ret = 0;
+
+	/* The base Platform default is off, so a platform that does not support
+	 * the feature reports it as unsupported. */
+	Default def;
+	if (def.platform_has_efa_hw_comp_cntr()) {
+		printf("base Platform platform_has_efa_hw_comp_cntr() must be false\n");
+		ret += 1;
+	}
+
+	/* OFI_NCCL_GDAKI_HW_COUNTER=on forces the counter on regardless of the
+	 * platform. The param is read once and cached, so set it before the
+	 * first query. */
+	ofi_nccl_gdaki_hw_counter.set(GDAKI_HW_COUNTER::ON);
+	TestablePlatformAWS p;
+	if (!p.platform_has_efa_hw_comp_cntr()) {
+		printf("OFI_NCCL_GDAKI_HW_COUNTER=on did not force the counter on\n");
+		ret += 1;
+	}
+
+	return ret;
+}
+
+
 static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 	{
 		.name = "first",
@@ -102,6 +137,7 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 	{
 		.name = "second",
@@ -112,6 +148,7 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::RDMA,
 		.env = {},
+		.efa_hw_comp_cntr = false,
 	},
 };
 
@@ -126,6 +163,9 @@ int main(int argc, char *argv[]) {
 	/* make sure we maintain ordering */
 	ret += check_value(test_map_1, 2, "platform-x", "first");
 	ret += check_value(test_map_1, 2, "platform-xy", "second");
+
+	/* feature-flag mechanism */
+	ret += check_hw_cntr_gate();
 
 	return ret;
 }


### PR DESCRIPTION
## Summary

  Adds a small per-platform feature-gating mechanism: a platform declares
  whether it supports a given feature, and the plugin uses the feature only
  where it is supported. The first (and only) consumer is the GDAKI EFA
  hardware-completion-counter path.

  ## Motivation

  Some capabilities are only usable on certain platforms. Rather than probe
  each host at runtime, a platform statically declares whether it supports the
  feature, so the answer is uniform for every process on that platform.

  The GDAKI GIN data path relies on the EFA hardware completion counter in GPU
  memory (`fi_efa_ops_gda::cntr_open_ext`), which is only usable where the
  platform supports it. Without a gate, an unsupported platform fails partway
  through `createContext` when `cntr_open_ext` errors; gating it up front turns
  that into a clear, early refusal.

  ## What's in it

  - **`platform_has_efa_hw_comp_cntr()`** on the base `Platform` interface
    (virtual, default `false`; overridden by `PlatformAWS`), so any transport
    can query it through `PlatformManager::get_platform()` without downcasting.
  - **`bool efa_hw_comp_cntr`** on each `ec2_platform_data` entry (defaults to
    `false`), the per-platform declaration of support.
  - **`OFI_NCCL_GDAKI_HW_COUNTER`** tristate param: `auto` (default) uses the
    feature where the platform supports it; `on` forces it enabled; `off` is a
    kill switch. `on`/`off` are explicit overrides, useful for development and
    validation.
  - **First consumer:** GDAKI `createContext` refuses with `ncclInvalidUsage`
    and an actionable message when the counter is not supported, instead of
    failing later.

  All platform entries default the feature **off**, so this is a no-op until a
  platform opts in.

  ## Testing

  - Unit tests (`aws_platform_mapper`) cover the base default (off) and the
    `on` override forcing the counter on where the platform would not support it.
  - Default build + unit tests pass.
  - GDAKI consumer compile-verified with `--enable-gdaki` against a libfabric
    build carrying the `fi_efa_ops_gda` hardware-counter ABI.