### PR TITLE
.ci/aws: Enable Trn2 testing

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -251,8 +251,7 @@ pipeline {
                     def p5_lock_label = "p5-1-4node"
                     def p5en_lock_label = "p5en-1-4node"
                     def g4dn_lock_label = "g4dn-1-4node"
-                    def trn1_lock_label = "trn1-1-4node"
-                    def trn1n_lock_label = "trn1n-1-4node"
+                    def trn2_lock_label = "trn2-1-4node"
 
                     def nvidia_test_list = "--test-list test_nccl_test test_ofi_nccl_functional"
                     def neuron_test_list = "--test-list test_nccom_test"
@@ -286,11 +285,8 @@ pipeline {
                     stages["4_g4dn_ubuntu2204"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
                     stages["4_g4dn_ubuntu2204_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204_tcp", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
 
-                    // trn1 tests
-                    // stages["4_trn1_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn1_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn1.32xlarge", trn1_lock_label, num_instances, neuron_addl_args)
-
-                    // trn1n tests
-                    // stages["4_trn1n_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn1n_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn1n.32xlarge", trn1n_lock_label, num_instances, neuron_addl_args)
+                    // trn2 tests
+                    stages["4_trn2_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn2_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn2.48xlarge", trn2_lock_label, num_instances, neuron_addl_args)
 
                     parallel stages
                 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Enable TRN2 testing.
- Remove TRN1 and TRN1N test stages from the CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
