### PR TITLE
Enabling Muti-segment Memory in the Proxy path

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -22,6 +22,29 @@ int nccl_net_ofi_gpu_init(void);
 int nccl_net_ofi_get_gpu_device_for_addr(void *data, int *dev_id);
 
 /*
+ * @brief Get / set the CUDA device for the calling thread. set_device also
+ *        establishes the thread's primary CUDA context, which bare worker
+ *        threads (e.g. the gdrcopy signal worker) otherwise lack.
+ */
+int nccl_net_ofi_gpu_get_device(int *dev_id);
+int nccl_net_ofi_gpu_set_device(int dev_id);
+
+/*
+ * @brief Retrieve the base address and size of the VMM segment (cuMemCreate
+ *        allocation) containing `ptr`, via cuMemGetAddressRange.
+ * @return 0 on success, -EINVAL if ptr is not a valid device pointer.
+ */
+int nccl_net_ofi_gpu_get_address_range(void *ptr, void **base_out, size_t *size_out);
+
+/*
+ * @brief Classify whether the VMM segment at `seg_base` is host-NUMA memory
+ *        (which cannot be GDRCopy-pinned) rather than device memory.
+ * @param is_host_out  set to true for a host-NUMA segment, false for device.
+ * @return 0 on success, -EINVAL if the segment's allocation cannot be queried.
+ */
+int nccl_net_ofi_gpu_seg_is_host(void *seg_base, bool *is_host_out);
+
+/*
  * @brief	wraps cudaFlushGPUDirectRDMAWrites() with default args.
 
  * @return	0 on success

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -18,6 +18,7 @@
 #include <bitset>
 #include <atomic>
 #include <cstdint>
+#include <mutex>
 #include <thread>
 
 /**
@@ -176,6 +177,19 @@ struct gin_remote_mr {
 };
 
 /**
+ * A discovered signal segment within a CUDA registration. Populated lazily on
+ * the first signal that lands in the segment, then cached for reuse.
+ */
+struct signal_seg_t {
+	uintptr_t seg_base;   /* pinned base VA (clamped to the MR range) */
+	size_t seg_size;      /* pinned length */
+	/* GDRCopy pin for a device segment, or null for a host-NUMA segment
+	   (which cannot be pinned and is updated with a CPU atomic instead). A
+	   null handle is how we distinguish the two. */
+	nccl_ofi_device_copy::RegHandle *gdr_handle;
+};
+
+/**
  * A symmetric memory registration handle. This is the result of GIN API's
  * regMrSym() family of functions.
  */
@@ -189,8 +203,9 @@ struct nccl_ofi_rdma_gin_symm_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 	nccl_ofi_gin_mr_handle_t *local_handle;
 	/* Type of registration (NCCL_PTR_HOST, NCCL_PTR_CUDA) */
 	int type;
-	/* GDRCopy handle */
-	nccl_ofi_device_copy::RegHandle *gdr_handle;
+	/* GDRCopy pins for the signal region, discovered lazily per-segment in
+	   ensure_signal_seg. Guarded by signal_segs_mtx. */
+	std::vector<signal_seg_t> signal_segs;
 
 	/* Remote MR information for each peer rank */
 	std::vector<gin_remote_mr> remote_mr;
@@ -580,6 +595,22 @@ private:
 	nccl_ofi_spsc_ring<gin_signal_work_entry> gdrcopy_work_queue;
 	nccl_ofi_spsc_ring<gin_signal_done_entry> gdrcopy_done_queue;
 	std::thread gdrcopy_thread;
+	int gdrcopy_cuda_dev = -1; /* CUDA device the worker binds to */
+
+	/* Protects mr_handle->signal_segs: the gdrcopy worker appends on first
+	   touch (ensure_signal_seg) and deregMrSym tears it down. */
+	std::mutex signal_segs_mtx;
+
+	/* Return the already-discovered signal segment containing signal_va, or
+	   null if none is cached yet. Lock-free; only ever called by the gdrcopy
+	   worker. */
+	signal_seg_t *find_signal_seg(nccl_ofi_rdma_gin_symm_mr_handle *mr,
+				      uintptr_t signal_va);
+	/* Return the signal segment containing signal_va, discovering, classifying
+	   and (for device memory) GDRCopy-pinning it on first touch. Caches the
+	   result in mr->signal_segs. Returns 0 and sets *out on success. */
+	int ensure_signal_seg(nccl_ofi_rdma_gin_symm_mr_handle *mr,
+			      uintptr_t signal_va, signal_seg_t **out);
 
 	void run_gdrcopy_worker_loop();
 	int enqueue_gdrcopy_work(uint32_t peer_rank,

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -96,6 +96,9 @@ DECLARE_CUDA_FUNCTION(cuMemMap, 10020);
 DECLARE_CUDA_FUNCTION(cuMemUnmap, 10020);
 DECLARE_CUDA_FUNCTION(cuMemSetAccess, 10020);
 DECLARE_CUDA_FUNCTION(cuMemGetAllocationGranularity, 10020);
+DECLARE_CUDA_FUNCTION(cuMemGetAddressRange, 3020);
+DECLARE_CUDA_FUNCTION(cuMemRetainAllocationHandle, 11000);
+DECLARE_CUDA_FUNCTION(cuMemGetAllocationPropertiesFromHandle, 10020);
 
 int nccl_net_ofi_gpu_init(void)
 {
@@ -177,6 +180,9 @@ int nccl_net_ofi_gpu_init(void)
 	RESOLVE_CUDA_FUNCTION(cuMemUnmap, 10020);
 	RESOLVE_CUDA_FUNCTION(cuMemSetAccess, 10020);
 	RESOLVE_CUDA_FUNCTION(cuMemGetAllocationGranularity, 10020);
+	RESOLVE_CUDA_FUNCTION(cuMemGetAddressRange, 3020);
+	RESOLVE_CUDA_FUNCTION(cuMemRetainAllocationHandle, 11000);
+	RESOLVE_CUDA_FUNCTION(cuMemGetAllocationPropertiesFromHandle, 10020);
 
 	cu_ret = pfn_cuDriverGetVersion(&driverVersion);
 	if (cu_ret != CUDA_SUCCESS) {
@@ -238,6 +244,62 @@ int nccl_net_ofi_gpu_mem_copy_host_to_device(void *dst, void *src, size_t size)
 {
 	CUresult ret = pfn_cuMemcpy((CUdeviceptr)dst, (CUdeviceptr)src, size);
 	return ret == CUDA_SUCCESS ? 0 : -EINVAL;
+}
+
+/*
+ * Bind the calling thread to a CUDA device (and lazily its primary context).
+ * The gdrcopy worker thread is a bare std::thread with no CUDA context, so the
+ * lazy signal-segment discovery it performs (cuMemGetAddressRange) fails there
+ * unless we set one.
+ */
+int nccl_net_ofi_gpu_get_device(int *dev_id)
+{
+	return cudaGetDevice(dev_id) == cudaSuccess ? 0 : -EINVAL;
+}
+
+int nccl_net_ofi_gpu_set_device(int dev_id)
+{
+	return cudaSetDevice(dev_id) == cudaSuccess ? 0 : -EINVAL;
+}
+
+int nccl_net_ofi_gpu_get_address_range(void *ptr, void **base_out, size_t *size_out)
+{
+	CUdeviceptr base;
+	size_t sz;
+	CUresult ret = pfn_cuMemGetAddressRange(&base, &sz, (CUdeviceptr)ptr);
+	if (ret != CUDA_SUCCESS) {
+		*base_out = nullptr;
+		*size_out = 0;
+		return -EINVAL;
+	}
+	*base_out = (void *)base;
+	*size_out = sz;
+	return 0;
+}
+
+int nccl_net_ofi_gpu_seg_is_host(void *seg_base, bool *is_host_out)
+{
+	CUmemGenericAllocationHandle handle;
+	CUresult ret = pfn_cuMemRetainAllocationHandle(&handle, seg_base);
+	if (ret != CUDA_SUCCESS) {
+		return -EINVAL;
+	}
+	CUmemAllocationProp prop = {};
+	ret = pfn_cuMemGetAllocationPropertiesFromHandle(&prop, handle);
+	/* Release the reference retained above regardless of the query result. */
+	pfn_cuMemRelease(handle);
+	if (ret != CUDA_SUCCESS) {
+		return -EINVAL;
+	}
+	/* CU_MEM_LOCATION_TYPE_HOST_NUMA{,_CURRENT} were added in CUDA 12.2;
+	   guard them so this still compiles against our 11.7 floor. */
+	*is_host_out = (prop.location.type == CU_MEM_LOCATION_TYPE_HOST
+#if CUDA_VERSION >= 12020
+			|| prop.location.type == CU_MEM_LOCATION_TYPE_HOST_NUMA
+			|| prop.location.type == CU_MEM_LOCATION_TYPE_HOST_NUMA_CURRENT
+#endif
+			);
+	return 0;
 }
 
 int nccl_net_ofi_gpu_host_register_iomem(void *ptr, size_t size)

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -344,7 +344,7 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 		   registered device buffer. */
 		if (mrFlags & NCCL_NET_MR_FLAG_SIGNAL_NEVER_RESET) {
 			mr_handle->signal_never_reset = true;
-			mr_handle->signal_shadow.assign(size / sizeof(uint64_t), 0);
+			mr_handle->signal_shadow.assign(mr_handle->size / sizeof(uint64_t), 0);
 		}
 	}
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -10,6 +10,7 @@
 #include "rdma/gin/nccl_ofi_gin.h"
 
 #include "nccl_ofi_assert.h"
+#include "nccl_ofi_cuda.h"
 #include "nccl_ofi_gdrcopy.h"
 #include "nccl_ofi_param.h"
 #include "nccl_ofi_rdma.h"
@@ -78,6 +79,19 @@ nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &r
 	 * running gdrcopy on the proxy thread, fail comm creation so we never
 	 * run in that degraded configuration. Undo the comm registration before
 	 * rethrowing so resources teardown does not see a dangling comm. */
+#if HAVE_CUDA
+	/* Capture the CUDA device on this (context-bearing) thread so the gdrcopy
+	 * worker can bind to it; the worker's lazy signal-segment discovery calls
+	 * cuMemGetAddressRange, which requires a current CUDA context. -1 means we
+	 * could not determine the device, in which case the worker skips binding
+	 * and falls back to whatever context it inherits (see
+	 * run_gdrcopy_worker_loop). cudaGetDevice failing here is unexpected. */
+	if (nccl_net_ofi_gpu_get_device(&gdrcopy_cuda_dev) != 0) {
+		NCCL_OFI_WARN("Could not query CUDA device for gdrcopy worker; "
+			      "it will not bind to a device");
+		gdrcopy_cuda_dev = -1;
+	}
+#endif
 	try {
 		gdrcopy_thread = std::thread(
 			&nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop, this);
@@ -326,25 +340,18 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 		return ret;
 	}
 
-	/* Proxy path only: for CUDA memory, also register with GDRCopy so the
-	   proxy can perform CPU-driven signal updates. On a duplicate hit the
-	   handle already carries a gdr_handle, so register only the first time. */
-	if (type == NCCL_PTR_CUDA && mr_handle->gdr_handle == nullptr) {
-		ret = get_device_copy().register_region(mr_handle->input_address, mr_handle->size,
-							mr_handle->gdr_handle);
-		if (ret != 0) {
-			NCCL_OFI_WARN("GDRCopy registration failed: %d", ret);
-			mr_handle_map.erase(mr_handle->input_address);
-			delete mr_handle;
-			return ret;
-		}
-		/* When NCCL marks this signal MR as never-reset, keep a host-side
-		   shadow of the signal values so do_gin_signal can skip the device
-		   read (see do_gin_signal). Zero-initialized to match the freshly
-		   registered device buffer. */
+	/* Signal pins are taken lazily per-segment in ensure_signal_seg, not
+	   here. Only set up the never-reset shadow here. regMrSymDmaBuf can be
+	   called more than once for the same buffer (duplicate / refcounted
+	   registration -- see gin_duplicate_mr), so the empty() check makes this
+	   idempotent: a repeat call must not re-initialize the shadow. It is
+	   sized from the MR so a smaller duplicate registration cannot shrink
+	   it. */
+	if (type == NCCL_PTR_CUDA && mr_handle->signal_shadow.empty()) {
 		if (mrFlags & NCCL_NET_MR_FLAG_SIGNAL_NEVER_RESET) {
 			mr_handle->signal_never_reset = true;
-			mr_handle->signal_shadow.assign(mr_handle->size / sizeof(uint64_t), 0);
+			mr_handle->signal_shadow.assign(
+				mr_handle->size / sizeof(uint64_t), 0);
 		}
 	}
 
@@ -447,13 +454,23 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 		return 0;
 	}
 
-	if (mr_handle->type == NCCL_PTR_CUDA && mr_handle->gdr_handle != nullptr) {
-		int ret = get_device_copy().deregister_region(mr_handle->gdr_handle);
-		if (ret != 0) {
-			NCCL_OFI_WARN("GDRCopy deregister failed: %d", ret);
-			return ret;
+	if (mr_handle->type == NCCL_PTR_CUDA) {
+		/* Release the lazily-pinned segments under the worker's append
+		   lock. Best-effort: log and continue on error, never bail out. */
+		std::lock_guard<std::mutex> seg_lock(signal_segs_mtx);
+		for (auto &seg : mr_handle->signal_segs) {
+			if (seg.gdr_handle != nullptr) {
+				int ret = get_device_copy().deregister_region(
+					seg.gdr_handle);
+				if (ret != 0) {
+					NCCL_OFI_WARN("GDRCopy segment deregister "
+						      "failed: %d", ret);
+				}
+				delete seg.gdr_handle;
+				seg.gdr_handle = nullptr;
+			}
 		}
-		mr_handle->gdr_handle = nullptr;
+		mr_handle->signal_segs.clear();
 	}
 
 	mr_handle_map.erase(it);
@@ -919,6 +936,100 @@ static inline uint64_t get_req_map_key(uint32_t peer_rank, uint16_t msg_seq_num)
 	return (static_cast<uint64_t>(peer_rank) << 16) | static_cast<uint64_t>(msg_seq_num);
 }
 
+signal_seg_t *nccl_ofi_rdma_gin_put_comm::find_signal_seg(
+	nccl_ofi_rdma_gin_symm_mr_handle *mr, uintptr_t signal_va)
+{
+	/* Linear scan: a CUDA signal region spans one segment in the common case,
+	   a few at most. Steady-state signals hit an already-discovered segment.
+	   Testing only signal_va (the counter's start) is sufficient: the 8-byte
+	   counter cannot straddle a segment boundary because VMM segments are
+	   allocation-granularity aligned (>= 2 MiB, divisible by 8). */
+	for (auto &seg : mr->signal_segs) {
+		if (signal_va >= seg.seg_base &&
+		    signal_va < seg.seg_base + seg.seg_size) {
+			return &seg;
+		}
+	}
+	return nullptr;
+}
+
+int nccl_ofi_rdma_gin_put_comm::ensure_signal_seg(
+	nccl_ofi_rdma_gin_symm_mr_handle *mr, uintptr_t signal_va,
+	signal_seg_t **out)
+{
+	/* Fast path, no lock: the segment is already discovered. deregMrSym
+	   cannot run against a live signal (the req stays in_flight until the
+	   proxy reaps this work), so the lock-free read is safe. */
+	signal_seg_t *seg = find_signal_seg(mr, signal_va);
+	if (seg != nullptr) {
+		*out = seg;
+		return 0;
+	}
+
+	/* Slow path: first signal to this segment -- discover, classify, pin. */
+	std::lock_guard<std::mutex> lock(signal_segs_mtx);
+	seg = find_signal_seg(mr, signal_va);  /* re-check under lock */
+	if (seg != nullptr) {
+		*out = seg;
+		return 0;
+	}
+
+	void *seg_base_ptr = nullptr;
+	size_t seg_size = 0;
+	int ret = nccl_net_ofi_gpu_get_address_range(
+		reinterpret_cast<void *>(signal_va), &seg_base_ptr, &seg_size);
+	if (ret != 0) {
+		NCCL_OFI_WARN("cuMemGetAddressRange failed for signal VA %p: %d",
+			      reinterpret_cast<void *>(signal_va), ret);
+		return ret;
+	}
+
+	/* Clamp to the MR: cuMemGetAddressRange returns the whole containing
+	   allocation, which can be far larger than the registered region. */
+	uintptr_t seg_base = reinterpret_cast<uintptr_t>(seg_base_ptr);
+	uintptr_t seg_end = seg_base + seg_size;
+	uintptr_t mr_start = reinterpret_cast<uintptr_t>(mr->input_address);
+	uintptr_t mr_end = mr_start + mr->size;
+	uintptr_t pin_base = seg_base > mr_start ? seg_base : mr_start;
+	uintptr_t pin_end = seg_end < mr_end ? seg_end : mr_end;
+	if (pin_end <= pin_base) {
+		NCCL_OFI_WARN("Signal VA %p outside MR range",
+			      reinterpret_cast<void *>(signal_va));
+		return -EINVAL;
+	}
+	size_t pin_len = pin_end - pin_base;
+
+	/* Host-NUMA segments can't be GDRCopy-pinned and are updated with a CPU
+	   atomic instead (gdr_handle stays null). We only reach this for a
+	   NCCL_PTR_CUDA MR, so the memory is either a VMM allocation (classified
+	   here) or a plain cudaMalloc buffer. classification via
+	   cuMemRetainAllocationHandle only works for VMM allocations, so a
+	   failure means the latter -- device memory that is GDRCopy-pinnable --
+	   hence we treat classify-failure as device (not host). */
+	bool is_host = false;
+	if (nccl_net_ofi_gpu_seg_is_host(reinterpret_cast<void *>(seg_base),
+					 &is_host) != 0) {
+		is_host = false;
+	}
+
+	nccl_ofi_device_copy::RegHandle *gdr = nullptr;
+	if (!is_host) {
+		ret = get_device_copy().register_region(
+			reinterpret_cast<void *>(pin_base), pin_len, gdr);
+		if (ret != 0) {
+			NCCL_OFI_WARN("GDRCopy segment pin failed for %p (len %zu): %d",
+				      reinterpret_cast<void *>(pin_base), pin_len, ret);
+			return ret;
+		}
+	}
+
+	/* gdr is null for a host segment, non-null for a pinned device segment;
+	   that null-ness is what do_gin_signal keys off. */
+	mr->signal_segs.push_back(signal_seg_t{pin_base, pin_len, gdr});
+	*out = &mr->signal_segs.back();
+	return 0;
+}
+
 int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata)
 {
 	void *signal_base = reinterpret_cast<void *>(metadata.signal_base_address);
@@ -934,44 +1045,64 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_meta
 	}
 	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = it->second.handle;
 
+	/* Reject a peer-supplied offset that would place the 8-byte counter
+	   outside the MR (overflow- and underflow-safe) before we use it. */
+	if (OFI_UNLIKELY(metadata.signal_offset > mr_handle->size ||
+			 mr_handle->size - metadata.signal_offset < sizeof(uint64_t))) {
+		NCCL_OFI_WARN("Signal offset %lu out of range for MR of size %zu",
+			      metadata.signal_offset, mr_handle->size);
+		return -EINVAL;
+	}
+
 	if (mr_handle->type == NCCL_PTR_CUDA) {
-		uint64_t new_value;
+		uintptr_t signal_va = metadata.signal_base_address +
+				      metadata.signal_offset;
 
-		if (mr_handle->signal_never_reset) {
-			/* Fast path: the signal is never reset, so our host-side
-			   shadow is authoritative. Add to the shadow and do a
-			   one-way write to the device, skipping the device read.
-			   do_gin_signal only ever runs on the gdrcopy worker
-			   thread, so the shadow needs no additional locking. */
-			uint64_t idx = metadata.signal_offset / sizeof(uint64_t);
-			assert(idx < mr_handle->signal_shadow.size());
-			new_value = (mr_handle->signal_shadow[idx] += add_value);
+		/* Lazily discover and pin the segment this signal lands in. */
+		signal_seg_t *seg = nullptr;
+		int ret = ensure_signal_seg(mr_handle, signal_va, &seg);
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Failed to ensure signal segment for VA %p",
+				      reinterpret_cast<void *>(signal_va));
+			return ret;
+		}
+
+		if (seg->gdr_handle == nullptr) {
+			/* Host-NUMA segment (not pinnable): update with a CPU
+			   atomic; the VA is host-accessible. */
+			auto *dest = reinterpret_cast<volatile uint64_t *>(signal_va);
+			__atomic_fetch_add(dest, add_value, __ATOMIC_RELAXED);
 		} else {
-			/* Slow path: the signal may have been reset out from under
-			   us (e.g. VA signals), so read the current value back from
-			   the device before adding. */
-			uint64_t old_value;
+			size_t off = signal_va - seg->seg_base;
+			uint64_t new_value;
 
-			int ret = get_device_copy().copy_from_device(*mr_handle->gdr_handle,
-								     metadata.signal_offset, &old_value,
-								     sizeof(old_value));
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_WARN("Failed to read current signal value");
-				return -ret;
+			if (mr_handle->signal_never_reset) {
+				/* Never-reset: the host shadow is authoritative,
+				   so skip the device read. */
+				uint64_t idx = metadata.signal_offset / sizeof(uint64_t);
+				assert(idx < mr_handle->signal_shadow.size());
+				new_value = (mr_handle->signal_shadow[idx] += add_value);
+			} else {
+				/* May have been reset (VA signals): read first. */
+				uint64_t old_value;
+				ret = get_device_copy().copy_from_device(
+					*seg->gdr_handle, off, &old_value,
+					sizeof(old_value));
+				if (OFI_UNLIKELY(ret != 0)) {
+					NCCL_OFI_WARN("Failed to read current signal value");
+					return -ret;
+				}
+				new_value = old_value + add_value;
 			}
 
-			/* We only support addition */
-			new_value = old_value + add_value;
+			/* Write using GDRCopy. */
+			ret = get_device_copy().copy_to_device(
+				&new_value, *seg->gdr_handle, off, sizeof(new_value));
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_WARN("Failed to update signal value");
+				return -ret;
+			}
 		}
-
-		/* Write using GDRcopy. */
-		int ret = get_device_copy().copy_to_device(&new_value, *mr_handle->gdr_handle,
-							   metadata.signal_offset, sizeof(new_value));
-		if (OFI_UNLIKELY(ret != 0)) {
-			NCCL_OFI_WARN("Failed to update signal value");
-			return -ret;
-		}
-
 	} else {
 		/**
 		 * Notes:
@@ -1083,6 +1214,17 @@ int nccl_ofi_rdma_gin_put_comm::drain_gdrcopy_done_queue()
 
 void nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop()
 {
+#if HAVE_CUDA
+	/* Bind this worker to the comm's CUDA device so its lazy segment
+	   discovery (cuMemGetAddressRange) has a valid CUDA context. A failure
+	   here leaves the worker without the intended context, so warn -- lazy
+	   discovery would then fail on the first signal. */
+	if (gdrcopy_cuda_dev >= 0 &&
+	    nccl_net_ofi_gpu_set_device(gdrcopy_cuda_dev) != 0) {
+		NCCL_OFI_WARN("gdrcopy worker failed to bind CUDA device %d",
+			      gdrcopy_cuda_dev);
+	}
+#endif
 	gin_signal_work_entry work;
 	while (true) {
 		if (!gdrcopy_work_queue.pop(work)) {

--- a/tests/functional/.gitignore
+++ b/tests/functional/.gitignore
@@ -5,6 +5,7 @@ reuse_listen_comm
 ring
 gin
 gin_duplicate_mr
+gin_multiseg_signal
 grouped_recv
 gin_gdaki_misconfig_probe
 eager_multirecv

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -34,6 +34,12 @@ if ENABLE_FUNC_TESTS
 noinst_HEADERS = functional_test.h
 
 bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_listen_comm gin gin_duplicate_mr grouped_recv gin_gdaki_misconfig_probe eager_multirecv
+
+# gin_multiseg_signal exercises the GIN host proxy on multi-segment CUDA VMM
+# memory. GIN is not supported on all CI platforms (e.g. g4dn / Turing), and
+# it is not part of the CI functional run-list, so keep it out of the default
+# build: it is an EXTRA_PROGRAM, built on demand with `make gin_multiseg_signal`.
+EXTRA_PROGRAMS = gin_multiseg_signal
 if ENABLE_GDAKI
 if HAVE_NVCC
 bin_PROGRAMS += gin_put_gdaki_gpu gin_signal_gdaki_gpu
@@ -48,6 +54,7 @@ ring_SOURCES = $(base_sources) ring.cpp
 inflight_close_SOURCES = $(base_sources) inflight_close.cpp
 reuse_listen_comm_SOURCES = $(base_sources) reuse_listen_comm.cpp
 gin_SOURCES = $(base_sources) gin.cpp
+gin_multiseg_signal_SOURCES = $(base_sources) gin_multiseg_signal.cpp
 gin_duplicate_mr_SOURCES = $(base_sources) gin_duplicate_mr.cpp
 grouped_recv_SOURCES = $(base_sources) grouped_recv.cpp
 gin_gdaki_misconfig_probe_SOURCES = $(base_sources) gin_gdaki_misconfig_probe.cpp

--- a/tests/functional/gin_multiseg_signal.cpp
+++ b/tests/functional/gin_multiseg_signal.cpp
@@ -1,0 +1,453 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include "functional_test.h"
+
+#include <assert.h>
+#include <deque>
+#include <vector>
+#include <unistd.h>
+
+#include <cuda.h>
+#include <cudaTypedefs.h>
+
+/**
+ * Functional test for the GIN host proxy's per-segment signal mapping.
+ *
+ * The proxy maps a signal region with GDRCopy so it can update the 8-byte
+ * counter. A CUDA VMM window can be one contiguous VA range backed by several
+ * cuMemCreate handles, and GDRCopy cannot map across handles, so the proxy
+ * maps each segment on demand (do_gin_signal -> ensure_signal_seg). A plain
+ * cudaMalloc buffer is a single allocation and only ever needs one mapping, so
+ * to drive the multi-segment path this test reserves one VA range and backs it
+ * with several handles, then sends signals to offsets in different segments.
+ *
+ * VMM memory must be registered via dma-buf on EFA, so the whole test is
+ * dma-buf-native and runs as its own program (not a subtest of gin).
+ */
+
+struct proc_handle {
+	char handle[NCCL_NET_HANDLE_MAXSIZE];
+};
+
+/* A signal buffer whose VA range is backed by nsegs independent cuMemCreate
+   handles, so each segment has its own base as reported by
+   cuMemGetAddressRange and a signal landing in it forces a distinct pin. */
+/*
+ * The CUDA driver VMM API (cuMem*) is resolved at run time via
+ * cudaGetDriverEntryPoint, exactly as the plugin does (see
+ * RESOLVE_CUDA_FUNCTION in src/nccl_ofi_cuda.cpp). This keeps the test linked
+ * against the CUDA runtime only (-lcudart), like every other functional test,
+ * so it builds on hosts without a CUDA driver (e.g. CI); the real driver is
+ * loaded at run time on GPU nodes.
+ */
+#define DRIVER_FN(fn, ver) static PFN_##fn##_v##ver pfn_##fn = nullptr
+
+DRIVER_FN(cuCtxGetDevice, 2000);
+DRIVER_FN(cuDeviceGetAttribute, 2000);
+DRIVER_FN(cuMemGetAllocationGranularity, 10020);
+DRIVER_FN(cuMemAddressReserve, 10020);
+DRIVER_FN(cuMemCreate, 10020);
+DRIVER_FN(cuMemMap, 10020);
+DRIVER_FN(cuMemSetAccess, 10020);
+DRIVER_FN(cuMemUnmap, 10020);
+DRIVER_FN(cuMemRelease, 10020);
+DRIVER_FN(cuMemAddressFree, 10020);
+DRIVER_FN(cuMemGetHandleForAddressRange, 11070);
+DRIVER_FN(cuMemGetAddressRange, 3020);
+
+#define RESOLVE_DRIVER_FN(fn) do {                                            \
+	cudaDriverEntryPointQueryResult q = cudaDriverEntryPointSymbolNotFound; \
+	if (cudaGetDriverEntryPoint(#fn, (void **)&pfn_##fn,                   \
+				    cudaEnableDefault, &q) != cudaSuccess ||  \
+	    pfn_##fn == nullptr) {                                            \
+		NCCL_OFI_WARN("multiseg: failed to resolve %s", #fn);         \
+		return ncclSystemError;                                       \
+	}                                                                     \
+} while (0)
+
+static ncclResult_t resolve_driver_api(void)
+{
+	RESOLVE_DRIVER_FN(cuCtxGetDevice);
+	RESOLVE_DRIVER_FN(cuDeviceGetAttribute);
+	RESOLVE_DRIVER_FN(cuMemGetAllocationGranularity);
+	RESOLVE_DRIVER_FN(cuMemAddressReserve);
+	RESOLVE_DRIVER_FN(cuMemCreate);
+	RESOLVE_DRIVER_FN(cuMemMap);
+	RESOLVE_DRIVER_FN(cuMemSetAccess);
+	RESOLVE_DRIVER_FN(cuMemUnmap);
+	RESOLVE_DRIVER_FN(cuMemRelease);
+	RESOLVE_DRIVER_FN(cuMemAddressFree);
+	RESOLVE_DRIVER_FN(cuMemGetHandleForAddressRange);
+	RESOLVE_DRIVER_FN(cuMemGetAddressRange);
+	return ncclSuccess;
+}
+
+struct multiseg_vmm_buf {
+	CUdeviceptr base = 0;
+	size_t seg_size = 0;
+	size_t nsegs = 0;
+	size_t total = 0;
+	std::vector<CUmemGenericAllocationHandle> handles;
+};
+
+static ncclResult_t multiseg_vmm_alloc(multiseg_vmm_buf *b, size_t nsegs,
+				       size_t min_seg_size)
+{
+	CUdevice dev;
+	if (pfn_cuCtxGetDevice(&dev) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("multiseg: cuCtxGetDevice failed");
+		return ncclSystemError;
+	}
+
+	CUmemAllocationProp prop = {};
+	prop.type = CU_MEM_ALLOCATION_TYPE_PINNED;
+	prop.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+	prop.location.id = dev;
+	int gdr = 0;
+	pfn_cuDeviceGetAttribute(&gdr,
+			     CU_DEVICE_ATTRIBUTE_GPU_DIRECT_RDMA_WITH_CUDA_VMM_SUPPORTED,
+			     dev);
+	if (gdr) prop.allocFlags.gpuDirectRDMACapable = 1;
+
+	size_t gran = 0;
+	if (pfn_cuMemGetAllocationGranularity(&gran, &prop,
+					  CU_MEM_ALLOC_GRANULARITY_MINIMUM) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("multiseg: cuMemGetAllocationGranularity failed");
+		return ncclSystemError;
+	}
+
+	size_t seg = ((min_seg_size + gran - 1) / gran) * gran;
+	size_t total = seg * nsegs;
+
+	CUdeviceptr base = 0;
+	if (pfn_cuMemAddressReserve(&base, total, gran, 0, 0) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("multiseg: pfn_cuMemAddressReserve(%zu) failed", total);
+		return ncclSystemError;
+	}
+
+	b->handles.assign(nsegs, 0);
+	for (size_t i = 0; i < nsegs; ++i) {
+		CUmemGenericAllocationHandle h;
+		if (pfn_cuMemCreate(&h, seg, &prop, 0) != CUDA_SUCCESS) {
+			NCCL_OFI_WARN("multiseg: cuMemCreate seg %zu failed", i);
+			return ncclSystemError;
+		}
+		if (pfn_cuMemMap(base + (CUdeviceptr)(i * seg), seg, 0, h, 0) != CUDA_SUCCESS) {
+			NCCL_OFI_WARN("multiseg: cuMemMap seg %zu failed", i);
+			pfn_cuMemRelease(h);
+			return ncclSystemError;
+		}
+		b->handles[i] = h;
+	}
+
+	CUmemAccessDesc access = {};
+	access.location.type = CU_MEM_LOCATION_TYPE_DEVICE;
+	access.location.id = dev;
+	access.flags = CU_MEM_ACCESS_FLAGS_PROT_READWRITE;
+	if (pfn_cuMemSetAccess(base, total, &access, 1) != CUDA_SUCCESS) {
+		NCCL_OFI_WARN("multiseg: cuMemSetAccess failed");
+		return ncclSystemError;
+	}
+
+	b->base = base;
+	b->seg_size = seg;
+	b->nsegs = nsegs;
+	b->total = total;
+
+	CUDACHECK(cudaMemset((void *)base, 0, total));
+	return ncclSuccess;
+}
+
+static void multiseg_vmm_free(multiseg_vmm_buf *b)
+{
+	if (b->base) {
+		pfn_cuMemUnmap(b->base, b->total);
+		for (auto h : b->handles) {
+			if (h) pfn_cuMemRelease(h);
+		}
+		pfn_cuMemAddressFree(b->base, b->total);
+		b->base = 0;
+	}
+}
+
+static inline ncclResult_t
+poll_request_completion(ncclGin_v13_t *extGin, std::deque<void *> &request_deque, void *collComm,
+		       void *ginCtx)
+{
+	int done = 0;
+	OFINCCLCHECK(extGin->test(collComm, request_deque.front(), &done));
+	if (done) {
+		request_deque.pop_front();
+	} else {
+		OFINCCLCHECK(extGin->ginProgress(ginCtx));
+	}
+	return ncclSuccess;
+}
+
+int main(int argc, char *argv[])
+{
+	ncclResult_t res = ncclSuccess;
+	int rank, nranks, proc_name_len, local_rank = 0;
+	int ndev, dev;
+
+	MPI_Init(&argc, &argv);
+	MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+	MPI_Comm_size(MPI_COMM_WORLD, &nranks);
+
+	std::vector<proc_handle> handles(nranks);
+	std::vector<void *> handles_ptrs(nranks);
+
+	if (nranks < 2) {
+		NCCL_OFI_WARN("Expected at least two ranks but got %d.", nranks);
+		return ncclInvalidArgument;
+	}
+
+	std::vector<char> all_proc_name(nranks * MPI_MAX_PROCESSOR_NAME);
+	MPI_Get_processor_name(&all_proc_name[PROC_NAME_IDX(rank)], &proc_name_len);
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, all_proc_name.data(),
+		      MPI_MAX_PROCESSOR_NAME, MPI_BYTE, MPI_COMM_WORLD);
+
+	for (int i = 0; i < nranks; i++) {
+		if (!strcmp(&all_proc_name[PROC_NAME_IDX(rank)],
+			    &all_proc_name[PROC_NAME_IDX(i)])) {
+			if (i < rank) {
+				++local_rank;
+			}
+		}
+	}
+
+	CUDACHECK(cudaSetDevice(local_rank));
+
+	/* Resolve the CUDA driver VMM API before using it. */
+	OFINCCLCHECK(resolve_driver_api());
+
+	set_system_page_size();
+	auto *net_plugin_handle = load_netPlugin();
+	auto *extNet = get_netPlugin_symbol(net_plugin_handle);
+	auto *extGin = get_ginPlugin_symbol(net_plugin_handle);
+	if (extNet == nullptr || extGin == NULL) {
+		return ncclInternalError;
+	}
+
+	void *netCtx = nullptr;
+	ncclNetCommConfig_v11_t netConfig = {};
+	OFINCCLCHECK(extNet->init(&netCtx, 0, &netConfig, &functional_test_logger, nullptr));
+
+	void *ginCtx = nullptr;
+	OFINCCLCHECK(extGin->init(&ginCtx, 0, &functional_test_logger));
+
+	OFINCCLCHECK(extGin->devices(&ndev));
+
+	std::vector<int> test_support_gdr(ndev);
+	for (dev = 0; dev < ndev; dev++) {
+		ncclNetProperties_v12_t props = {};
+		OFINCCLCHECK(extGin->getProperties(dev, &props));
+		test_support_gdr[dev] = is_gdr_supported_nic(props.ptrSupport);
+	}
+
+	dev = local_rank % ndev;
+
+	/* This test drives the proxy signal path with CUDA VMM memory, so it
+	   needs a GDR-capable NIC. */
+	if (test_support_gdr[dev] != 1) {
+		NCCL_OFI_WARN("Network does not support CUDA buffers. Dev: %d", dev);
+		return 1;
+	}
+
+	void *listenComm = nullptr;
+	OFINCCLCHECK(extGin->listen(ginCtx, dev, handles[rank].handle, &listenComm));
+	assert(listenComm);
+
+	MPI_Allgather(MPI_IN_PLACE, 0, MPI_DATATYPE_NULL, handles.data(), NCCL_NET_HANDLE_MAXSIZE,
+		      MPI_CHAR, MPI_COMM_WORLD);
+
+	for (int i = 0; i < nranks; ++i) {
+		handles_ptrs[i] = &(handles[i]);
+	}
+
+	void *collComm = nullptr;
+	OFINCCLCHECK(
+		extGin->connect(ginCtx, handles_ptrs.data(), nranks, rank, listenComm, &collComm));
+	assert(collComm != nullptr);
+
+	ncclGinConfig_v13_t ginConfig = {};
+	ginConfig.nSignals = 64;
+	ginConfig.nContexts = 1;
+	ginConfig.queueDepth = 64;
+	ginConfig.trafficClass = -1;
+
+	void *proxyCtx = nullptr;
+	ncclNetDeviceHandle_v11_t *devHandle = nullptr;
+	OFINCCLCHECK(extGin->createContext(collComm, &ginConfig, &proxyCtx, &devHandle));
+	assert(proxyCtx != nullptr);
+
+	const size_t MSEG_NSEGS = 2;
+	const size_t MSEG_MIN = 2 * 1024 * 1024; /* >= VMM granularity */
+	const int MSEG_SIGNALS_PER_SEG = 16;
+	/* Payload transfer straddles the boundary between payload segment 0 and
+	   segment 1, so the multi-segment payload MR is genuinely exercised (data
+	   moved across a cuMemCreate-handle boundary), not just registered. */
+	const size_t MSEG_PAY_BYTES = 64 * 1024;
+
+	auto reg_dmabuf = [&](CUdeviceptr base, size_t len, void **mh, void **gin) -> ncclResult_t {
+		int fd = -1;
+		if (pfn_cuMemGetHandleForAddressRange(&fd, base, len,
+				CU_MEM_RANGE_HANDLE_TYPE_DMA_BUF_FD, 0) != CUDA_SUCCESS) {
+			NCCL_OFI_WARN("multiseg: cuMemGetHandleForAddressRange failed");
+			return ncclSystemError;
+		}
+		ncclResult_t r = extGin->regMrSymDmaBuf(collComm, (void *)base, len,
+							NCCL_PTR_CUDA, 0, fd, 0, mh, gin);
+		close(fd);
+		return r;
+	};
+
+	/* Multi-segment signal window. */
+	multiseg_vmm_buf msig = {};
+	OFINCCLCHECK(multiseg_vmm_alloc(&msig, MSEG_NSEGS, MSEG_MIN));
+	void *msig_mh = nullptr, *msig_gin = nullptr;
+	OFINCCLCHECK(reg_dmabuf(msig.base, msig.total, &msig_mh, &msig_gin));
+	assert(msig_mh != nullptr);
+
+	/* Multi-segment payload windows (src + dst), also VMM + dma-buf. Both the
+	   signal MR and the payload MR are multi-segment, matching the real use
+	   case (multi-segment payload) and giving the widest coverage. */
+	multiseg_vmm_buf msrc = {};
+	OFINCCLCHECK(multiseg_vmm_alloc(&msrc, MSEG_NSEGS, MSEG_MIN));
+	void *msrc_mh = nullptr, *msrc_gin = nullptr;
+	OFINCCLCHECK(reg_dmabuf(msrc.base, msrc.total, &msrc_mh, &msrc_gin));
+	assert(msrc_mh != nullptr);
+
+	multiseg_vmm_buf mdst = {};
+	OFINCCLCHECK(multiseg_vmm_alloc(&mdst, MSEG_NSEGS, MSEG_MIN));
+	void *mdst_mh = nullptr, *mdst_gin = nullptr;
+	OFINCCLCHECK(reg_dmabuf(mdst.base, mdst.total, &mdst_mh, &mdst_gin));
+	assert(mdst_mh != nullptr);
+
+	const uint64_t seg0_off = 0;
+	const uint64_t seg1_off = msig.seg_size; /* lands in signal segment 1 */
+
+	/* Payload offset straddles the payload seg0/seg1 boundary: start half a
+	   transfer before the boundary so the put crosses into segment 1. */
+	const uint64_t pay_off = msrc.seg_size - MSEG_PAY_BYTES / 2;
+
+	/* Assert the two signal offsets really fall in DISTINCT VMM segments, so
+	   this test genuinely exercises the multi-segment pin path (each segment
+	   forces its own pin). cuMemGetAddressRange reports per-cuMemCreate-handle
+	   bounds, so distinct handles give distinct bases. */
+	{
+		CUdeviceptr b0 = 0, b1 = 0; size_t z0 = 0, z1 = 0;
+		if (pfn_cuMemGetAddressRange(&b0, &z0, msig.base + seg0_off) != CUDA_SUCCESS ||
+		    pfn_cuMemGetAddressRange(&b1, &z1, msig.base + seg1_off) != CUDA_SUCCESS) {
+			NCCL_OFI_WARN("multiseg: cuMemGetAddressRange failed");
+			return ncclSystemError;
+		}
+		if (b0 == b1) {
+			NCCL_OFI_WARN("multiseg: signal offsets share segment base 0x%llx "
+				      "- test would not exercise multi-segment pinning",
+				      (unsigned long long)b0);
+			return ncclSystemError;
+		}
+		NCCL_OFI_INFO(NCCL_NET,
+			"multiseg: seg0 base=0x%llx seg1 base=0x%llx (distinct segments)",
+			(unsigned long long)b0, (unsigned long long)b1);
+	}
+
+	/* Rank 0 fills its payload src with a known per-byte pattern (over the
+	   straddling range) so the receiver can verify the multi-segment data
+	   transfer, not just the signal counters. */
+	if (rank == 0) {
+		std::vector<uint8_t> pat(MSEG_PAY_BYTES);
+		for (size_t i = 0; i < MSEG_PAY_BYTES; ++i)
+			pat[i] = (uint8_t)((i * 131 + 7) & 0xff);
+		CUDACHECK(cudaMemcpy((void *)(msrc.base + pay_off), pat.data(),
+				     MSEG_PAY_BYTES, cudaMemcpyDefault));
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank == 0) {
+		std::deque<void *> dq;
+		for (int dst = 1; dst < nranks; ++dst) {
+			for (int s = 0; s < MSEG_SIGNALS_PER_SEG; ++s) {
+				void *r0 = nullptr, *r1 = nullptr;
+				/* Spanning payload put into signal segment 0's counter. */
+				OFINCCLCHECK(extGin->iputSignal(proxyCtx, 0, pay_off, msrc_mh,
+					MSEG_PAY_BYTES, pay_off, mdst_mh, dst, seg0_off, msig_mh, 1,
+					NCCL_NET_SIGNAL_OP_INC, &r0));
+				assert(r0 != nullptr);
+				dq.push_back(r0);
+				/* Spanning payload put into signal segment 1's counter. */
+				OFINCCLCHECK(extGin->iputSignal(proxyCtx, 0, pay_off, msrc_mh,
+					MSEG_PAY_BYTES, pay_off, mdst_mh, dst, seg1_off, msig_mh, 1,
+					NCCL_NET_SIGNAL_OP_INC, &r1));
+				assert(r1 != nullptr);
+				dq.push_back(r1);
+			}
+		}
+		while (!dq.empty()) {
+			OFINCCLCHECK(poll_request_completion(extGin, dq, collComm, proxyCtx));
+		}
+	} else {
+		uint64_t s0 = 0, s1 = 0;
+		while (s0 != (uint64_t)MSEG_SIGNALS_PER_SEG ||
+		       s1 != (uint64_t)MSEG_SIGNALS_PER_SEG) {
+			OFINCCLCHECK(extGin->ginProgress(proxyCtx));
+			CUDACHECK(cudaMemcpy(&s0, (void *)(msig.base + seg0_off),
+					     sizeof(uint64_t), cudaMemcpyDefault));
+			CUDACHECK(cudaMemcpy(&s1, (void *)(msig.base + seg1_off),
+					     sizeof(uint64_t), cudaMemcpyDefault));
+		}
+		/* The loop above only exits once both counters reach the expected
+		   value, so reaching here means the signals landed correctly. */
+		NCCL_OFI_INFO(NCCL_NET,
+			"=== Verified multi-segment signal result (seg0=%lu seg1=%lu) ===",
+			(unsigned long)s0, (unsigned long)s1);
+
+		/* Signals are delivered after the payload writes, so the straddling
+		   payload data is now in mdst; verify it landed across the payload
+		   segment boundary byte-for-byte. */
+		std::vector<uint8_t> got(MSEG_PAY_BYTES);
+		CUDACHECK(cudaMemcpy(got.data(), (void *)(mdst.base + pay_off),
+				     MSEG_PAY_BYTES, cudaMemcpyDefault));
+		for (size_t i = 0; i < MSEG_PAY_BYTES; ++i) {
+			uint8_t want = (uint8_t)((i * 131 + 7) & 0xff);
+			if (got[i] != want) {
+				NCCL_OFI_WARN("multiseg payload mismatch at byte %zu: got %u want %u",
+					      i, got[i], want);
+				return ncclSystemError;
+			}
+		}
+		NCCL_OFI_INFO(NCCL_NET,
+			"=== Verified multi-segment payload (%zu bytes across seg boundary) ===",
+			(size_t)MSEG_PAY_BYTES);
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	OFINCCLCHECK(extGin->deregMrSym(collComm, msig_mh));
+	OFINCCLCHECK(extGin->deregMrSym(collComm, msrc_mh));
+	OFINCCLCHECK(extGin->deregMrSym(collComm, mdst_mh));
+	multiseg_vmm_free(&msig);
+	multiseg_vmm_free(&msrc);
+	multiseg_vmm_free(&mdst);
+
+	OFINCCLCHECK(extGin->destroyContext(proxyCtx));
+	OFINCCLCHECK(extGin->closeColl(collComm));
+	OFINCCLCHECK(extGin->closeListen(listenComm));
+	OFINCCLCHECK(extGin->finalize(ginCtx));
+	OFINCCLCHECK(extNet->finalize(netCtx));
+
+	dlclose(net_plugin_handle);
+
+	MPI_Barrier(MPI_COMM_WORLD);
+	MPI_Finalize();
+
+	NCCL_OFI_INFO(NCCL_NET, "Test completed successfully for rank %d", rank);
+
+	return res;
+}


### PR DESCRIPTION
*Description of changes:*

- The GIN host proxy GDRCopy-pinned the entire signal registration up front. That fails when the signal window is a CUDA VMM allocation backed by several `cuMemCreate` handles. `nvidia_p2p_get_pages` can't pin across handles or pin host-NUMA segments, so registration returned EINVAL.

- The pin only exists so the proxy can update an 8-byte counter, which always lives in a single segment. This changes the proxy to pin lazily and per-segment: on the first signal to a segment, it resolves the segment, classifies it, and pins just that one . A plain `cudaMalloc` buffer can't be classified and defaults to a device pin, matching the previous behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
