### PR TITLE
ci: Move the thread-safety analysis job to clang-19

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -192,6 +192,7 @@ jobs:
           - gcc-13
           - gcc-14
           - clang-18
+          - clang-19
         tracing:
           - lttng
           - nvtx
@@ -275,7 +276,7 @@ jobs:
     strategy:
       matrix:
         cc:
-          - clang-18
+          - clang-19
         tracing:
           - none
         sdk:


### PR DESCRIPTION
Move the thread-safety analysis job from clang-18 to clang-19, so the plugin is exercised against a newer libc++
(needed for std::atomic_ref, a libc++-19 feature).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
