### PR TITLE
mailmap: correct author email for commit 5a7bcba

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -40,3 +40,6 @@ ilya minkin <imminkin@amazon.com>
 <raghunch@amazon.com> <rajachan@users.noreply.github.com>
 <rashika@amazon.com> <42682819+rashikakheria@users.noreply.github.com>
 <rashika@amazon.com> <rashika@f4d4888cbd16.ant.amazon.com>
+# Fix up a commit landed with the wrong author email (not current work
+# email).
+<xuanj@amazon.com> <xuanjiang@google.com>


### PR DESCRIPTION
I committed 5a7bcba with the wrong email (not current my work email). Add a .mailmap entry so tools that respect it show the right email, without rewriting history.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
