### PR TITLE
gin/gdaki: request FI_HMEM on the GDAKI endpoint hints

### DIFF
--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -26,12 +26,12 @@
  *
  * GDAKI does not register memory on this EP — the proxy's regMrSym
  * registers on the shared domain — and does not do fi_cq_readfrom,
- * so FI_HMEM and FI_SOURCE are not requested. efa-direct requires
- * FI_CONTEXT2 per fi_efa(7).
+ * so FI_SOURCE is not requested. FI_HMEM is still needed because the endpoint
+ * is used to access GPU memory. efa-direct requires FI_CONTEXT2 per fi_efa(7).
  */
 static void get_gdaki_hints(struct fi_info &hints, struct fi_info *ref_info)
 {
-	hints.caps = FI_MSG | FI_RMA;
+	hints.caps = FI_MSG | FI_RMA | FI_HMEM;
 	hints.mode = FI_CONTEXT2;
 
 	hints.ep_attr->type = FI_EP_RDM;


### PR DESCRIPTION
The GIN endpoint [correctly uses](https://github.com/aws/aws-ofi-nccl/blob/44d0b55142459178cc94d3a6d018a834d2c521bc/src/rdma/gin/nccl_ofi_gin_resources.cpp#L301) FI_HMEM. Before this PR, the GIN GDAKI endpoint [did not](https://github.com/aws/aws-ofi-nccl/blob/44d0b55142459178cc94d3a6d018a834d2c521bc/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp#L34). Even though, the GIN GDAKI endpoint is not directly used and only `gda_ops` queried resources from it are, it is still a violation of the spec to not set `FI_HMEM` given those resources are used to access GPU memory.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
