### PR TITLE
gin/gdaki: gate the EFA hardware completion counter per platform

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -376,6 +376,28 @@ OFI_NCCL_PARAM_VALUE_SET(NVTX_TRACE_DIMENSION, (PER_COMM)(PER_DEV))
 OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSION", NVTX_TRACE_DIMENSION::PER_COMM)
 
 /*
+ * Whether the GDAKI GIN data path may use the EFA hardware completion
+ * counter in GPU memory (fi_efa_ops_gda::cntr_open_ext). Support is decided
+ * per platform (see PlatformAWS::config_gdaki_domain); this knob overrides
+ * that per-platform decision.
+ *
+ * This is an override / escape hatch, NOT a general enable switch: it only
+ * controls whether the hardware completion counter is used by the GDAKI
+ * data path.
+ *
+ *   auto: use the counter where the running platform declares support
+ *         (default; normal deployments should leave it here)
+ *   off:  do not use the counter even where the platform supports it
+ *   on:   attempt the counter even if the platform does not declare
+ *         support (for bring-up / validation on a system known to have it).
+ *         This does NOT make the counter work on hardware that lacks it: if
+ *         the counter cannot be opened, GDAKI context creation fails rather
+ *         than falling back.
+ */
+OFI_NCCL_PARAM_VALUE_SET(GDAKI_EFA_HW_COUNTER, (AUTO)(ON)(OFF))
+OFI_NCCL_PARAM(GDAKI_EFA_HW_COUNTER, gdaki_efa_hw_counter, "GDAKI_EFA_HW_COUNTER", GDAKI_EFA_HW_COUNTER::AUTO)
+
+/*
  * Enable strong-signal semantics for the GIN plugin.
  *
  * When true, completed requests are delivered to the application in

--- a/include/nccl_ofi_platform.h
+++ b/include/nccl_ofi_platform.h
@@ -11,6 +11,7 @@
 #include <rdma/fabric.h>
 #include <rdma/fi_eq.h>
 #include <rdma/fi_endpoint.h>
+#include <rdma/fi_errno.h>
 
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_system.h"
@@ -126,6 +127,29 @@ public:
 			      err_entry->err, err_entry->flags, err_entry->prov_errno,
 			      fi_cq_strerror(cq, err_entry->prov_errno, err_entry->err_data, NULL, 0),
 			      (long)err_entry->len);
+	}
+
+	/**
+	 * @brief	Authorize/configure the GDAKI GIN data path on a domain.
+	 *
+	 *		Called during GDAKI GIN context setup for each domain the
+	 *		data path will use, before resources are opened on it.
+	 *		A platform returns 0 to allow GDAKI on this domain, or a
+	 *		negative libfabric error (e.g. -FI_ENOSYS) to refuse.
+	 *		Deciding here gives a single deterministic answer per
+	 *		platform before resources are built.
+	 *
+	 *		The base implementation refuses: an unknown platform is
+	 *		not assumed to support GDAKI. Concrete platforms override
+	 *		this to opt in and decide how they determine support.
+	 *
+	 * @param	domain	The libfabric domain GDAKI will run on
+	 * @param	info	The fi_info associated with that domain
+	 * @return	0 if GDAKI may run on this domain, negative errno otherwise
+	 */
+	virtual int config_gdaki_domain(struct fid_domain *domain, struct fi_info *info)
+	{
+		return -FI_ENOSYS;
 	}
 };
 

--- a/include/platform-aws.h
+++ b/include/platform-aws.h
@@ -38,6 +38,7 @@ public:
 	uint64_t device_get_guid(struct fi_info *info, int dev_id) override;
 	void log_cq_error(void *req_p, struct fid_cq *cq, struct fi_cq_err_entry *err_entry,
 			  const char *req_type) override;
+	int config_gdaki_domain(struct fid_domain *domain, struct fi_info *info) override;
 
 protected:
 	struct ec2_platform_data {
@@ -48,6 +49,11 @@ protected:
 		float latency;
 		bool gdr_required;
 		PROTOCOL default_protocol;
+		/* True if the EFA hardware completion counter (used by the
+		 * GDAKI GIN data path) is supported on this platform.
+		 * Consulted by PlatformAWS::config_gdaki_domain(). Set per platform
+		 * row; false where the feature is not supported. */
+		bool efa_hw_comp_cntr;
 		std::map<std::string, std::string> env;
 	};
 

--- a/src/platform-aws.cpp
+++ b/src/platform-aws.cpp
@@ -87,6 +87,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -100,6 +101,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -113,6 +115,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 150.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 	{
@@ -123,6 +126,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 	{
@@ -133,6 +137,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -149,6 +154,9 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
+		/* EFA hardware completion counter (GDAKI) is supported on
+		 * P5en and P6-B200. */
+		.efa_hw_comp_cntr = true,
 		/*
 		 * Note: Based on empirical testing, setting the
 		 * NCCL_NETDEVS_POLICY=max:1 gives optimal performance
@@ -162,6 +170,25 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
 			{ "NCCL_NET_FORCE_FLUSH", "0" },
 			{ "NCCL_NETDEVS_POLICY", "max:1" },
+		},
+	},
+	{
+		.name = "p6-b300",
+		.regex = "^p6-b300.*",
+		.topology = NULL,
+		.default_dup_conns = 0,
+		.latency = 35.0,
+		.gdr_required = true,
+		.default_protocol = PROTOCOL::RDMA,
+		/* EFA hardware completion counter (GDAKI) is supported on
+		 * P6-B300. */
+		.efa_hw_comp_cntr = true,
+		.env = {
+			{ "NCCL_BUFFSIZE", "8388608" },
+			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
+			{ "NCCL_NVLSTREE_MAX_CHUNKSIZE", "524288" },
+			{ "NCCL_NVLS_CHUNKSIZE", "524288" },
+			{ "NCCL_NET_FORCE_FLUSH", "0" },
 		},
 	},
 	{
@@ -182,6 +209,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -198,6 +226,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 	{
@@ -208,6 +237,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -221,6 +251,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 35.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
+		.efa_hw_comp_cntr = false,
 		.env = {
 			{ "NCCL_BUFFSIZE", "8388608" },
 			{ "NCCL_P2P_NET_CHUNKSIZE", "524288" },
@@ -234,6 +265,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::RDMA,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 	{
@@ -244,6 +276,7 @@ const PlatformAWS::ec2_platform_data PlatformAWS::platform_data_map[] = {
 		.latency = 75.0,
 		.gdr_required = true,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 };
@@ -342,6 +375,50 @@ const PlatformAWS::ec2_platform_data *PlatformAWS::get_platform_data()
 
 	cached_platform_data_ = get_platform_entry(platform_type, platform_data_list, platform_data_len);
 	return cached_platform_data_;
+}
+
+
+/*
+ * On AWS, GDAKI support is decided per platform, from whether the platform
+ * is declared to have the EFA hardware completion counter that the GDAKI
+ * data path requires (opened on the domain via cntr_open_ext).
+ *
+ * This knob only controls whether config_gdaki_domain authorizes GDAKI to
+ * proceed; it does not enable or provide the counter. Turning it on does
+ * NOT make the feature work on hardware that lacks the counter: if the
+ * counter cannot be opened at runtime, GDAKI context creation still fails
+ * later (surfaced as ncclSystemError). It is a development / bring-up
+ * override, not a general enable switch. The decision is made per platform:
+ *
+ *   OFI_NCCL_GDAKI_EFA_HW_COUNTER=on/off  explicit override: on authorizes
+ *                                     this hook regardless of the platform
+ *                                     declaration (runtime may still fail
+ *                                     if the counter is absent); off refuses
+ *                                     regardless
+ *   OFI_NCCL_GDAKI_EFA_HW_COUNTER=auto    defer to the platform declaration
+ *                                     (ec2_platform_data::efa_hw_comp_cntr)
+ *
+ * domain/info are unused today (the decision is a per-platform
+ * declaration) but are part of the hook so a platform could probe the
+ * domain directly in the future. Returns 0 to allow GDAKI on this
+ * domain, -FI_ENOSYS to refuse.
+ */
+int PlatformAWS::config_gdaki_domain([[maybe_unused]] struct fid_domain *domain,
+				     [[maybe_unused]] struct fi_info *info)
+{
+	GDAKI_EFA_HW_COUNTER mode = ofi_nccl_gdaki_efa_hw_counter.get();
+	bool supported;
+
+	if (mode != GDAKI_EFA_HW_COUNTER::AUTO) {
+		/* Explicit on/off override. */
+		supported = (mode == GDAKI_EFA_HW_COUNTER::ON);
+	} else {
+		/* auto: use it where this platform declares support. */
+		const ec2_platform_data *data = get_platform_data();
+		supported = (data != NULL && data->efa_hw_comp_cntr);
+	}
+
+	return supported ? 0 : -FI_ENOSYS;
 }
 
 

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -17,6 +17,7 @@
 #include "rdma/gin/nccl_ofi_gin_gdaki.h"
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
+#include "nccl_ofi_platform.h"
 
 #include <algorithm>
 #include <cstdlib>
@@ -640,6 +641,27 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				throw std::runtime_error(
 					"rail " + std::to_string(r) + " fi_info is null");
 			}
+
+			/*
+			 * Per-platform gate, applied to each rail's domain
+			 * before we open GDA ops / endpoints / counters on it.
+			 * The GDAKI hardware completion counter is a
+			 * domain-scoped capability (opened on the domain, before
+			 * any endpoint exists), so the platform authorizes each
+			 * domain the data path will use. Refusing here with a
+			 * direct return keeps it as ncclInvalidUsage before
+			 * anything is built on this domain (dev_handle_out is
+			 * null, ctx unwinds via RAII). A platform that authorizes
+			 * but still cannot open the counter surfaces later as
+			 * ncclSystemError.
+			 */
+			if (PlatformManager::get_global().get_platform().config_gdaki_domain(
+				    dom_r, info_r) != 0) {
+				NCCL_OFI_WARN("gin GDAKI: not supported on this platform; "
+					      "cannot create a GDAKI context here");
+				return ncclInvalidUsage;
+			}
+
 			struct fi_efa_ops_gda *ops_r = nullptr;
 			int ret = fi_open_ops(&dom_r->fid, FI_EFA_GDA_OPS, 0,
 					      reinterpret_cast<void **>(&ops_r), nullptr);

--- a/tests/unit/aws_platform_mapper.cpp
+++ b/tests/unit/aws_platform_mapper.cpp
@@ -45,6 +45,49 @@ static int check_value(const TestablePlatformAWS::ec2_platform_data *platform_da
 	return 0;
 }
 
+/* check that a platform entry advertises the expected efa_hw_comp_cntr
+ * (GDAKI) value. Only P5en / P6-B200 / P6-B300 opt in; everything else defaults false. */
+static int check_gdaki_flag(const TestablePlatformAWS::ec2_platform_data *platform_data_list,
+			    const size_t len, const char *platform_type, bool expected)
+{
+	const TestablePlatformAWS::ec2_platform_data *entry =
+		TestablePlatformAWS::get_platform_entry(platform_type, platform_data_list, len);
+
+	if (NULL == entry) {
+		printf("check_gdaki_flag: no entry for %s\n", platform_type);
+		return 1;
+	}
+	if (entry->efa_hw_comp_cntr != expected) {
+		printf("efa_hw_comp_cntr for %s: got %d, expected %d\n",
+		       platform_type, (int)entry->efa_hw_comp_cntr, (int)expected);
+		return 1;
+	}
+	return 0;
+}
+
+static int check_gdaki_flags(void)
+{
+	const TestablePlatformAWS::ec2_platform_data *platform_data_list;
+	size_t len;
+	int ret = 0;
+	TestablePlatformAWS platform;
+
+	platform_data_list = platform.get_platform_map(&len);
+
+	/* Opted in. */
+	ret += check_gdaki_flag(platform_data_list, len, "p5en.48xlarge", true);
+	ret += check_gdaki_flag(platform_data_list, len, "p6-b200.48xlarge", true);
+	ret += check_gdaki_flag(platform_data_list, len, "p6-b300.48xlarge", true);
+	/* Not opted in. */
+	ret += check_gdaki_flag(platform_data_list, len, "p5.48xlarge", false);
+	ret += check_gdaki_flag(platform_data_list, len, "p5e.48xlarge", false);
+	ret += check_gdaki_flag(platform_data_list, len, "p4d.24xlarge", false);
+	ret += check_gdaki_flag(platform_data_list, len, "trn2.48xlarge", false);
+	ret += check_gdaki_flag(platform_data_list, len, "p6e-gb200.36xlarge", false);
+
+	return ret;
+}
+
 static int check_known_platforms(void)
 {
 	const TestablePlatformAWS::ec2_platform_data *platform_data_list;
@@ -72,6 +115,7 @@ static int check_known_platforms(void)
 	ret += check_value(platform_data_list, len, "p5e.48xlarge", "p5/p5e");
 	ret += check_value(platform_data_list, len, "p5en.48xlarge", "p5en/p6-b200");
 	ret += check_value(platform_data_list, len, "p6-b200.48xlarge", "p5en/p6-b200");
+	ret += check_value(platform_data_list, len, "p6-b300.48xlarge", "p6-b300");
 	ret += check_value(platform_data_list, len, "p6e-gb200.36xlarge", "p-series");
 	ret += check_value(platform_data_list, len, "g5.48xlarge", "g5.48xlarge");
 	ret += check_value(platform_data_list, len, "g6.16xlarge", NULL);
@@ -101,6 +145,7 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.latency = 0.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::SENDRECV,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 	{
@@ -111,6 +156,7 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 		.latency = 0.0,
 		.gdr_required = false,
 		.default_protocol = PROTOCOL::RDMA,
+		.efa_hw_comp_cntr = false,
 		.env = {},
 	},
 };
@@ -118,10 +164,34 @@ static TestablePlatformAWS::ec2_platform_data test_map_1[] = {
 int main(int argc, char *argv[]) {
 	int ret = 0;
 
+	/* Force the GDAKI hw-counter override ON before any param read so
+	 * config_gdaki_domain() authorizes regardless of the (unknown)
+	 * unit-test host platform. */
+	setenv("OFI_NCCL_GDAKI_EFA_HW_COUNTER", "on", 1);
+
 	unit_test_init();
 
 	/* verify we get the answer we want on real platforms */
 	ret += check_known_platforms();
+
+	/* verify the per-platform GDAKI hw-counter opt-in flags */
+	ret += check_gdaki_flags();
+
+	/* rows that are not opted in carry efa_hw_comp_cntr = false */
+	if (test_map_1[0].efa_hw_comp_cntr != false || test_map_1[1].efa_hw_comp_cntr != false) {
+		printf("test_map_1 efa_hw_comp_cntr should be false\n");
+		ret += 1;
+	}
+
+	/* OFI_NCCL_GDAKI_EFA_HW_COUNTER=on -> config_gdaki_domain authorizes (returns 0).
+	 * AWS's impl decides from the platform/param, so domain/info can be null. */
+	{
+		TestablePlatformAWS platform;
+		if (platform.config_gdaki_domain(nullptr, nullptr) != 0) {
+			printf("config_gdaki_domain() with override=on: expected 0\n");
+			ret += 1;
+		}
+	}
 
 	/* make sure we maintain ordering */
 	ret += check_value(test_map_1, 2, "platform-x", "first");


### PR DESCRIPTION
## Summary

The GDAKI data path requires the EFA hardware completion counter in GPU
memory (gdaki_hw_counter, via fi_efa_ops_gda::cntr_open_ext). Only some
platforms support it, so the plugin should decide up front whether GDAKI
may run and refuse cleanly where it may not.

Add a generic Platform hook, config_gdaki_domain(fid_domain*, fi_info*),
alongside the existing platform hooks (init, config_endpoint, ...). The
data path is set up per domain, so the domain is the resource the hook
gates on. It returns 0 to allow GDAKI on the domain, or a negative
libfabric error to refuse. The base refuses, so an unknown platform is
never assumed to support GDAKI, and PlatformAWS overrides it. The base
interface stays provider-agnostic.

PlatformAWS::config_gdaki_domain() answers using the EFA hardware
completion counter: a per-platform declaration
(ec2_platform_data::efa_hw_comp_cntr, set for P5en, P6-B200, and P6-B300),
selectable and overridable via the tristate OFI_NCCL_GDAKI_EFA_HW_COUNTER
(auto/on/off). GDAKI createContext calls the hook up front, before opening
any endpoints or counters, and returns ncclInvalidUsage when it is not
supported. On a platform that authorizes but still cannot open the
counter, createContext surfaces the failure as ncclSystemError.

The gin/gdaki file builds only when GDAKI support is enabled (HAVE_GDAKI,
auto-detected from libfabric GDA ops + hw-counter ABI + CUDA);
compile-verified against a libfabric carrying the fi_efa_ops_gda
hardware-counter ABI. The platform hook, the param, and the unit test
build in the default configuration; aws_platform_mapper covers the
per-platform flags.
