### PR TITLE
gin: Add MPSC ring buffer for shared gdrcopy worker

### DIFF
--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -35,6 +35,7 @@ noinst_HEADERS = \
 	nccl_ofi_memcheck_asan.h \
 	nccl_ofi_memcheck_nop.h \
 	nccl_ofi_memcheck_valgrind.h \
+	nccl_ofi_mpsc_ring.h \
 	nccl_ofi_mr.h \
 	nccl_ofi_msgbuff.h \
 	nccl_ofi_ofiutils.h \

--- a/include/nccl_ofi_mpsc_ring.h
+++ b/include/nccl_ofi_mpsc_ring.h
@@ -1,0 +1,165 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef NCCL_OFI_MPSC_RING_H_
+#define NCCL_OFI_MPSC_RING_H_
+
+#include <atomic>
+#include <cstdint>
+#include <type_traits>
+
+/**
+ * Multi-producer / single-consumer lock-free ring buffer.
+ *
+ * Any number of threads call push() concurrently; exactly one thread calls
+ * pop(). This is the companion to nccl_ofi_spsc_ring for the case where N
+ * proxy threads (one per GIN comm) feed a single process-wide gdrcopy worker.
+ * The API matches the SPSC ring: push()/pop() never block, returning false
+ * when the ring is full / empty so the caller decides whether to spin, back
+ * off, or do other work.
+ *
+ * Design (bounded MPMC slot ring, Dmitry Vyukov's scheme, restricted to a
+ * single consumer). Each slot carries a sequence number that encodes whose
+ * turn the slot is on:
+ *
+ *   - A producer reserves a slot by CAS-advancing enqueue_pos. It owns the
+ *     slot whose sequence equals the position it reserved. It writes the
+ *     payload, then publishes by storing sequence = pos + 1 (release).
+ *   - The consumer owns the slot whose sequence equals dequeue_pos + 1. It
+ *     reads the payload, then frees the slot by storing sequence = pos +
+ *     CAPACITY (release), making it available to the producer one lap later.
+ *
+ * The sequence comparison is wrap-safe: producers compute (sequence - pos) as
+ * a signed difference, so it stays correct across the uint32_t rollover of the
+ * monotonic positions.
+ *
+ * Correctness highlights:
+ *   - No torn reads: a slot's payload is written before its publish-store and
+ *     read after the matching publish-load, paired release/acquire on sequence.
+ *   - No lost entries: enqueue_pos is advanced only by a successful CAS, so two
+ *     producers never claim the same slot; the consumer only consumes a slot
+ *     after its producer published.
+ *   - No ABA on the positions: positions are monotonic 32-bit counters; the
+ *     sequence lap-offset (pos vs pos + CAPACITY) keeps a slow producer from
+ *     colliding with the next lap's consumer because the sequence won't match
+ *     until the consumer has freed the slot.
+ *
+ * CAPACITY must be a power of two so the slot index is a mask, not a modulo,
+ * and so the lap arithmetic on the sequence number is exact. Unlike the SPSC
+ * ring, every slot is usable: full/empty are told apart by the sequences, not
+ * by keeping one slot empty, so the ring holds up to CAPACITY entries.
+ *
+ * T is copied by value into and out of the ring, so keep it trivially copyable
+ * and cheap.
+ */
+template <typename T, uint32_t CAPACITY = 1024>
+class nccl_ofi_mpsc_ring {
+	static_assert((CAPACITY & (CAPACITY - 1)) == 0,
+		      "nccl_ofi_mpsc_ring CAPACITY must be a power of two");
+	static_assert(std::is_trivially_copyable<T>::value,
+		      "nccl_ofi_mpsc_ring: T must be trivially copyable");
+
+public:
+	nccl_ofi_mpsc_ring()
+	{
+		for (uint32_t i = 0; i < CAPACITY; ++i) {
+			ring[i].sequence.store(i, std::memory_order_relaxed);
+		}
+	}
+
+	nccl_ofi_mpsc_ring(const nccl_ofi_mpsc_ring &) = delete;
+	nccl_ofi_mpsc_ring &operator=(const nccl_ofi_mpsc_ring &) = delete;
+
+	/**
+	 * Reserve a slot, write the entry, and publish it. Safe to call from
+	 * many producer threads at once. Returns false (without writing) when
+	 * the ring is full.
+	 */
+	bool push(const T &entry)
+	{
+		cell *c;
+		uint32_t pos = enqueue_pos.load(std::memory_order_relaxed);
+		while (true) {
+			c = &ring[pos & (CAPACITY - 1)];
+			uint32_t seq = c->sequence.load(std::memory_order_acquire);
+			int32_t diff = static_cast<int32_t>(seq) - static_cast<int32_t>(pos);
+			if (diff == 0) {
+				/* Slot is free for this lap; try to claim pos.
+				   We CAS rather than an unconditional fetch_add
+				   because a full ring must fail cleanly: with
+				   fetch_add a producer would have already advanced
+				   enqueue_pos past a slot it can't use, leaving a
+				   hole the consumer would wait on forever. The CAS
+				   only commits the position once we've confirmed
+				   the slot is actually free. */
+				if (enqueue_pos.compare_exchange_weak(
+					    pos, pos + 1, std::memory_order_relaxed)) {
+					break;
+				}
+				/* Lost the race; pos was reloaded with the winner's
+				   value, retry from the top. */
+			} else if (diff < 0) {
+				/* Consumer has not yet freed this slot from the
+				   previous lap: the ring is full. */
+				return false;
+			} else {
+				/* Another producer already advanced past pos;
+				   catch up to the current tail. */
+				pos = enqueue_pos.load(std::memory_order_relaxed);
+			}
+		}
+
+		c->data = entry;
+		/* Publish: release so the consumer's acquire-load of sequence
+		   observes the payload store above. */
+		c->sequence.store(pos + 1, std::memory_order_release);
+		return true;
+	}
+
+	/**
+	 * Pop one entry. Single consumer only. Returns false when the ring is
+	 * empty.
+	 */
+	bool pop(T &entry)
+	{
+		uint32_t pos = dequeue_pos;
+		cell *c = &ring[pos & (CAPACITY - 1)];
+		uint32_t seq = c->sequence.load(std::memory_order_acquire);
+		int32_t diff = static_cast<int32_t>(seq) - static_cast<int32_t>(pos + 1);
+		if (diff != 0) {
+			/* diff < 0: producer has not published this slot yet
+			   (ring empty). diff > 0 cannot happen with one consumer
+			   advancing dequeue_pos in lockstep. */
+			return false;
+		}
+
+		entry = c->data;
+		dequeue_pos = pos + 1;
+		/* Free the slot for the producer one lap later. Release so a
+		   producer's acquire-load sees the slot is reusable only after
+		   we've finished reading the payload above. */
+		c->sequence.store(pos + CAPACITY, std::memory_order_release);
+		return true;
+	}
+
+private:
+	struct cell {
+		std::atomic<uint32_t> sequence;
+		T data;
+	};
+
+	/* Slot array. Sized to CAPACITY; each cell's sequence is seeded to its
+	   index so the first lap of producers finds sequence == pos. */
+	cell ring[CAPACITY];
+
+	/* enqueue_pos and dequeue_pos sit on separate cache lines so producers
+	   contending on enqueue_pos don't false-share with the consumer's
+	   dequeue_pos. enqueue_pos is atomic (contended by all producers);
+	   dequeue_pos is only touched by the single consumer, so it needs no
+	   atomicity. */
+	alignas(64) std::atomic<uint32_t> enqueue_pos{0};
+	alignas(64) uint32_t dequeue_pos{0};
+};
+
+#endif

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -29,7 +29,8 @@ noinst_PROGRAMS = \
 	param \
 	platform_manager \
 	spinlock \
-	spsc_ring
+	spsc_ring \
+	mpsc_ring
 
 if WANT_PLATFORM_AWS
 noinst_PROGRAMS += aws_platform_mapper
@@ -69,6 +70,7 @@ param_SOURCES = $(base_sources) param.cpp
 platform_manager_SOURCES = $(base_sources) platform_manager.cpp
 spinlock_SOURCES = $(base_sources) spinlock.cpp
 spsc_ring_SOURCES = $(base_sources) spsc_ring.cpp
+mpsc_ring_SOURCES = $(base_sources) mpsc_ring.cpp
 
 TESTS = $(noinst_PROGRAMS)
 endif

--- a/tests/unit/mpsc_ring.cpp
+++ b/tests/unit/mpsc_ring.cpp
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#include "config.h"
+
+#include <cstdio>
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "unit_test.h"
+#include "nccl_ofi_assert.h"
+#include "nccl_ofi_mpsc_ring.h"
+
+static void test_empty_pop()
+{
+	nccl_ofi_mpsc_ring<uint32_t, 4> ring;
+	uint32_t val = 0;
+	assert_always(!ring.pop(val));
+}
+
+static void test_push_pop_fifo()
+{
+	nccl_ofi_mpsc_ring<uint32_t, 8> ring;
+
+	for (uint32_t i = 0; i < 8; ++i) {
+		assert_always(ring.push(i));
+	}
+
+	for (uint32_t i = 0; i < 8; ++i) {
+		uint32_t val = 0;
+		assert_always(ring.pop(val));
+		assert_always(val == i);
+	}
+
+	uint32_t val = 0;
+	assert_always(!ring.pop(val));
+}
+
+/* Unlike the SPSC ring, the MPSC ring uses all CAPACITY slots: full and
+   empty are told apart by the per-slot sequence stamp, not by reserving a
+   slot. So a CAPACITY=4 ring holds exactly 4 entries. */
+static void test_full_uses_all_slots()
+{
+	nccl_ofi_mpsc_ring<uint32_t, 4> ring;
+
+	assert_always(ring.push(10));
+	assert_always(ring.push(11));
+	assert_always(ring.push(12));
+	assert_always(ring.push(13));
+	/* Fifth push has no free slot -- reject. */
+	assert_always(!ring.push(14));
+
+	uint32_t val = 0;
+	assert_always(ring.pop(val));
+	assert_always(val == 10);
+	/* A freed slot lets exactly one more push through. */
+	assert_always(ring.push(14));
+	assert_always(!ring.push(15));
+}
+
+/* Push and pop many times so enqueue/dequeue positions wrap past CAPACITY
+   repeatedly (exercises the lap-offset stamp arithmetic under uint32 wrap). */
+static void test_wraparound()
+{
+	nccl_ofi_mpsc_ring<uint32_t, 4> ring;
+
+	for (uint32_t i = 0; i < 100; ++i) {
+		assert_always(ring.push(i));
+		uint32_t val = 0;
+		assert_always(ring.pop(val));
+		assert_always(val == i);
+		assert_always(!ring.pop(val));
+	}
+}
+
+/* Interleave so the ring sits partially full while indices wrap. */
+static void test_interleaved()
+{
+	nccl_ofi_mpsc_ring<uint32_t, 4> ring;
+
+	assert_always(ring.push(1));
+	assert_always(ring.push(2));
+
+	uint32_t val = 0;
+	assert_always(ring.pop(val));
+	assert_always(val == 1);
+
+	assert_always(ring.push(3));
+	assert_always(ring.push(4));
+	assert_always(ring.push(5));
+	/* Holding 2, 3, 4, 5 -- all CAPACITY slots, so full. */
+	assert_always(!ring.push(6));
+
+	assert_always(ring.pop(val));
+	assert_always(val == 2);
+	assert_always(ring.pop(val));
+	assert_always(val == 3);
+	assert_always(ring.pop(val));
+	assert_always(val == 4);
+	assert_always(ring.pop(val));
+	assert_always(val == 5);
+	assert_always(!ring.pop(val));
+}
+
+/* One producer thread, one consumer: with a single producer the ring is
+   strict FIFO, so every value must be popped exactly once and in order. */
+static void test_single_producer_fifo()
+{
+	constexpr uint32_t num_items = 1000000;
+	nccl_ofi_mpsc_ring<uint32_t, 1024> ring;
+
+	std::thread producer([&ring]() {
+		uint32_t i = 0;
+		while (i < num_items) {
+			if (ring.push(i)) {
+				++i;
+			}
+		}
+	});
+
+	uint32_t expected = 0;
+	while (expected < num_items) {
+		uint32_t val = 0;
+		if (ring.pop(val)) {
+			assert_always(val == expected);
+			++expected;
+		}
+	}
+
+	producer.join();
+	assert_always(expected == num_items);
+}
+
+/* N producer threads, one consumer. Each producer P pushes values tagged with
+   its id in the high bits and a per-producer monotonic counter in the low
+   bits. The consumer must observe: (a) every (producer, counter) pair exactly
+   once -- no loss, no duplication, no torn reads; and (b) per-producer FIFO --
+   for each producer the counters arrive strictly increasing. Cross-producer
+   ordering is not guaranteed and not required. This is the property the
+   single gdrcopy worker relies on: one proxy thread per comm produces that
+   comm's signals in seq order, and the worker must see them in that order. */
+static void test_mpsc_threaded()
+{
+	constexpr uint32_t num_producers = 4;
+	constexpr uint32_t per_producer = 250000;
+	constexpr uint32_t tag_shift = 28; /* high 4 bits = producer id */
+	constexpr uint32_t counter_mask = (1u << tag_shift) - 1;
+	nccl_ofi_mpsc_ring<uint32_t, 1024> ring;
+
+	std::vector<std::thread> producers;
+	for (uint32_t p = 0; p < num_producers; ++p) {
+		producers.emplace_back([&ring, p]() {
+			uint32_t i = 0;
+			while (i < per_producer) {
+				uint32_t v = (p << tag_shift) | i;
+				if (ring.push(v)) {
+					++i;
+				}
+			}
+		});
+	}
+
+	std::vector<uint32_t> next_expected(num_producers, 0);
+	uint32_t total = 0;
+	const uint32_t total_items = num_producers * per_producer;
+	while (total < total_items) {
+		uint32_t val = 0;
+		if (ring.pop(val)) {
+			uint32_t p = val >> tag_shift;
+			uint32_t counter = val & counter_mask;
+			assert_always(p < num_producers);
+			/* Per-producer FIFO: counters arrive in order, no gaps. */
+			assert_always(counter == next_expected[p]);
+			next_expected[p] = counter + 1;
+			++total;
+		}
+	}
+
+	for (auto &t : producers) {
+		t.join();
+	}
+
+	assert_always(total == total_items);
+	for (uint32_t p = 0; p < num_producers; ++p) {
+		assert_always(next_expected[p] == per_producer);
+	}
+}
+
+int main(int argc, char *argv[])
+{
+	unit_test_init();
+
+	test_empty_pop();
+	test_push_pop_fifo();
+	test_full_uses_all_slots();
+	test_wraparound();
+	test_interleaved();
+	test_single_producer_fifo();
+	test_mpsc_threaded();
+
+	printf("Test completed successfully!\n");
+
+	return 0;
+}


### PR DESCRIPTION
This change collapses the per-comm gdrcopy worker threads into one worker per process. That worker is fed by every comm's proxy thread, so the SPSC work ring from PR #1256 no longer fits: it needs many producers and one consumer.

Add a bounded MPSC ring as the companion to nccl_ofi_spsc_ring, same push/pop-returns-false API. It is a Vyukov bounded queue restricted to a single consumer: producers claim a slot by CAS-advancing enqueue_pos and publish via a per-slot sequence stamp, the lone consumer pops in lockstep without a CAS. A single producer's pushes stay FIFO, which is what lets the worker preserve per-(comm, peer) signal order. Prefer this in-tree header over vendoring a third-party queue: it mirrors the existing SPSC ring a reviewer already knows, carries no new dependency, and gives the bounded back-pressure the proxy enqueue path relies on.

The unit test covers the wrap arithmetic and a 4-producer stress that checks per-producer FIFO with no loss, duplication, or torn reads.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
