### PR TITLE
gin/gdaki: Adds a data endpoint for only sending PutValues

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -249,15 +249,9 @@ struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
 
 	uint32_t putvalue_pad;
 
-	/* Base address of this endpoint's slice of the shared PutValue source
-	 * slot pool. The pool itself is one contiguous GPU-VMM region
-	 * registered as a single FI_HMEM_CUDA / FI_MR_DMABUF MR (see
-	 * dev_handle->putvalue_lkey). Slice size is implied by sq_size; per-call
-	 * slot byte offset is
-	 *     (submitted_count % sq_size) * dev_handle->putvalue_slot_size.
-	 * Set by setup_putvalue_pool; valid for the lifetime of the context.
-	 * Zero on endpoints that don't host PutValue traffic, but every
-	 * endpoint participating in the slot pool gets a unique non-zero base. */
+	/* Base of the PutValue source-slot pool; used only by the dedicated
+	 * PutValue endpoint (dev_handle.pvdata). Holds sq_size slots; the device
+	 * stages into slot (SQ_reservation_index % sq_size) * putvalue_slot_size. */
 	uint64_t putvalue_slice_base;
 };
 
@@ -316,6 +310,13 @@ struct nccl_ofi_gin_gdaki_dev_handle {
 	 * createContext time. */
 	struct nccl_ofi_gin_gdaki_dev_endpoint_handle data;
 
+	/* Dedicated PutValue endpoint (qp / cq / addressing / sq_lock /
+	 * counter completion tracking via local_cntr_value /
+	 * submitted_count / sq_size). All PutValues post from here; it
+	 * binds a FI_WRITE counter and populates pvdata.local_cntr_value at
+	 * createContext time. */
+	struct nccl_ofi_gin_gdaki_dev_endpoint_handle pvdata;
+
 	/* Per-counter device handle array, [nCounters]. NULL when nCounters == 0. */
 	struct nccl_ofi_gin_gdaki_dev_counter_handle **counter_handles;
 
@@ -370,39 +371,15 @@ struct nccl_ofi_gin_gdaki_dev_handle {
 	/* Per-peer remote scratch rkeys, indexed by rank. [nranks] in GPU mem. */
 	uint32_t *scratch_remote_rkeys;
 
-	/* PutValue source slot pool, shared across the data endpoint and
-	 * every signal/counter (sc) endpoint.
+	/* PutValue source slot pool for the dedicated pvdata endpoint. PutValue
+	 * stages srcVal through a registered local slot, then RDMA-writes it to
+	 * the user's destination; the write arrives on the peer's target endpoint
+	 * chosen by the signal (sc EP for a signalled PutValue, data EP for
+	 * no-signal), bumping FI_REMOTE_WRITE where applicable.
 	 *
-	 * EFA's RDMA_WRITE WQE cannot use inline data (efa-dp-direct's
-	 * wr_set_inline_data only supports SEND opcode), so PutValue stages
-	 * srcVal through a registered local slot, then posts an RDMA_WRITE
-	 * from the slot to the user's destination. The same WQE arrival on
-	 * the receiver's chosen sc_endpoint bumps that endpoint's
-	 * FI_REMOTE_WRITE counter — i.e. value-and-signal in one WQE.
-	 *
-	 * Routing mirrors Put:
-	 *   signal != NONE  -> sc_endpoints[signalId]
-	 *   signal == NONE  -> data endpoint
-	 *
-	 * Each participating endpoint owns a slice of the pool; the slice
-	 * base lives on its dev_endpoint_handle (see putvalue_slice_base
-	 * above). The pool is one contiguous GPU-VMM region registered as
-	 * a single FI_HMEM_CUDA / FI_MR_DMABUF MR, so a single lkey covers
-	 * every slice. Slot stride is uniform
-	 * (== NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE — the maximum sizeof(T)
-	 * PutValue accepts). Per-endpoint slot reuse uses each endpoint's
-	 * existing (submitted_count - *local_cntr_value) backpressure;
-	 * slot index inside a slice is (ep.submitted_count % ep.sq_size).
-	 *
-	 * That backpressure does double duty for PutValue. For Put it only
-	 * bounds SQ-ring capacity, but PutValue additionally relies on it
-	 * for source-slot lifetime: an RDMA_WRITE's source SGE is DMA-read
-	 * by the NIC before the WR completes, and *local_cntr_value (the
-	 * FI_WRITE counter) ticks on completion. So gating reuse of slot N
-	 * on completion of the WR sq_size posts earlier transitively
-	 * guarantees the NIC has already consumed that slot's prior value
-	 * before we overwrite it — no separate source-buffer fence needed.
-	 */
+	 * The pool holds pvdata.sq_size slots. Slot stride is uniform
+	 * (== NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE, the max sizeof(T) PutValue
+	 * accepts); pool base lives on pvdata.putvalue_slice_base. */
 	uint32_t putvalue_lkey;
 	uint32_t putvalue_slot_size;
 };

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -564,15 +564,6 @@ public:
 	void populate(struct fi_efa_ops_gda *gda_ops,
 		      const std::vector<uint8_t> &all_addrs,
 		      size_t ep_addr_len, int total_slots, int nranks);
-
-	/**
-	 * Set the PutValue slot pool slice base on both
-	 * counter_dev_handle and signal_dev_handle (they alias the same
-	 * QP / sq_size / etc., and either may be selected by the kernel).
-	 * Re-commits both handles since populate() already uploaded their
-	 * initial host state.
-	 */
-	void set_putvalue_slice_base(uint64_t slice_base);
 };
 
 /**
@@ -663,6 +654,12 @@ struct nccl_ofi_gin_gdaki_context {
 	 * logical context. unique_ptr because gdaki_data_endpoint owns
 	 * non-movable members (libfabric/CUDA handles). */
 	std::vector<std::unique_ptr<gdaki_data_endpoint>> data;                            /* [nContexts]      */
+
+	/* Per-ctx DEDICATED PutValue poster endpoint. PutValue posts only from
+	 * here (never the data EP or an sc EP). Costs one extra QP per context.
+	 * Same class as `data`; its target table resolves the same target slots
+	 * (peer data EP = slot 0, peer sc EP = slot 1+s). */
+	std::vector<std::unique_ptr<gdaki_data_endpoint>> pvdata;                          /* [nContexts]      */
 
 	/* Per-ctx signal/counter endpoints. data[c]'s sibling: each
 	 * logical ctx c owns max(nSignals, nCounters) sc endpoints,

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -336,29 +336,16 @@ static void setup_putvalue_pool(nccl_ofi_gin_gdaki_context *ctx,
 {
 	const int nContexts = ctx->nContexts;
 
-	/* Total pool size = sum over all contexts of
-	 *   data[c].sq_size + sum_i(sc_endpoints[c][i].sq_size).
-	 * Per-endpoint slice sizes are implied by each endpoint's sq_size; we
-	 * don't need a separate size array. */
+	/* One pool slice per context, holding pvdata[c].sq_size slots. Total =
+	 * sum over contexts of pvdata[c].sq_size. */
 	uint64_t total_slots = 0;
 	for (int c = 0; c < nContexts; c++) {
-		const uint32_t data_sq_size = ctx->data[c]->base.sq_size;
-		if (data_sq_size == 0) {
+		if (ctx->pvdata[c]->base.sq_size == 0) {
 			throw std::runtime_error(
-				"putvalue: data endpoint sq_size is zero (ctx " +
+				"putvalue: pvdata endpoint sq_size is zero (ctx " +
 				std::to_string(c) + ")");
 		}
-		total_slots += data_sq_size;
-		const int nSc = (int)ctx->sc_endpoints[c].size();
-		for (int i = 0; i < nSc; i++) {
-			uint32_t sz = ctx->sc_endpoints[c][i]->base.sq_size;
-			if (sz == 0) {
-				throw std::runtime_error(
-					"putvalue: sc_endpoint sq_size is zero (ctx " +
-					std::to_string(c) + ", sc " + std::to_string(i) + ")");
-			}
-			total_slots += sz;
-		}
+		total_slots += ctx->pvdata[c]->base.sq_size;
 	}
 
 	ctx->putvalue_slot_size = NCCL_OFI_GDAKI_PUTVALUE_SLOT_SIZE;
@@ -435,24 +422,14 @@ static void setup_putvalue_pool(nccl_ofi_gin_gdaki_context *ctx,
 		rs.putvalue_lkey = (uint32_t)fi_mr_key(rs.putvalue_mr);
 	}
 
-	/* Assign per-endpoint slice bases across every context. Each
-	 * endpoint stores its slice base on its own GPU-resident
-	 * dev_endpoint_handle, so the kernel reads it from the same struct
-	 * it already selects for QP / sq_lock / etc. The data endpoint
-	 * stashes on host (uploaded later by populate_dev_handle); each
-	 * sc_endpoint commits both its counter_dev_handle and
-	 * signal_dev_handle inline. Slices are laid out context-major:
-	 * for each context, the data slice followed by its sc slices. */
+	/* Assign each context's pool slice to its dedicated PutValue endpoint
+	 * (pvdata). The slice base is stashed on pvdata's host state and uploaded
+	 * later by populate_dev_handle into dev_handle.pvdata.putvalue_slice_base.
+	 * Slices are laid out context-major, each pvdata[c].sq_size slots. */
 	uint64_t cursor = ctx->putvalue_local_addr;
 	for (int c = 0; c < nContexts; c++) {
-		ctx->data[c]->set_putvalue_slice_base(cursor);
-		cursor += (uint64_t)ctx->data[c]->base.sq_size * ctx->putvalue_slot_size;
-		const int nSc = (int)ctx->sc_endpoints[c].size();
-		for (int i = 0; i < nSc; i++) {
-			ctx->sc_endpoints[c][i]->set_putvalue_slice_base(cursor);
-			cursor += (uint64_t)ctx->sc_endpoints[c][i]->base.sq_size
-				* ctx->putvalue_slot_size;
-		}
+		ctx->pvdata[c]->set_putvalue_slice_base(cursor);
+		cursor += (uint64_t)ctx->pvdata[c]->base.sq_size * ctx->putvalue_slot_size;
 	}
 }
 
@@ -477,6 +454,20 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 	h.data.local_cntr_value = ctx->data[ctx_id]->write_cntr.gpu_ptr();
 	h.data.submitted_count = 0;
 	h.data.sq_size = ctx->data[ctx_id]->base.sq_size;
+
+	/* Dedicated PutValue poster endpoint: same field set as data. Its target
+	 * table resolves the same peer target slots (built in populate above). */
+	h.pvdata.qp = ctx->pvdata[ctx_id]->base.gpu_qp.dev();
+	h.pvdata.cq = ctx->pvdata[ctx_id]->base.gpu_cq.dev();
+	h.pvdata.target_address_handles = ctx->pvdata[ctx_id]->base.targets.ahs.dev;
+	h.pvdata.target_remote_qpns     = ctx->pvdata[ctx_id]->base.targets.qpns.dev;
+	h.pvdata.target_qkey            = ctx->pvdata[ctx_id]->base.targets.qkeys.dev;
+	h.pvdata.sq_lock = 0;
+	h.pvdata.local_cntr_value = ctx->pvdata[ctx_id]->write_cntr.gpu_ptr();
+	h.pvdata.submitted_count = 0;
+	h.pvdata.sq_size = ctx->pvdata[ctx_id]->base.sq_size;
+	h.pvdata.putvalue_slice_base = ctx->pvdata[ctx_id]->putvalue_slice_base;
+
 	h.counter_handles = (ctx->nCounters > 0) ? ctx->d_counter_handles[ctx_id]->dev : nullptr;
 	h.signal_handles  = (ctx->nSignals  > 0) ? ctx->d_signal_handles[ctx_id]->dev  : nullptr;
 	h.nCounters = ctx->nCounters;
@@ -497,19 +488,14 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 	h.scratch_local_addr   = ctx->scratch_local_addr;
 	h.scratch_remote_addrs = rs.scratch_remote_addrs_buf.dev;
 	h.scratch_remote_rkeys = rs.scratch_remote_rkeys_buf.dev;
-	/* PutValue slot pool. The pool is allocated unconditionally
-	 * (sized off every context's data.sq_size, which is always
-	 * non-zero), so we always populate these fields. The slot_size and
-	 * slice base are rail-independent (one pool, same GPU VA on every
-	 * rail); only the lkey is per-rail (from rail_shared[rail_id]).
-	 * sc_endpoint slice bases live on each sc_endpoint's
-	 * counter_dev_handle / signal_dev_handle, set by
-	 * gdaki_sc_endpoint::set_putvalue_slice_base in setup_putvalue_pool.
-	 * No commit here — the caller commits the whole dev_handles[] array
-	 * once after every entry is filled. */
+	/* PutValue slot pool. slot_size and the pool base are rail-independent
+	 * (one pool, same GPU VA on every rail); the per-context pool base lives
+	 * on pvdata (set above from ctx->pvdata[ctx_id]->putvalue_slice_base).
+	 * Only the lkey is per-rail (from rail_shared[rail_id]). No commit here —
+	 * the caller commits the whole dev_handles[] array once after every entry
+	 * is filled. */
 	h.putvalue_lkey            = rs.putvalue_lkey;
 	h.putvalue_slot_size       = (uint32_t)ctx->putvalue_slot_size;
-	h.data.putvalue_slice_base = ctx->data[ctx_id]->putvalue_slice_base;
 }
 
 static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConfig_v13_t *config,
@@ -663,6 +649,9 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		ctx->data.resize(nContexts);
 		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++)
 			ctx->data[ctx_id] = std::make_unique<gdaki_data_endpoint>();
+		ctx->pvdata.resize(nContexts);
+		for (int ctx_id = 0; ctx_id < nContexts; ctx_id++)
+			ctx->pvdata[ctx_id] = std::make_unique<gdaki_data_endpoint>();
 		ctx->sc_endpoints.resize(nContexts);
 		ctx->d_counter_handles.resize(nContexts);
 		ctx->d_signal_handles.resize(nContexts);
@@ -735,6 +724,8 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				ctx->sc_endpoints[ctx_id].push_back(std::make_unique<gdaki_sc_endpoint>());
 				ctx->sc_endpoints[ctx_id][i]->open(ofi_domain, proxy_info, gda_ops);
 			}
+			/* Dedicated PutValue poster endpoint. */
+			ctx->pvdata[ctx_id]->open(ofi_domain, proxy_info, gda_ops);
 
 			/*
 			 * Step 5: Exchange ALL of this ctx's endpoint addresses in a
@@ -781,6 +772,11 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 			 */
 			ctx->data[ctx_id]->populate(gda_ops, all_addrs, ep_addr_len,
 						    (int)total_slots, nranks);
+			/* pvdata's target table resolves the same peer target slots as
+			 * data (through its own AV), so signalled PutValue can address the
+			 * peer sc EP and no-signal PutValue the peer data EP. */
+			ctx->pvdata[ctx_id]->populate(gda_ops, all_addrs, ep_addr_len,
+						      (int)total_slots, nranks);
 			for (int i = 0; i < local_n_sc; i++) {
 				ctx->sc_endpoints[ctx_id][i]->populate(
 					gda_ops, all_addrs, ep_addr_len,

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -414,18 +414,3 @@ void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 	signal_dev_handle.host[0].base.local_cntr_value = write_cntr.gpu_ptr();
 	signal_dev_handle.commit();
 }
-
-void gdaki_sc_endpoint::set_putvalue_slice_base(uint64_t slice_base)
-{
-	/* Both counter_dev_handle and signal_dev_handle alias the same QP /
-	 * sq_lock / sq_size / submitted_count layout — only their cntr_value
-	 * differs. Either may be selected by the kernel (counter_handles[]
-	 * for Counter ops, signal_handles[] for Signal ops). PutValue uses
-	 * signal_handles[] when a signal is requested; we write both for
-	 * consistency so a future Counter-only PutValue path would also
-	 * find a valid slice. */
-	counter_dev_handle.host[0].base.putvalue_slice_base = slice_base;
-	signal_dev_handle.host[0].base.putvalue_slice_base = slice_base;
-	counter_dev_handle.commit();
-	signal_dev_handle.commit();
-}


### PR DESCRIPTION
PutValue stages the user value into a registered GPU source slot and RDMA-writes that slot to the destination. The slot must not be reused until the NIC has finished reading it. 

- One extra QP per context 
- The staging pool is the same size as the SQ depth
- Target routing is unchanged: a signalled PutValue targets the peer's sc endpoint, and a no-signal PutValue targets the peer's data endpoint
- Multi-rail: the pool MR is registered per rail; the per-context pool base is rail-independent

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
