### PR TITLE
gin/gdaki: skip GDRCopy registration in GDAKI mode

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -298,6 +298,13 @@ public:
 	int regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
 			   uint64_t mrFlags, nccl_ofi_gin_symm_mr_handle_t **mr_handle_out) override;
 
+	/* Shared core behind the proxy regMrSymDmaBuf and the GDAKI regMrSymDmaBuf
+	 * entry point: duplicate detection/refcount, local EFA registration, MR-map
+	 * insertion, and the per-rank key all-gather. Leaves gdr_handle == nullptr;
+	 * GDRCopy (proxy only) is layered on top by the caller. Caller holds ep_lock. */
+	int regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
+				 nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out);
+
 	int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) override;
 
 	void increment_outstanding_ack_counter()

--- a/include/rdma/gin/nccl_ofi_gin_api.h
+++ b/include/rdma/gin/nccl_ofi_gin_api.h
@@ -25,6 +25,10 @@ ncclResult_t nccl_ofi_gin_regMrSym(void *collComm, void *data, size_t size, int 
 ncclResult_t nccl_ofi_gin_regMrSymDmaBuf(void *collComm, void *data, size_t size, int type,
 					 uint64_t offset, int fd, uint64_t mrFlags,
 					 void **mhandle, void **ginHandle);
+/* Build a registration cache key (VA or DMA-BUF), shared by the proxy and
+   GDAKI regMrSymDmaBuf entry points. */
+ncclResult_t nccl_ofi_gin_make_ckey(void *data, size_t size, uint64_t offset, int fd,
+				    nccl_ofi_mr_ckey_t *ckey_out);
 ncclResult_t nccl_ofi_gin_deregMrSym(void *collComm, void *mhandle);
 ncclResult_t nccl_ofi_gin_closeColl(void *collComm);
 ncclResult_t nccl_ofi_gin_closeListen(void *listenComm);

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -316,8 +316,38 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 				      int type, uint64_t mrFlags, nccl_ofi_gin_symm_mr_handle_t **mr_handle_out)
 {
 	auto &gin_ep = resources.get_ep();
-
 	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+
+	/* Shared core: dedup/refcount, local EFA registration, MR-map insert,
+	   per-rank key all-gather. */
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = nullptr;
+	int ret = regMrSymDmaBufCommon(ckey, data_ptr, size, type, &mr_handle);
+	if (ret != 0) {
+		return ret;
+	}
+
+	/* Proxy path only: for CUDA memory, also register with GDRCopy so the
+	   proxy can perform CPU-driven signal updates. On a duplicate hit the
+	   handle already carries a gdr_handle, so register only the first time. */
+	if (type == NCCL_PTR_CUDA && mr_handle->gdr_handle == nullptr) {
+		ret = get_device_copy().register_region(mr_handle->input_address, mr_handle->size,
+							mr_handle->gdr_handle);
+		if (ret != 0) {
+			NCCL_OFI_WARN("GDRCopy registration failed: %d", ret);
+			mr_handle_map.erase(mr_handle->input_address);
+			delete mr_handle;
+			return ret;
+		}
+	}
+
+	*mr_handle_out = mr_handle;
+	return 0;
+}
+
+int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
+				      int type, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
+{
+	auto &gin_ep = resources.get_ep();
 
 	/* Check for duplicate registration */
 	auto it = mr_handle_map.find(data_ptr);
@@ -337,8 +367,8 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 
 	auto *mr_handle = new nccl_ofi_rdma_gin_symm_mr_handle {};
 
-	NCCL_OFI_TRACE(NCCL_NET, "regMrSymDmaBuf ptr %p size %zu type %d flags %lu handle %p",
-		       data_ptr, size, type, mrFlags, mr_handle);
+	NCCL_OFI_TRACE(NCCL_NET, "regMrSymDmaBuf ptr %p size %zu type %d handle %p",
+		       data_ptr, size, type, mr_handle);
 
 	/**
 	 * Local registration with the endpoint
@@ -368,24 +398,12 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 	my_remote_mr.num_rails = gin_ep.get_num_rails();
 
 	auto *local_handle = mr_handle->local_handle;
-	if (type == NCCL_PTR_CUDA) {
-		/* For CUDA registrations, we also register the memory with
-		   GDRCopy, in case we are asked to do a signal update to this
-		   region. */
-		ret = get_device_copy().register_region(mr_handle->input_address, mr_handle->size,
-							mr_handle->gdr_handle);
-		if (ret != 0) {
-			NCCL_OFI_WARN("GDRCopy registration failed: %d", ret);
-			goto err;
-		}
-	}
-
 	for (unsigned i = 0; i < gin_ep.get_num_rails(); ++i) {
 		my_remote_mr.mr_key[i] = fi_mr_key(local_handle->get_mr(i));
 		if (my_remote_mr.mr_key[i] == FI_KEY_NOTAVAIL) {
 			NCCL_OFI_WARN("Memory registration key is not available");
-			ret = -EIO;
-			goto err;
+			delete mr_handle;
+			return -EIO;
 		}
 	}
 
@@ -401,10 +419,6 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 
 	*mr_handle_out = mr_handle;
 	return 0;
-
-err:
-	delete mr_handle;
-	return ret;
 }
 
 int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle_base)
@@ -425,7 +439,7 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 		return 0;
 	}
 
-	if (mr_handle->type == NCCL_PTR_CUDA) {
+	if (mr_handle->type == NCCL_PTR_CUDA && mr_handle->gdr_handle != nullptr) {
 		int ret = get_device_copy().deregister_region(mr_handle->gdr_handle);
 		if (ret != 0) {
 			NCCL_OFI_WARN("GDRCopy deregister failed: %d", ret);

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -219,25 +219,35 @@ ncclResult_t nccl_ofi_gin_connect(void *ctx, void *handles[], int nranks, int ra
 	return nccl_net_ofi_retval_translate(ret);
 }
 
-ncclResult_t nccl_ofi_gin_regMrSymDmaBuf(void *collComm, void *data, size_t size, int type,
-						uint64_t offset, int fd, uint64_t mrFlags,
-						void **mhandle, void **ginHandle)
+ncclResult_t nccl_ofi_gin_make_ckey(void *data, size_t size, uint64_t offset, int fd,
+				    nccl_ofi_mr_ckey_t *ckey_out)
 {
-	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
-	nccl_ofi_gin_symm_mr_handle_t *mr_handle = nullptr;
-
 #if HAVE_DECL_FI_MR_DMABUF
-	const nccl_ofi_mr_ckey_t cache_key =
-		(fd == -1) ? nccl_ofi_mr_ckey_mk_vec(data, size, nullptr)
-			   : nccl_ofi_mr_ckey_mk_dmabuf(fd, offset, size, data, nullptr);
+	*ckey_out = (fd == -1) ? nccl_ofi_mr_ckey_mk_vec(data, size, nullptr)
+			       : nccl_ofi_mr_ckey_mk_dmabuf(fd, offset, size, data, nullptr);
 #else
 	if (fd != -1) {
 		NCCL_OFI_WARN("Passed fd handle, but not compiled with DMA-BUF support.");
 		return nccl_net_ofi_retval_translate(-EINVAL);
 	}
-	const nccl_ofi_mr_ckey_t cache_key = nccl_ofi_mr_ckey_mk_vec(data, size, nullptr);
+	*ckey_out = nccl_ofi_mr_ckey_mk_vec(data, size, nullptr);
 #endif
+	return ncclSuccess;
+}
 
+ncclResult_t nccl_ofi_gin_regMrSymDmaBuf(void *collComm, void *data, size_t size, int type,
+						uint64_t offset, int fd, uint64_t mrFlags,
+						void **mhandle, void **ginHandle)
+{
+	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+
+	nccl_ofi_mr_ckey_t cache_key;
+	ncclResult_t cret = nccl_ofi_gin_make_ckey(data, size, offset, fd, &cache_key);
+	if (cret != ncclSuccess) {
+		return cret;
+	}
+
+	nccl_ofi_gin_symm_mr_handle_t *mr_handle = nullptr;
 	int ret = comm->regMrSymDmaBuf(&cache_key, data, size, type, mrFlags, &mr_handle);
 	if (ret != 0) {
 		return nccl_net_ofi_retval_translate(ret);

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -904,6 +904,40 @@ static ncclResult_t nccl_ofi_gin_gdaki_closeColl(void *collComm)
 }
 
 /*
+ * GDAKI regMrSymDmaBuf: build the registration cache key, then run the shared
+ * core registration (comm->regMrSymDmaBufCommon) under the endpoint lock with
+ * no GDRCopy — signals are delivered GPU-side via HW counters, and GDRCopy
+ * cannot pin multi-segment VMM allocations. (The proxy path adds GDRCopy on top
+ * of the same core.)
+ */
+static ncclResult_t nccl_ofi_gin_gdaki_regMrSymDmaBuf(void *collComm, void *data, size_t size,
+						int type, uint64_t offset, int fd, uint64_t mrFlags,
+						void **mhandle, void **ginHandle)
+{
+	auto *comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
+
+	nccl_ofi_mr_ckey_t cache_key;
+	ncclResult_t cret = nccl_ofi_gin_make_ckey(data, size, offset, fd, &cache_key);
+	if (cret != ncclSuccess) {
+		return cret;
+	}
+
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = nullptr;
+	int ret;
+	{
+		std::lock_guard scoped_ep_lock(comm->get_ep_lock());
+		ret = comm->regMrSymDmaBufCommon(&cache_key, data, size, type, &mr_handle);
+	}
+	if (ret != 0) {
+		return nccl_net_ofi_retval_translate(ret);
+	}
+
+	*mhandle = mr_handle;
+	*ginHandle = mr_handle;
+	return ncclSuccess;
+}
+
+/*
  * GDAKI regMrSym:
  *
  *   1. Call the shared proxy regMrSym. Because createContext opens the
@@ -929,10 +963,10 @@ static ncclResult_t nccl_ofi_gin_gdaki_regMrSym(void *collComm, void *data, size
 						int type, uint64_t mrFlags,
 						void **mhandle, void **ginHandle)
 {
-	/* Step 1: delegate to the shared proxy regMrSym for the actual
-	 * memory registration and per-peer rkey allgather. */
-	ncclResult_t nret = nccl_ofi_gin_regMrSym(collComm, data, size, type,
-						  mrFlags, mhandle, ginHandle);
+	/* Step 1: delegate to the GDAKI regMrSymDmaBuf (skips GDRCopy) for the
+	 * actual memory registration and per-peer rkey allgather. */
+	ncclResult_t nret = nccl_ofi_gin_gdaki_regMrSymDmaBuf(collComm, data, size, type,
+						  0, -1, mrFlags, mhandle, ginHandle);
 	if (nret != ncclSuccess) {
 		return nret;
 	}
@@ -1112,7 +1146,7 @@ ncclGin_v13_t nccl_ofi_gin_gdaki_plugin = {
 	.connect = nccl_ofi_gin_connect,
 	.createContext = nccl_ofi_gin_gdaki_createContext,
 	.regMrSym = nccl_ofi_gin_gdaki_regMrSym,
-	.regMrSymDmaBuf = nccl_ofi_gin_regMrSymDmaBuf,
+	.regMrSymDmaBuf = nccl_ofi_gin_gdaki_regMrSymDmaBuf,
 	.deregMrSym = nccl_ofi_gin_gdaki_deregMrSym,
 	.destroyContext = nccl_ofi_gin_gdaki_destroyContext,
 	.closeColl = nccl_ofi_gin_gdaki_closeColl,


### PR DESCRIPTION
In GDAKI mode, signal updates are delivered GPU-side via hardware counters, so the CPU GDRCopy signal-delivery path is never used. Skip the GDRCopy region registration for CUDA memory when the GIN type is GDAKI (it is also unable to pin multi-segment VMM allocations, which otherwise fails registration of segmented windows). The GDRCopy deregister is made null-safe so skipped registrations tear down cleanly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
