### PR TITLE
[DONT MERGE] Add coarse field diagnostics for init, connection setup, and teardown

### DIFF
--- a/DIAGNOSTICS.md
+++ b/DIAGNOSTICS.md
@@ -1,0 +1,88 @@
+# OFI plugin diagnostics (OFI_NCCL_DIAG)
+
+This branch adds lightweight, human-readable diagnostics to the aws-ofi-nccl plugin to help locate where time goes during NCCL initialization, connection setup, and teardown.
+
+## Enabling
+
+Build the plugin normally, then run your job with:
+
+```
+OFI_NCCL_DIAG=1
+NCCL_DEBUG=INFO
+NCCL_DEBUG_SUBSYS=INIT,NET
+NCCL_DEBUG_FILE=/some/path/nccl.%h.%p.log
+```
+
+- `OFI_NCCL_DIAG=1` turns the instrumentation on (off by default; when off the overhead is a single branch per call and nothing prints).
+- The diagnostic lines are emitted through NCCL's standard logger at INFO level in the INIT/NET subsystems, so `NCCL_DEBUG=INFO` with `NCCL_DEBUG_SUBSYS=INIT,NET` shows them alongside NCCL's own initialization and network messages (useful context) while keeping the noisier subsystems quiet.
+- `NCCL_DEBUG_FILE` with `%h` (hostname) and `%p` (pid) gives one log file per rank, the standard NCCL way.
+
+Every diagnostic line looks like a normal NCCL log line carrying the `OFI-DIAG` tag and a wall-clock timestamp:
+
+```
+host:pid:tid [cudaDev] NCCL INFO OFI-DIAG <HH:MM:SS.mmm> <event>
+```
+
+The timestamp is local wall-clock so you can correlate lines with your own application markers. Filter with `grep OFI-DIAG`.
+
+## Events printed as they happen
+
+| line | meaning |
+|------|---------|
+| `INIT topology discovery took=...` | PCI topology scan during plugin init |
+| `INIT plugin init (...) took=...` | total plugin initialization (device discovery, topology, platform setup) |
+| `DOMAIN_CREATE dev=N took=...` | libfabric domain creation for a NIC group |
+| `EP_CREATE dev=N took=...` | libfabric endpoint (queue pair) creation |
+| `CONNECT dev=N window=... inside=...(P%) polls=... incomplete=... gap_mean=... gap_max=...` | one outbound connection completed (see below) |
+| `ACCEPT ...` | one inbound connection completed (same fields) |
+| `regMr LARGE/SLOW size=... type=... took=...` | any single memory registration that is >= 32 MB or took >= 5 ms |
+| `FINI plugin finalize (...) took=...` | plugin teardown time |
+
+## How to read the CONNECT / ACCEPT lines
+
+NCCL establishes connections by polling the plugin repeatedly until the connection completes. For each completed connection:
+
+- `window`: wall-clock from the first poll to completion. This is the user-visible duration of that connection.
+- `inside (P%)`: how much of that window was spent executing plugin code. If P is high, the plugin itself is the cost (typically memory registration performed during connection setup). If P is low, the time went to waiting: either the remote peer had not answered yet, or NCCL's proxy thread was busy elsewhere and stopped polling.
+- `polls` / `incomplete`: how many times NCCL called the plugin for this connection, and how many of those calls returned without completing it.
+- `gap_mean` / `gap_max`: time between consecutive polls. A large `gap_max` means NCCL's proxy thread went away from this connection for that long (busy with other work).
+
+## The end-of-run summary
+
+Printed once per process at exit:
+
+- `api <name> calls=... incomplete=... time_inside=...`: every plugin API (including `closeSend`/`closeRecv`/`closeListen` teardown calls), how often it was called, how many calls returned without completion (polling), and the total time spent inside the plugin for that API.
+- `conn connect(out)/accept(in) completed=... window_sum=... window_max=... inside_sum=...`: aggregate connection statistics per direction. `window_sum` counts overlapping windows, so treat it as an upper bound; `inside_sum` is real plugin time.
+- `conn phase: first_poll=... last_completion=... span=...`: wall-clock bracket of the whole connection-establishment phase on this process. Compare these timestamps with your application's own phase markers.
+- `mr registrations=... (host=... cuda=... dmabuf_fd=...) bytes=... time=... cache_hits=... cache_misses=...`: total memory registrations, split by memory type, whether NCCL provided a dmabuf fd, total bytes and time, and MR-cache behavior.
+
+## What to look for
+
+1. Is initialization slow? Check the `INIT` lines.
+2. Is connection setup slow? Check `conn phase: span`, then the per-connection lines: high `inside%` means plugin cost (look next at the `mr` summary); low `inside%` with large gaps means the time is outside the plugin (peer wait or NCCL-internal work).
+3. Are registrations slow or huge? `regMr LARGE/SLOW` lines fire individually; the `mr` summary gives totals. A large `host=` count with big `bytes=` is significant: host memory registration costs about 30 ms per GB. CUDA registrations with dmabuf are size-independent (fractions of a millisecond even for multi-GB buffers).
+4. Is teardown slow? Check the `closeSend`/`closeRecv`/`closeListen` census rows and the `FINI` line.
+
+## Example (48-GPU run, 9 communicators, one rank's summary)
+
+```
+NCCL INFO OFI-DIAG 00:31:11.580 CONNECT dev=0 window=23.46ms inside=3.69ms(16%) polls=5 incomplete=4 gap_mean=4941.9us gap_max=18.11ms
+...
+NCCL INFO OFI-DIAG 00:31:16.048 ---- OFI plugin diagnostic summary ----
+NCCL INFO OFI-DIAG 00:31:16.048 api connect       calls=79168  incomplete=79148  time_inside=59.8ms
+NCCL INFO OFI-DIAG 00:31:16.048 api regMr         calls=120    incomplete=0      time_inside=80.8ms
+NCCL INFO OFI-DIAG 00:31:16.048 api closeSend     calls=20     incomplete=0      time_inside=65.1ms
+NCCL INFO OFI-DIAG 00:31:16.048 conn connect(out) completed=20 window_sum=1132.7ms window_max=163.9ms inside_sum=56.8ms
+NCCL INFO OFI-DIAG 00:31:16.048 conn phase: first_poll=00:31:11.556 last_completion=00:31:12.225 span=668.6ms
+NCCL INFO OFI-DIAG 00:31:16.048 mr  registrations=255 (host=150 cuda=105 dmabuf_fd=105) bytes=0.52GB time=176.2ms cache_hits=0 cache_misses=255
+NCCL INFO OFI-DIAG 00:31:16.048 ---- end summary ----
+```
+
+Reading this example: this rank established 40 connections in a 669 ms window; NCCL polled connect 79k times but the plugin only consumed 60 ms of that (the waits were elsewhere); registration cost 176 ms across 255 registrations, all CUDA ones via dmabuf fds; teardown cost ~100 ms in close calls.
+
+## Limitations
+
+- The plugin cannot see NCCL-internal work: bootstrap/out-of-band TCP exchange, channel/ring computation, kernel launches. Those appear here only indirectly, as gaps in which NCCL stopped polling the plugin (and in NCCL's own INIT/NET lines around ours).
+- For CUDA registrations without an NCCL-provided dmabuf fd, whether the libfabric provider uses dmabuf internally is decided below the plugin and is not visible here.
+- The summary prints when the plugin is finalized (with an at-exit fallback); if the process is killed with SIGKILL the summary is lost (the per-event lines are not).
+- In the rare window where NCCL's logger is not yet available, lines fall back to stderr with an `[OFI-DIAG host:pid]` prefix.

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -22,6 +22,7 @@ noinst_HEADERS = \
 	nccl_ofi_config_bottom.h \
 	nccl_ofi_cuda.h \
 	nccl_ofi_device_copy.h \
+	nccl_ofi_diag.h \
 	nccl_ofi_dlist.h \
 	nccl_ofi_dmabuf.h \
 	nccl_ofi_environ.h \

--- a/include/nccl_ofi_diag.h
+++ b/include/nccl_ofi_diag.h
@@ -1,0 +1,385 @@
+/*
+ * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
+ *
+ * Coarse, self-contained diagnostics for troubleshooting slow initialization /
+ * connection setup / teardown in the field.
+ *
+ * Enable at runtime with OFI_NCCL_DIAG=1. All output goes to stderr, one line
+ * per event, prefixed with "[OFI-DIAG host:pid HH:MM:SS.mmm]". Output is
+ * independent of NCCL_DEBUG so it can run with production log levels. When
+ * disabled, the overhead is a single branch per call site.
+ *
+ * What it reports:
+ *  - init phases (plugin init total, topology discovery) and plugin finalize
+ *  - domain / endpoint creation, one line each with duration
+ *  - per-connection poll statistics for connect() and accept(): total window,
+ *    time spent inside the plugin vs waiting, number of polls, polls that
+ *    returned incomplete, mean/max gap between polls
+ *  - a per-process connection-phase bracket (first poll to last completion)
+ *  - per-registration lines for large or slow memory registrations, plus
+ *    aggregate totals (count, bytes, time, cache hits/misses, host vs cuda,
+ *    fd-based dmabuf registrations)
+ *  - a final per-process summary of every plugin API (calls, incomplete
+ *    returns, total time inside), including the close/teardown calls
+ */
+#ifndef NCCL_OFI_DIAG_H_
+#define NCCL_OFI_DIAG_H_
+
+#include <atomic>
+#include <cstdarg>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <mutex>
+#include <unistd.h>
+
+#include "nccl_ofi_log.h"
+
+namespace ofi_diag {
+
+inline bool enabled()
+{
+	static int v = -1;
+	if (v < 0) {
+		const char *e = getenv("OFI_NCCL_DIAG");
+		v = (e && atoi(e) != 0) ? 1 : 0;
+	}
+	return v != 0;
+}
+
+inline uint64_t now_ns()
+{
+	struct timespec t;
+	clock_gettime(CLOCK_MONOTONIC, &t);
+	return (uint64_t)t.tv_sec * 1000000000ull + (uint64_t)t.tv_nsec;
+}
+
+inline uint64_t wall_ns()
+{
+	struct timespec t;
+	clock_gettime(CLOCK_REALTIME, &t);
+	return (uint64_t)t.tv_sec * 1000000000ull + (uint64_t)t.tv_nsec;
+}
+
+/* Format a CLOCK_REALTIME ns value as HH:MM:SS.mmm (local time). */
+inline void fmt_wall(uint64_t ns, char *out, size_t outsz)
+{
+	time_t sec = (time_t)(ns / 1000000000ull);
+	struct tm tmv;
+	localtime_r(&sec, &tmv);
+	snprintf(out, outsz, "%02d:%02d:%02d.%03d", tmv.tm_hour, tmv.tm_min,
+		 tmv.tm_sec, (int)((ns / 1000000ull) % 1000));
+}
+
+__attribute__((format(printf, 1, 2)))
+inline void print(const char *fmt, ...)
+{
+	if (!enabled()) {
+		return;
+	}
+	char ts[16];
+	fmt_wall(wall_ns(), ts, sizeof(ts));
+	char buf[512];
+	va_list ap;
+	va_start(ap, fmt);
+	vsnprintf(buf, sizeof(buf), fmt, ap);
+	va_end(ap);
+	if (ofi_log_function != nullptr) {
+		/* Standard path: emit through NCCL's logger at INFO level with the
+		 * INIT|NET subsystems, so lines land in the customer's normal NCCL
+		 * log (including NCCL_DEBUG_FILE per-rank files) interleaved with
+		 * NCCL's own messages. */
+		(*ofi_log_function)(NCCL_LOG_INFO, NCCL_INIT | NCCL_NET, "OFI-DIAG", 0,
+				    "OFI-DIAG %s %s", ts, buf);
+	} else {
+		/* Fallback for the rare window where the logger is not available. */
+		static char host[64];
+		if (!host[0]) {
+			if (gethostname(host, sizeof(host) - 1) != 0) {
+				snprintf(host, sizeof(host), "?");
+			}
+		}
+		fprintf(stderr, "[OFI-DIAG %s:%d %s] %s\n", host, (int)getpid(), ts, buf);
+	}
+}
+
+/* ---------------- API census: calls / incomplete / time per op ------------ */
+
+enum Op {
+	LISTEN, CONNECT, ACCEPT, REGMR, DEREGMR, ISEND, IRECV, IFLUSH, TEST,
+	CLOSE_SEND, CLOSE_RECV, CLOSE_LISTEN, DEVICES, GET_PROPERTIES,
+	GET_MR_KEY, IWRITE, IREAD, OP_N
+};
+
+inline const char *op_name(int op)
+{
+	static const char *names[OP_N] = {
+		"listen", "connect", "accept", "regMr", "deregMr", "isend",
+		"irecv", "iflush", "test", "closeSend", "closeRecv",
+		"closeListen", "devices", "getProperties", "getMrKey",
+		"iwrite", "iread"
+	};
+	return names[op];
+}
+
+struct Census {
+	std::atomic<uint64_t> ns[OP_N];
+	std::atomic<uint64_t> calls[OP_N];
+	std::atomic<uint64_t> incomplete[OP_N];
+};
+inline Census g_census;
+
+inline void census_add(int op, uint64_t ns, bool completed)
+{
+	g_census.ns[op].fetch_add(ns, std::memory_order_relaxed);
+	g_census.calls[op].fetch_add(1, std::memory_order_relaxed);
+	if (!completed) {
+		g_census.incomplete[op].fetch_add(1, std::memory_order_relaxed);
+	}
+}
+
+/* RAII census scope: records elapsed time for every exit path. The caller
+ * marks completion on the success path; error/incomplete paths default to
+ * incomplete for the pollable ops and complete for the synchronous ones. */
+inline void register_summary_atexit();
+struct ApiScope {
+	int op;
+	uint64_t t0;
+	bool on;
+	bool completed;
+	ApiScope(int op_arg, bool default_completed) : op(op_arg), t0(0), on(enabled()), completed(default_completed)
+	{
+		if (on) {
+			register_summary_atexit();
+			t0 = now_ns();
+		}
+	}
+	~ApiScope()
+	{
+		if (on) {
+			census_add(op, now_ns() - t0, completed);
+		}
+	}
+};
+
+/* ------------- per-connection poll stats (connect / accept) --------------- */
+
+struct ConnStats {
+	const void *key;
+	uint64_t first_ns;
+	uint64_t last_exit_ns;
+	uint64_t gap_sum_ns;
+	uint64_t gap_max_ns;
+	uint64_t inside_sum_ns;
+	uint32_t calls;
+	uint32_t incomplete;
+	int dev;
+	bool used;
+};
+
+/* Small open-addressing map keyed by an NCCL-provided pointer that is stable
+ * across the polls of one connection (the handle for connect, the listen comm
+ * for accept). Mutex-protected; contention is negligible (proxy threads). */
+struct ConnMap {
+	static constexpr int SZ = 4096;
+	std::mutex mu;
+	ConnStats slots[SZ];
+
+	ConnStats *get(const void *key, int dev)
+	{
+		std::lock_guard<std::mutex> lk(mu);
+		size_t h = ((uintptr_t)key >> 4) % SZ;
+		for (int i = 0; i < SZ; i++) {
+			ConnStats *s = &slots[(h + i) % SZ];
+			if (s->used && s->key == key) {
+				return s;
+			}
+			if (!s->used) {
+				memset(s, 0, sizeof(*s));
+				s->used = true;
+				s->key = key;
+				s->dev = dev;
+				return s;
+			}
+		}
+		return nullptr;  /* full: silently drop stats for this connection */
+	}
+	void release(ConnStats *s)
+	{
+		if (!s) {
+			return;
+		}
+		std::lock_guard<std::mutex> lk(mu);
+		s->used = false;
+	}
+};
+inline ConnMap g_connect_map;
+inline ConnMap g_accept_map;
+
+/* Per-direction aggregates (0 = connect / send side, 1 = accept / recv side)
+ * and the per-process connection-phase bracket. */
+struct ConnAgg {
+	std::atomic<uint64_t> completed;
+	std::atomic<uint64_t> window_sum_ns;
+	std::atomic<uint64_t> window_max_ns;
+	std::atomic<uint64_t> inside_sum_ns;
+};
+inline ConnAgg g_conn_agg[2];
+inline std::atomic<uint64_t> g_phase_first_mono{0};
+inline std::atomic<uint64_t> g_phase_first_wall{0};
+inline std::atomic<uint64_t> g_phase_last_mono{0};
+inline std::atomic<uint64_t> g_phase_last_wall{0};
+
+inline void atomic_max(std::atomic<uint64_t> &a, uint64_t v)
+{
+	uint64_t cur = a.load(std::memory_order_relaxed);
+	while (cur < v && !a.compare_exchange_weak(cur, v)) {}
+}
+
+inline void poll_begin(ConnStats *s, uint64_t t_in)
+{
+	if (!s) {
+		return;
+	}
+	if (s->calls == 0) {
+		s->first_ns = t_in;
+		/* connection-phase bracket: first poll of the first connection */
+		uint64_t expect = 0;
+		if (g_phase_first_mono.compare_exchange_strong(expect, t_in)) {
+			g_phase_first_wall.store(wall_ns());
+		}
+	} else {
+		uint64_t gap = t_in - s->last_exit_ns;
+		s->gap_sum_ns += gap;
+		if (gap > s->gap_max_ns) {
+			s->gap_max_ns = gap;
+		}
+	}
+	s->calls++;
+}
+
+/* Call at poll exit. On completion prints the one-line connection summary,
+ * updates the aggregates and phase bracket, and frees the slot. inside_sum_ns
+ * must already include this call's time. dir: 0 = connect, 1 = accept. */
+inline void poll_end(ConnMap &map, ConnStats *s, uint64_t t_out, bool completed, int dir, const char *what)
+{
+	if (!s) {
+		return;
+	}
+	s->last_exit_ns = t_out;
+	if (!completed) {
+		s->incomplete++;
+		return;
+	}
+	uint64_t window = t_out - s->first_ns;
+	print("%s dev=%d window=%.2fms inside=%.2fms(%.0f%%) polls=%u incomplete=%u gap_mean=%.1fus gap_max=%.2fms",
+	      what, s->dev, window / 1e6, s->inside_sum_ns / 1e6,
+	      window ? 100.0 * (double)s->inside_sum_ns / (double)window : 0.0,
+	      s->calls, s->incomplete,
+	      s->calls > 1 ? (double)s->gap_sum_ns / 1e3 / (double)(s->calls - 1) : 0.0,
+	      s->gap_max_ns / 1e6);
+	ConnAgg &agg = g_conn_agg[dir ? 1 : 0];
+	agg.completed.fetch_add(1, std::memory_order_relaxed);
+	agg.window_sum_ns.fetch_add(window, std::memory_order_relaxed);
+	agg.inside_sum_ns.fetch_add(s->inside_sum_ns, std::memory_order_relaxed);
+	atomic_max(agg.window_max_ns, window);
+	atomic_max(g_phase_last_mono, t_out);
+	g_phase_last_wall.store(wall_ns());
+	map.release(s);
+}
+
+/* --------------------------- MR registration ------------------------------ */
+
+struct MrAgg {
+	std::atomic<uint64_t> count, bytes, ns;
+	std::atomic<uint64_t> host_count, cuda_count, fd_dmabuf_count;
+	std::atomic<uint64_t> cache_hits, cache_misses;
+};
+inline MrAgg g_mr;
+
+/* Per-registration record; prints its own line only for large (>=32 MB) or
+ * slow (>=5 ms) registrations so the log stays coarse.
+ * fd_dmabuf: NCCL provided a dmabuf fd for this registration. Note: for
+ * plain virtual-address CUDA registrations the libfabric provider may still
+ * use dmabuf internally; that decision is below the plugin and not visible
+ * here. */
+inline void mr_add(uint64_t ns, size_t bytes, bool is_cuda, bool fd_dmabuf)
+{
+	g_mr.count.fetch_add(1, std::memory_order_relaxed);
+	g_mr.bytes.fetch_add(bytes, std::memory_order_relaxed);
+	g_mr.ns.fetch_add(ns, std::memory_order_relaxed);
+	(is_cuda ? g_mr.cuda_count : g_mr.host_count).fetch_add(1, std::memory_order_relaxed);
+	if (fd_dmabuf) {
+		g_mr.fd_dmabuf_count.fetch_add(1, std::memory_order_relaxed);
+	}
+	if (bytes >= (32ull << 20) || ns >= 5000000ull) {
+		print("regMr LARGE/SLOW size=%.1fMB type=%s%s took=%.2fms",
+		      bytes / 1048576.0, is_cuda ? "cuda" : "host",
+		      fd_dmabuf ? "+dmabuf_fd" : "", ns / 1e6);
+	}
+}
+
+/* ------------------------------ summary ----------------------------------- */
+
+inline void summary()
+{
+	if (!enabled()) {
+		return;
+	}
+	/* Print at most once (called from plugin finalize; atexit is a fallback
+	 * for paths where finalize never runs). */
+	static std::atomic<bool> printed{false};
+	if (printed.exchange(true)) {
+		return;
+	}
+	print("---- OFI plugin diagnostic summary ----");
+	for (int op = 0; op < OP_N; op++) {
+		/* Zero-call ops are printed too: "never called" is itself useful
+		 * evidence (e.g. iflush not being used on a given platform). */
+		print("api %-13s calls=%-10lu incomplete=%-10lu time_inside=%.1fms",
+		      op_name(op), (unsigned long)g_census.calls[op].load(),
+		      (unsigned long)g_census.incomplete[op].load(),
+		      g_census.ns[op].load() / 1e6);
+	}
+	static const char *dir_name[2] = {"connect(out)", "accept(in)"};
+	for (int d = 0; d < 2; d++) {
+		ConnAgg &a = g_conn_agg[d];
+		uint64_t n = a.completed.load();
+		if (!n) {
+			continue;
+		}
+		print("conn %-12s completed=%-6lu window_sum=%.1fms window_max=%.1fms inside_sum=%.1fms",
+		      dir_name[d], (unsigned long)n, a.window_sum_ns.load() / 1e6,
+		      a.window_max_ns.load() / 1e6, a.inside_sum_ns.load() / 1e6);
+	}
+	if (g_phase_first_mono.load() && g_phase_last_mono.load()) {
+		char t0[16], t1[16];
+		fmt_wall(g_phase_first_wall.load(), t0, sizeof(t0));
+		fmt_wall(g_phase_last_wall.load(), t1, sizeof(t1));
+		print("conn phase: first_poll=%s last_completion=%s span=%.1fms",
+		      t0, t1, (g_phase_last_mono.load() - g_phase_first_mono.load()) / 1e6);
+	}
+	print("mr  registrations=%lu (host=%lu cuda=%lu dmabuf_fd=%lu) bytes=%.2fGB time=%.1fms cache_hits=%lu cache_misses=%lu",
+	      (unsigned long)g_mr.count.load(), (unsigned long)g_mr.host_count.load(),
+	      (unsigned long)g_mr.cuda_count.load(), (unsigned long)g_mr.fd_dmabuf_count.load(),
+	      g_mr.bytes.load() / 1073741824.0, g_mr.ns.load() / 1e6,
+	      (unsigned long)g_mr.cache_hits.load(), (unsigned long)g_mr.cache_misses.load());
+	print("---- end summary ----");
+}
+
+/* Register the summary once at first instrumented call. */
+inline void register_summary_atexit()
+{
+	static std::once_flag once;
+	std::call_once(once, [] {
+		if (enabled()) {
+			std::atexit([] { summary(); });
+		}
+	});
+}
+
+}  // namespace ofi_diag
+
+#endif  // NCCL_OFI_DIAG_H_

--- a/src/nccl_ofi_api.cpp
+++ b/src/nccl_ofi_api.cpp
@@ -10,6 +10,7 @@
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 #include "nccl_ofi_param.h"
+#include "nccl_ofi_diag.h"
 
 
 static_assert(sizeof(nccl_net_ofi_conn_handle_t) <= NCCL_NET_HANDLE_MAXSIZE,
@@ -73,10 +74,15 @@ ncclResult_t nccl_net_ofi_init(ncclDebugLogger_t logFunction)
 
 	abort_on_error = (ofi_nccl_abort_on_error() != 0);
 	try {
+		const uint64_t _diag_t0 = ofi_diag::enabled() ? ofi_diag::now_ns() : 0;
 		ret = nccl_net_ofi_create_plugin(&plugin);
 		if (OFI_UNLIKELY(ret != 0)) {
 			NCCL_OFI_WARN("Initializing plugin failed");
 			return nccl_net_ofi_retval_translate_impl(ret);
+		}
+		if (_diag_t0) {
+			ofi_diag::print("INIT plugin init (device discovery, topology, platform) took=%.1fms",
+					(ofi_diag::now_ns() - _diag_t0) / 1e6);
 		}
 	}
 	catch (const std::exception &e) {
@@ -95,8 +101,15 @@ ncclResult_t nccl_net_ofi_fini()
 		NCCL_OFI_WARN("Finalizing already finalized plugin");
 		ret = check_return(ncclSystemError);
 	} else {
+		const uint64_t _diag_t0 = ofi_diag::enabled() ? ofi_diag::now_ns() : 0;
 		delete plugin;
 		plugin = NULL;
+		if (_diag_t0) {
+			ofi_diag::print("FINI plugin finalize (teardown of domains/endpoints/fabric) took=%.1fms",
+					(ofi_diag::now_ns() - _diag_t0) / 1e6);
+			/* Emit the summary here, while NCCL's logger is guaranteed valid. */
+			ofi_diag::summary();
+		}
 	}
 	return ret;
 }
@@ -110,6 +123,7 @@ nccl_net_ofi_plugin_t *nccl_net_ofi_get_plugin()
 
 ncclResult_t nccl_net_ofi_devices(int *num_devices)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::DEVICES, true);
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == NULL)) {
 		NCCL_OFI_WARN("Error accessing plugin. Plugin has not been initialized yet.");
@@ -128,6 +142,7 @@ ncclResult_t nccl_net_ofi_devices(int *num_devices)
 
 ncclResult_t nccl_net_ofi_get_properties(int dev_id, nccl_ofi_properties_t *ofi_properties)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::GET_PROPERTIES, true);
 	nccl_net_ofi_device_t *device;
 
 	/* Validate plugin */
@@ -155,6 +170,7 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 	std::shared_ptr<nccl_net_ofi_ep_t> ep;
 	nccl_net_ofi_listen_comm **listen_comm =
 		reinterpret_cast<nccl_net_ofi_listen_comm **>(lComm);
+	ofi_diag::ApiScope _diag(ofi_diag::LISTEN, true);
 
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == nullptr)) {
@@ -187,6 +203,12 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 		ret = -EINVAL;
 	}
 
+	/* Diag: pre-create the accept-side stats entry, keyed by the listen comm,
+	 * so accept() polls know the device id. */
+	if (_diag.on && ret == 0 && *listen_comm != nullptr) {
+		(void)ofi_diag::g_accept_map.get(*listen_comm, dev_id);
+	}
+
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -217,6 +239,13 @@ ncclResult_t nccl_net_ofi_listen(int dev_id, void *handle, void **lComm,
 ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int trafficClass,
 				  unsigned int domain_key, unsigned int resource_key)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::CONNECT, false);
+	ofi_diag::ConnStats *_diag_cs = nullptr;
+	if (_diag.on) {
+		_diag_cs = ofi_diag::g_connect_map.get(handle, dev_id);
+		ofi_diag::poll_begin(_diag_cs, _diag.t0);
+	}
+
 	/* Validate plugin */
 	if (OFI_UNLIKELY(plugin == nullptr)) {
 		NCCL_OFI_WARN("Error accessing plugin. Plugin has not been initialized yet.");
@@ -267,6 +296,14 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
 		ret = -EINVAL;
 	}
 
+	if (_diag.on) {
+		uint64_t _t_out = ofi_diag::now_ns();
+		bool _done = (ret == 0 && *sComm != nullptr);
+		if (_diag_cs) _diag_cs->inside_sum_ns += _t_out - _diag.t0;
+		_diag.completed = _done;
+		ofi_diag::poll_end(ofi_diag::g_connect_map, _diag_cs, _t_out, _done, 0, "CONNECT");
+	}
+
 	/* ep shared_ptr drops on scope exit. No manual release needed */
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
@@ -290,6 +327,13 @@ ncclResult_t nccl_net_ofi_connect(int dev_id, void *handle, void **sComm, int tr
  */
 ncclResult_t nccl_net_ofi_accept(void *lComm, void **rComm)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::ACCEPT, false);
+	ofi_diag::ConnStats *_diag_cs = nullptr;
+	if (_diag.on) {
+		_diag_cs = ofi_diag::g_accept_map.get(lComm, -1);
+		ofi_diag::poll_begin(_diag_cs, _diag.t0);
+	}
+
 	if (OFI_UNLIKELY(plugin == nullptr)) {
 		NCCL_OFI_WARN("Error accessing plugin. Plugin has not been initialized yet.");
 		return check_return(ncclInvalidArgument);
@@ -315,6 +359,14 @@ ncclResult_t nccl_net_ofi_accept(void *lComm, void **rComm)
 		ret = -EINVAL;
 	}
 
+	if (_diag.on) {
+		uint64_t _t_out = ofi_diag::now_ns();
+		bool _done = (ret == 0 && *rComm != nullptr);
+		if (_diag_cs) _diag_cs->inside_sum_ns += _t_out - _diag.t0;
+		_diag.completed = _done;
+		ofi_diag::poll_end(ofi_diag::g_accept_map, _diag_cs, _t_out, _done, 1, "ACCEPT");
+	}
+
 	/* On failure, the listen comm's ep shared_ptr will be
 	 * released when the listen comm is destroyed. No manual
 	 * release needed. */
@@ -327,6 +379,7 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 				      int type, uint64_t offset,
 				      int fd, void** mhandle)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::REGMR, true);
 	int ret;
 	/* Retrieve and validate comm */
 	nccl_net_ofi_comm *base_comm =
@@ -395,6 +448,7 @@ ncclResult_t nccl_net_ofi_regMrDmaBuf(void* comm, void* data, size_t size,
 
 ncclResult_t nccl_net_ofi_deregMr(void *comm, void *mhandle)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::DEREGMR, true);
 	/* Retrieve and validate comm */
 	nccl_net_ofi_comm *base_comm =
 		(nccl_net_ofi_comm *)comm;
@@ -460,7 +514,9 @@ ncclResult_t nccl_net_ofi_isend(void* sendComm, void* data, size_t size,
 		return check_return(ncclInternalError);
 	}
 
+	ofi_diag::ApiScope _diag(ofi_diag::ISEND, false);
 	int ret = send_comm->send(data, size, tag, handle, base_req);
+	_diag.completed = (ret == 0 && *request != NULL);
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -507,13 +563,16 @@ ncclResult_t nccl_net_ofi_irecv(void* recvComm, int n, void** data,
 		return check_return(ncclInternalError);
 	}
 
+	ofi_diag::ApiScope _diag(ofi_diag::IRECV, false);
 	int ret = recv_comm->recv(n, data, sizes, tags, handles, base_req);
+	_diag.completed = (ret == 0 && *request != NULL);
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
 
 ncclResult_t nccl_net_ofi_test(void* req, int* done, int* size)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::TEST, false);
 	/* Validate request */
 	if (OFI_UNLIKELY(req == NULL)) {
 		return check_return(ncclInternalError);
@@ -521,6 +580,7 @@ ncclResult_t nccl_net_ofi_test(void* req, int* done, int* size)
 
 	nccl_net_ofi_req *base_req = (nccl_net_ofi_req *)req;
 	int ret = base_req->test(done, size);
+	_diag.completed = (ret == 0 && *done != 0);
 	return nccl_net_ofi_retval_translate_impl(ret);
 }
 
@@ -528,6 +588,7 @@ ncclResult_t nccl_net_ofi_test(void* req, int* done, int* size)
 ncclResult_t nccl_net_ofi_iflush(void* rComm, int n, void** buffers, int* sizes,
 				 void** mhandles, void** req)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::IFLUSH, true);
 	nccl_net_ofi_recv_comm *recv_comm =
 		(nccl_net_ofi_recv_comm *)rComm;
 	nccl_net_ofi_mr_handle_t **handles = (nccl_net_ofi_mr_handle_t **)mhandles;
@@ -570,6 +631,7 @@ ncclResult_t nccl_net_ofi_iflush(void* rComm, int n, void** buffers, int* sizes,
  */
 ncclResult_t nccl_net_ofi_closeSend(void *sComm)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::CLOSE_SEND, true);
 	nccl_net_ofi_send_comm *send_comm = (nccl_net_ofi_send_comm *)sComm;
 
 	/* neuron has a cleanup race between the atexit handler and *
@@ -597,6 +659,7 @@ ncclResult_t nccl_net_ofi_closeSend(void *sComm)
  */
 ncclResult_t nccl_net_ofi_closeRecv(void *rComm)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::CLOSE_RECV, true);
 	nccl_net_ofi_recv_comm *recv_comm = (nccl_net_ofi_recv_comm *)rComm;
 
 	/* neuron has a cleanup race between the atexit handler and *
@@ -621,6 +684,7 @@ ncclResult_t nccl_net_ofi_closeRecv(void *rComm)
 
 ncclResult_t nccl_net_ofi_closeListen(void *lComm)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::CLOSE_LISTEN, true);
 	nccl_net_ofi_listen_comm *listen_comm =
 		(nccl_net_ofi_listen_comm *)lComm;
 
@@ -645,6 +709,7 @@ ncclResult_t nccl_net_ofi_closeListen(void *lComm)
 
 ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::GET_MR_KEY, true);
 	int ret = 0;
 	nccl_net_ofi_device_t *device = NULL;
 	auto *mhandle_ptr = static_cast<nccl_net_ofi_mr_handle_t *>(mhandle);
@@ -673,6 +738,7 @@ ncclResult_t nccl_net_ofi_get_mr_key(void* mhandle, uint64_t* mr_key)
 ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhandle,
 				 uint64_t dest, uint64_t mr_key, void** req)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::IWRITE, true);
 	nccl_net_ofi_send_comm *send_comm =
 		(nccl_net_ofi_send_comm *)sComm;
 	nccl_net_ofi_req **base_req = (nccl_net_ofi_req **)req;
@@ -696,6 +762,7 @@ ncclResult_t nccl_net_ofi_iwrite(void* sComm, void* src, size_t size, void* mhan
 ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
 					uint64_t dest, uint64_t mr_key, void** req)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::IWRITE, true);
 	nccl_net_ofi_send_comm *send_comm =
 		(nccl_net_ofi_send_comm *)sComm;
 	nccl_net_ofi_req **base_req = (nccl_net_ofi_req **)req;
@@ -719,6 +786,7 @@ ncclResult_t nccl_net_ofi_iwrite_inline(void* sComm, void* src, size_t size,
 ncclResult_t nccl_net_ofi_iread(void* rComm, void* dest, size_t size, void* mhandle,
 				uint64_t src, uint64_t mr_key, void** req)
 {
+	ofi_diag::ApiScope _diag(ofi_diag::IREAD, true);
 	nccl_net_ofi_recv_comm *recv_comm =
 		(nccl_net_ofi_recv_comm *)rComm;
 	nccl_net_ofi_req **base_req = (nccl_net_ofi_req **)req;

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -25,6 +25,7 @@
 #include "nccl_ofi_assert.h"
 #include "nccl_ofi_environ.h"
 #include "nccl_ofi_param.h"
+#include "nccl_ofi_diag.h"
 #include "nccl_ofi_tracepoint.h"
 #if HAVE_CUDA
 #include "nccl_ofi_cuda.h"
@@ -220,7 +221,14 @@ int nccl_net_ofi_create_plugin(nccl_net_ofi_plugin_t **plugin_p)
 	/* configuration parameters */
 	cq_read_count = ofi_nccl_cq_read_count();
 
-	topo.reset(nccl_ofi_topo_create());
+	{
+		const uint64_t _diag_t0 = ofi_diag::enabled() ? ofi_diag::now_ns() : 0;
+		topo.reset(nccl_ofi_topo_create());
+		if (_diag_t0) {
+			ofi_diag::print("INIT topology discovery took=%.1fms",
+					(ofi_diag::now_ns() - _diag_t0) / 1e6);
+		}
+	}
 	if (!topo) {
 		NCCL_OFI_WARN("Failed to create NCCL OFI topology");
 		ret = -ENODEV;

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7,6 +7,9 @@
 #include <deque>
 #include <stdexcept>
 
+#include "nccl_ofi_diag.h"
+
+
 #include <assert.h>
 #include <inttypes.h>
 #include <stdio.h>
@@ -2936,6 +2939,18 @@ error:
 }
 
 
+/* diag helper: whether a registration ckey carries a dmabuf fd (guarded for
+ * builds without FI_MR_DMABUF support) */
+static inline bool diag_ckey_is_dmabuf(nccl_ofi_mr_ckey_ref ckey)
+{
+#if HAVE_DECL_FI_MR_DMABUF
+	return ckey->type == NCCL_OFI_MR_CKEY_DMABUF;
+#else
+	(void)ckey;
+	return false;
+#endif
+}
+
 int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 				       int type,
 				       nccl_net_ofi_rdma_ep_t *ep,
@@ -2944,6 +2959,9 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 	int ret = 0;
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	*mhandle = NULL;
+
+	const bool _diag_on = ofi_diag::enabled();
+	uint64_t _diag_t0 = 0;
 
 	if (this->mr_cache) {
 		/*
@@ -2956,14 +2974,26 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 			this->mr_cache->lookup_entry(ckey, endpoint_mr));
 		if (ret_handle) {
 			/* Cache hit */
+			if (_diag_on) {
+				ofi_diag::g_mr.cache_hits.fetch_add(1, std::memory_order_relaxed);
+			}
 			*mhandle = ret_handle;
 			return ret;
 		}
 		/* Cache miss */
+		if (_diag_on) {
+			ofi_diag::g_mr.cache_misses.fetch_add(1, std::memory_order_relaxed);
+			_diag_t0 = ofi_diag::now_ns();
+		}
 
 		ret = this->reg_mr_on_device(ckey, type, ep, &ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
+		}
+		if (_diag_on) {
+			ofi_diag::mr_add(ofi_diag::now_ns() - _diag_t0,
+					 nccl_ofi_mr_ckey_len(ckey), type == NCCL_PTR_CUDA,
+					 diag_ckey_is_dmabuf(ckey));
 		}
 
 		ret = this->mr_cache->insert_entry(ckey,
@@ -2976,9 +3006,17 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 			return ret;
 		}
 	} else {
+		if (_diag_on) {
+			_diag_t0 = ofi_diag::now_ns();
+		}
 		ret = this->reg_mr_on_device(ckey, type, ep, &ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
+		}
+		if (_diag_on) {
+			ofi_diag::mr_add(ofi_diag::now_ns() - _diag_t0,
+					 nccl_ofi_mr_ckey_len(ckey), type == NCCL_PTR_CUDA,
+					 diag_ckey_is_dmabuf(ckey));
 		}
 	}
 
@@ -6997,6 +7035,7 @@ std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_rdma_domain_t::create_endpoint()
 	int ret = 0;
 	nccl_net_ofi_rdma_device_t *device_ptr = this->rdma_domain_get_device();
 	assert(device_ptr != nullptr);
+	const uint64_t _diag_t0 = ofi_diag::enabled() ? ofi_diag::now_ns() : 0;
 
 	/* Allocate endpoint. Pass shared_from_this() so the ep
 	 * holds a shared_ptr to this domain */
@@ -7015,6 +7054,11 @@ std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_rdma_domain_t::create_endpoint()
 	ret = init_max_write_inline_size_if_not_initialized(device_ptr, ep.get());
 	if (ret != 0) {
 		return nullptr;
+	}
+
+	if (_diag_t0) {
+		ofi_diag::print("EP_CREATE dev=%d took=%.2fms",
+				device_ptr->dev_id, (ofi_diag::now_ns() - _diag_t0) / 1e6);
 	}
 
 	return ep;
@@ -7126,8 +7170,14 @@ nccl_net_ofi_rdma_domain_t::nccl_net_ofi_rdma_domain_t(nccl_net_ofi_rdma_device_
 
 nccl_net_ofi_domain_t *nccl_net_ofi_rdma_device_t::create_domain(unsigned int domain_key)
 {
+	const uint64_t _diag_t0 = ofi_diag::enabled() ? ofi_diag::now_ns() : 0;
 
 	auto *domain = new nccl_net_ofi_rdma_domain_t(this, domain_key);
+
+	if (_diag_t0) {
+		ofi_diag::print("DOMAIN_CREATE dev=%d key=%u took=%.2fms",
+				this->dev_id, domain_key, (ofi_diag::now_ns() - _diag_t0) / 1e6);
+	}
 
 	return domain;
 }


### PR DESCRIPTION
*Description of changes:* 

When initialization or connection setup takes longer than expected in a production environment, the options for investigating are limited: full NCCL debug output is too noisy to interpret, and tracing frameworks are impractical to deploy in the field. What is usually needed is coarse, per-phase evidence of where the time went: whether the plugin itself was busy and in what, or whether NCCL simply was not calling into the plugin at all.

This adds a diagnostic mode, enabled with OFI_NCCL_DIAG=1, that emits a small number of human-readable lines through NCCL's standard logger so they land in the normal per-rank NCCL log files, interleaved with NCCL's own INIT/NET messages for context. Because NCCL establishes connections by polling connect and accept until completion, each completed connection reports its wall-clock window split into time spent inside the plugin versus time spent waiting between polls, which separates plugin cost from peer-side or NCCL-side stalls without any tracing infrastructure. Memory registration is summarized by count, bytes, time, memory type, dmabuf usage, and cache behavior, with individual lines only for unusually large or slow registrations. Every plugin API entry point, including the close and finalize paths, is accounted in a final per-process census so that teardown cost is visible as well, and a connection-phase bracket with wall-clock timestamps lets the numbers be correlated directly against the application's own phase markers.

The mode is off by default and costs a single branch per call site when disabled. `DIAGNOSTICS.md` documents the run recipe and how to interpret each line.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
