### PR TITLE
ci: Fetch submodules for GitHub Actions

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -51,6 +51,8 @@ jobs:
     name: al2023/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/${{ matrix.build-type }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -125,6 +127,8 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.cc-variant }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -211,6 +215,8 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -282,6 +288,8 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -334,6 +342,8 @@ jobs:
     name: CodeChecker - ${{ matrix.sdk }}
     steps:
       - uses: actions/checkout@v6
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -32,6 +32,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
+          submodules: recursive
 
       - name: Configure and build
         run: |

--- a/.github/workflows/tag-makedist.yaml
+++ b/.github/workflows/tag-makedist.yaml
@@ -36,6 +36,8 @@ jobs:
       - run: |
           yum -y update && yum -y install git tar util-linux findutils yum-utils
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"


### PR DESCRIPTION
Prepare GitHub Actions build and release workflows for code that consumes the existing [efa-dp-direct](https://github.com/amzn/efa-dp-direct) submodule. GitHub Actions checks out submodule references but not their contents by default, so fetch submodules recursively.

Prerequisite for https://github.com/aws/aws-ofi-nccl/pull/1321 to be able to pass the `make distcheck` calls in the GitHub Actions workflows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
