### PR TITLE
Update GDAKI plugin code to directly use efa-dp-direct queue types and host APIs

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,12 +1,27 @@
-### Build Instructions
+### Prerequisites
 
 We strongly recommend starting with a release tarball available on the
 [GitHub Release Page](https://github.com/aws/aws-ofi-nccl/releases) when
 building from source for production uses.
 
+#### Git checkout
+
+Before running `./configure` from a Git checkout, initialize the required
+`3rd-party/efa-dp-direct` source dependency:
+
+```
+git submodule update --init --recursive 3rd-party/efa-dp-direct
+```
+
+Release tarballs already include this dependency.
+
+#### Libfabric
+
 `aws-ofi-nccl` requires a working installation of Libfabric (v1.18.0 or newer). You can
 find the instructions for installing libfabric at
 [libfabric installation](https://github.com/ofiwg/libfabric).
+
+### Build Instructions
 
 The plugin uses GNU autotools for its build system. You can build it
 as follows:

--- a/autogen.sh
+++ b/autogen.sh
@@ -1,9 +1,31 @@
+#!/bin/sh -x
 #
-# Copyright (c) 2018-2019, Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2018-2026, Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
 
-#! /bin/sh -x
+set -eu
+
+submodule=3rd-party/efa-dp-direct
+
+# In a Git checkout, only initialize the efa-dp-direct submodule only when its 
+# directory is empty.
+# Do not update a populated checkout, which may contain local development changes.
+# Release tarballs must already include the pinned efa-dp-direct source version
+# associated with the release.
+if test -d "$submodule" &&
+   test -n "$(find "$submodule" -maxdepth 0 -empty -print)" &&
+   { test -d .git || test -f .git; }; then
+  if ! git submodule update --init --recursive "$submodule"; then
+    cat >&2 <<EOF
+error: unable to initialize required submodule: $submodule
+
+Check Git access, network connectivity, and credentials, then retry:
+  git submodule update --init --recursive $submodule
+EOF
+    exit 1
+  fi
+fi
 
 autoreconf -ivf

--- a/configure.ac
+++ b/configure.ac
@@ -14,6 +14,19 @@ AC_INIT([aws-ofi-nccl],
         [al-ofi-nccl-team@amazon.com], , [http://github.com/aws/aws-ofi-nccl])
 AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.cpp])
+
+AC_MSG_CHECKING([for required efa-dp-direct CUDA sources])
+AS_IF([test -f "$srcdir/3rd-party/efa-dp-direct/CUDA/README.md"],
+      [AC_MSG_RESULT([yes])],
+      [AC_MSG_RESULT([no])
+       AC_MSG_ERROR([Missing required file:
+  3rd-party/efa-dp-direct/CUDA/README.md
+
+If this is a Git checkout, initialize the dependency with:
+  git submodule update --init --recursive 3rd-party/efa-dp-direct
+
+Release tarballs must include this file.])])
+
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([include/config.h])
 AC_CONFIG_MACRO_DIRS([m4])

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_dev.h
@@ -6,13 +6,17 @@
  * memory and destroyContext tears down.
  *
  * This header is plugin-internal. NCCL does not include it: NCCL's kernel
- * code uses the layout-compatible efa_cuda_qp / efa_cuda_cq types provided
- * by efa-dp-direct. This header exists so that both createContext (which
- * builds the device handle on the host) and destroyContext (which frees it)
- * agree on the struct layout.
+ * code and the plugin both use the canonical efa_cuda_qp / efa_cuda_cq
+ * types provided by efa-dp-direct. Using those dependency definitions directly
+ * makes incompatible queue-layout changes surface at build time rather than
+ * silently diverging from a plugin-local mirror. This header exists so that
+ * both createContext (which builds the device handle on the host) and
+ * destroyContext (which frees it) agree on the remaining GIN-specific
+ * struct layout.
  *
- * Keep this header free of libfabric and plugin-internal transport types;
- * it is intended to be a stable contract for the GPU-memory layout.
+ * Keep this header free of libfabric and plugin-internal transport types.
+ * It depends only on efa-dp-direct's plain C queue-layout header and is a
+ * stable contract for the GPU-memory layout.
  */
 
 #ifndef NCCL_OFI_GIN_GDAKI_DEV_H_
@@ -20,23 +24,11 @@
 
 #include <stdint.h>
 
+#include "efa_cuda_dp_types.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/* Size of the inline-data slot reserved in each SQ WQE. */
-#define NCCL_OFI_GDAKI_SQ_INLINE_DATA_BYTES 32
-
-/* Number of SGEs the SQ WQE layout accommodates per RDMA_WRITE. */
-#define NCCL_OFI_GDAKI_SQ_RDMA_SGES 2
-
-/*
- * Phase-bit initial values for the EFA ownership-bit protocol:
- * WQEs start at 0, CQEs and RQ entries start at 1.
- */
-#define NCCL_OFI_GDAKI_SQ_INITIAL_PHASE 0
-#define NCCL_OFI_GDAKI_RQ_INITIAL_PHASE 1
-#define NCCL_OFI_GDAKI_CQ_INITIAL_PHASE 1
 
 /* Per-slot stride (bytes) of the PutValue source pool. PutValue's T
  * is asserted by the kernel template to be <= 8 bytes; using 8 lets
@@ -100,70 +92,11 @@ struct nccl_ofi_gin_gdaki_mr_handle {
  * during createContext / regMrSym. */
 #define NCCL_OFI_GDAKI_MAX_RAILS 2
 
-/**
- * Work queue descriptor, layout-compatible with efa_cuda_wq from efa-dp-direct.
- *
- * The kernel-side code (in NCCL's transport/net_efa) casts this to
- * efa_cuda_wq* for use with efa-dp-direct device functions.
+/*
+ * QP/CQ/WQ layouts are canonical efa-dp-direct types. The device handle
+ * stores them directly, so device code no longer relies on representation
+ * casts from plugin-local mirrors.
  */
-struct nccl_ofi_gin_gdaki_wq {
-	uint32_t max_sge;
-	uint32_t max_wqes;
-	uint32_t queue_mask;
-	uint32_t queue_size_shift;
-	uint32_t max_batch;
-	uint32_t wqes_pending;
-	uint32_t wqes_posted;
-	uint32_t wqes_completed;
-	uint32_t pc;
-	int phase;
-	uint8_t *buf;
-	uint32_t *db;
-};
-
-/**
- * Send queue descriptor, layout-compatible with efa_cuda_sq.
- */
-struct nccl_ofi_gin_gdaki_sq {
-	struct nccl_ofi_gin_gdaki_wq wq;
-	uint32_t max_inline_data;
-	uint32_t max_rdma_sges;
-};
-
-/**
- * Receive queue descriptor, layout-compatible with efa_cuda_rq.
- */
-struct nccl_ofi_gin_gdaki_rq {
-	struct nccl_ofi_gin_gdaki_wq wq;
-};
-
-/**
- * QP descriptor, layout-compatible with efa_cuda_qp.
- * Allocated in GPU memory by createContext. The kernel casts this to
- * efa_cuda_qp* for use with efa-dp-direct device functions.
- */
-struct nccl_ofi_gin_gdaki_qp {
-	uint64_t comp_mask;
-	struct nccl_ofi_gin_gdaki_sq sq;
-	struct nccl_ofi_gin_gdaki_rq rq;
-};
-
-/**
- * CQ descriptor, layout-compatible with efa_cuda_cq.
- * Allocated in GPU memory by createContext. The kernel casts this to
- * efa_cuda_cq* for use with efa-dp-direct device functions.
- */
-struct nccl_ofi_gin_gdaki_cq {
-	uint64_t comp_mask;
-	uint32_t entry_size;
-	uint32_t num_entries;
-	uint32_t queue_mask;
-	uint32_t queue_size_shift;
-	uint32_t cc;
-	int phase;
-	uint8_t *buf;
-	uint32_t *db;
-};
 
 /**
  * Common per-endpoint state shared by the data, counter, and signal
@@ -179,10 +112,10 @@ struct nccl_ofi_gin_gdaki_cq {
  */
 struct nccl_ofi_gin_gdaki_dev_endpoint_handle {
 	/* GPU-resident QP for this endpoint. */
-	struct nccl_ofi_gin_gdaki_qp *qp;
+	struct efa_cuda_qp *qp;
 
 	/* GPU-resident CQ for this endpoint. */
-	struct nccl_ofi_gin_gdaki_cq *cq;
+	struct efa_cuda_cq *cq;
 
 	/* Target addressing for this (poster) endpoint's QP.
 	 *

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -8,12 +8,10 @@
  * calls symmetrically. nccl_ofi_gin_gdaki_context composes them, and
  * createContext / destroyContext orchestrate via the composed type.
  *
- * All GPU memory access goes through the plugin's accelerator
- * abstraction (nccl_net_ofi_gpu_*); this file contains no direct
- * CUDA API calls. The GDAKI code path is gated at Makefile level on
- * HAVE_CUDA today, but using the abstraction leaves GDAKI portable to
- * any accelerator that implements the gpu_mem / host_register_iomem
- * family.
+ * Plugin-owned GPU buffers and MMIO mappings use the accelerator
+ * abstraction (nccl_net_ofi_gpu_*). Canonical QP/CQ descriptors instead
+ * delegate allocation and destruction to the pinned efa-dp-direct host
+ * API, which uses the CUDA Runtime API. The GDAKI code path is CUDA-only.
  */
 
 #ifndef NCCL_OFI_GIN_GDAKI_RESOURCES_H_
@@ -270,13 +268,21 @@ public:
 /**
  * A GPU-resident canonical efa_cuda_qp descriptor.
  *
- * Built from fi_efa_wq_attr returned by gda_ops->query_qp_wqs, plus
- * the GPU-visible device pointers for the SQ buffer and doorbell
- * MMIO mappings.
+ * Owns the descriptor created through the pinned efa-dp-direct host API.
+ * `build()` is deliberately single-use: each host API create call allocates a
+ * fresh GPU descriptor, so rebuilding would overwrite an owned pointer. The
+ * destructor calls the paired host API destroy function. The SQ buffer and
+ * doorbell inputs are GPU-visible device pointers for the existing MMIO
+ * mappings; the RQ inputs remain raw EFA pointers.
  */
 class gdaki_gpu_qp {
 public:
-	gdaki_gpu_buf<efa_cuda_qp> buf;
+	gdaki_gpu_qp() = default;
+	~gdaki_gpu_qp();
+	gdaki_gpu_qp(const gdaki_gpu_qp &) = delete;
+	gdaki_gpu_qp &operator=(const gdaki_gpu_qp &) = delete;
+	gdaki_gpu_qp(gdaki_gpu_qp &&) = delete;
+	gdaki_gpu_qp &operator=(gdaki_gpu_qp &&) = delete;
 
 	void build(const struct fi_efa_wq_attr &sq_attr,
 		   const struct fi_efa_wq_attr &rq_attr,
@@ -284,28 +290,41 @@ public:
 
 	efa_cuda_qp *dev() const
 	{
-		return buf.dev;
+		return qp;
 	}
+
+private:
+	efa_cuda_qp *qp = nullptr;
 };
 
 /**
  * A GPU-resident canonical efa_cuda_cq descriptor.
  *
- * On P5en the CQ buffer is polled via its host pointer rather than
- * through a GPU-mapped MMIO region; IOMEMORY|DEVICEMAP registration of
- * the CQ BAR fails, and the host pointer is usable from both CPU and
- * CUDA kernels for CQ polling.
+ * Owns the descriptor created through the pinned efa-dp-direct host API.
+ * `build()` is deliberately single-use: each host API create call allocates a
+ * fresh GPU descriptor, and the destructor calls the paired destroy function.
+ * On P5en the CQ buffer is polled via its host pointer rather than through a
+ * GPU-mapped MMIO region; IOMEMORY|DEVICEMAP registration of the CQ BAR
+ * fails, and the host pointer is usable from both CPU and CUDA kernels.
  */
 class gdaki_gpu_cq {
 public:
-	gdaki_gpu_buf<efa_cuda_cq> buf;
+	gdaki_gpu_cq() = default;
+	~gdaki_gpu_cq();
+	gdaki_gpu_cq(const gdaki_gpu_cq &) = delete;
+	gdaki_gpu_cq &operator=(const gdaki_gpu_cq &) = delete;
+	gdaki_gpu_cq(gdaki_gpu_cq &&) = delete;
+	gdaki_gpu_cq &operator=(gdaki_gpu_cq &&) = delete;
 
 	void build(const struct fi_efa_cq_attr &cq_attr);
 
 	efa_cuda_cq *dev() const
 	{
-		return buf.dev;
+		return cq;
 	}
+
+private:
+	efa_cuda_cq *cq = nullptr;
 };
 
 /**

--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -268,7 +268,7 @@ public:
 };
 
 /**
- * A GPU-resident efa_cuda_qp-compatible descriptor.
+ * A GPU-resident canonical efa_cuda_qp descriptor.
  *
  * Built from fi_efa_wq_attr returned by gda_ops->query_qp_wqs, plus
  * the GPU-visible device pointers for the SQ buffer and doorbell
@@ -276,20 +276,20 @@ public:
  */
 class gdaki_gpu_qp {
 public:
-	gdaki_gpu_buf<nccl_ofi_gin_gdaki_qp> buf;
+	gdaki_gpu_buf<efa_cuda_qp> buf;
 
 	void build(const struct fi_efa_wq_attr &sq_attr,
 		   const struct fi_efa_wq_attr &rq_attr,
 		   void *sq_buf_dev, void *sq_db_dev);
 
-	nccl_ofi_gin_gdaki_qp *dev() const
+	efa_cuda_qp *dev() const
 	{
 		return buf.dev;
 	}
 };
 
 /**
- * A GPU-resident efa_cuda_cq-compatible descriptor.
+ * A GPU-resident canonical efa_cuda_cq descriptor.
  *
  * On P5en the CQ buffer is polled via its host pointer rather than
  * through a GPU-mapped MMIO region; IOMEMORY|DEVICEMAP registration of
@@ -298,11 +298,11 @@ public:
  */
 class gdaki_gpu_cq {
 public:
-	gdaki_gpu_buf<nccl_ofi_gin_gdaki_cq> buf;
+	gdaki_gpu_buf<efa_cuda_cq> buf;
 
 	void build(const struct fi_efa_cq_attr &cq_attr);
 
-	nccl_ofi_gin_gdaki_cq *dev() const
+	efa_cuda_cq *dev() const
 	{
 		return buf.dev;
 	}

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -82,6 +82,44 @@ libinternal_plugin_la_SOURCES = $(sources)
 libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS) $(ROCM_LDFLAGS)
 libinternal_plugin_la_LIBADD  = $(CUDA_LIBS) $(ROCM_LIBS)
 
+if ENABLE_GDAKI
+# TODO: Pinned efa-dp-direct submodule commit 81c4dc7 has a bug that causes a 
+# "sign-compare" error. To avoid relaxing the sign-compare compilation check
+# when building the entire OFI NCCL plugin library, we separately build a
+# libefa_cuda_dp.la library with "-Wno-error=sign-compare" set. Once we 
+# digest an efa-dp-direct version with the sign-compare error bug fixed, we 
+# should stop building a separate libefa_cuda_dp.la library and instead just
+# ingest the efa-dp-direct files directly as sources for the libinternal_plugin.la
+# library.
+
+noinst_LTLIBRARIES += libefa_cuda_dp.la
+
+libefa_cuda_dp_la_SOURCES = \
+	$(top_srcdir)/3rd-party/efa-dp-direct/CUDA/host/efa_cuda_dp.cpp
+
+libefa_cuda_dp_la_CPPFLAGS = \
+	$(CUDA_CPPFLAGS) \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/host
+
+# The pinned host source compares its `int` loop index with a `size_t` length.
+# Scope this temporary warning-as-error exception to third-party code so
+# plugin-owned sources remain subject to the project warning policy.
+libefa_cuda_dp_la_CXXFLAGS = \
+	-Wno-error=sign-compare
+
+AM_CPPFLAGS += \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/host
+
+# Make the private host implementation available to the internal plugin for
+# later GDAKI integration. It uses CUDA Runtime APIs, so add CUDART only for
+# GDAKI builds and preserve the existing non-GDAKI dependency set.
+libinternal_plugin_la_LIBADD += \
+	libefa_cuda_dp.la \
+	$(CUDA_RUNTIME_LIBS)
+endif
+
 lib_LTLIBRARIES =
 
 if ENABLE_NEURON

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -153,7 +153,7 @@ void gdaki_gpu_qp::build(const struct fi_efa_wq_attr &sq_attr,
 {
 	buf.allocate(1);
 
-	nccl_ofi_gin_gdaki_qp &h = *buf.host;
+	efa_cuda_qp &h = *buf.host;
 	h.sq.wq.buf = static_cast<uint8_t *>(sq_buf_dev);
 	h.sq.wq.db = static_cast<uint32_t *>(sq_db_dev);
 	h.sq.wq.max_wqes = sq_attr.num_entries;
@@ -178,7 +178,7 @@ void gdaki_gpu_cq::build(const struct fi_efa_cq_attr &cq_attr)
 {
 	buf.allocate(1);
 
-	nccl_ofi_gin_gdaki_cq &h = *buf.host;
+	efa_cuda_cq &h = *buf.host;
 	h.buf = cq_attr.buffer;
 	h.entry_size = cq_attr.entry_size;
 	h.num_entries = cq_attr.num_entries;

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -12,6 +12,8 @@
 #include "nccl_ofi_param.h"
 #include "rdma/gin/nccl_ofi_gin_gdaki_resources.h"
 
+#include "efa_cuda_dp.h"
+
 #include <rdma/fi_cm.h>
 #include <rdma/fi_ext_efa.h>
 
@@ -147,46 +149,70 @@ void gdaki_fi_endpoint::bind(struct fid *fid, uint64_t flags)
 	}
 }
 
+gdaki_gpu_qp::~gdaki_gpu_qp()
+{
+	if (qp != nullptr) {
+		efa_cuda_destroy_qp(qp);
+	}
+}
+
 void gdaki_gpu_qp::build(const struct fi_efa_wq_attr &sq_attr,
 			 const struct fi_efa_wq_attr &rq_attr,
 			 void *sq_buf_dev, void *sq_db_dev)
 {
-	buf.allocate(1);
+	/* The host API allocates GPU memory; rebuilding would overwrite the only
+	 * owned pointer and leak the previous descriptor. */
+	if (qp != nullptr) {
+		throw std::runtime_error("gdaki_gpu_qp: double build");
+	}
 
-	efa_cuda_qp &h = *buf.host;
-	h.sq.wq.buf = static_cast<uint8_t *>(sq_buf_dev);
-	h.sq.wq.db = static_cast<uint32_t *>(sq_db_dev);
-	h.sq.wq.max_wqes = sq_attr.num_entries;
-	h.sq.wq.queue_mask = sq_attr.num_entries - 1;
-	h.sq.wq.queue_size_shift = __builtin_ctz(sq_attr.num_entries);
-	h.sq.wq.max_batch = sq_attr.max_batch;
-	h.sq.wq.phase = NCCL_OFI_GDAKI_SQ_INITIAL_PHASE;
-	h.sq.max_inline_data = NCCL_OFI_GDAKI_SQ_INLINE_DATA_BYTES;
-	h.sq.max_rdma_sges = NCCL_OFI_GDAKI_SQ_RDMA_SGES;
-	h.rq.wq.buf = rq_attr.buffer;
-	h.rq.wq.db = rq_attr.doorbell;
-	h.rq.wq.max_wqes = rq_attr.num_entries;
-	h.rq.wq.queue_mask = rq_attr.num_entries - 1;
-	h.rq.wq.queue_size_shift = __builtin_ctz(rq_attr.num_entries);
-	h.rq.wq.max_batch = rq_attr.num_entries;
-	h.rq.wq.phase = NCCL_OFI_GDAKI_RQ_INITIAL_PHASE;
+	/* The plugin supplies provider-probed buffers and geometry. The host API
+	 * validates the attributes and initializes queue masks, counters, and phase
+	 * state before uploading the canonical descriptor to GPU memory. */
+	struct efa_cuda_qp_attrs attrs = {};
+	attrs.sq_buffer = static_cast<uint8_t *>(sq_buf_dev);
+	attrs.rq_buffer = static_cast<uint8_t *>(rq_attr.buffer);
+	attrs.sq_doorbell = static_cast<uint32_t *>(sq_db_dev);
+	attrs.rq_doorbell = static_cast<uint32_t *>(rq_attr.doorbell);
+	attrs.sq_num_entries = sq_attr.num_entries;
+	attrs.sq_entry_size = sq_attr.entry_size;
+	attrs.sq_max_batch = sq_attr.max_batch;
+	attrs.rq_num_entries = rq_attr.num_entries;
+	attrs.rq_entry_size = rq_attr.entry_size;
 
-	buf.commit();
+	qp = efa_cuda_create_qp(&attrs, sizeof(attrs));
+	if (qp == nullptr) {
+		throw std::runtime_error("gdaki_gpu_qp: efa_cuda_create_qp failed");
+	}
+}
+
+gdaki_gpu_cq::~gdaki_gpu_cq()
+{
+	if (cq != nullptr) {
+		efa_cuda_destroy_cq(cq);
+	}
 }
 
 void gdaki_gpu_cq::build(const struct fi_efa_cq_attr &cq_attr)
 {
-	buf.allocate(1);
+	/* The host API allocates GPU memory; rebuilding would overwrite the only
+	 * owned pointer and leak the previous descriptor. */
+	if (cq != nullptr) {
+		throw std::runtime_error("gdaki_gpu_cq: double build");
+	}
 
-	efa_cuda_cq &h = *buf.host;
-	h.buf = cq_attr.buffer;
-	h.entry_size = cq_attr.entry_size;
-	h.num_entries = cq_attr.num_entries;
-	h.queue_mask = cq_attr.num_entries - 1;
-	h.queue_size_shift = __builtin_ctz(cq_attr.num_entries);
-	h.phase = NCCL_OFI_GDAKI_CQ_INITIAL_PHASE;
+	/* The plugin supplies the provider-probed CQ buffer and geometry. The host
+	 * API validates the attributes and initializes queue masks and phase state
+	 * before uploading the canonical descriptor to GPU memory. */
+	struct efa_cuda_cq_attrs attrs = {};
+	attrs.buffer = static_cast<uint8_t *>(cq_attr.buffer);
+	attrs.num_entries = cq_attr.num_entries;
+	attrs.entry_size = cq_attr.entry_size;
 
-	buf.commit();
+	cq = efa_cuda_create_cq(&attrs, sizeof(attrs));
+	if (cq == nullptr) {
+		throw std::runtime_error("gdaki_gpu_cq: efa_cuda_create_cq failed");
+	}
 }
 
 /*

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -75,6 +75,9 @@ gin_put_gdaki_gpu_LDADD = $(LDADD) -lcuda
 gin_signal_gdaki_gpu_SOURCES = $(base_sources) gin_signal_gdaki_gpu.cu
 gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 
+# efa-dp-direct splits shared definitions from GPU device helpers. These
+# kernel-only functional tests use common/device APIs and deliberately do not
+# include the CUDA host API.
 .cu.o:
 	$(NVCC) -std=c++17 $(NVCC_GENCODE) \
 		-ccbin=$(MPICXX) \
@@ -84,7 +87,8 @@ gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 		-I$(top_srcdir)/include \
 		-I$(top_srcdir)/3rd-party \
 		-I$(top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include \
-		-I$(top_srcdir)/3rd-party/efa-dp-direct/CUDA/src \
+		-isystem $(top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
+		-isystem $(top_srcdir)/3rd-party/efa-dp-direct/CUDA/device \
 		$(MPI_CPPFLAGS) $(CUDA_CPPFLAGS) \
 		-c -o $@ $<
 endif # HAVE_NVCC

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -58,8 +58,8 @@ __global__ void gin_put_gpu_kernel(nccl_ofi_gin_gdaki_dev_handle *dev,
 {
 	if (threadIdx.x != 0 || blockIdx.x != 0) return;
 
-	auto *qp = reinterpret_cast<efa_cuda_qp *>(dev->data.qp);
-	auto *cq = reinterpret_cast<efa_cuda_cq *>(dev->data.cq);
+	auto *qp = dev->data.qp;
+	auto *cq = dev->data.cq;
 
 	efa_io_tx_wqe wr;
 	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);

--- a/tests/functional/gin_signal_gdaki_gpu.cu
+++ b/tests/functional/gin_signal_gdaki_gpu.cu
@@ -54,8 +54,8 @@ __global__ void gin_signal_gpu_kernel(nccl_ofi_gin_gdaki_dev_counter_handle *sig
 {
 	if (threadIdx.x != 0 || blockIdx.x != 0) return;
 
-	auto *qp = reinterpret_cast<efa_cuda_qp *>(sig->base.qp);
-	auto *cq = reinterpret_cast<efa_cuda_cq *>(sig->base.cq);
+	auto *qp = sig->base.qp;
+	auto *cq = sig->base.cq;
 
 	efa_io_tx_wqe wr;
 	efa_cuda_init_rdma_write_wr(&wr, /*wr_id=*/0, dst_rkey, dst_addr);


### PR DESCRIPTION
Prior to this PR, the OFI NCCL plugin's GDAKI code kept local type definitions and host APIs implementations from external repository https://github.com/amzn/efa-dp-direct. E.g. the `nccl_ofi_gin_gdaki_wq` type mirrored the [efa_cuda_wq](https://github.com/amzn/efa-dp-direct/blob/81c4dc76da2c2568306a34ae876b7604f25cae2e/CUDA/common/efa_cuda_dp_types.h#L25) type defined in `efa-dp-direct`, and the `gdaki_gpu_cq::build` function mirrored the [efa_cuda_create_qp](https://github.com/amzn/efa-dp-direct/blob/81c4dc76da2c2568306a34ae876b7604f25cae2e/CUDA/host/efa_cuda_dp.cpp#L74) host API implemented in `efa-dp-direct` (all my links are for the state of the efa-dp-direct repo at commit `81c4dc7`). This PR aims to directly use the `efa-dp-direct` types/APIs by adding the specific `efa-dp-direct` header and sources to the OFI NCCL plugin compilation when `ENABLE_GDAKI` is set, including the headers and replace the local copies of the types/APIs with the original definition/implementation.

As is, this PR requires the user to ensure the `efa-dp-direct` git submodule is loaded (e.g. with `git submodule update --init --recursive`) for the source/header files to be available and the compilation with `ENABLE_GDAKI` set to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
