### PR TITLE
c++: Require c++20 in the plugin

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -61,8 +61,8 @@ AC_USE_SYSTEM_EXTENSIONS
 AC_PROG_CXX
 AC_LANG([C++])
 
-dnl use C++17, disable runtime type information
-AX_CXX_COMPILE_STDCXX([17], [noext], [mandatory])
+dnl use C++20, disable runtime type information
+AX_CXX_COMPILE_STDCXX([20], [noext], [mandatory])
 CXXFLAGS="${CXXFLAGS} -fno-rtti"
 
 AX_COMPILER_VENDOR

--- a/include/cm/nccl_ofi_cm_resources.h
+++ b/include/cm/nccl_ofi_cm_resources.h
@@ -34,6 +34,12 @@ public:
 		/* Default constructor */
 		mr_handle_t() = default;
 
+		/* Member-wise constructor. C++20 no longer treats a class with any
+		   user-declared constructor as an aggregate, so callers can no longer
+		   brace-initialize the members directly. */
+		mr_handle_t(ofi_mr_ptr mr_arg, uint64_t mr_key_arg, endpoint *ep_arg)
+			: mr(std::move(mr_arg)), mr_key(mr_key_arg), ep(ep_arg) {}
+
 		/* Move constructor and assignment */
 		mr_handle_t(mr_handle_t&&) = default;
 		mr_handle_t& operator=(mr_handle_t&&) = default;

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -79,7 +79,7 @@ gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 # kernel-only functional tests use common/device APIs and deliberately do not
 # include the CUDA host API.
 .cu.o:
-	$(NVCC) -std=c++17 $(NVCC_GENCODE) \
+	$(NVCC) -std=c++20 $(NVCC_GENCODE) \
 		-ccbin=$(MPICXX) \
 		-Xcompiler -fPIC \
 		-Xcompiler -Wno-error \


### PR DESCRIPTION
Bump the mandatory C++ standard from C++17 to C++20 in configure.ac and the CUDA compile rule in tests/functional/Makefile.am. Also add an explicit member-wise constructor to endpoint::mr_handle_t since in C++20 a class with any user-declared constructor is no longer an aggregate, so its members can no longer be brace-initialized directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
