### PR TITLE
tuner: Add chunk size tuning for P5en

### DIFF
--- a/include/tuner/nccl_ofi_tuner_common.h
+++ b/include/tuner/nccl_ofi_tuner_common.h
@@ -66,6 +66,14 @@ struct nccl_ofi_tuner_context {
 						  int *protocol,
 						  int* nChannels);
 
+	ncclResult_t (*get_chunk_size_internal)(nccl_ofi_tuner_context_t *ctx,
+					       ncclFunc_t collType,
+					       size_t nBytes,
+					       int algo,
+					       int proto,
+					       int nChannels,
+					       size_t *chunkSize);
+
 	ncclResult_t (*destroy_internal)(nccl_ofi_tuner_context_t *ctx);
 };
 

--- a/include/tuner/nccl_ofi_tuner_region.h
+++ b/include/tuner/nccl_ofi_tuner_region.h
@@ -50,6 +50,14 @@ ncclResult_t region_get_coll_info_internal_v2(nccl_ofi_tuner_context_t *ctx,
 					      int *protocol,
 					      int *nChannels);
 
+ncclResult_t region_get_chunk_size_internal(nccl_ofi_tuner_context_t *ctx,
+					    ncclFunc_t collType,
+					    size_t nBytes,
+					    int algo,
+					    int proto,
+					    int nChannels,
+					    size_t *chunkSize);
+
 ncclResult_t region_destroy_internal(nccl_ofi_tuner_context_t *ctx);
 
 /* Maximum number of vertices per region */

--- a/src/tuner/nccl_ofi_regions.cpp
+++ b/src/tuner/nccl_ofi_regions.cpp
@@ -504,30 +504,36 @@ static ncclResult_t region_init_internal_p5en(nccl_ofi_tuner_region_context_t *r
 				 .vertices = {{0, 2}, {65536, 2}, {65536, 64}, {65536, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_TREE,
 				 .protocol = NCCL_PROTO_LL128,
-				 .num_vertices = 7,
+				 .num_vertices = 11,
 				 .vertices = {{65536, TUNER_MAX_RANKS},
 							  {65536, 64},
 							  {65536, 2},
 							  {262144, 2},
-							  {524288, 8},
+							  {1048576, 4},
+							  {4194304, 8},
+							  {16777216, 16},
+							  {33554432, 32},
+							  {1048576, 32},
 							  {1048576, 96},
 							  extended_tree_ll128}},
 				{.algorithm = NCCL_ALGO_TREE,
 				 .protocol = NCCL_PROTO_SIMPLE,
-				 .num_vertices = 7,
+				 .num_vertices = 6,
 				 .vertices = {extended_tree_ll128,
 							  {1048576, 96},
-							  {524288, 8},
-							  {262144, 2},
-							  {8388608, 32},
+							  {1048577, 32},
+							  {33554431, 32},
 							  {33554432, 128},
 							  extended_tree_simple}},
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL128,
-				 .num_vertices = 8,
+				 .num_vertices = 11,
 				 .vertices = {extended_tree_simple,
 							  {33554432, 128},
-							  {8388608, 32},
+							  {33554433, 32},
+							  {16777217, 16},
+							  {4194305, 8},
+							  {1048577, 4},
 							  {262144, 2},
 							  {6291456, 2},
 							  {50331648, 16},
@@ -2143,6 +2149,97 @@ ncclResult_t region_get_coll_info_internal_v3(nccl_ofi_tuner_context_t *ctx,
 	NCCL_OFI_INFO(NCCL_TUNING, "Setting nChannels to %d at nBytes=%ld.", *nChannels, nBytes);
 exit:
 	return ret;
+}
+
+static size_t chunkSizeTuningTreeLL128P5en(size_t nBytes, int log2_nnodes)
+{
+	/*
+	 * Picks a chunk size by stepping down a power-of-2 ladder
+	 * (288000 -> 144000 -> 72000 -> 36000 -> 18000) based on how many chunks the
+	 * per-channel message would be split into. NCCL later grains these to the
+	 * sizes it actually uses (e.g. 36000 -> 34560, 72000 -> 71040).
+	 *
+	 * Key quantities:
+	 * nBytes = per-channel byte count (msg_size / nChannels).
+	 * nsteps = 1 + log2(nNodes)
+	 *                         = tree depth (levels per direction). The tree is a
+	 *                           multi-level pipeline (reduce up, broadcast down);
+	 *                           keeping it full needs roughly one in-flight chunk
+	 *                           per level, so every threshold scales with nsteps.
+	 * nBytes / tunedChunkSize = number of chunks at the current chunk size. Few
+	 *                           chunks => shallow pipeline; many chunks => full
+	 *                           pipeline.
+	 *
+	 * Trade-off at every chunk size: larger chunks put more bytes in flight, which
+	 * EFA rewards only up to its inflight saturation point; smaller chunks give more
+	 * chunks to keep a deep tree pipeline full. */
+	size_t nsteps = 1 + log2_nnodes;
+
+	/*
+	 * The network path saturates once the in-flight data per rank fills the link's
+	 * capacity; beyond that point additional in-flight data only adds queuing
+	 * latency without improving throughput. For large message sizes, a chunk size
+	 * of 288,000 Bytes keeps in-flight data near this saturation point while still
+	 * producing enough chunks to keep the pipeline full. Larger chunk sizes push
+	 * in-flight data past saturation, adding queuing latency with no throughput
+	 * gain. */
+	size_t tunedChunkSize = 288000;
+
+	/*
+	 * Step 1: 288000 → 144000 (threshold: 2 × nsteps²)
+	 * The quadratic scaling captures the observation that larger clusters need
+	 * proportionally many more chunks before the biggest chunk size becomes
+	 * beneficial. Choosing chunk size of 144,000 Bytes will keep inflight at
+	 * 1MB while having more chunks to maximize the pipeline efficiency. Deeper
+	 * trees need more chunks in the pipeline to keep all links busy
+	 * simultaneously, because there are more hops to fill. */
+	if (nBytes / tunedChunkSize < 2 * nsteps * nsteps)
+		tunedChunkSize /= 2;
+
+	/*
+	 * Step 2: 144000 → 72000 (threshold: 1.5 × nsteps)
+	 * At the 144 KB chunk size, decide whether there are enough chunks to keep
+	 * 144 KB or whether to step down to 72 KB for better pipelining on smaller
+	 * messages. Keeping a deeper pipeline full needs roughly "one chunk per
+	 * level," so the threshold scales linearly with depth. */
+	if (nBytes / tunedChunkSize < (size_t)(1.5 * nsteps))
+		tunedChunkSize /= 2;
+
+	/*
+	 * Step 3: 72000 → 36000 → 18000 (threshold: nsteps + 1)
+	 * At small chunk chunk sizes, per-chunk inflight is small, and the EFA bandwidth
+	 * benefit of larger chunks is negligible, so the only concern is filling
+	 * the pipeline. That needs about one chunk per tree level. */
+	while (nBytes / tunedChunkSize < nsteps + 1 && tunedChunkSize > 18000)
+		tunedChunkSize /= 2;
+
+	return tunedChunkSize;
+}
+
+ncclResult_t region_get_chunk_size_internal(nccl_ofi_tuner_context_t *ctx,
+					    ncclFunc_t collType,
+					    size_t nBytes,
+					    int algo,
+					    int proto,
+					    int nChannels,
+					    size_t *chunkSize)
+{
+	nccl_ofi_tuner_region_context_t *region_ctx = (nccl_ofi_tuner_region_context_t *)ctx->type_ctx;
+	if (region_ctx == nullptr) {
+		return ncclSuccess;
+	}
+
+	/* Chunk size tuning for 1-rank-per-node (nNodes == nRanks) */
+	if (region_ctx->dims.num_nodes == region_ctx->dims.num_ranks) {
+		if (collType == ncclFuncAllReduce && algo == NCCL_ALGO_TREE &&
+		    proto == NCCL_PROTO_LL128) {
+			if (region_ctx->platform == NCCL_OFI_TUNER_P5EN) {
+				*chunkSize = chunkSizeTuningTreeLL128P5en(nBytes, region_ctx->log2_nnodes);
+			}
+		}
+	}
+
+	return ncclSuccess;
 }
 
 ncclResult_t region_destroy_internal(nccl_ofi_tuner_context_t *ctx)

--- a/src/tuner/nccl_ofi_regions.cpp
+++ b/src/tuner/nccl_ofi_regions.cpp
@@ -4,6 +4,7 @@
 
 #include "config.h"
 
+#include <algorithm>
 #include <cassert>
 #include <cstring>
 #include <math.h>
@@ -566,10 +567,12 @@ static ncclResult_t region_init_internal_p5en(nccl_ofi_tuner_region_context_t *r
 			const nccl_ofi_tuner_region_t regions[] = {
 				{.algorithm = NCCL_ALGO_PAT,
 				 .protocol = NCCL_PROTO_SIMPLE,
-				 .num_vertices = 10,
+				 .num_vertices = 12,
 				 .vertices = {{0, 2},
 							  {65536, 2},
 							  {1048576, 2},
+							  {8388608, 8},
+							  {16777216, 16},
 							  {16777216, 32},
 							  {50331648, 64},
 							  {117440512, 128},
@@ -579,11 +582,13 @@ static ncclResult_t region_init_internal_p5en(nccl_ofi_tuner_region_context_t *r
 							  {0, TUNER_MAX_RANKS}}},
 				{.algorithm = NCCL_ALGO_RING,
 				 .protocol = NCCL_PROTO_LL128,
-				 .num_vertices = 9,
+				 .num_vertices = 11,
 				 .vertices = {extended_pat_simple,
 							  {117440512, 128},
 							  {50331648, 64},
 							  {16777216, 32},
+							  {16777217, 16},
+							  {8388609, 8},
 							  {1048576, 2},
 							  {4194304, 2},
 							  {50331648, 16},
@@ -2151,6 +2156,58 @@ exit:
 	return ret;
 }
 
+static size_t chunkSizeTuningAllGatherPatSimpleP5en(size_t nBytes, size_t nNodes)
+{
+	/*
+	 * Steps DOWN a power-of-2 ladder from a per-cluster ceiling, choosing the
+	 * largest chunk that still yields at least T chunks for the current zone.
+	 * nNodes < 16: 1048576 -> 524288 -> 262144 -> 131072 -> 65536 -> 32768
+	 * nNodes >= 16:           524288 -> 262144 -> 131072 -> 65536 -> 32768
+	 * NCCL later grains these to the sizes it actually uses.
+	 *
+	 * Why chunk count matters for PAT: PAT's time is ~ log2(nNodes)*RTT (latency)
+	 * + serialization, and the latency term is paid per phase -- PAT pipelines
+	 * within a phase but not across phases. Phase count is set by how the per-
+	 * channel data fragments against PAT's inflight budget (NCCL_STEPS = 8 per
+	 * channel): if nchunks fits the 8-steps buffer, the collective runs as one
+	 * pipelined phase; if nchunks exceeds it, the channel must drain/refill mid-
+	 * collective, splitting into multiple non-pipelined phases and paying the
+	 * latency term again. So fewer chunks (larger size) keep it single-phase
+	 * (helps mid/large messages); more chunks (smaller size) fill the recursive
+	 * doubling pipeline faster (helps latency-bound small messages). */
+
+	/*
+	 * Ceiling: small clusters can use a larger single-phase chunk on big messages.
+	 * Larger clusters partition data across more ranks and top out a lower saturation
+	 * chunk size. */
+	size_t satChunkSize = nNodes >= 16 ? 524288 : 1048576;
+
+	/* Per-zone minimum chunk counts */
+	size_t T1 = nNodes >= 16 ? 32 : std::min(nNodes, (size_t)8) + 1; /* cap zone */
+	size_t T2 = std::min(nNodes, (size_t)16);                        /* mid zone */
+	size_t T3 = std::min(nNodes, (size_t)8);                         /* low zone */
+
+	size_t tunedChunkSize = satChunkSize;
+
+	/*
+	 * Step 1 (cap): one conditional halve off the ceiling. Let big messages use
+	 * larger chunk size to force it single-phase. */
+	while (nBytes / tunedChunkSize < T1 && tunedChunkSize > satChunkSize / 2)
+		tunedChunkSize /= 2;
+
+	/* Step 2 (mid): walk the mid chunks down to 64K chunk */
+	while (nBytes / tunedChunkSize < T2 && tunedChunkSize > 65536)
+		tunedChunkSize /= 2;
+
+	/*
+	 * Step 3 (low): final 64K->32K. At these sizes, the single-phase gain is
+	 * gone and only pipeline fill masters, so the threshold is the lowest. */
+	while (nBytes / tunedChunkSize < T3 && tunedChunkSize > 32768)
+		tunedChunkSize /= 2;
+
+	return tunedChunkSize;
+}
+
 static size_t chunkSizeTuningTreeLL128P5en(size_t nBytes, int log2_nnodes)
 {
 	/*
@@ -2235,6 +2292,12 @@ ncclResult_t region_get_chunk_size_internal(nccl_ofi_tuner_context_t *ctx,
 		    proto == NCCL_PROTO_LL128) {
 			if (region_ctx->platform == NCCL_OFI_TUNER_P5EN) {
 				*chunkSize = chunkSizeTuningTreeLL128P5en(nBytes, region_ctx->log2_nnodes);
+			}
+		}
+		if (collType == ncclFuncAllGather && algo == NCCL_ALGO_PAT &&
+		    proto == NCCL_PROTO_SIMPLE) {
+			if (region_ctx->platform == NCCL_OFI_TUNER_P5EN) {
+				*chunkSize = chunkSizeTuningAllGatherPatSimpleP5en(nBytes, region_ctx->dims.num_nodes);
 			}
 		}
 	}

--- a/src/tuner/nccl_ofi_tuner.cpp
+++ b/src/tuner/nccl_ofi_tuner.cpp
@@ -103,6 +103,7 @@ static ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugL
 		ctx->get_coll_info_internal_v6 = region_get_coll_info_internal_v6;
 		ctx->get_coll_info_internal_v3 = region_get_coll_info_internal_v3;
 		ctx->get_coll_info_internal_v2 = region_get_coll_info_internal_v2;
+		ctx->get_chunk_size_internal = region_get_chunk_size_internal;
 		ctx->destroy_internal = region_destroy_internal;
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING, "Region base Tuner is chosen for platform: %s",
 			constants.get_platform_type());
@@ -113,6 +114,7 @@ static ncclResult_t nccl_ofi_tuner_init(size_t nRanks, size_t nNodes, ncclDebugL
 		ctx->get_coll_info_internal_v6 = model_get_coll_info_internal_v6;
 		ctx->get_coll_info_internal_v3 = model_get_coll_info_internal_v3;
 		ctx->get_coll_info_internal_v2 = model_get_coll_info_internal_v2;
+		ctx->get_chunk_size_internal = nullptr;
 		ctx->destroy_internal = model_destroy_internal;
 		NCCL_OFI_INFO(NCCL_INIT | NCCL_TUNING, "Model base Tuner is chosen for platform: %s",
 			constants.get_platform_type());
@@ -219,12 +221,29 @@ static ncclResult_t nccl_ofi_tuner_finalize(void *context)
 	return nccl_ofi_tuner_destroy(context);
 }
 
+static ncclResult_t nccl_ofi_tuner_get_chunk_size(void *context,
+						  ncclFunc_t collType,
+						  size_t nBytes,
+						  int algo,
+						  int proto,
+						  int nChannels,
+						  size_t *chunkSize)
+{
+	nccl_ofi_tuner_context_t *ctx = (nccl_ofi_tuner_context_t *)context;
+	if (ctx == nullptr || ctx->get_chunk_size_internal == nullptr) {
+		/* Fall back to NCCL's chunk size */
+		return ncclSuccess;
+	}
+
+	return ctx->get_chunk_size_internal(ctx, collType, nBytes, algo, proto, nChannels, chunkSize);
+}
+
 /* Tuner v6 was introduced in NCCL 2.30.3 */
 NCCL_OFI_EXPORT_SYMBOL ncclTuner_v6_t ncclTunerPlugin_v6 = {.name = "nccl_ofi_tuner",
 					   .init = nccl_ofi_tuner_init_v6,
 					   .getCollInfo = nccl_ofi_tuner_get_coll_info_v6,
 					   .finalize = nccl_ofi_tuner_finalize,
-					   .getChunkSize = nullptr};
+					   .getChunkSize = nccl_ofi_tuner_get_chunk_size};
 
 /* **** V2 **** */
 static ncclResult_t nccl_ofi_tuner_get_coll_info_v2(


### PR DESCRIPTION
*Description of changes:*

This PR wires up the NCCL tuner v6 getChunkSize callback and adds P5en-specific chunk size heuristics for two algorithm/protocol combinations in the 1-rank-per-node case:
  
1. `AllReduce Tree/LL128` — steps down a power-of-two ladder from 288 KB to 18 KB based on how many chunks the per-channel message produces relative to tree depth. The trade-off is between keeping enough data in flight to saturate EFA versus producing enough chunks to keep a deep tree pipeline full.
2. `AllGather PAT/Simple` — steps down from a per-cluster ceiling (1 MB for small clusters, 512 KB for 16+ nodes) to 32 KB. PAT pipelines within a phase but not across phases, so the heuristic balances single-phase execution for larger messages against pipeline fill for latency-bound smaller messages.
  
The region boundaries are updated to reflect the new crossover points where the tuned algorithm/protocol combinations now outperform previously selected algorithm/protocol combinations.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
