### PR TITLE
gin: Use one gdrcopy worker per process with signal coalescing

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -9,6 +9,7 @@
 #include "rdma/gin/nccl_ofi_gin_resources.h"
 #include "rdma/gin/nccl_ofi_gin_types.h"
 #include "nccl_ofi_dlist.h"
+#include "nccl_ofi_mpsc_ring.h"
 #include "nccl_ofi_spsc_ring.h"
 
 #include "nccl_ofi.h"
@@ -18,8 +19,12 @@
 #include <bitset>
 #include <atomic>
 #include <cstdint>
+#include <deque>
 #include <mutex>
 #include <thread>
+#include <type_traits>
+#include <unordered_map>
+#include <vector>
 
 /**
  * Get singleton instance of the device copy context shared across all GIN communicators.
@@ -238,14 +243,58 @@ struct nccl_ofi_rdma_gin_symm_mr_handle : public nccl_ofi_gin_symm_mr_handle_t {
 };
 
 /**
- * Work descriptor enqueued by the proxy CQ-drain thread for the gdrcopy
- * worker. The signal metadata is captured by value so the recv buffer
- * can be re-armed without waiting for the worker to consume.
+ * Work descriptor enqueued by a proxy CQ-drain thread for the single
+ * process-wide gdrcopy worker.
+ *
+ * Everything the worker needs to perform the signal read-modify-write is
+ * captured here by value at enqueue time, while the producing proxy still
+ * holds its ep_lock and the comm's mr_handle_map is stable. The worker
+ * therefore never dereferences mr_handle_map (which a concurrent deregMrSym
+ * could mutate) and only touches the owning comm through `comm` to route the
+ * result to its done queue and to drop the outstanding-gdrcopy reference.
  */
 struct gin_signal_work_entry {
-	nccl_net_ofi_gin_signal_metadata_msg_t metadata;
+	/* Owning comm. Used only to push the done entry into comm's per-comm
+	   done queue and to decrement comm->outstanding_gdrcopy. Kept alive
+	   across the worker's last touch by the closeColl quiesce protocol. */
+	nccl_ofi_rdma_gin_put_comm *comm;
+
+	/* The recv req this signal belongs to; travels through to the done
+	   entry. The worker never dereferences it (status travels by value). */
 	nccl_net_ofi_gin_iputsignal_recv_req *req;
+
+	/* GDRCopy pin for the signal's segment, resolved by build_signal_work
+	   via ensure_signal_seg on the proxy (under ep_lock). Null when the
+	   segment is host-NUMA (not GDRCopy-pinnable) — the worker uses a CPU
+	   atomic via host_signal_va in that case. */
+	nccl_ofi_device_copy::RegHandle *gdr_handle;
+
+	/* MR-level base address used for the consumer-side fold key (same-slot
+	   identification across entries). Not used by apply_signal_work. */
+	uint64_t signal_base_address;
+
+	/* Segment-relative offset for GDRCopy read-modify-write.
+	   Computed as (signal_va - seg->seg_base) in build_signal_work. */
+	uint64_t signal_offset;
+	uint64_t signal_value;
+	int type;
+
+	/* Virtual address of the signal counter, for paths that use a CPU
+	   atomic: host-NUMA segments within a CUDA MR (gdr_handle == nullptr),
+	   or the NCCL_PTR_HOST type. */
+	uintptr_t host_signal_va;
+
+	/* True when the MR was registered with NCCL_NET_MR_FLAG_SIGNAL_NEVER_RESET.
+	   Lets the worker skip the device read in the read-modify-write. */
+	bool signal_never_reset;
+
+	/* Pointer into mr_handle->signal_shadow[idx] for the fast path.
+	   The worker atomically updates this shadow entry. Non-null only
+	   when signal_never_reset is true. */
+	uint64_t *signal_shadow_slot;
+
 	uint32_t peer_rank;
+	uint16_t seq_num;
 };
 
 /**
@@ -262,6 +311,131 @@ struct gin_signal_done_entry {
 	uint32_t peer_rank;
 	uint16_t seq_num;
 	int status;
+};
+
+/* Both ring entries are copied by value through the lock-free rings, so they
+   must be trivially copyable. */
+static_assert(std::is_trivially_copyable<gin_signal_work_entry>::value,
+	      "gin_signal_work_entry must be trivially copyable for the MPSC ring");
+static_assert(std::is_trivially_copyable<gin_signal_done_entry>::value,
+	      "gin_signal_done_entry must be trivially copyable for the SPSC ring");
+
+/**
+ * Single process-wide gdrcopy worker.
+ *
+ * With GIN_NCONNECTIONS proxy threads, running one gdrcopy worker per put-comm
+ * is one gdrcopy thread per connection; this collapses them to one thread for
+ * the whole process. The worker pops signal work from a shared MPSC ring fed
+ * by every comm's proxy thread, coalesces entries that target the same signal
+ * slot into a single PCIe read-modify-write, and pushes one done entry per
+ * request back into the owning comm's per-comm SPSC done queue.
+ *
+ * Lifetime: spawned on the first comm that needs it; runs until process
+ * teardown. There is no per-comm join — comm teardown instead quiesces via
+ * the per-comm outstanding_gdrcopy counter (see closeColl). Construction
+ * failure (thread spawn) throws, aborting the first comm's creation, so we
+ * never silently run the read-modify-write on a proxy thread (two concurrent
+ * r-m-w against a PCIe-mapped counter can lose increments).
+ */
+class nccl_ofi_gin_gdrcopy_worker {
+public:
+	/* Process singleton. Throws std::system_error if the worker thread
+	   cannot be spawned on first use. */
+	static nccl_ofi_gin_gdrcopy_worker &get();
+
+	nccl_ofi_gin_gdrcopy_worker(const nccl_ofi_gin_gdrcopy_worker &) = delete;
+	nccl_ofi_gin_gdrcopy_worker &operator=(const nccl_ofi_gin_gdrcopy_worker &) = delete;
+
+	/* Enqueue one signal-delivery work item. Multi-producer: any comm's
+	   proxy thread may call concurrently. Returns false when the shared
+	   ring is full, leaving the caller to drain its done queue and retry. */
+	bool enqueue(const gin_signal_work_entry &work)
+	{
+		return work_queue.push(work);
+	}
+
+private:
+	nccl_ofi_gin_gdrcopy_worker();
+	~nccl_ofi_gin_gdrcopy_worker();
+
+	void run_loop();
+
+	/* Apply one batch of work, coalescing same-slot entries into a single
+	   read-modify-write, and complete each request into its comm's done
+	   queue. */
+	void apply_and_complete(gin_signal_work_entry *batch, size_t n);
+
+	/* Route one completed signal to its comm's done queue. On a full done
+	   queue the entry is stashed rather than blocked on, so a slow comm
+	   cannot head-of-line block delivery for every other comm. */
+	void deliver_done(nccl_ofi_rdma_gin_put_comm *comm,
+			  const gin_signal_done_entry &done);
+
+	/* Retry stashed done entries. Skips comms whose done queue is still
+	   full (preserving per-comm FIFO) so one backed-up comm does not stall
+	   the others. */
+	void flush_done_entries();
+
+	/* Back-pressure buffer between the producer proxy threads and the single
+	   consumer. The consumer drains up to MAX_BATCH per pass (see run_loop),
+	   so a burst deeper than MAX_BATCH is coalesced across successive drains
+	   rather than all at once. */
+	nccl_ofi_mpsc_ring<gin_signal_work_entry> work_queue;
+	std::thread thread;
+	std::atomic<int> stop{0};
+
+	/* Done entries the worker has produced but could not yet push because
+	   the target comm's done queue was full. Owned solely by the worker
+	   thread. The paired comm pointer routes the retry and the eventual
+	   outstanding_gdrcopy decrement. */
+	struct deferred_done {
+		nccl_ofi_rdma_gin_put_comm *comm;
+		gin_signal_done_entry done;
+	};
+	std::deque<deferred_done> done_entries;
+	/* Scratch reused by flush_done_entries to mark comms blocked this pass. */
+	std::vector<nccl_ofi_rdma_gin_put_comm *> blocked_comms;
+
+
+	/* Consumer-side same-slot fold (see apply_and_complete). A signal slot is
+	   identified by (gdr_handle, base, offset, type); entries sharing a slot in
+	   one batch coalesce into a single PCIe r-m-w. The map + scratch vectors are
+	   members reused across drains (cleared each call) so the fold does not
+	   allocate on the worker's hot path. Worker-thread-only, no locking. */
+	struct fold_slot_key {
+		/* The worker is process-wide and a batch mixes entries from different
+		   comms, so the slot identity must include the comm: two comms can share
+		   a (base, offset) and the host path leaves gdr_handle null for all
+		   entries. Without comm here, cross-comm entries would wrongly fold into
+		   one r-m-w against the wrong comm's counter. */
+		nccl_ofi_rdma_gin_put_comm *comm;
+		nccl_ofi_device_copy::RegHandle *gdr_handle;
+		uint64_t signal_base_address;
+		uint64_t signal_offset;
+		int type;
+		bool operator==(const fold_slot_key &o) const
+		{
+			return comm == o.comm &&
+			       gdr_handle == o.gdr_handle &&
+			       signal_base_address == o.signal_base_address &&
+			       signal_offset == o.signal_offset &&
+			       type == o.type;
+		}
+	};
+	struct fold_slot_hash {
+		size_t operator()(const fold_slot_key &k) const
+		{
+			size_t h = reinterpret_cast<uintptr_t>(k.comm);
+			h = h * 31 + reinterpret_cast<uintptr_t>(k.gdr_handle);
+			h = h * 31 + k.signal_base_address;
+			h = h * 31 + k.signal_offset;
+			h = h * 31 + static_cast<size_t>(k.type);
+			return h;
+		}
+	};
+	std::unordered_map<fold_slot_key, size_t, fold_slot_hash> fold_index;
+	std::vector<size_t> fold_lead;
+	std::vector<int> fold_status;
 };
 
 /**
@@ -478,6 +652,8 @@ private:
 	std::unique_ptr<nccl_ofi_freelist, decltype(&freelist_deleter)> metadata_fl;
 	int dev;
 
+       int gdrcopy_cuda_dev = -1; /* CUDA device the worker binds to */
+
 	/* --- TIER 2: Receiver side — every CQ completion --- */
 	/* Controls signal delivery ordering on this communicator
 	   (env: OFI_NCCL_GIN_STRONG_SIGNAL, default true).
@@ -532,7 +708,7 @@ private:
 	   Used to wait for remaining acknowledgements on communicator close. */
 	uint32_t outstanding_ack_counter = 0;
 
-	/* --- TIER 4: signal delivery (do_gin_signal) --- */
+	/* --- TIER 4: signal delivery (build_signal_work / apply_signal_work) --- */
 	/* Map from pointers to memory registration handle. Used to look up
 	   GDRCopy handle for signal delivery.
 
@@ -566,7 +742,28 @@ private:
 	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
 		     uint32_t rx_consumed) REQUIRES(get_ep_lock());
 
-	int do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata);
+	/* Look up the signal's GDRCopy handle in mr_handle_map and fill `work`
+	   with everything the worker needs to apply the read-modify-write.
+	   Runs on the proxy under ep_lock (map stable), so the worker never
+	   touches mr_handle_map. */
+	int build_signal_work(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata,
+			      gin_signal_work_entry &work) REQUIRES(get_ep_lock());
+
+	/* Apply one signal read-modify-write directly from captured work-entry
+	   fields (no mr_handle_map lookup). Used by the worker, and by the
+	   proxy itself during closeColl teardown when the worker is quiesced. */
+	static int apply_signal_work(const gin_signal_work_entry &work);
+
+	/* Hand a signal-delivery work item to the single process-wide gdrcopy
+	   worker. `gate_req` is the req that carries the in-flight gate (for a
+	   folded run, its last req; for a single signal, that signal's req).
+	   On the teardown (closing) path the signal is applied synchronously on the
+	   proxy instead; see the definition. Fills in work.comm/req/peer_rank/
+	   seq_num from gate_req and peer_rank. */
+	int hand_off_signal_work(gin_signal_work_entry &work,
+				 nccl_net_ofi_gin_iputsignal_recv_req *gate_req,
+				 uint32_t peer_rank)
+		REQUIRES(get_ep_lock());
 
 	int do_gin_signal_and_trace(uint32_t peer_rank,
 				    nccl_net_ofi_gin_iputsignal_recv_req *req) REQUIRES(get_ep_lock());
@@ -583,20 +780,15 @@ private:
 
 	int retire_completed_peer_iput_ops(uint32_t peer_rank) REQUIRES(get_ep_lock());
 
-	/* --- gdrcopy worker thread (signal delivery off proxy) ---
-	 * The proxy CQ-drain thread pushes completed signal recv reqs into
-	 * gdrcopy_work_queue; the worker pops, runs do_gin_signal (the gdrcopy
-	 * read-modify-write to/from device memory), and pushes results to
-	 * gdrcopy_done_queue. The proxy drains the done queue every progress
-	 * tick. The SPSC ring's FIFO guarantee preserves seq-num delivery
-	 * order under strong_signal_ordering. */
-	std::atomic<int> gdrcopy_thread_stop{0};
-	std::atomic<int> gdrcopy_thread_exited{0};
-	nccl_ofi_spsc_ring<gin_signal_work_entry> gdrcopy_work_queue;
+	/* --- gdrcopy worker (signal delivery off proxy) ---
+	 * The proxy thread enqueues completed signal recv reqs into
+	 * the single process-wide nccl_ofi_gin_gdrcopy_worker (shared MPSC
+	 * ring). The worker does the gdrcopy read-modify-write and pushes a
+	 * result into this comm's own SPSC done queue, which only this comm's
+	 * proxy drains. The done queue stays single-producer (the one worker) /
+	 * single-consumer (this proxy), so SPSC FIFO still preserves per-peer
+	 * seq order under strong_signal_ordering. */
 	nccl_ofi_spsc_ring<gin_signal_done_entry> gdrcopy_done_queue;
-	std::thread gdrcopy_thread;
-	int gdrcopy_cuda_dev = -1; /* CUDA device the worker binds to */
-
 	/* Protects mr_handle->signal_segs: the gdrcopy worker appends on first
 	   touch (ensure_signal_seg) and deregMrSym tears it down. */
 	std::mutex signal_segs_mtx;
@@ -612,16 +804,53 @@ private:
 	int ensure_signal_seg(nccl_ofi_rdma_gin_symm_mr_handle *mr,
 			      uintptr_t signal_va, signal_seg_t **out);
 
-	void run_gdrcopy_worker_loop();
-	int enqueue_gdrcopy_work(uint32_t peer_rank,
-				 nccl_net_ofi_gin_iputsignal_recv_req *req) REQUIRES(get_ep_lock());
+	/* Outstanding signal r-m-w handed to the worker for this comm but not
+	   yet completed back through the done queue. Incremented on the proxy
+	   under ep_lock at enqueue; decremented by the worker after it has
+	   finished touching this comm (applied the signal AND pushed the done
+	   entry). closeColl drains this to zero before deleting the comm, so
+	   the worker can never reference a freed comm. Atomic: the worker
+	   decrements without ep_lock. */
+	std::atomic<uint32_t> outstanding_gdrcopy{0};
+
+	/* Set under ep_lock at the start of closeColl teardown. Once set, the
+	   CQ-completion paths stop handing new work to the shared worker and
+	   apply any late signal synchronously on the proxy instead, so the
+	   outstanding-gdrcopy count cannot rise again after it reaches zero. */
+	std::atomic<bool> closing{false};
+
+
 
 	friend class nccl_ofi_rdma_gin_listen_comm;
+	friend class nccl_ofi_gin_gdrcopy_worker;
 
 public:
+	bool has_outstanding_gdrcopy() const
+	{
+		/* Acquire, not relaxed. closeColl's quiesce loop spins on this until it
+		   reads zero, then lets the teardown path apply late signals synchronously
+		   on the proxy (see hand_off_signal_work's closing branch). The worker
+		   applies each signal's device read-modify-write BEFORE its release
+		   fetch_sub, so observing zero must synchronize-with that release for the
+		   worker's last counter write to happen-before the proxy's synchronous
+		   apply -- otherwise the two r-m-w's race and an increment can be lost.
+		   A relaxed load would form no such edge. */
+		return outstanding_gdrcopy.load(std::memory_order_acquire) != 0;
+	}
+
+	/* Mark this comm as tearing down. After this, the CQ-completion paths
+	   apply any late signal synchronously on the proxy rather than handing
+	   it to the shared worker, so outstanding_gdrcopy cannot rise again once
+	   closeColl has drained it to zero. Called from closeColl under ep_lock
+	   intent (the store itself is atomic). */
+	void begin_closing()
+	{
+		closing.store(true, std::memory_order_release);
+	}
+
 	/* Reap completed signal-delivery work from the gdrcopy worker. Called
-	 * from ginProgress every progress tick and from the destructor while
-	 * joining the worker; both hold the ep lock, which is why we advance
+	 * from ginProgress every progress tick and from closeColl while
+	 * quiescing the worker; both hold the ep lock, which is why we advance
 	 * retire_completed_peer_iput_ops (and thus emit ACKs) from here. */
 	int drain_gdrcopy_done_queue() REQUIRES(get_ep_lock());
 

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -19,6 +19,9 @@
 #include <system_error>
 #include <vector>
 
+/* Max signal work items the gdrcopy worker drains and folds per pass. */
+#define OFI_NCCL_MAX_GDR_COPY_BATCH 512
+
 struct gin_connect_handle {
 	/* Number of rails */
 	uint16_t num_rails;
@@ -73,55 +76,43 @@ nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &r
 	resources.set_comm(local_comm_id, *this);
 	resources.increment_ref_cnt();
 
-	/* Spawn the gdrcopy worker thread that runs the signal-delivery
-	 * read-modify-write off the proxy CQ-drain thread. A spawn failure is
-	 * unexpected (thread/FD exhaustion); rather than silently fall back to
-	 * running gdrcopy on the proxy thread, fail comm creation so we never
-	 * run in that degraded configuration. Undo the comm registration before
-	 * rethrowing so resources teardown does not see a dangling comm. */
 #if HAVE_CUDA
-	/* Capture the CUDA device on this (context-bearing) thread so the gdrcopy
-	 * worker can bind to it; the worker's lazy signal-segment discovery calls
-	 * cuMemGetAddressRange, which requires a current CUDA context. -1 means we
-	 * could not determine the device, in which case the worker skips binding
-	 * and falls back to whatever context it inherits (see
-	 * run_gdrcopy_worker_loop). cudaGetDevice failing here is unexpected. */
-	if (nccl_net_ofi_gpu_get_device(&gdrcopy_cuda_dev) != 0) {
-		NCCL_OFI_WARN("Could not query CUDA device for gdrcopy worker; "
-			      "it will not bind to a device");
-		gdrcopy_cuda_dev = -1;
-	}
+       /* Capture the CUDA device on this (context-bearing) thread so the gdrcopy
+        * worker can bind to it; the worker's lazy signal-segment discovery calls
+        * cuMemGetAddressRange, which requires a current CUDA context. -1 means we
+        * could not determine the device, in which case the worker skips binding
+        * and falls back to whatever context it inherits (see
+        * run_gdrcopy_worker_loop). cudaGetDevice failing here is unexpected. */
+       if (nccl_net_ofi_gpu_get_device(&gdrcopy_cuda_dev) != 0) {
+               NCCL_OFI_WARN("Could not query CUDA device for gdrcopy worker; "
+                             "it will not bind to a device");
+               gdrcopy_cuda_dev = -1;
+       }
 #endif
+
+	/* Ensure the single process-wide gdrcopy worker exists. It is spawned
+	 * lazily on the first comm and runs until process teardown; later comms
+	 * just attach to it. A spawn failure (thread/FD exhaustion) is fatal:
+	 * rather than silently fall back to running gdrcopy on the proxy thread,
+	 * fail comm creation so we never run in that degraded configuration.
+	 * Undo the comm registration before rethrowing so resources teardown
+	 * does not see a dangling comm. */
 	try {
-		gdrcopy_thread = std::thread(
-			&nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop, this);
-	} catch (const std::system_error &err) {
-		NCCL_OFI_WARN("Failed to spawn GIN gdrcopy worker thread: %s",
-			      err.what());
+		(void)nccl_ofi_gin_gdrcopy_worker::get();
+	} catch (const std::exception &err) {
+		NCCL_OFI_WARN("Failed to start GIN gdrcopy worker: %s", err.what());
 		resources.remove_comm(local_comm_id);
 		throw;
 	}
 }
 
-/* closeColl() holds the ep lock across `delete gin_comm`, so the drain calls
- * below run with the lock held. Clang TSA does not track the held lock across
- * the implicit destructor invocation, so suppress analysis here rather than
- * weakening drain_gdrcopy_done_queue()'s REQUIRES(get_ep_lock()). */
-nccl_ofi_rdma_gin_put_comm::~nccl_ofi_rdma_gin_put_comm() NO_THREAD_SAFETY_ANALYSIS
+nccl_ofi_rdma_gin_put_comm::~nccl_ofi_rdma_gin_put_comm()
 {
-	/* Stop and join the gdrcopy worker thread. The proxy is the only
-	 * consumer of gdrcopy_done_queue, so it must keep draining while the
-	 * worker is shutting down — otherwise a worker that finds the done
-	 * queue full spins forever on push and we self-deadlock on join. */
-	if (gdrcopy_thread.joinable()) {
-		gdrcopy_thread_stop.store(1, std::memory_order_release);
-		while (!gdrcopy_thread_exited.load(std::memory_order_acquire)) {
-			drain_gdrcopy_done_queue();
-		}
-		gdrcopy_thread.join();
-	}
-	/* Drain any leftover done-queue entries (best effort). */
-	drain_gdrcopy_done_queue();
+	/* The shared gdrcopy worker is not joined here — it outlives every
+	 * comm. closeColl() has already quiesced it for this comm (drained
+	 * outstanding_gdrcopy to zero under ep_lock and emptied the done
+	 * queue), so by the time we get here no work entry references this
+	 * comm and nothing more will be pushed into its done queue. */
 
 #if HAVE_NVTX_TRACING
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_COMM) {
@@ -974,6 +965,18 @@ int nccl_ofi_rdma_gin_put_comm::ensure_signal_seg(
 		return 0;
 	}
 
+#if HAVE_CUDA
+       /* Bind this worker to the comm's CUDA device so its lazy segment
+          discovery (cuMemGetAddressRange) has a valid CUDA context. A failure
+          here leaves the worker without the intended context, so warn -- lazy
+          discovery would then fail on the first signal. */
+       if (gdrcopy_cuda_dev >= 0 &&
+           nccl_net_ofi_gpu_set_device(gdrcopy_cuda_dev) != 0) {
+               NCCL_OFI_WARN("gdrcopy worker failed to bind CUDA device %d",
+                             gdrcopy_cuda_dev);
+       }
+#endif
+
 	void *seg_base_ptr = nullptr;
 	size_t seg_size = 0;
 	int ret = nccl_net_ofi_gpu_get_address_range(
@@ -1030,20 +1033,27 @@ int nccl_ofi_rdma_gin_put_comm::ensure_signal_seg(
 	return 0;
 }
 
-int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_metadata_msg_t &metadata)
+/* Fill `work` with everything the worker needs to apply this signal's
+ * read-modify-write. The mr_handle_map lookup and segment discovery happen
+ * here, on the proxy thread under ep_lock, so the worker never touches the
+ * map (which a concurrent deregMrSym could mutate) or needs a CUDA context
+ * (ensure_signal_seg uses cuMemGetAddressRange). */
+int nccl_ofi_rdma_gin_put_comm::build_signal_work(
+	const nccl_net_ofi_gin_signal_metadata_msg_t &metadata, gin_signal_work_entry &work)
 {
 	void *signal_base = reinterpret_cast<void *>(metadata.signal_base_address);
 
-	/* Value to increment the signal. For increment ops, this will be 1 */
-	uint64_t add_value = metadata.signal_value;
-
-	/* Look up the MR handle associated with this signal */
 	auto it = this->mr_handle_map.find(signal_base);
 	if (OFI_UNLIKELY(it == this->mr_handle_map.end())) {
 		NCCL_OFI_WARN("Signal base address %p not found in MR handle map", signal_base);
 		return -EINVAL;
 	}
 	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = it->second.handle;
+
+	work.signal_base_address = metadata.signal_base_address;
+	work.signal_value = metadata.signal_value;
+	work.type = mr_handle->type;
+	work.signal_never_reset = mr_handle->signal_never_reset;
 
 	/* Reject a peer-supplied offset that would place the 8-byte counter
 	   outside the MR (overflow- and underflow-safe) before we use it. */
@@ -1058,7 +1068,10 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_meta
 		uintptr_t signal_va = metadata.signal_base_address +
 				      metadata.signal_offset;
 
-		/* Lazily discover and pin the segment this signal lands in. */
+		/* Lazily discover and pin the segment this signal lands in.
+		   This runs on the proxy thread (under ep_lock) where the CUDA
+		   context is current, so cuMemGetAddressRange succeeds. The worker
+		   only ever touches the pre-resolved segment handle. */
 		signal_seg_t *seg = nullptr;
 		int ret = ensure_signal_seg(mr_handle, signal_va, &seg);
 		if (OFI_UNLIKELY(ret != 0)) {
@@ -1067,57 +1080,90 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal(const nccl_net_ofi_gin_signal_meta
 			return ret;
 		}
 
-		if (seg->gdr_handle == nullptr) {
-			/* Host-NUMA segment (not pinnable): update with a CPU
-			   atomic; the VA is host-accessible. */
-			auto *dest = reinterpret_cast<volatile uint64_t *>(signal_va);
-			__atomic_fetch_add(dest, add_value, __ATOMIC_RELAXED);
+		work.gdr_handle = seg->gdr_handle;  /* null for host-NUMA segment */
+		work.signal_offset = signal_va - seg->seg_base;  /* segment-relative */
+		work.host_signal_va = signal_va;  /* for host-NUMA CPU-atomic path */
+
+		if (mr_handle->signal_never_reset && seg->gdr_handle != nullptr) {
+			uint64_t idx = metadata.signal_offset / sizeof(uint64_t);
+			work.signal_shadow_slot = &mr_handle->signal_shadow[idx];
 		} else {
-			size_t off = signal_va - seg->seg_base;
-			uint64_t new_value;
-
-			if (mr_handle->signal_never_reset) {
-				/* Never-reset: the host shadow is authoritative,
-				   so skip the device read. */
-				uint64_t idx = metadata.signal_offset / sizeof(uint64_t);
-				assert(idx < mr_handle->signal_shadow.size());
-				new_value = (mr_handle->signal_shadow[idx] += add_value);
-			} else {
-				/* May have been reset (VA signals): read first. */
-				uint64_t old_value;
-				ret = get_device_copy().copy_from_device(
-					*seg->gdr_handle, off, &old_value,
-					sizeof(old_value));
-				if (OFI_UNLIKELY(ret != 0)) {
-					NCCL_OFI_WARN("Failed to read current signal value");
-					return -ret;
-				}
-				new_value = old_value + add_value;
-			}
-
-			/* Write using GDRCopy. */
-			ret = get_device_copy().copy_to_device(
-				&new_value, *seg->gdr_handle, off, sizeof(new_value));
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_WARN("Failed to update signal value");
-				return -ret;
-			}
+			work.signal_shadow_slot = nullptr;
 		}
 	} else {
-		/**
-		 * Notes:
-		 * 1. This code (host memory signal update) will never be used
-		 *    in practice, because NCCL's GIN proxy thread always
-		 *    allocates signals in GPU memory
-		 *
-		 * 2. Using relaxed ordering here is OK because signals
-		 *    themselves need not be ordered, as long as all previous
-		 *    puts() have arrived.
-		 */
-		assert(mr_handle->type == NCCL_PTR_HOST);
-		auto *dest = reinterpret_cast<volatile uint64_t *>(metadata.signal_base_address +
-								   metadata.signal_offset);
-		__atomic_fetch_add(dest, add_value, __ATOMIC_RELAXED);
+		/* Host path: worker uses a CPU atomic at the signal VA. */
+		work.gdr_handle = nullptr;
+		work.signal_offset = metadata.signal_offset;
+		work.host_signal_va = metadata.signal_base_address + metadata.signal_offset;
+		work.signal_shadow_slot = nullptr;
+	}
+	return 0;
+}
+
+/* Apply one signal read-modify-write from the captured work-entry fields.
+ * Static: it needs no comm state (the segment gdr handle and offsets are all
+ * in the entry), which is what lets the shared worker run it without touching
+ * any comm's mr_handle_map or calling ensure_signal_seg. */
+int nccl_ofi_rdma_gin_put_comm::apply_signal_work(const gin_signal_work_entry &work)
+{
+	uint64_t add_value = work.signal_value;
+
+	if (work.type == NCCL_PTR_CUDA) {
+
+		if (work.gdr_handle == nullptr) {
+			/* Host-NUMA segment within a CUDA MR: not GDRCopy-pinnable,
+			   update with a CPU atomic at the host-accessible signal VA. The
+			   counter is foreign (non-std::atomic) storage, so wrap it with
+			   std::atomic_ref. Relaxed: only atomicity is needed, ordering is
+			   handled by the put-before-signal protocol upstream. */
+			auto *dest = reinterpret_cast<uint64_t *>(work.host_signal_va);
+			std::atomic_ref<uint64_t>(*dest).fetch_add(add_value,
+								   std::memory_order_relaxed);
+			return 0;
+		}
+
+		uint64_t new_value;
+		int ret;
+
+		if (work.signal_never_reset) {
+			/* Fast path: the signal is never reset, so our host-side
+			   shadow is authoritative. Add to the shadow and do a
+			   one-way write to the device, skipping the device read.
+			   apply_signal_work only ever runs on the gdrcopy worker
+			   thread, so the shadow needs no additional locking. */
+			new_value = (*work.signal_shadow_slot += add_value);
+		} else {
+			/* Slow path: the signal may have been reset out from under
+			   us (e.g. VA signals), so read the current value back from
+			   the device before adding. */
+			uint64_t old_value;
+
+			ret = get_device_copy().copy_from_device(*work.gdr_handle,
+								 work.signal_offset, &old_value,
+								 sizeof(old_value));
+			if (OFI_UNLIKELY(ret != 0)) {
+				NCCL_OFI_WARN("Failed to read current signal value");
+				return -ret;
+			}
+
+			new_value = old_value + add_value;
+		}
+
+		/* Write using GDRcopy. */
+		ret = get_device_copy().copy_to_device(&new_value, *work.gdr_handle,
+						       work.signal_offset, sizeof(new_value));
+		if (OFI_UNLIKELY(ret != 0)) {
+			NCCL_OFI_WARN("Failed to update signal value");
+			return -ret;
+		}
+
+	} else {
+		assert(work.type == NCCL_PTR_HOST);
+		/* Foreign (non-std::atomic) storage wrapped with std::atomic_ref.
+		   Relaxed as above -- see the host-NUMA path. */
+		auto *dest = reinterpret_cast<uint64_t *>(work.host_signal_va);
+		std::atomic_ref<uint64_t>(*dest).fetch_add(add_value,
+							   std::memory_order_relaxed);
 	}
 
 	return 0;
@@ -1129,53 +1175,94 @@ int nccl_ofi_rdma_gin_put_comm::do_gin_signal_and_trace(uint32_t peer_rank,
 	NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_BEGIN(dev, this, peer_rank,
 						 req->metadata.header.seq_num, req);
 
-	/* Hand the gdrcopy work off to the worker thread. The proxy reaps via
-	 * drain_gdrcopy_done_queue() each progress tick, which emits the
-	 * matching DELIVERY_END trace once the gdrcopy has actually landed. The
-	 * worker is spawned at comm construction (a spawn failure aborts comm
-	 * creation), so it is always running here. */
-	return enqueue_gdrcopy_work(peer_rank, req);
+	/* Build this signal's work item and hand it to the shared worker. The
+	 * proxy reaps via drain_gdrcopy_done_queue() each progress tick, which
+	 * emits the matching DELIVERY_END trace once the gdrcopy has landed. */
+	gin_signal_work_entry work;
+	int ret = build_signal_work(req->metadata, work);
+	if (OFI_UNLIKELY(ret != 0)) {
+		return ret;
+	}
+	return hand_off_signal_work(work, req, peer_rank);
 }
 
-/* Push a signal-delivery work item to the gdrcopy worker. On a full work
- * ring the proxy must not fall back to running gdrcopy itself: the worker
- * is the sole owner of that read-modify-write, and two concurrent r-m-w
- * sequences against a PCIe-mapped counter can race and lose increments. We
- * spin instead, draining the worker's done ring while we wait so it keeps
- * making room. The ring holds nearly its full CAPACITY of entries, so under
- * normal load this loop never iterates; if it does, a recv burst genuinely
- * outpaced gdrcopy and throttling the proxy until the worker catches up is
- * the behavior we want.
+/* Hand a signal-delivery work item to the single process-wide gdrcopy worker.
+ * `gate_req` carries the in-flight gate (its done entry re-runs retire); for a
+ * folded run `work` already holds the summed value, for a single signal the
+ * caller built `work` from that req's metadata.
  *
- * The req is marked in_flight before the push so retire_completed_peer_iput_ops
- * will not advance past it, return it to the pool, or stash an ACK while
- * the gdrcopy is outstanding. */
-int nccl_ofi_rdma_gin_put_comm::enqueue_gdrcopy_work(uint32_t peer_rank,
-						nccl_net_ofi_gin_iputsignal_recv_req *req)
+ * On the teardown (closing) path the worker is already quiesced for this comm,
+ * so apply the signal synchronously on the proxy and complete gate_req inline.
+ * This cannot race the worker's read-modify-write: closeColl sets `closing` and
+ * then drains outstanding_gdrcopy to zero before proceeding, so once any signal
+ * reaches this branch the worker provably holds no entry for this comm (and
+ * `closing` stops new entries reaching it), making the proxy the sole writer of
+ * the counter. Otherwise mark gate_req in-flight, account the hand-off, and spin
+ * enqueueing to the worker, draining our done queue to make room. */
+int nccl_ofi_rdma_gin_put_comm::hand_off_signal_work(
+	gin_signal_work_entry &work, nccl_net_ofi_gin_iputsignal_recv_req *gate_req,
+	uint32_t peer_rank)
 {
-	gin_signal_work_entry work;
-	work.metadata = req->metadata;
-	work.req = req;
+	work.comm = this;
+	work.req = gate_req;
 	work.peer_rank = peer_rank;
+	work.seq_num = gate_req->metadata.header.seq_num;
 
-	req->gdrcopy_in_flight = true;
-	req->gdrcopy_status = 0;
+	if (OFI_UNLIKELY(closing.load(std::memory_order_acquire))) {
+		gate_req->gdrcopy_status = apply_signal_work(work);
+		gate_req->gdrcopy_in_flight = false;
+		NCCL_OFI_TRACE_GIN_SIGNAL_DELIVERY_END(dev, this, work.peer_rank, work.seq_num,
+						       gate_req);
+		return gate_req->gdrcopy_status;
+	}
 
-	while (!gdrcopy_work_queue.push(work)) {
+	gate_req->gdrcopy_in_flight = true;
+	gate_req->gdrcopy_status = 0;
+
+	/* Count the outstanding hand-off before publishing it to the worker.
+	 * Release so this increment happens-before the enqueue, without relying on
+	 * the ring's internal ordering: the worker must never observe the queued
+	 * item before the count reflects it. */
+	outstanding_gdrcopy.fetch_add(1, std::memory_order_release);
+
+	auto &worker = nccl_ofi_gin_gdrcopy_worker::get();
+	while (!worker.enqueue(work)) {
 		int drain_ret = drain_gdrcopy_done_queue();
 		if (OFI_UNLIKELY(drain_ret != 0)) {
+			/* Roll back the count for the entry we never enqueued. */
+			outstanding_gdrcopy.fetch_sub(1, std::memory_order_acq_rel);
+			gate_req->gdrcopy_in_flight = false;
 			return drain_ret;
 		}
-		asm volatile("" ::: "memory");
+		/* drain_gdrcopy_done_queue() and worker.enqueue() both perform atomic
+		   ring operations, which are themselves compiler barriers, so the loop
+		   re-reads ring state each iteration without an explicit barrier. */
 	}
 	return 0;
 }
 
-/* Drain the worker's done queue. Each entry is a signal whose gdrcopy
- * has already been applied. Clearing gdrcopy_in_flight here is what
- * unblocks retire_completed_peer_iput_ops for this seq num: ACK stash,
- * map erase and request pool return all run after this point. Returns
- * the first nonzero worker status so callers can propagate failures. */
+/* Hand a signal-delivery work item to the single process-wide gdrcopy worker.
+ *
+ * During teardown (closing set) the worker has already been quiesced for this
+ * comm, so we apply the signal synchronously on the proxy instead of handing
+ * it to the worker — this keeps outstanding_gdrcopy from rising again after
+ * closeColl drove it to zero, and is race-free because the worker provably
+ * holds no entry for this comm at that point.
+ *
+ * On a full work ring the proxy must not run the gdrcopy itself in steady
+ * state: the worker is the sole owner of that read-modify-write, and two
+ * concurrent r-m-w against a PCIe-mapped counter can lose increments. We spin
+ * instead, draining our done queue while we wait so the worker keeps making
+ * room.
+ *
+ * The req is marked in_flight before enqueue so retire_completed_peer_iput_ops
+ * will not advance past it, return it to the pool, or stash an ACK while the
+ * gdrcopy is outstanding. */
+/* Drain this comm's done queue. Each entry is a signal whose gdrcopy has
+ * already been applied by the worker. Clearing gdrcopy_in_flight here is what
+ * unblocks retire_completed_peer_iput_ops for this seq num: ACK stash, map
+ * erase and request pool return all run after this point. Returns the first
+ * nonzero worker status so callers can propagate failures. */
 int nccl_ofi_rdma_gin_put_comm::drain_gdrcopy_done_queue()
 {
 	gin_signal_done_entry done;
@@ -1212,53 +1299,196 @@ int nccl_ofi_rdma_gin_put_comm::drain_gdrcopy_done_queue()
 	return ret;
 }
 
-void nccl_ofi_rdma_gin_put_comm::run_gdrcopy_worker_loop()
+/* ---- Single process-wide gdrcopy worker ---- */
+
+nccl_ofi_gin_gdrcopy_worker &nccl_ofi_gin_gdrcopy_worker::get()
 {
-#if HAVE_CUDA
-	/* Bind this worker to the comm's CUDA device so its lazy segment
-	   discovery (cuMemGetAddressRange) has a valid CUDA context. A failure
-	   here leaves the worker without the intended context, so warn -- lazy
-	   discovery would then fail on the first signal. */
-	if (gdrcopy_cuda_dev >= 0 &&
-	    nccl_net_ofi_gpu_set_device(gdrcopy_cuda_dev) != 0) {
-		NCCL_OFI_WARN("gdrcopy worker failed to bind CUDA device %d",
-			      gdrcopy_cuda_dev);
+	static nccl_ofi_gin_gdrcopy_worker instance;
+	return instance;
+}
+
+nccl_ofi_gin_gdrcopy_worker::nccl_ofi_gin_gdrcopy_worker()
+{
+	/* Throws std::system_error on spawn failure; the first comm's ctor
+	 * catches it and aborts comm creation (we never run the r-m-w on a
+	 * proxy thread in steady state). */
+	thread = std::thread(&nccl_ofi_gin_gdrcopy_worker::run_loop, this);
+}
+
+nccl_ofi_gin_gdrcopy_worker::~nccl_ofi_gin_gdrcopy_worker()
+{
+	stop.store(1, std::memory_order_release);
+	/* The constructor always spawns the worker and the class is non-copyable,
+	   non-movable, and never detaches, so the thread is always joinable here. */
+	thread.join();
+}
+
+/* Apply a batch of work items, coalescing entries that target the same signal
+ * slot into a single read-modify-write. Signal ops are pure additions, which
+ * commute, so summing the add-values of N entries hitting one slot and applying
+ * them as one r-m-w yields the same counter value as N separate r-m-w -- while
+ * saving N-1 PCIe round trips. One done entry is still pushed per request, so
+ * each req's gdrcopy_in_flight clears individually and retire advances in seq
+ * order.
+ *
+ * O(n) single pass: a hash map on the slot key assigns each entry to the first
+ * entry that hit its slot ("lead"); duplicates fold their value into the lead.
+ * Each lead is then applied once and every entry's done is delivered with its
+ * lead's status. The map and scratch vectors are reused members, cleared here
+ * rather than reallocated, so steady state does no heap work. */
+void nccl_ofi_gin_gdrcopy_worker::apply_and_complete(gin_signal_work_entry *batch, size_t n)
+{
+	/* Fast path for the common low-pressure case: a single work item has
+	 * nothing to coalesce with, so skip the map machinery and apply it
+	 * directly. */
+	if (n == 1) {
+		gin_signal_work_entry &w = batch[0];
+		int status = nccl_ofi_rdma_gin_put_comm::apply_signal_work(w);
+
+		gin_signal_done_entry done;
+		done.req = w.req;
+		done.peer_rank = w.peer_rank;
+		done.seq_num = w.seq_num;
+		done.status = status;
+		deliver_done(w.comm, done);
+		return;
 	}
-#endif
-	gin_signal_work_entry work;
+
+	fold_index.clear();
+	fold_lead.resize(n);
+	fold_status.resize(n);
+
+	/* Pass 1: map each entry to its slot lead, summing duplicates into it. */
+	for (size_t i = 0; i < n; ++i) {
+		const gin_signal_work_entry &e = batch[i];
+		fold_slot_key key{e.comm, e.gdr_handle, e.signal_base_address, e.signal_offset, e.type};
+		auto it = fold_index.find(key);
+		if (it == fold_index.end()) {
+			fold_index.emplace(key, i);
+			fold_lead[i] = i;
+		} else {
+			size_t lead = it->second;
+			fold_lead[i] = lead;
+			batch[lead].signal_value += e.signal_value;
+		}
+	}
+
+	/* Pass 2: apply each lead's combined value with one PCIe r-m-w. */
+	for (size_t i = 0; i < n; ++i) {
+		if (fold_lead[i] == i) {
+			fold_status[i] = nccl_ofi_rdma_gin_put_comm::apply_signal_work(batch[i]);
+		}
+	}
+
+	/* Pass 3: deliver one done per request, carrying its lead's status. */
+	for (size_t i = 0; i < n; ++i) {
+		gin_signal_work_entry &member = batch[i];
+		gin_signal_done_entry done;
+		done.req = member.req;
+		done.peer_rank = member.peer_rank;
+		done.seq_num = member.seq_num;
+		done.status = fold_status[fold_lead[i]];
+		deliver_done(member.comm, done);
+	}
+}
+
+/* Route one completed signal to its comm's done queue. The worker must never
+ * block here: a comm whose proxy has momentarily stopped draining (e.g. it is
+ * in await_pending_requests at closeColl) would otherwise head-of-line block
+ * delivery for every other comm and deadlock the process. So on a full done
+ * queue we stash the entry and move on; flush_done_entries retries it later.
+ *
+ * The outstanding_gdrcopy decrement happens only once the entry is actually in
+ * the comm's done queue (here or in the flush), never while it is stashed:
+ * closeColl reads that count to decide the comm is safe to delete, so the
+ * worker must still hold a reference for any entry it has not yet handed off. */
+void nccl_ofi_gin_gdrcopy_worker::deliver_done(nccl_ofi_rdma_gin_put_comm *comm,
+					       const gin_signal_done_entry &done)
+{
+	if (!done_entries.empty() || !comm->gdrcopy_done_queue.push(done)) {
+		/* Either this comm (or an earlier one) already has stashed
+		 * entries — push here would jump ahead of them and break
+		 * per-comm FIFO — or the queue is full right now. Stash. */
+		done_entries.push_back({comm, done});
+		return;
+	}
+	comm->outstanding_gdrcopy.fetch_sub(1, std::memory_order_release);
+}
+
+/* Retry stashed done entries in FIFO order. A comm whose queue is still full
+ * is marked blocked for this pass and all its later stashed entries are kept
+ * (preserving per-comm order) while other comms continue to drain. */
+void nccl_ofi_gin_gdrcopy_worker::flush_done_entries()
+{
+	if (done_entries.empty()) {
+		return;
+	}
+
+	blocked_comms.clear();
+	size_t kept = 0;
+	for (size_t i = 0; i < done_entries.size(); ++i) {
+		deferred_done &s = done_entries[i];
+
+		bool blocked = false;
+		for (auto *c : blocked_comms) {
+			if (c == s.comm) {
+				blocked = true;
+				break;
+			}
+		}
+
+		if (!blocked && s.comm->gdrcopy_done_queue.push(s.done)) {
+			s.comm->outstanding_gdrcopy.fetch_sub(1, std::memory_order_release);
+			continue;
+		}
+
+		/* Could not deliver: keep it, and block this comm so we do not
+		 * reorder its later entries ahead of this one. */
+		blocked_comms.push_back(s.comm);
+		done_entries[kept++] = s;
+	}
+	done_entries.resize(kept);
+}
+
+void nccl_ofi_gin_gdrcopy_worker::run_loop()
+{
+	/* Drain up to OFI_NCCL_MAX_GDR_COPY_BATCH work items each iteration and hand
+	 * them to apply_and_complete, which coalesces the same-slot entries within
+	 * the batch. A deeper batch lets more same-slot entries land together and
+	 * collapse into one PCIe r-m-w; too shallow a batch splits a burst across
+	 * iterations and re-issues a write per slot per batch. static (not on the
+	 * stack) because the buffer is large and the worker is the sole thread
+	 * touching it. */
+	static gin_signal_work_entry batch[OFI_NCCL_MAX_GDR_COPY_BATCH];
+
 	while (true) {
-		if (!gdrcopy_work_queue.pop(work)) {
-			/* Empty queue. After stop is set, draining to empty
-			 * means we're done; otherwise busy-poll. We deliberately
-			 * busy-poll rather than block on a condition variable:
-			 * signal delivery is latency-critical and a wakeup
-			 * syscall round-trip would show up directly in the
-			 * critical path, so the worker pegs one core instead. */
-			if (gdrcopy_thread_stop.load(std::memory_order_acquire)) {
+		/* Retry any done entries a full comm queue made us stash on a
+		 * previous iteration before producing more. */
+		flush_done_entries();
+
+		size_t n = 0;
+		while (n < OFI_NCCL_MAX_GDR_COPY_BATCH && work_queue.pop(batch[n])) {
+			++n;
+		}
+
+		if (n == 0) {
+			/* Nothing new to apply. After stop is set, exit once both
+			 * the work ring and the done stash are fully drained, so
+			 * no completed signal is left undelivered. Otherwise
+			 * busy-poll: we deliberately busy-poll rather than block on
+			 * a condition variable because signal delivery is
+			 * latency-critical and a wakeup syscall round-trip would
+			 * show up directly in the critical path, so the worker pegs
+			 * one core instead. */
+			if (stop.load(std::memory_order_acquire) && done_entries.empty()) {
 				break;
 			}
 			asm volatile("" ::: "memory");
 			continue;
 		}
 
-		int status = do_gin_signal(work.metadata);
-
-		gin_signal_done_entry done;
-		done.req = work.req;
-		done.peer_rank = work.peer_rank;
-		done.seq_num = work.metadata.header.seq_num;
-		done.status = status;
-		while (!gdrcopy_done_queue.push(done)) {
-			/* Done queue full: brief pause, proxy will drain on its
-			 * next tick. Both rings share the same CAPACITY, so this
-			 * is unlikely under normal operation. */
-			asm volatile("" ::: "memory");
-		}
+		apply_and_complete(batch, n);
 	}
-
-	/* Signal the destructor that we have exited so it stops draining
-	 * the done queue and joins. */
-	gdrcopy_thread_exited.store(1, std::memory_order_release);
 }
 
 int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_rank, uint64_t map_key,
@@ -1310,7 +1540,16 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 
 	/* Walk in-order delivered ops, advancing rx_consumed as we go. The
 	   sender's flow-control window opens once we send back a standalone
-	   ACK (maybe_send_ack at the end of this function). */
+	   ACK (maybe_send_ack at the end of this function).
+
+	   Producer-side coalescing (strong ordering): rather than post one
+	   gdrcopy work item per signal, we greedily fold a maximal run of
+	   consecutive ready signals targeting the SAME (base,offset) slot into
+	   a single +N read-modify-write, posted once to the worker. Signal adds
+	   commute, so summing the run's values and applying them as one r-m-w
+	   lands the counter on the same value while collapsing the run to one
+	   PCIe write and one ring slot. Only the run's last req carries the
+	   in-flight gate; its done entry re-runs retire for the whole run. */
 	while (true) {
 		auto &rank_comm = this->rank_comms[peer_rank];
 		uint16_t next_seq_num = rank_comm.next_delivered_signal_seq_num;
@@ -1339,19 +1578,129 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 			return ret;
 		}
 
-		ack_requested = ack_requested || req->is_ack_requested;
-		rank_comm.rx_consumed = gin_cursor_inc(rank_comm.rx_consumed);
-		rank_comm.next_delivered_signal_seq_num =
-			(rank_comm.next_delivered_signal_seq_num + 1) & GIN_IMM_SEQ_MASK;
-		ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
+		/* Fall back to the original per-req completion path when there is
+		   nothing to fold:
+		     - weak ordering: the signal was already posted (and maybe
+		       applied) at CQ-completion time, so retire only advances; or
+		     - the req has no metadata yet (a write-only completion can mark
+		       a req segment-complete before its metadata message arrives,
+		       so signal_base_address is not populated) — the per-req path
+		       correctly skips the gdrcopy in that case.
+		   Producer-side folding only applies under strong ordering with
+		   metadata in hand, which is also the only case build_signal_work
+		   can resolve the slot. */
+		if (!strong_signal_ordering_enabled || !req->metadata_received) {
+			ack_requested = ack_requested || req->is_ack_requested;
+			rank_comm.rx_consumed = gin_cursor_inc(rank_comm.rx_consumed);
+			rank_comm.next_delivered_signal_seq_num =
+				(rank_comm.next_delivered_signal_seq_num + 1) & GIN_IMM_SEQ_MASK;
+			ret = iput_signal_recv_req_completion(peer_rank, map_key, req);
+			if (OFI_UNLIKELY(ret != 0)) {
+				return ret;
+			}
+			this->resources.return_req_to_pool(req);
+			continue;
+		}
+
+		/* Strong ordering: build the work item for this slot once, then
+		   greedily extend the run over consecutive same-slot ready
+		   signals. For each member of the run we sum its value into the
+		   fold, advance the cursor, erase it from the outstanding map and
+		   recycle it inline — the same per-req lifecycle as before, except
+		   the whole run posts a single +N work item (below) instead of K.
+
+		   Recycling reqs that the fold's gdrcopy still covers is safe for
+		   the same reason the per-signal path could recycle an in-flight
+		   req: the worker captured the folded work by value, so the done
+		   entry's req pointer is never dereferenced (status travels by
+		   value). Cursor + map are fully advanced before we post, so the
+		   drain-spin inside hand_off_signal_work can re-enter retire
+		   without reprocessing this run. */
+		gin_signal_work_entry folded {};
+		ret = build_signal_work(req->metadata, folded);
 		if (OFI_UNLIKELY(ret != 0)) {
 			return ret;
 		}
-		if (req->gdrcopy_in_flight) {
-			req->gdrcopy_pool_return_deferred = true;
+		folded.signal_value = 0;
+
+		/* First pass: extend the run over consecutive same-slot ready
+		   signals, summing values and advancing the cursor / erasing /
+		   recycling each member EXCEPT the last (gate) req. The gate req
+		   stays live until after we post, so hand_off_signal_work can
+		   set its in-flight gate before it returns to the pool — matching
+		   the original mark-in-flight-then-recycle ordering. */
+		nccl_net_ofi_gin_iputsignal_recv_req *gate_req = req;
+		uint64_t gate_key = map_key;
+		uint16_t cur_seq = next_seq_num;
+		uint64_t cur_key = map_key;
+		auto *cur_req = req;
+
+		while (true) {
+			folded.signal_value += cur_req->metadata.signal_value;
+			ack_requested = ack_requested || cur_req->is_ack_requested;
+			rank_comm.rx_consumed = gin_cursor_inc(rank_comm.rx_consumed);
+			rank_comm.next_delivered_signal_seq_num =
+				(rank_comm.next_delivered_signal_seq_num + 1) & GIN_IMM_SEQ_MASK;
+
+			/* Peek the next consecutive seq; fold only if it is ready and
+			   hits the same slot. */
+			uint16_t peek_seq = (cur_seq + 1) & GIN_IMM_SEQ_MASK;
+			uint64_t peek_key = get_req_map_key(peer_rank, peek_seq);
+			auto peek_it = this->outstanding_iput_signal_recv_reqs.find(peek_key);
+			bool extend = peek_it != this->outstanding_iput_signal_recv_reqs.end();
+			nccl_net_ofi_gin_iputsignal_recv_req *peek_req = nullptr;
+			if (extend) {
+				peek_req = peek_it->second;
+				extend = peek_req->num_seg_completions == peek_req->total_segments &&
+					 peek_req->metadata_received &&
+					 !peek_req->gdrcopy_in_flight &&
+					 peek_req->gdrcopy_status == 0 &&
+					 peek_req->metadata.signal_base_address ==
+						 folded.signal_base_address &&
+					 peek_req->metadata.signal_offset == folded.signal_offset;
+			}
+
+			if (!extend) {
+				/* cur_req is the gate; leave it in the map + live and
+				   stop. */
+				gate_req = cur_req;
+				gate_key = cur_key;
+				break;
+			}
+
+			/* cur_req is an interior member: erase + recycle it now. */
+			size_t n_removed = this->outstanding_iput_signal_recv_reqs.erase(cur_key);
+			assert_always(n_removed == 1);
+			this->resources.return_req_to_pool(cur_req);
+
+			cur_seq = peek_seq;
+			cur_key = peek_key;
+			cur_req = peek_req;
+		}
+
+		/* Post the single folded +N work item, gated on the run's last
+		   req (its done entry re-runs retire for the whole run). The gate
+		   req is still in the map and live here. */
+		ret = hand_off_signal_work(folded, gate_req, peer_rank);
+		if (OFI_UNLIKELY(ret != 0)) {
+			return ret;
+		}
+
+		/* Now retire the gate req: erase + recycle, mirroring the original
+		   post-then-recycle for an in-flight req (benign: the worker holds
+		   the folded work by value). */
+		size_t n_removed = this->outstanding_iput_signal_recv_reqs.erase(gate_key);
+		assert_always(n_removed == 1);
+
+		/* If the worker still has the gate req's gdrcopy in flight, defer its
+		   return to the pool: the done entry will re-run retire and recycle it
+		   then. Otherwise (synchronous closing-path apply) recycle it now. */
+		if (gate_req->gdrcopy_in_flight) {
+			gate_req->gdrcopy_pool_return_deferred = true;
 			break;
 		}
-		this->resources.return_req_to_pool(req);
+
+		this->resources.return_req_to_pool(gate_req);
 	}
 
 	/* If the sender requested an ACK, emit a standalone ACK now. */

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -6,6 +6,7 @@
 
 #include <atomic>
 #include <cstring>
+#include <thread>
 
 #include "rdma/gin/nccl_ofi_gin.h"
 #include "rdma/gin/nccl_ofi_gin_api.h"
@@ -304,12 +305,40 @@ ncclResult_t nccl_ofi_gin_closeColl(void *collComm)
 		return nccl_net_ofi_retval_translate(ret);
 	}
 
-	/* Under ep_lock: drain any outbound ACK sends (their CQ handler
-	   references this comm), then atomically remove + delete so no new
-	   work can be dispatched to this comm in between. */
-	auto &ep_lock = gin_comm->get_ep_lock();
+	/* Phase 1 — quiesce the shared gdrcopy worker for this comm. The worker
+	   outlives every comm and is never joined here, so before we can free
+	   this comm we must guarantee it holds no work entry referencing it. We
+	   set `closing` (so the CQ-completion paths stop handing this comm new
+	   async work) and then drain outstanding_gdrcopy to zero WITHOUT calling
+	   progress(): the worker decrements autonomously as it finishes this
+	   comm's entries, and not calling progress() means no new entry can be
+	   enqueued and no synchronous apply can race the worker's r-m-w. The
+	   final drain after the count hits zero reaps the last done entry (frees
+	   its req and clears in_flight) — the release/acquire on the counter
+	   guarantees that last done push is visible to it. */
+	gin_comm->begin_closing();
 	while (true) {
-		std::lock_guard<std::mutex> lock(ep_lock);
+		std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
+		/* Drain first so we both pump the worker toward zero and reap the
+		   final done entry in the iteration that observes the count at zero. */
+		ret = gin_comm->drain_gdrcopy_done_queue();
+		if (OFI_UNLIKELY(ret != 0)) {
+			return nccl_net_ofi_retval_translate(ret);
+		}
+		if (!gin_comm->has_outstanding_gdrcopy()) {
+			break;
+		}
+		std::this_thread::yield();
+	}
+
+	/* Phase 2 — drain outbound ACK sends (their CQ handler references this
+	   comm), then atomically remove + delete. progress() here is now safe:
+	   `closing` routes any late inbound signal through the synchronous
+	   teardown apply (enqueue_gdrcopy_work), which never hands work to the
+	   worker, so outstanding_gdrcopy stays zero and the worker can never
+	   reference this comm again. */
+	while (true) {
+		std::lock_guard<std::mutex> lock(gin_comm->get_ep_lock());
 		if (gin_comm->has_outstanding_ack_sends()) {
 			ret = gin_comm->get_resources().progress();
 			if (OFI_UNLIKELY(ret != 0)) {


### PR DESCRIPTION
Move signal delivery to a single process-wide worker. The proxy threads feed it through the shared MPSC ring; the worker drains a batch, folds entries that target the same signal slot into one read- modify-write (signal adds commute, so the counter lands on the same value while saving N-1 PCIe round trips), and pushes one done entry per request into that comm's own SPSC done queue. The done queues stay per comm because their consumer is the owning proxy under its ep_lock, which is also what keeps per-(comm, peer) seq order intact.
Because the worker outlives every comm it cannot be joined at close. closeColl instead quiesces: it sets a closing flag so late completions apply synchronously on the proxy, drains the per-comm outstanding-gdrcopy count to zero without driving progress (the worker decrements as it finishes the comm's entries), reaps the final done entry, and only then frees the comm. That count reaching zero is the proof the worker holds no reference to the comm, which replaces the old per-comm join.

The same-slot fold also runs on the producer side before the worker handoff: when retire walks a run of consecutive ready signals hitting the same (base,offset) slot under strong ordering, it sums their increments and posts a single +N read-modify-write instead of N separate +1s. Only the run's last req carries the in-flight gate; its done entry re-runs retire for the whole run. rx_consumed/ACK timing is unchanged from the per-signal path (both advance before the async gdrcopy lands).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
