### PR TITLE
 gin: enable GDAKI automatically, remove OFI_NCCL_GIN_TYPE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,20 +351,15 @@ AS_IF([test -e "${srcdir}/.git" -a -z "${enable_werror}"],
       [AC_MSG_NOTICE([Adding ${werror_flags} to CXXFLAGS.])
        CXXFLAGS="${werror_flags} ${CXXFLAGS} "])
 
-AC_ARG_ENABLE([gdaki],
-   [AS_HELP_STRING([--enable-gdaki],
-       [Build GDAKI (GPUDirect Async Kernel-Initiated) support for the GIN plugin. [default=no]])])
-AS_IF([test "${enable_gdaki}" = "yes"],
-      [AS_IF([test "${ac_cv_have_decl_FI_EFA_GDA_OPS}" != "yes"],
-             [AC_MSG_ERROR([--enable-gdaki requires a libfabric build with FI_EFA_GDA_OPS support (libfabric >= 2.3.0).])])
-       AS_IF([test "${have_device_interface}" != "cuda"],
-             [AC_MSG_ERROR([--enable-gdaki requires CUDA support.])])
-       AS_IF([test "${have_fi_efa_comp_cntr}" != "1"],
-             [AC_MSG_ERROR([--enable-gdaki requires libfabric with the fi_efa_ops_gda hardware-counter ABI (libfabric >= 2.5.0).])])
-       have_gdaki=1],
-      [have_gdaki=0])
+AS_IF([test "${ac_cv_have_decl_FI_EFA_GDA_OPS}" = "yes" \
+       && test "${have_fi_efa_comp_cntr}" = "1" \
+       && test "${have_device_interface}" = "cuda"],
+      [have_gdaki=1
+       AC_MSG_NOTICE([GDAKI support enabled (libfabric GDA ops + hw counters + CUDA present).])],
+      [have_gdaki=0
+       AC_MSG_NOTICE([GDAKI support disabled (requires libfabric >= 2.5 GDA ops + hw-counter ABI and CUDA); building proxy-only GIN.])])
 AC_DEFINE_UNQUOTED([HAVE_GDAKI], [${have_gdaki}], [Defined to 1 if GDAKI support is enabled])
-AM_CONDITIONAL([ENABLE_GDAKI], [test "${have_gdaki}" = "1"])
+AM_CONDITIONAL([HAVE_GDAKI], [test "${have_gdaki}" = "1"])
 
 AC_ARG_ENABLE([nccl-net-library],
       [AS_HELP_STRING([--disable-nccl-net-library],

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -65,7 +65,7 @@ noinst_HEADERS = \
 	tuner/nccl_ofi_tuner_region.h \
 	tuner/nccl_ofi_tuner_model.h
 
-if ENABLE_GDAKI
+if HAVE_GDAKI
 noinst_HEADERS += \
 	rdma/gin/nccl_ofi_gin_gdaki.h \
 	rdma/gin/nccl_ofi_gin_gdaki_dev.h \

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -375,20 +375,6 @@ OFI_NCCL_PARAM_VALUE_SET(NVTX_TRACE_DIMENSION, (PER_COMM)(PER_DEV))
 OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSION", NVTX_TRACE_DIMENSION::PER_COMM)
 
 /*
- * Selects the GIN plugin variant exported to NCCL.
- *
- *   PROXY: proxy-mode GIN (GDAKI disabled)
- *   GDAKI: kernel-initiated GDAKI mode; requires plugin built with
- *          --enable-gdaki
- *
- * Default is proxy mode. Setting this to GDAKI on a plugin built without
- * GDAKI support causes plugin init to fail with ncclInvalidUsage rather
- * than silently falling back.
- */
-OFI_NCCL_PARAM_VALUE_SET(GIN_TYPE, (PROXY)(GDAKI))
-OFI_NCCL_PARAM(GIN_TYPE, gin_type, "GIN_TYPE", GIN_TYPE::PROXY)
-
-/*
  * Enable strong-signal semantics for the GIN plugin.
  *
  * When true, completed requests are delivered to the application in

--- a/include/rdma/gin/nccl_ofi_gin_gdaki.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki.h
@@ -5,13 +5,42 @@
 #ifndef NCCL_OFI_GIN_GDAKI_H_
 #define NCCL_OFI_GIN_GDAKI_H_
 
+#include <cstring>
+
 #include "nccl_ofi.h"
+#include "nccl_ofi_api.h"
+#include "nccl_ofi_dmabuf.h"
 
 /*
- * The GDAKI plugin. Shared plugin APIs (declared in nccl_ofi_gin.h) are
- * assigned into this plugin at compile time; GDAKI-specific APIs live in
- * nccl_ofi_gin_gdaki.cpp.
+ * Whether GDAKI (kernel-initiated) mode can run in this environment.
+ *
+ * Returns true iff GDAKI is compiled in (HAVE_GDAKI) and the runtime
+ * environment can drive it: runtime libfabric >= 2.5, DMA-BUF viable, and
+ * the provider is an EFA provider (efa / efa-direct, the only provider
+ * family exposing FI_EFA_GDA_OPS). `prov` is the provider fi_info to check
+ * (e.g. a specific rail's); when omitted, the plugin's first device is used.
  */
-extern ncclGin_v13_t nccl_ofi_gin_gdaki_plugin;
+inline bool nccl_ofi_gin_gdaki_capable(const struct fi_info *prov = nullptr)
+{
+#if HAVE_GDAKI
+	if (prov == nullptr) {
+		nccl_net_ofi_plugin_t *plugin = nccl_net_ofi_get_plugin();
+		if (plugin != nullptr && plugin->get_num_devices() > 0 &&
+		    plugin->get_device(0) != nullptr) {
+			prov = plugin->get_device(0)->get_ofi_info();
+		}
+	}
+	if (prov == nullptr || prov->fabric_attr == nullptr ||
+	    prov->fabric_attr->prov_name == nullptr) {
+		return false;
+	}
+	return FI_VERSION_GE(fi_version(), FI_VERSION(2, 5)) &&
+	       nccl_ofi_dmabuf_viable() &&
+	       strncmp("efa", prov->fabric_attr->prov_name, strlen("efa")) == 0;
+#else
+	(void)prov;
+	return false;
+#endif
+}
 
 #endif /* NCCL_OFI_GIN_GDAKI_H_ */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -57,7 +57,7 @@ sources += \
 	rdma/gin/nccl_ofi_gin_api.cpp \
 	rdma/gin/nccl_ofi_gin_reqs.cpp \
 	rdma/gin/nccl_ofi_gin_resources.cpp
-if ENABLE_GDAKI
+if HAVE_GDAKI
 sources += \
 	rdma/gin/nccl_ofi_gin_gdaki.cpp \
 	rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -82,7 +82,7 @@ libinternal_plugin_la_SOURCES = $(sources)
 libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS) $(ROCM_LDFLAGS)
 libinternal_plugin_la_LIBADD  = $(CUDA_LIBS) $(ROCM_LIBS)
 
-if ENABLE_GDAKI
+if HAVE_GDAKI
 # TODO: Pinned efa-dp-direct submodule commit 81c4dc7 has a bug that causes a 
 # "sign-compare" error. To avoid relaxing the sign-compare compilation check
 # when building the entire OFI NCCL plugin library, we separately build a

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -7235,22 +7235,23 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 	get_hints(hints);
 	/*
 	 * Select libfabric API version.
-	 *   - GDAKI: hard requirements — CUDA, DMA-BUF, libfabric 2.5+.
+	 *   - GDAKI: requirements — HAVE_GDAKI, DMA-BUF, runtime libfabric 2.5+.
 	 *     The proxy domain opened here is reused by the GDAKI plugin,
 	 *     so the domain must be created with the 2.5 ABI to expose the
-	 *     EFA hardware-counter ops via fi_open_ops. Fail loudly if any
-	 *     prerequisite is missing.
+	 *     EFA hardware-counter ops via fi_open_ops. Fall back to proxy
+	 *     if any prerequisite is missing.
 	 *   - Proxy: 1.20 with DMA-BUF (FI_MR_DMABUF support), 1.18 otherwise.
+	 *
+	 * TODO: remove the GDAKI term here once the GDAKI plugin opens its own
+	 * domain (with its own MR registrations) instead of reusing the proxy
+	 * domain; the net plugin could then always request the proxy ABI.
 	 */
-	if (ofi_nccl_gin_type.get() == GIN_TYPE::GDAKI) {
-#if !HAVE_CUDA
-		NCCL_OFI_WARN("OFI_NCCL_GIN_TYPE=GDAKI set but plugin built without CUDA");
-		return -FI_EINVAL;
+	bool gdaki_usable = false;
+#if HAVE_GDAKI
+	gdaki_usable = FI_VERSION_GE(fi_version(), FI_VERSION(2, 5)) &&
+		       nccl_ofi_dmabuf_viable();
 #endif
-		if (!nccl_ofi_dmabuf_viable()) {
-			NCCL_OFI_WARN("OFI_NCCL_GIN_TYPE=GDAKI set but DMA-BUF is not viable");
-			return -FI_EINVAL;
-		}
+	if (gdaki_usable) {
 		api_version = FI_VERSION(2, 5);
 	} else {
 		api_version = nccl_ofi_dmabuf_viable() ? FI_VERSION(1, 20) : FI_VERSION(1, 18);

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -10,15 +10,9 @@
 #include "rdma/gin/nccl_ofi_gin.h"
 #include "rdma/gin/nccl_ofi_gin_api.h"
 #include "rdma/gin/nccl_ofi_gin_types.h"
-#if HAVE_GDAKI
-#include "rdma/gin/nccl_ofi_gin_gdaki.h"
-#endif
 #include "nccl_ofi.h"
 #include "nccl_ofi_api.h"
 #include "nccl_ofi_param.h"
-
-/* Forward declaration — defined at bottom of this file */
-extern ncclGin_v13_t ncclGinPlugin_v13;
 
 struct nccl_ofi_gin_context {
 	/* Per-init() sequence number used as endpoint cache key so that the
@@ -92,36 +86,6 @@ ncclResult_t nccl_ofi_gin_init(void **ctx, uint64_t commId, ncclDebugLogger_t lo
 	} catch (const std::exception &e) {
 		NCCL_OFI_WARN("Failed to allocate GIN context: %s", e.what());
 		return ncclSystemError;
-	}
-
-	/*
-	 * Choose the GIN plugin variant based on OFI_NCCL_GIN_TYPE.
-	 *   GIN_TYPE::PROXY: keep the default (proxy) plugin.
-	 *   GIN_TYPE::GDAKI: morph the exported v13 plugin to GDAKI.
-	 *
-	 * Shared plugin APIs are wired into nccl_ofi_gin_gdaki_plugin at
-	 * compile time, so to engage GDAKI we just overwrite the exported
-	 * symbol.
-	 *
-	 * If the user requested GDAKI but the plugin was built without
-	 * --enable-gdaki, fail init rather than silently falling back: GDAKI
-	 * was an explicit opt-in.
-	 */
-	switch (ofi_nccl_gin_type.get()) {
-	case GIN_TYPE::PROXY:
-		break;
-	case GIN_TYPE::GDAKI:
-#if HAVE_GDAKI
-		NCCL_OFI_INFO(NCCL_NET | NCCL_INIT,
-			      "gin: GDAKI mode enabled (OFI_NCCL_GIN_TYPE=GDAKI)");
-		memcpy(&ncclGinPlugin_v13, &nccl_ofi_gin_gdaki_plugin, sizeof(ncclGinPlugin_v13));
-		break;
-#else
-		NCCL_OFI_WARN("OFI_NCCL_GIN_TYPE=GDAKI requested but plugin "
-			      "was built without GDAKI support (configure with "
-			      "--enable-gdaki); failing init");
-		return ncclInvalidUsage;
-#endif
 	}
 
 	return ncclSuccess;

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -507,6 +507,21 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 		return ncclInvalidArgument;
 	}
 
+	/*
+	 * NCCL binds this op-table directly; there is no plugin-side mode
+	 * selection. This is the only capability gate on the GDAKI path —
+	 * verify here so failure is early and actionable rather than an
+	 * obscure cntr_open_ext error mid-setup.
+	 */
+	if (!nccl_ofi_gin_gdaki_capable()) {
+		NCCL_OFI_WARN(
+			"gin GDAKI: createContext on a non-GDA-capable "
+			"environment (requires an EFA provider, runtime "
+			"libfabric >= 2.5, and viable DMA-BUF); GDAKI is "
+			"unavailable here");
+		return ncclInvalidUsage;
+	}
+
 	NCCL_OFI_INFO(NCCL_NET,
 		      "gin GDAKI: createContext request: nSignals=%d nCounters=%d "
 		      "nContexts=%d queueDepth=%d",
@@ -1131,35 +1146,6 @@ static ncclResult_t nccl_ofi_gin_gdaki_queryLastError(void *ginCtx, bool *hasErr
 	*hasError = false;
 	return ncclSuccess;
 }
-
-/*
- * GDAKI plugin. Shared APIs are wired directly from nccl_ofi_gin_api.cpp;
- * GDAKI-specific ones above. iput/iputSignal/iget/iflush/test are nullptr —
- * no CPU involvement in GDAKI mode.
- */
-ncclGin_v13_t nccl_ofi_gin_gdaki_plugin = {
-	.name = "Libfabric_GDAKI",
-	.init = nccl_ofi_gin_init,
-	.devices = nccl_ofi_gin_devices,
-	.getProperties = nccl_ofi_gin_gdaki_get_properties,
-	.listen = nccl_ofi_gin_listen,
-	.connect = nccl_ofi_gin_connect,
-	.createContext = nccl_ofi_gin_gdaki_createContext,
-	.regMrSym = nccl_ofi_gin_gdaki_regMrSym,
-	.regMrSymDmaBuf = nccl_ofi_gin_gdaki_regMrSymDmaBuf,
-	.deregMrSym = nccl_ofi_gin_gdaki_deregMrSym,
-	.destroyContext = nccl_ofi_gin_gdaki_destroyContext,
-	.closeColl = nccl_ofi_gin_gdaki_closeColl,
-	.closeListen = nccl_ofi_gin_closeListen,
-	.iput = nullptr,
-	.iputSignal = nullptr,
-	.iget = nullptr,
-	.iflush = nullptr,
-	.test = nullptr,
-	.ginProgress = nccl_ofi_gin_ginProgress,
-	.queryLastError = nccl_ofi_gin_gdaki_queryLastError,
-	.finalize = nccl_ofi_gin_finalize
-};
 
 /* v14 GIN op-table: control-plane + device handle only (host data path is in
  * the RMA op-table). Exported as the GDAKI backend; built only with GDAKI. */

--- a/src/rdma/gin/nccl_ofi_gin_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_resources.cpp
@@ -6,6 +6,7 @@
 
 #include "rdma/gin/nccl_ofi_gin_resources.h"
 #include "rdma/gin/nccl_ofi_gin_reqs.h"
+#include "rdma/gin/nccl_ofi_gin_gdaki.h"
 
 #include "nccl_ofi_assert.h"
 #include <cstdlib>
@@ -336,25 +337,16 @@ static inline struct fi_info *get_gin_info(struct fi_info *info)
 	get_gin_hints(*gin_hints.get(), info);
 
 	/*
-	 * Select libfabric API version.
-	 *   - GDAKI: hard requirements — CUDA, DMA-BUF, libfabric 2.5+ (the
-	 *     hardware-counter ABI). Fail loudly if any prerequisite is
-	 *     missing rather than silently degrading.
-	 *   - Proxy: works on any libfabric >= 1.18; the GIN endpoint hints
-	 *     (FI_RX_CQ_DATA, cq_data_size = 4) don't use any 1.20+ features,
-	 *     so 1.18 is sufficient and avoids requesting a contract we don't
+	 * Select libfabric API version:
+	 *   - GDA-capable EFA provider (GDAKI compiled in, DMA-BUF viable): 2.5,
+	 *     the hardware-counter ABI the GDAKI plugin reuses via fi_open_ops.
+	 *   - Otherwise (non-EFA / tcp / proxy-only build): 1.18 is sufficient;
+	 *     the GIN endpoint hints (FI_RX_CQ_DATA, cq_data_size = 4) don't use
+	 *     any 1.20+ features, so we avoid requesting a contract we don't
 	 *     consume.
 	 */
 	uint32_t api_version;
-	if (ofi_nccl_gin_type.get() == GIN_TYPE::GDAKI) {
-#if !HAVE_CUDA
-		throw std::runtime_error(
-			"OFI_NCCL_GIN_TYPE=GDAKI set but plugin built without CUDA");
-#endif
-		if (!nccl_ofi_dmabuf_viable()) {
-			throw std::runtime_error(
-				"OFI_NCCL_GIN_TYPE=GDAKI set but DMA-BUF is not viable");
-		}
+	if (nccl_ofi_gin_gdaki_capable(info)) {
 		api_version = FI_VERSION(2, 5);
 	} else {
 		api_version = FI_VERSION(1, 18);

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -40,7 +40,7 @@ bin_PROGRAMS = nccl_connection nccl_message_transfer ring inflight_close reuse_l
 # it is not part of the CI functional run-list, so keep it out of the default
 # build: it is an EXTRA_PROGRAM, built on demand with `make gin_multiseg_signal`.
 EXTRA_PROGRAMS = gin_multiseg_signal
-if ENABLE_GDAKI
+if HAVE_GDAKI
 if HAVE_NVCC
 bin_PROGRAMS += gin_put_gdaki_gpu gin_signal_gdaki_gpu
 endif
@@ -65,7 +65,7 @@ gin_gdaki_misconfig_probe_SOURCES = $(base_sources) gin_gdaki_misconfig_probe.cp
 # nvcc -c (not -dc) fully resolves device code in the object file, so
 # no nvcc-driven device link step is required. -Wno-error works around
 # benign NCCL macro redefinitions that fire under -Werror.
-if ENABLE_GDAKI
+if HAVE_GDAKI
 if HAVE_NVCC
 SUFFIXES = .cu
 
@@ -92,7 +92,7 @@ gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 		$(MPI_CPPFLAGS) $(CUDA_CPPFLAGS) \
 		-c -o $@ $<
 endif # HAVE_NVCC
-endif # ENABLE_GDAKI
+endif # HAVE_GDAKI
 
 endif # ENABLE_FUNC_TESTS
 eager_multirecv_SOURCES = $(base_sources) eager_multirecv.cpp

--- a/tests/functional/gin_gdaki_misconfig_probe.cpp
+++ b/tests/functional/gin_gdaki_misconfig_probe.cpp
@@ -1,23 +1,15 @@
 /*
  * Copyright (c) 2026 Amazon.com, Inc. or its affiliates. All rights reserved.
  *
- * GDAKI misconfig probe.
+ * GDAKI build probe.
  *
- * Loads the plugin, calls extNet->init then extGin->init. Used to verify
- * that opting in to GDAKI (OFI_NCCL_GIN_TYPE=GDAKI) on a plugin built
- * without --enable-gdaki fails plugin init with ncclInvalidUsage rather
- * than silently falling back to the proxy path.
+ * Asserts that the exported GIN symbols match the build configuration:
+ *   - ncclGinPlugin_v13 (the proxy op-table) must always be present.
+ *   - ncclGinPlugin_v14 (the GDAKI op-table) must be present iff the plugin
+ *     was built with GDAKI support (HAVE_GDAKI), i.e. configure detected a
+ *     capable toolchain.
  *
- * Expected return codes:
- *   - GDAKI compiled in (HAVE_GDAKI=1):
- *       opt-in or not — extGin->init returns ncclSuccess (0)
- *   - GDAKI NOT compiled in AND OFI_NCCL_GIN_TYPE=GDAKI:
- *       extGin->init returns ncclInvalidUsage (5)
- *   - GDAKI NOT compiled in AND OFI_NCCL_GIN_TYPE unset/PROXY:
- *       extGin->init returns ncclSuccess (0)
- *
- * The probe runs as a single process (no MPI) — plugin init does not
- * require collective coordination.
+ * Pure symbol check (dlsym) — no plugin init, no MPI, no fabric required.
  */
 
 #include "config.h"
@@ -25,8 +17,7 @@
 #include "functional_test.h"
 
 #include <cstdio>
-#include <cstdlib>
-#include <cstring>
+#include <dlfcn.h>
 
 int main(int argc, char *argv[])
 {
@@ -34,63 +25,38 @@ int main(int argc, char *argv[])
 	(void)argv;
 
 	set_system_page_size();
-	auto *net_plugin_handle = load_netPlugin();
-	auto *extNet = get_netPlugin_symbol(net_plugin_handle);
-	auto *extGin = get_ginPlugin_symbol(net_plugin_handle);
-	if (!extNet || !extGin) {
-		fprintf(stderr, "probe: failed to load plugin symbols\n");
+	void *net_plugin_handle = load_netPlugin();
+	if (net_plugin_handle == nullptr) {
+		fprintf(stderr, "probe: failed to load plugin library\n");
 		return 1;
 	}
 
-	void *netCtx = nullptr;
-	ncclNetCommConfig_v11_t netConfig = {};
-	ncclResult_t net_rc = extNet->init(&netCtx, 0, &netConfig,
-					   &functional_test_logger, nullptr);
-	if (net_rc != ncclSuccess) {
-		fprintf(stderr, "probe: extNet->init returned %d\n", net_rc);
+	void *gin_v13 = dlsym(net_plugin_handle, "ncclGinPlugin_v13");
+	void *gin_v14 = dlsym(net_plugin_handle, "ncclGinPlugin_v14");
+
+	fprintf(stderr, "probe: HAVE_GDAKI=%d, ncclGinPlugin_v13=%s, ncclGinPlugin_v14=%s\n",
+		HAVE_GDAKI, gin_v13 ? "present" : "absent",
+		gin_v14 ? "present" : "absent");
+
+	if (gin_v13 == nullptr) {
+		fprintf(stderr, "probe: FAIL (proxy GIN op-table ncclGinPlugin_v13 missing)\n");
 		return 1;
 	}
 
-	void *ginCtx = nullptr;
-	ncclResult_t gin_rc = extGin->init(&ginCtx, 0, &functional_test_logger);
-
-	const char *opt_in = getenv("OFI_NCCL_GIN_TYPE");
-	bool requested = (opt_in != nullptr) && (strcasecmp(opt_in, "GDAKI") == 0);
-
-	fprintf(stderr,
-		"probe: HAVE_GDAKI=%d, OFI_NCCL_GIN_TYPE=%s, "
-		"extGin->init returned %d\n",
-		HAVE_GDAKI,
-		opt_in ? opt_in : "(unset)", gin_rc);
-
-	/* Validate the result against expectations. */
 #if HAVE_GDAKI
-	(void)requested;
-	if (gin_rc == ncclSuccess) {
-		fprintf(stderr, "probe: PASS (GDAKI compiled in, init succeeded)\n");
-		return 0;
+	if (gin_v14 == nullptr) {
+		fprintf(stderr, "probe: FAIL (built with GDAKI support but GDAKI "
+				"op-table ncclGinPlugin_v14 missing)\n");
+		return 1;
 	}
 #else
-	if (requested) {
-		if (gin_rc == ncclInvalidUsage) {
-			fprintf(stderr, "probe: PASS (GDAKI requested without "
-					"compile-time support, init refused with "
-					"ncclInvalidUsage)\n");
-			return 0;
-		}
-		fprintf(stderr, "probe: FAIL (expected ncclInvalidUsage=%d, "
-				"got %d)\n",
-			ncclInvalidUsage, gin_rc);
+	if (gin_v14 != nullptr) {
+		fprintf(stderr, "probe: FAIL (built without GDAKI support but GDAKI "
+				"op-table ncclGinPlugin_v14 exported)\n");
 		return 1;
-	} else {
-		if (gin_rc == ncclSuccess) {
-			fprintf(stderr, "probe: PASS (GDAKI not requested, "
-					"init succeeded in proxy mode)\n");
-			return 0;
-		}
 	}
 #endif
 
-	fprintf(stderr, "probe: FAIL (unexpected return code %d)\n", gin_rc);
-	return 1;
+	fprintf(stderr, "probe: PASS (exported GIN symbols match build configuration)\n");
+	return 0;
 }

--- a/tests/functional/gin_put_gdaki_gpu.cu
+++ b/tests/functional/gin_put_gdaki_gpu.cu
@@ -16,7 +16,7 @@
  * destination address is allgathered out-of-band over MPI to keep the
  * test free of plugin-internal mhandle reach-through.
  *
- * Run with at least 2 MPI ranks and OFI_NCCL_GIN_TYPE=GDAKI.
+ * Run with at least 2 MPI ranks on an EFA (GDA-capable) provider.
  */
 
 #include "functional_test.h"

--- a/tests/functional/gin_signal_gdaki_gpu.cu
+++ b/tests/functional/gin_signal_gdaki_gpu.cu
@@ -17,8 +17,9 @@
  * dev->signal_handles[i]->base.local_cntr_value is the FI_WRITE counter
  * (the sender sees this increment).
  *
- * Built only when configure finds nvcc (HAVE_NVCC) and --enable-gdaki.
- * Run with at least 2 MPI ranks and OFI_NCCL_GIN_TYPE=GDAKI.
+ * Built only when configure finds nvcc (HAVE_NVCC) and GDAKI support
+ * (HAVE_GDAKI). Run with at least 2 MPI ranks on an EFA (GDA-capable)
+ * provider.
  */
 
 #include "functional_test.h"


### PR DESCRIPTION
*Issue #, if available:*

GDAKI previously required both a build-time opt-in (--enable-gdaki) and a runtime opt-in (OFI_NCCL_GIN_TYPE=GDAKI). Users should not need to know about either: whether the kernel-initiated data path can run is a property of the toolchain, the runtime environment, and the selected provider — all discoverable by the plugin itself.

*Description of changes:*

Build time: drop the --enable-gdaki option. configure now enables GDAKI whenever the toolchain supports it (libfabric with the EFA GDA ops and hardware-counter ABI, i.e. >= 2.5, plus the CUDA device interface) and otherwise builds proxy-only GIN without error, following the same detect-and-compile-out pattern as libfabric's own HAVE_EFA_DATA_PATH_DIRECT. The automake conditional is renamed ENABLE_GDAKI -> HAVE_GDAKI to match (cf. HAVE_CUDA/HAVE_ROCM).

Runtime: remove the OFI_NCCL_GIN_TYPE parameter. GIN mode is selected per environment by a new predicate, nccl_ofi_gin_gdaki_capable(prov): true iff GDAKI is compiled in, the runtime libfabric is >= 2.5, DMA-BUF is viable, and the provider is an EFA provider (efa / efa-direct, the only family exposing FI_EFA_GDA_OPS). The fi_info argument is optional and defaults to the plugin's first device; the per-rail GIN endpoint path passes its own rail's fi_info. The predicate drives:

- nccl_net_ofi_rdma_init(): request the libfabric 2.5 ABI only when GDAKI is usable (the domain opened here is reused by the GDAKI plugin and must expose the hardware-counter ops via fi_open_ops); fall back to the 1.20/1.18 proxy ABI otherwise, including when the plugin was compiled against >= 2.5 headers but runs against an older libfabric.so.
- nccl_ofi_gin_init(): morph the exported v13 symbol to the GDAKI op-table when capable, else keep proxy. No error path remains: with no explicit opt-in to honor, an incapable environment simply runs proxy mode.
- GDAKI createContext: re-verify capability before allocating. NCCL v14 selects between the separately exported proxy and GDAKI op-tables itself, bypassing the v13 morph decision, so an incapable environment now fails init early with an actionable message instead of an obscure cntr_open_ext error mid-setup. This also fixes a live failure mode on master, where NCCL_GIN_TYPE=5 with OFI_NCCL_GIN_TYPE unset opened the domain at the 1.x ABI but still bound the GDAKI table, crashing in cntr_open_ext.

GIN over non-RDMA transports is unchanged: gin_init still refuses non-RDMA protocols (e.g. the tcp provider), and a GDAKI-capable build requesting the 2.5 ABI does not affect non-EFA providers, which never open the GDA ops.

The gin_gdaki_misconfig_probe functional test is repurposed: with no misconfiguration path left, it now asserts that GIN init succeeds in every configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
