### PR TITLE
ci: Update containers to use clang-19 for Ubuntu 24.04

### DIFF
--- a/.github/matrix-config.json
+++ b/.github/matrix-config.json
@@ -23,7 +23,7 @@
       ]
     },
     "ubuntu2404": {
-      "cc": ["gcc-13", "gcc-14", "clang-18"],
+      "cc": ["gcc-13", "gcc-14", "clang-18", "clang-19"],
       "tracing": ["lttng", "none"],
       "sdk": ["cuda", "neuron"]
     },

--- a/docker/base/Dockerfile.ubuntu2404
+++ b/docker/base/Dockerfile.ubuntu2404
@@ -30,7 +30,7 @@ RUN cc_family=`echo ${CC_TYPE} | awk -F'-' '{print $1}'` && \
     cc_version=`echo ${CC_TYPE} | awk -F'-' '{print $2}'` && \
     if [ "$cc_family" = "clang" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install -y \
-	    libc++-dev clang-${cc_version} lldb-${cc_version} lld-${cc_version} ; \
+	    libc++-${cc_version}-dev clang-${cc_version} lldb-${cc_version} lld-${cc_version} ; \
     elif [ "$cc_family" = "gcc" ]; then \
         DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-${cc_version} g++-${cc_version} ; \
     else \


### PR DESCRIPTION
Install libc++-${cc_version}-dev rather than the unversioned libc++-dev
 in the clang container: on Ubuntu 24.04 the unversioned package always
pulls libc++-18, so libc++ would not track the compiler version. Add clang-19 to the container-build matrix so the matching image is built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
