### PR TITLE
gin: defer recv-req pool return until gdrcopy signal completes

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -353,6 +353,14 @@ private:
 	 */
 	int gdrcopy_status = 0;
 
+	/**
+	 * Set by retire when the signal was re-enqueued to the gdrcopy
+	 * worker; the req is pool-returned by drain once the worker is done,
+	 * not by retire (which would recycle it while the worker still
+	 * holds it via done.req).
+	 */
+	bool gdrcopy_pool_return_deferred = false;
+
 	/* This request structure doesn't have any use outside of gin_comm.
 	   So, instead of adding a bunch of getters/setters, just add a
 	   friend class. */

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -1068,6 +1068,11 @@ int nccl_ofi_rdma_gin_put_comm::drain_gdrcopy_done_queue()
 			}
 		}
 
+		if (req->gdrcopy_pool_return_deferred) {
+			req->gdrcopy_pool_return_deferred = false;
+			this->resources.return_req_to_pool(req);
+		}
+
 		int retire_ret = retire_completed_peer_iput_ops(done.peer_rank);
 		if (OFI_UNLIKELY(retire_ret != 0) && ret == 0) {
 			ret = retire_ret;
@@ -1199,6 +1204,10 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 		ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
+		}
+		if (req->gdrcopy_in_flight) {
+			req->gdrcopy_pool_return_deferred = true;
+			break;
 		}
 		this->resources.return_req_to_pool(req);
 	}


### PR DESCRIPTION
Under strong ordering, retire re-enqueues a req's signal to the gdrcopy worker (setting `gdrcopy_in_flight`) and then returned it to the pool. The worker still references that req via done.req, so the drain path writes through recycled memory once the slot is reused, corrupting a live req.

Instead we should defer the pool return to drain, which recycles the req once the worker reports completion.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
