### PR TITLE
trace: Add recv_idx and tag to receive tracepoints

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -919,7 +919,7 @@ public:
 				nccl_net_ofi_rdma_req **ret_req,
 				bool recv_completion_optional);
 	int drain_recv_eager_queue();
-	int handle_eager_recv(uint16_t msg_seq_num, nccl_net_ofi_rdma_req *rx_buff_req);
+	int handle_eager_recv(uint16_t msg_seq_num, nccl_net_ofi_rdma_req *rx_buff_req, uint16_t rail_id);
 	int eager_match_recv(nccl_net_ofi_rdma_req *recv_req, int32_t eager_tag);
 	int eager_copy_to_sub_recv(nccl_net_ofi_rdma_req *recv_req, nccl_net_ofi_rdma_req *rx_buff_req, int sub_idx);
 

--- a/include/nccl_ofi_tracepoint.h
+++ b/include/nccl_ofi_tracepoint.h
@@ -82,13 +82,13 @@
 	NCCL_OFI_TRACE_RECV_END_NVTX(request); \
 } while(0)
 
-#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, comm, size, request, msg_seq_num) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, comm, size, request, msg_seq_num); \
+#define NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(dev, rail_id, comm, size, request, msg_seq_num, recv_idx) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Recv_segment_complete, dev, rail_id, comm, size, request, msg_seq_num, recv_idx); \
 	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE_NVTX(dev, rail_id, size, request, msg_seq_num); \
 } while(0)
 
-#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num) do { \
-	lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num); \
+#define NCCL_OFI_TRACE_EAGER_RECV(dev, rail_id, comm, msg_seq_num, tag) do { \
+	lttng_ust_tracepoint(nccl_ofi_plugin, Eager_recv, dev, rail_id, comm, msg_seq_num, tag); \
 	NCCL_OFI_TRACE_EAGER_RECV_NVTX(dev, rail_id, comm, msg_seq_num); \
 } while(0)
 

--- a/include/tracing_impl/lttng.h
+++ b/include/tracing_impl/lttng.h
@@ -286,7 +286,8 @@ LTTNG_UST_TRACEPOINT_EVENT(
             void *, comm,
             size_t, size,
             void *, request,
-            uint16_t, msg_seq_num
+            uint16_t, msg_seq_num,
+            uint8_t, recv_idx
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
@@ -295,6 +296,7 @@ LTTNG_UST_TRACEPOINT_EVENT(
             lttng_ust_field_integer(size_t, size, size)
             lttng_ust_field_integer_hex(uint64_t, request, (uint64_t)request)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(uint8_t, recv_idx, recv_idx)
     )
 )
 
@@ -306,13 +308,15 @@ LTTNG_UST_TRACEPOINT_EVENT(
             int, dev,
             int, rail_id,
             void *, comm,
-            uint16_t, msg_seq_num
+            uint16_t, msg_seq_num,
+            uint32_t, tag
     ),
     LTTNG_UST_TP_FIELDS(
             lttng_ust_field_integer(int, dev, dev)
             lttng_ust_field_integer(int, rail_id, rail_id)
             lttng_ust_field_integer_hex(uint64_t, comm, (uint64_t)comm)
             lttng_ust_field_integer(uint16_t, msg_seq_num, msg_seq_num)
+            lttng_ust_field_integer(uint32_t, tag, tag)
     )
 )
 

--- a/include/tracing_impl/nvtx.h
+++ b/include/tracing_impl/nvtx.h
@@ -187,7 +187,7 @@ static inline void nvtx_end(nvtxRangeId_t id) {
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 	if (ofi_nccl_nvtx_trace_dimension() == NVTX_TRACE_DIMENSION::PER_DEV) { \
-		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(r_comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
+		handle = static_cast<nccl_net_ofi_rdma_ep_t *>(comm->ep.get())->rdma_endpoint_get_device()->nvtx_domain[rail_id]; \
 		nvtx_mark_domain(handle, "Eager_recv", 0x0000FF); \
 	} \
 } while(0)

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -1061,7 +1061,8 @@ int nccl_net_ofi_rdma_recv_comm::drain_recv_eager_queue()
  */
 int nccl_net_ofi_rdma_recv_comm::handle_eager_recv(
 					     uint16_t msg_seq_num,
-					     nccl_net_ofi_rdma_req *rx_buff_req)
+					     nccl_net_ofi_rdma_req *rx_buff_req,
+						 uint16_t rail_id)
 {
 	int ret;
 	nccl_net_ofi_rdma_ep_t *local_ep = (nccl_net_ofi_rdma_ep_t *)this->ep.get();
@@ -1101,6 +1102,9 @@ int nccl_net_ofi_rdma_recv_comm::handle_eager_recv(
 	new_entry->recv_len = rx_data->recv_len;
 	new_entry->handled = false;
 	recv_eager_sorted_insert(&this->recv_eager_list, new_entry);
+
+	NCCL_OFI_TRACE_EAGER_RECV(this->dev_id, rail_id, this, msg_seq_num,
+							eager_tag);
 
 	ret = this->drain_recv_eager_queue();
 
@@ -1202,10 +1206,7 @@ static inline int handle_rx_buff_recv(nccl_net_ofi_rdma_device_t *device, uint16
 			goto exit;
 		}
 
-		NCCL_OFI_TRACE_EAGER_RECV(r_comm->dev_id, rail_id, r_comm,
-					  GET_SEQ_NUM_FROM_IMM(cq_entry->data));
-
-		ret = r_comm->handle_eager_recv(GET_SEQ_NUM_FROM_IMM(cq_entry->data), rx_buff_req);
+		ret = r_comm->handle_eager_recv(GET_SEQ_NUM_FROM_IMM(cq_entry->data), rx_buff_req, rail_id);
 		if (OFI_UNLIKELY(ret != 0)) {
 			goto exit;
 		}
@@ -1290,7 +1291,7 @@ static inline int handle_write_comp(struct fi_cq_data_entry *cq_entry, nccl_net_
 		}
 	}
 
-	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(req->dev_id, rail_id, req->comm, cq_entry->len, req, req->msg_seq_num);
+	NCCL_OFI_TRACE_RECV_SEGMENT_COMPLETE(req->dev_id, rail_id, req->comm, cq_entry->len, req, req->msg_seq_num, recv_idx);
 
 	return 0;
 }


### PR DESCRIPTION
Add recv_idx to Recv_segment_complete and eager_tag to Eager_recv LTTng tracepoints for improved debugging of multi-rail receive completions.

Changes:
- Add recv_idx (uint8_t) field to Recv_segment_complete tracepoint
- Add tag (uint32_t) field to Eager_recv tracepoint
- Move NCCL_OFI_TRACE_EAGER_RECV into handle_eager_recv() where eager_tag is available
- Pass rail_id through to handle_eager_recv() for tracing context