### PR TITLE
gin: populate local_cntr_value on counter dev handles

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -404,8 +404,10 @@ void gdaki_sc_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 
 	counter_dev_handle.allocate(1);
 	fill_common(counter_dev_handle.host[0]);
+	/* TODO: Refactor counter_dev_handle so the same gpu memory is not
+	 * being used by multiple fields */
 	counter_dev_handle.host[0].cntr_value = write_cntr.gpu_ptr();
-	counter_dev_handle.host[0].base.local_cntr_value = nullptr; /* unused on counter handles */
+	counter_dev_handle.host[0].base.local_cntr_value = write_cntr.gpu_ptr();
 	counter_dev_handle.commit();
 
 	signal_dev_handle.allocate(1);


### PR DESCRIPTION
The counter endpoint's local_cntr_value was set to nullptr, but the kernel's flush path polls this field to track local write completions. Point it at the write counter (same as cntr_value) so flush can observe completion on counter endpoints. Also, need to followup by restructuring counter_dev_handle so that we don't maintain 2 copies of the same memory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
