### PR TITLE
Adding GIN FI_MORE Capability to proxy side on plugin

### DIFF
--- a/3rd-party/nccl/cuda/include/nccl/net.h
+++ b/3rd-party/nccl/cuda/include/nccl/net.h
@@ -59,5 +59,6 @@ typedef ncclResult_t (*ncclProfilerCallback_t)(void** eHandle, int type, void* p
 #include "gin_v13.h"
 
 #include "rma_v14.h"
+#include "rma_v15.h"
 
 #endif // end include guard

--- a/3rd-party/nccl/cuda/include/nccl/rma_v15.h
+++ b/3rd-party/nccl/cuda/include/nccl/rma_v15.h
@@ -1,0 +1,56 @@
+/*************************************************************************
+ * SPDX-FileCopyrightText: Copyright (c) 2017-2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See LICENSE.txt for more license information
+ *************************************************************************/
+
+#ifndef RMA_V15_H_
+#define RMA_V15_H_
+/* aws-ofi-nccl vendors net_v12.h (which defines ncclNetProperties_v12_t) and
+ * rma_v14.h (which defines ncclRmaConfig_v14_t); NCCL upstream includes
+ * nccl_net.h and rma/rma_v14.h here. */
+#include "net_v12.h"
+#include "rma_v14.h"
+
+typedef ncclRmaConfig_v14_t ncclRmaConfig_v15_t;
+
+// Flags passed via the optFlags argument of the RMA op-table entry points.
+enum ncclRmaOptFlags {
+  ncclRmaOptFlagsDefault = 0,
+  ncclRmaOptFlagsAggregateRequests = (1 << 0),
+};
+
+typedef struct {
+  const char* name;
+  ncclResult_t (*init)(void** ctx, uint64_t commId, ncclDebugLogger_t logFunction);
+  ncclResult_t (*devices)(int* ndev);
+  ncclResult_t (*getProperties)(int dev, ncclNetProperties_v12_t* props);
+  ncclResult_t (*listen)(void* ctx, int dev, void* handle, void** listenComm);
+  ncclResult_t (*connect)(void* ctx, void* handles[], int nranks, int rank, void* listenComm, void** collComm);
+  ncclResult_t (*createContext)(void* collComm, ncclRmaConfig_v15_t* config, void** rmaCtx);
+  ncclResult_t (*regMrSym)(void* collComm, void* data, size_t size, int type, uint64_t mrFlags, void** mhandle);
+  ncclResult_t (*regMrSymDmaBuf)(void* collComm, void* data, size_t size, int type, uint64_t offset, int fd,
+                                 uint64_t mrFlags, void** mhandle);
+  ncclResult_t (*deregMrSym)(void* collComm, void* mhandle);
+  ncclResult_t (*destroyContext)(void* rmaCtx);
+  ncclResult_t (*closeColl)(void* collComm);
+  ncclResult_t (*closeListen)(void* listenComm);
+
+  // optFlags carries ncclRmaOptFlags.
+  ncclResult_t (*iput)(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                       void* dstMhandle, uint32_t rank, uint32_t optFlags, void** request);
+  ncclResult_t (*iputSignal)(void* rmaCtx, int context, uint64_t srcOff, void* srcMhandle, size_t size, uint64_t dstOff,
+                             void* dstMhandle, uint32_t rank, uint64_t signalOff, void* signalMhandle,
+                             uint64_t signalValue, uint32_t signalOp, bool isStrongSignal, uint32_t optFlags,
+                             void** request);
+  ncclResult_t (*iget)(void* rmaCtx, int context, uint64_t remoteOff, void* remoteMhandle, size_t size,
+                       uint64_t localOff, void* localMhandle, uint32_t rank, uint32_t optFlags, void** request);
+
+  ncclResult_t (*iflush)(void* rmaCtx, int context, void* mhandle, uint32_t rank, void** request);
+  ncclResult_t (*test)(void* collComm, void* request, int* done);
+  ncclResult_t (*rmaProgress)(void* rmaCtx);
+  ncclResult_t (*queryLastError)(void* rmaCtx, bool* hasError);
+  ncclResult_t (*finalize)(void* ctx);
+} ncclRma_v15_t;
+#endif // end include guard

--- a/include/nccl_ofi_gin_base.h
+++ b/include/nccl_ofi_gin_base.h
@@ -76,6 +76,10 @@ public:
 
 	virtual int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) = 0;
 
+	/* optFlags is a bitmask of hints from the op-table caller. When the
+	 * aggregate-requests bit is set, more operations follow on this
+	 * (comm, rank), so the backend may defer the doorbell until a
+	 * non-aggregate operation. Backends that do not batch may ignore it. */
 	virtual int iputSignal(uint64_t srcOff,
 			       nccl_ofi_gin_symm_mr_handle_t *srcMhandle,
 			       size_t size, uint64_t dstOff,
@@ -83,12 +87,13 @@ public:
 			       uint32_t rank, uint64_t signalOff,
 			       nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
 			       uint64_t signalValue, uint32_t signalOp,
+			       uint32_t optFlags,
 			       nccl_ofi_gin_req_t **request) = 0;
 
 	virtual int iget(uint64_t remoteOff, nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
 			 size_t size, uint64_t localOff,
 			 nccl_ofi_gin_symm_mr_handle_t *localMhandle,
-			 uint32_t rank, nccl_ofi_gin_req_t **request) = 0;
+			 uint32_t rank, uint32_t optFlags, nccl_ofi_gin_req_t **request) = 0;
 
 	virtual int iflush(nccl_ofi_gin_symm_mr_handle_t *mhandle,
 			   uint32_t rank, nccl_ofi_gin_req_t **request) = 0;

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -576,11 +576,11 @@ public:
 	int iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size, uint64_t dstOff,
 		       nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t rank, uint64_t signalOff,
 		       nccl_ofi_gin_symm_mr_handle_t *signalMhandle, uint64_t signalValue, uint32_t signalOp,
-		       nccl_ofi_gin_req_t **request) override;
+		       uint32_t optFlags, nccl_ofi_gin_req_t **request) override;
 
 	int iget(uint64_t remoteOff, nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
 		 size_t size, uint64_t localOff, nccl_ofi_gin_symm_mr_handle_t *localMhandle,
-		 uint32_t rank, nccl_ofi_gin_req_t **request) override;
+		 uint32_t rank, uint32_t optFlags, nccl_ofi_gin_req_t **request) override;
 
 	/**
 	 * Fence prior iget operations to ensure data is visible locally.

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -655,6 +655,13 @@ private:
        int gdrcopy_cuda_dev = -1; /* CUDA device the worker binds to */
 
 	/* --- TIER 2: Receiver side — every CQ completion --- */
+	/* Rail pinned across an aggregated iputSignal sequence: when an op is
+	   posted with FI_MORE, the next op must reuse this rail to flush it.
+	   -1 means no pin (consult get_next_rail()). Guarded by ep_lock. */
+	int pinned_rail_id = -1;
+	/* Count of ops coalesced onto pinned_rail_id so far. The pin rotates to
+	   the next rail after GIN_REQS_PER_DOORBELL. Guarded by ep_lock. */
+	uint32_t pinned_rail_run = 0;
 	/* For each rail, direct-indexed table of fi_addr => peer comm rank.
 	 * Requires FI_AV_TABLE so that fi_addr_t values are dense 0-based
 	 * indices. Unused slots are set to UINT32_MAX as a sentinel. */
@@ -706,6 +713,14 @@ private:
 	 */
 	int send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, uint32_t peer_rank,
 		     uint32_t rx_consumed) REQUIRES(get_ep_lock());
+
+	/* Update the pinned-rail state after an op posted on `rail_id`:
+	   - deferring: this op kept its doorbell (FI_MORE); hold the rail and
+	     count it toward the rotation interval.
+	   - otherwise: this op rang its doorbell, so nothing is left deferred;
+	     release the pin (the next op re-pins on the scheduler's rail). */
+	void update_pin(bool defer, uint16_t rail_id)
+		REQUIRES(get_ep_lock());
 
 	/* Look up the signal's GDRCopy handle in mr_handle_map and fill `work`
 	   with everything the worker needs to apply the read-modify-write.

--- a/include/rdma/gin/nccl_ofi_gin_reqs.h
+++ b/include/rdma/gin/nccl_ofi_gin_reqs.h
@@ -455,9 +455,10 @@ public:
 					     nccl_ofi_freelist::fl_entry *metadata_elem_arg,
 					     fi_addr_t remote_addr_arg,
 					     nccl_ofi_freelist *metadata_fl_arg,
-					     void *comm_arg)
+					     void *comm_arg, uint64_t msg_flags = 0)
 	    : ep(ep_arg), rail_id(rail_id_arg), metadata_elem(metadata_elem_arg),
-	      remote_addr(remote_addr_arg), metadata_fl(metadata_fl_arg), comm(comm_arg)
+	      remote_addr(remote_addr_arg), metadata_fl(metadata_fl_arg), flags(msg_flags),
+	      comm(comm_arg)
 	{
 	}
 	int post() override;
@@ -473,6 +474,9 @@ private:
 	nccl_ofi_freelist::fl_entry *metadata_elem;
 	fi_addr_t remote_addr;
 	nccl_ofi_freelist *metadata_fl;
+	/* Flags for fi_sendmsg. On retry FI_MORE is dropped as the request
+	   must be handled immediately and should not remain pending. */
+	uint64_t flags;
 
 public:
 	/* Placed after private fields for cache locality with post() hot path above.

--- a/include/rdma/gin/nccl_ofi_gin_types.h
+++ b/include/rdma/gin/nccl_ofi_gin_types.h
@@ -100,6 +100,11 @@ static_assert((1ULL << GIN_RX_CONSUMED_BITS) == 2ULL * (GIN_IMM_SEQ_MASK + 1),
    producing an ACK storm rather than the slow drip the receiver needs
    to drain the bitset. */
 #define GIN_ACK_INTERVAL  64
+
+/* Max consecutive iputSignal ops coalesced onto one pinned rail before the pin
+ * rotates to the next rail (so no single rail is pinned indefinitely). The
+ * boundary op drops FI_MORE to flush the rail, then the pin advances. */
+#define GIN_REQS_PER_DOORBELL 16
 static_assert(GIN_ACK_INTERVAL <= (GIN_IMM_SEQ_MASK >> 1),
 	      "GIN_ACK_INTERVAL must be much smaller than the seq window so "
 	      "ack-request hysteresis does not delay drain past wrap");

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -552,9 +552,12 @@ static inline void clear_write_reqs_pending_back_pointers(
 int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size,
 				  uint64_t dstOff, nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t dst_rank,
 				  uint64_t signalOff, nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
-				  uint64_t signalValue, uint32_t signalOp,
+				  uint64_t signalValue, uint32_t signalOp, uint32_t optFlags,
 				  nccl_ofi_gin_req_t **request)
 {
+	/* optFlags carries ncclRmaOptFlags from the v15 RMA op-table. The aggregate
+	   hint is honored in a later change; threaded through here behavior-neutral. */
+	(void)optFlags;
 	auto *src_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(srcMhandle);
 	auto *dst_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(dstMhandle);
 	auto *sig_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(signalMhandle);
@@ -790,8 +793,10 @@ int nccl_ofi_rdma_gin_put_comm::iget(uint64_t remoteOff,
 				      nccl_ofi_gin_symm_mr_handle_t *remoteMhandle,
 				      size_t size, uint64_t localOff,
 				      nccl_ofi_gin_symm_mr_handle_t *localMhandle,
-				      uint32_t dst_rank, nccl_ofi_gin_req_t **request)
+				      uint32_t dst_rank, uint32_t optFlags, nccl_ofi_gin_req_t **request)
 {
+	/* iget uses fi_read — not part of the FI_MORE write-doorbell path. */
+	(void)optFlags;
 	auto *remote_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(remoteMhandle);
 	auto *local_mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(localMhandle);
 	auto &gin_ep = resources.get_ep();

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -549,15 +549,32 @@ static inline void clear_write_reqs_pending_back_pointers(
 	}
 }
 
+void nccl_ofi_rdma_gin_put_comm::update_pin(bool defer, uint16_t rail_id)
+{
+	if (defer) {
+		/* This op withheld its doorbell (FI_MORE) on rail_id. Hold the
+		   rail so the next op batches onto it, and count it toward the
+		   rotation interval. */
+		pinned_rail_id = static_cast<int>(rail_id);
+		pinned_rail_run++;
+	} else {
+		/* This op rang its doorbell, so nothing is left deferred on the
+		   pinned rail. Release the pin: the next op starts a fresh batch
+		   on whatever rail the scheduler hands it. This keeps the
+		   invariant that an open pin always means a waiting doorbell. */
+		pinned_rail_id = -1;
+		pinned_rail_run = 0;
+	}
+}
+
 int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr_handle_t *srcMhandle, size_t size,
 				  uint64_t dstOff, nccl_ofi_gin_symm_mr_handle_t *dstMhandle, uint32_t dst_rank,
 				  uint64_t signalOff, nccl_ofi_gin_symm_mr_handle_t *signalMhandle,
 				  uint64_t signalValue, uint32_t signalOp, uint32_t optFlags,
 				  nccl_ofi_gin_req_t **request)
 {
-	/* optFlags carries ncclRmaOptFlags from the v15 RMA op-table. The aggregate
-	   hint is honored in a later change; threaded through here behavior-neutral. */
-	(void)optFlags;
+	/* NCCL's hint that more ops for this peer follow (see the defer decision below). */
+	const bool aggregate = (optFlags & ncclRmaOptFlagsAggregateRequests) != 0;
 	auto *src_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(srcMhandle);
 	auto *dst_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(dstMhandle);
 	auto *sig_mr = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(signalMhandle);
@@ -573,10 +590,9 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	uint16_t msg_seq_num = rank_comm.tx_head & GIN_IMM_SEQ_MASK;
 	uint32_t remote_comm_id = rank_comm.comm_id;
 	auto scheduler = gin_ep.get_scheduler();
-	/* rail_id for metadata send is determined below: either from the
-	   scheduler's first write rail (for coalescing) or from
-	   get_next_rail() when there is no data to coalesce with. */
-	uint16_t rail_id = 0;
+	/* Rail for this op's write(s) and metadata send; assigned in the
+	   size branch below (both size>0 and signal-only paths set it). */
+	uint16_t rail_id;
 
 	/* Wait for a free slot in the TX window if full. */
 	{
@@ -605,12 +621,35 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		}
 	}
 
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+	std::lock_guard<std::mutex> scoped_ep_lock(get_ep_lock());
 
 	if (is_ack_requested) {
 		rank_comm.last_ack_requested_seq = rank_comm.tx_head;
 		rank_comm.has_pending_ack_request = true;
 	}
+
+	/* Two flags drive doorbell coalescing; both set in the size branch below.
+
+	     aggregate  NCCL's per-op hint that another op for this peer is already
+	                queued, so batching this op's doorbell is worthwhile.
+	                (Derived from optFlags at the top of the function.)
+
+	     defer      This op withholds its doorbell (posts FI_MORE) so a later
+	                op on the pinned rail rings it. Set for a single-stripe op
+	                that is aggregating, EXCEPT on the rotation-boundary op
+	                (every GIN_REQS_PER_DOORBELL) which rings instead, to
+	                flush the rail so the pin can move to a fresh rail.
+
+	   A single-stripe op also rides the open pinned rail (if any) so its
+	   doorbell batches with the ops already queued there. A multi-stripe
+	   (large) op never defers or pins: it stripes across all rails and rings
+	   each one.
+
+	   No hang: defer implies aggregate, and NCCL ends every batch with a
+	   non-aggregate op. That op does not defer and is forced onto the pinned
+	   rail, so it rings the deferred doorbell. The rotation boundary is a
+	   second flush point. */
+	bool defer = false;
 
 	/* Determine how many segments to send */
 	uint16_t nseg = 0;
@@ -639,64 +678,105 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 	NCCL_OFI_TRACE_GIN_IPUT_SIGNAL_BEGIN(dev, size, this, dst_rank, msg_seq_num, req);
 
 	if (OFI_LIKELY(size > 0)) {
-		/* Post write-immediate request with user data */
 		void *src = static_cast<uint8_t *>(src_mr->input_address) + srcOff;
 		auto *src_mhandle = src_mr->local_handle;
-
-		const auto schedule =
-			scheduler->get_schedule(size, gin_ep.get_num_rails());
-		auto &xfers = schedule->rail_xfer_infos;
-
-		nseg += schedule->num_xfer_infos;
-		assert_always(nseg > 0);
-
-		uint64_t data = GIN_IMM_SEG_DATA(remote_comm_id, msg_seq_num, nseg, is_ack_requested);
-
 		auto &dest_remote_mr = dst_mr->remote_mr[dst_rank];
 		uint64_t dest = dest_remote_mr.address_offset + dstOff;
-		int wr_it = 0;
 
-		/* When sending both data and metadata (put+signal), colocate
-		 * the first write and the metadata send on the same rail.
-		 * The first write is posted with FI_MORE to hint the provider
-		 * that more operations follow on this EP, enabling doorbell
-		 * coalescing (single PCIe doorbell for write + send). */
+		/* Let the scheduler lay out the stripes. A multi-stripe (large) message
+		   stripes across rails and never defers; a single-stripe (small)
+		   message may ride one pinned rail when aggregating (or when a pin
+		   is already open). */
+		nccl_net_ofi_schedule_t *schedule =
+			scheduler->get_schedule(size, gin_ep.get_num_rails());
+		if (OFI_UNLIKELY(schedule == nullptr)) {
+			clear_write_reqs_pending_back_pointers(write_reqs);
+			resources.return_req_to_pool(req);
+			return -ENOMEM;
+		}
+		nccl_net_ofi_xfer_info_t *xfers = schedule->rail_xfer_infos;
+		uint16_t num_xfers = schedule->num_xfer_infos;
+
+		if (num_xfers == 1 && pinned_rail_id >= 0) {
+			/* A pin is open: a prior op left a deferred (un-rung)
+			   doorbell on pinned_rail_id. Land this single-stripe op on
+			   that same rail so the batch continues and the eventual
+			   non-deferring op (the rotation boundary, or the app
+			   clearing the aggregate hint) flushes it there; otherwise
+			   the scheduler would round-robin us elsewhere and strand
+			   the pinned rail. Overwriting xfers[0] is safe: num_xfers
+			   == 1, so there is no second stripe to collide with here. */
+			xfers[0].rail_id = static_cast<uint16_t>(pinned_rail_id);
+		} else if (num_xfers > 1 && pinned_rail_id >= 0) {
+			/* A multi-stripe op ran while a pin was open. It does not
+			   defer, so update_pin() releases the pin below; the pinned
+			   rail's deferred doorbell must be rung now or it strands. A
+			   striped op rings a doorbell on every rail it touches -- but
+			   with num_stripes < num_rails it may not touch pinned_rail_id.
+			   If so, redirect one stripe onto it (stripes carry distinct
+			   rails, so this only swaps a rail, never doubles one). */
+			bool touches_pin = false;
+			for (uint16_t i = 0; i < num_xfers; i++) {
+				if (xfers[i].rail_id == pinned_rail_id) {
+					touches_pin = true;
+					break;
+				}
+			}
+			if (!touches_pin) {
+				xfers[0].rail_id = static_cast<uint16_t>(pinned_rail_id);
+			}
+		}
+		defer = (num_xfers == 1) && aggregate &&
+			(pinned_rail_run + 1 < GIN_REQS_PER_DOORBELL);
+
+		nseg += num_xfers;
+		assert_always(nseg > 0);
+		uint64_t data = GIN_IMM_SEG_DATA(remote_comm_id, msg_seq_num, nseg, is_ack_requested);
+
+		/* The metadata send (if any) colocates with the first stripe's rail. */
 		rail_id = xfers[0].rail_id;
 
-		for (uint16_t rail_it = 0; rail_it < schedule->num_xfer_infos; rail_it++) {
+		for (uint16_t rail_it = 0; rail_it < num_xfers; rail_it++) {
 			nccl_net_ofi_xfer_info_t *xfer_info = &xfers[rail_it];
-			void *desc = fi_mr_desc(src_mhandle->get_mr(xfer_info->rail_id));
+			const uint16_t rail = xfer_info->rail_id;
+			void *desc = fi_mr_desc(src_mhandle->get_mr(rail));
 
-			/* Set FI_MORE on the first write when it shares a rail
-			 * with the subsequent metadata send */
+			/* FI_MORE defers this rail's doorbell: for the first stripe of a
+			   put+signal (the metadata send that follows flushes it), or while
+			   deferring, to batch with the next op on the pinned rail. A striped
+			   op never defers, so it rings per stripe. */
 			uint64_t wr_flags = FI_REMOTE_CQ_DATA;
-			if (has_signal && rail_it == 0)
+			if ((has_signal && rail_it == 0) || defer)
 				wr_flags |= FI_MORE;
 
 			auto write_req = resources.get_req_from_pool<nccl_net_ofi_gin_write_req_t>(
-				gin_ep.get_rail(xfer_info->rail_id).ofi_ep.get(),
+				gin_ep.get_rail(rail).ofi_ep.get(),
 				(void *)((uintptr_t)src + xfer_info->offset), xfer_info->msg_size,
-				desc, data, rank_comm.address[xfer_info->rail_id],
-				dest + xfer_info->offset, dest_remote_mr.mr_key[xfer_info->rail_id],
+				desc, data, rank_comm.address[rail],
+				dest + xfer_info->offset, dest_remote_mr.mr_key[rail],
 				this, wr_flags);
 
-			write_req->pending_flag = &(req->reqs_pending[wr_it]);
+			write_req->pending_flag = &(req->reqs_pending[rail_it]);
 #if HAVE_NVTX_TRACING || HAVE_LIBLTTNG_UST
 			write_req->set_info(dev, dst_rank, msg_seq_num);
 #endif
-			req->reqs_pending[wr_it] = true;
-			write_reqs[wr_it++] = write_req;
+			req->reqs_pending[rail_it] = true;
+			write_reqs[rail_it] = write_req;
 
-			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, xfer_info->rail_id, xfer_info->msg_size,
-						       this, dst_rank, msg_seq_num, write_req);
+			NCCL_OFI_TRACE_GIN_WRITE_BEGIN(dev, rail, xfer_info->msg_size, this,
+						       dst_rank, msg_seq_num, write_req);
 			ret = write_req->post();
 			if (OFI_UNLIKELY(ret != 0)) {
 				if (ret == -FI_EAGAIN) {
+					/* SQ full: queue for retry (FI_MORE dropped on retry). */
 					resources.add_pending_req(write_req);
-					ret = 0;
-					break;
+					continue;
 				}
 				NCCL_OFI_WARN("Write failed for seq_num %hu", msg_seq_num);
+				/* Drop our slot's back-pointer before returning the req to
+				   the pool, so clear_write_reqs_pending_back_pointers() below
+				   does not write through a pooled pointer. */
+				write_reqs[rail_it] = nullptr;
 				resources.return_req_to_pool(write_req);
 				nccl_net_ofi_release_schedule(scheduler, schedule);
 				clear_write_reqs_pending_back_pointers(write_reqs);
@@ -706,7 +786,12 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 		}
 		nccl_net_ofi_release_schedule(scheduler, schedule);
 	} else {
-		rail_id = resources.get_next_rail();
+		/* Signal-only: no data write, inherently single rail (pin-eligible). */
+		rail_id = (pinned_rail_id >= 0)
+			? static_cast<uint16_t>(pinned_rail_id)
+			: resources.get_next_rail();
+		defer = aggregate &&
+			(pinned_rail_run + 1 < GIN_REQS_PER_DOORBELL);
 	}
 
 	if (has_signal) {
@@ -740,13 +825,15 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 			metadata_send->signal_value = 0;
 		}
 
-		/* This send flushes the QP work queue on the first rail,
-		   issuing a doorbell that includes the coalesced writedata
-		   WQE posted with FI_MORE above. */
+		/* Rings the pinned write's doorbell too -- unless this op is
+		   deferring, in which case the send is also deferred and flushed
+		   by a later op on this rail. */
+		const bool defer_doorbell = defer;
 		nccl_net_ofi_gin_metadata_send_req_t *send_req;
 		send_req = resources.get_req_from_pool<nccl_net_ofi_gin_metadata_send_req_t>(
 			gin_ep.get_rail(rail_id).ofi_ep.get(), rail_id, metadata_elem,
-			rank_comm.address[rail_id], metadata_fl.get(), this);
+			rank_comm.address[rail_id], metadata_fl.get(), this,
+			defer_doorbell ? (uint64_t)FI_MORE : 0);
 
 		NCCL_OFI_TRACE_GIN_METADATA_SEND_BEGIN(dev, rail_id, sizeof(nccl_net_ofi_gin_signal_metadata_msg_t), this, dst_rank, msg_seq_num,
 						       send_req);
@@ -769,6 +856,8 @@ int nccl_ofi_rdma_gin_put_comm::iputSignal(uint64_t srcOff, nccl_ofi_gin_symm_mr
 #endif
 		req->reqs_pending[MAX_NUM_RAILS] = true;
 	}
+
+	update_pin(defer, rail_id);
 
 	rank_comm.tx_head = gin_cursor_inc(rank_comm.tx_head);
 

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -648,9 +648,7 @@ static ncclResult_t nccl_ofi_rma_regMrSymDmaBuf_v14(void *collComm, void *data, 
 					   &unusedGinHandle);
 }
 
-/* v14 iputSignal adds a trailing isStrongSignal hint. The plugin does not
- * consult it: signal ordering is selected per-comm at construction from
- * OFI_NCCL_GIN_STRONG_SIGNAL (see strong_signal_ordering_enabled), not per op. */
+/* v14 iputSignal adds a trailing isStrongSignal; the plugin's signals are always strong. */
 static ncclResult_t nccl_ofi_rma_iputSignal_v14(void *rmaCtx, int context, uint64_t srcOff,
 						void *srcMhandle, size_t size, uint64_t dstOff,
 						void *dstMhandle, uint32_t rank, uint64_t signalOff,
@@ -712,8 +710,7 @@ static ncclResult_t nccl_ofi_rma_iputSignal_v15(void *rmaCtx, int context, uint6
 						uint32_t optFlags, void **request)
 {
 	(void)context;
-	/* Signal ordering is selected per-comm from OFI_NCCL_GIN_STRONG_SIGNAL, not
-	   from NCCL's per-op isStrongSignal hint (same as v14). */
+	/* v15 iputSignal adds a trailing isStrongSignal; the plugin's signals are always strong. */
 	(void)isStrongSignal;
 	return nccl_ofi_gin_iputSignal(rmaCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
 				       signalOff, signalMhandle, signalValue, signalOp, optFlags,

--- a/src/rdma/gin/nccl_ofi_gin_api.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_api.cpp
@@ -370,7 +370,8 @@ static ncclResult_t nccl_ofi_gin_test(void *collComm, void *request, int *done)
 static ncclResult_t nccl_ofi_gin_iputSignal(void *collComm, uint64_t srcOff, void *srcMhandle,
 					    size_t size, uint64_t dstOff, void *dstMhandle,
 					    uint32_t rank, uint64_t signalOff, void *signalMhandle,
-					    uint64_t signalValue, uint32_t signalOp, void **request)
+					    uint64_t signalValue, uint32_t signalOp, uint32_t optFlags,
+					    void **request)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	auto *src_mr_handle = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(srcMhandle);
@@ -379,7 +380,8 @@ static ncclResult_t nccl_ofi_gin_iputSignal(void *collComm, uint64_t srcOff, voi
 
 	nccl_ofi_gin_req_t *req = nullptr;
 	int ret = gin_comm->iputSignal(srcOff, src_mr_handle, size, dstOff, dst_mr_handle, rank,
-				       signalOff, signal_mr_handle, signalValue, signalOp, &req);
+				       signalOff, signal_mr_handle, signalValue, signalOp, optFlags,
+				       &req);
 	if (ret != 0) {
 		return nccl_net_ofi_retval_translate(ret);
 	}
@@ -390,24 +392,24 @@ static ncclResult_t nccl_ofi_gin_iputSignal(void *collComm, uint64_t srcOff, voi
 
 static ncclResult_t nccl_ofi_gin_iput(void *collComm, uint64_t srcOff, void *srcMhandle,
 				      size_t size, uint64_t dstOff, void *dstMhandle, uint32_t rank,
-				      void **request)
+				      uint32_t optFlags, void **request)
 {
 	/* Currently, due to ordering requirements, iput is just implemented as an
 	   iputSignal with a zero'd signal address (instead of a write-without-immediate) */
 	return nccl_ofi_gin_iputSignal(collComm, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
-				       0, nullptr, 0, 0, request);
+				       0, nullptr, 0, 0, optFlags, request);
 }
 
 static ncclResult_t nccl_ofi_gin_iget(void *collComm, uint64_t remoteOff, void *remoteMhandle,
 				      size_t size, uint64_t localOff, void *localMhandle,
-				      uint32_t rank, void **request)
+				      uint32_t rank, uint32_t optFlags, void **request)
 {
 	auto *gin_comm = static_cast<nccl_ofi_rdma_gin_put_comm *>(collComm);
 	auto *remote_mr = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(remoteMhandle);
 	auto *local_mr = static_cast<nccl_ofi_gin_symm_mr_handle_t *>(localMhandle);
 
 	nccl_ofi_gin_req_t *req = nullptr;
-	int ret = gin_comm->iget(remoteOff, remote_mr, size, localOff, local_mr, rank, &req);
+	int ret = gin_comm->iget(remoteOff, remote_mr, size, localOff, local_mr, rank, optFlags, &req);
 	if (ret != 0) {
 		return nccl_net_ofi_retval_translate(ret);
 	}
@@ -505,7 +507,7 @@ static ncclResult_t nccl_ofi_gin_iput_v13(void *ginCtx, int context, uint64_t sr
 					  void *dstMhandle, uint32_t rank, void **request)
 {
 	return nccl_ofi_gin_iput(ginCtx, srcOff, srcMhandle, size,
-				 dstOff, dstMhandle, rank, request);
+				 dstOff, dstMhandle, rank, /*optFlags*/ 0, request);
 }
 
 static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint64_t srcOff,
@@ -516,7 +518,7 @@ static ncclResult_t nccl_ofi_gin_iputSignal_v13(void *ginCtx, int context, uint6
 {
 	return nccl_ofi_gin_iputSignal(ginCtx, srcOff, srcMhandle, size,
 				       dstOff, dstMhandle, rank, signalOff, signalMhandle,
-				       signalValue, signalOp, request);
+				       signalValue, signalOp, /*optFlags*/ 0, request);
 }
 
 static ncclResult_t nccl_ofi_gin_iget_v13(void *ginCtx, int context, uint64_t remoteOff,
@@ -524,7 +526,7 @@ static ncclResult_t nccl_ofi_gin_iget_v13(void *ginCtx, int context, uint64_t re
 					  void *localMhandle, uint32_t rank, void **request)
 {
 	return nccl_ofi_gin_iget(ginCtx, remoteOff, remoteMhandle, size,
-				 localOff, localMhandle, rank, request);
+				 localOff, localMhandle, rank, /*optFlags*/ 0, request);
 }
 
 static ncclResult_t nccl_ofi_gin_iflush_v13(void *ginCtx, int context, void *mhandle,
@@ -541,6 +543,24 @@ static ncclResult_t nccl_ofi_gin_iflush_v13(void *ginCtx, int context, void *mha
 
 	*request = req;
 	return ncclSuccess;
+}
+
+/* The v11 GIN op-table has no optFlags argument; forward the default (0). */
+static ncclResult_t nccl_ofi_gin_iput_v11(void *collComm, uint64_t srcOff, void *srcMhandle, size_t size,
+					  uint64_t dstOff, void *dstMhandle, uint32_t rank, void **request)
+{
+	return nccl_ofi_gin_iput(collComm, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
+				 /*optFlags*/ 0, request);
+}
+
+static ncclResult_t nccl_ofi_gin_iputSignal_v11(void *collComm, uint64_t srcOff, void *srcMhandle,
+						size_t size, uint64_t dstOff, void *dstMhandle,
+						uint32_t rank, uint64_t signalOff, void *signalMhandle,
+						uint64_t signalValue, uint32_t signalOp, void **request)
+{
+	return nccl_ofi_gin_iputSignal(collComm, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
+				       signalOff, signalMhandle, signalValue, signalOp,
+				       /*optFlags*/ 0, request);
 }
 
 NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
@@ -562,8 +582,8 @@ NCCL_OFI_EXPORT_SYMBOL ncclGin_v11_t ncclGinPlugin_v11 = {
 	.destroyContext = nullptr,
 	.closeColl = nccl_ofi_gin_closeColl,
 	.closeListen = nccl_ofi_gin_closeListen,
-	.iput = nccl_ofi_gin_iput,
-	.iputSignal = nccl_ofi_gin_iputSignal,
+	.iput = nccl_ofi_gin_iput_v11,
+	.iputSignal = nccl_ofi_gin_iputSignal_v11,
 	.test = nccl_ofi_gin_test,
 	.ginProgress = nccl_ofi_gin_ginProgress,
 	/* Not used by NCCL in proxy mode */
@@ -628,7 +648,9 @@ static ncclResult_t nccl_ofi_rma_regMrSymDmaBuf_v14(void *collComm, void *data, 
 					   &unusedGinHandle);
 }
 
-/* v14 iputSignal adds a trailing isStrongSignal; the plugin's signals are always strong. */
+/* v14 iputSignal adds a trailing isStrongSignal hint. The plugin does not
+ * consult it: signal ordering is selected per-comm at construction from
+ * OFI_NCCL_GIN_STRONG_SIGNAL (see strong_signal_ordering_enabled), not per op. */
 static ncclResult_t nccl_ofi_rma_iputSignal_v14(void *rmaCtx, int context, uint64_t srcOff,
 						void *srcMhandle, size_t size, uint64_t dstOff,
 						void *dstMhandle, uint32_t rank, uint64_t signalOff,
@@ -660,6 +682,73 @@ NCCL_OFI_EXPORT_SYMBOL ncclRma_v14_t ncclRmaPlugin_v14 = {
 	.iput = nccl_ofi_gin_iput_v13,
 	.iputSignal = nccl_ofi_rma_iputSignal_v14,
 	.iget = nccl_ofi_gin_iget_v13,
+	.iflush = nccl_ofi_gin_iflush_v13,
+	.test = nccl_ofi_gin_test,
+	.rmaProgress = nccl_ofi_gin_ginProgress,
+	.queryLastError = nullptr,
+	.finalize = nccl_ofi_gin_finalize
+};
+
+/* RMA v15 export. Extends v14 by carrying optFlags (ncclRmaOptFlags) end-to-end so the
+ * caller's ncclRmaOptFlagsAggregateRequests hint reaches the doorbell-coalescing path.
+ * createContext/regMrSym/regMrSymDmaBuf are unchanged from v14 (ncclRmaConfig_v15_t is a
+ * typedef of ncclRmaConfig_v14_t), so those wrappers are reused directly. */
+static ncclResult_t nccl_ofi_rma_iput_v15(void *rmaCtx, int context, uint64_t srcOff,
+					  void *srcMhandle, size_t size, uint64_t dstOff,
+					  void *dstMhandle, uint32_t rank, uint32_t optFlags,
+					  void **request)
+{
+	(void)context;
+	/* Forward optFlags into the doorbell-coalescing path. */
+	return nccl_ofi_gin_iput(rmaCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
+				 optFlags, request);
+}
+
+static ncclResult_t nccl_ofi_rma_iputSignal_v15(void *rmaCtx, int context, uint64_t srcOff,
+						void *srcMhandle, size_t size, uint64_t dstOff,
+						void *dstMhandle, uint32_t rank, uint64_t signalOff,
+						void *signalMhandle, uint64_t signalValue,
+						uint32_t signalOp, bool isStrongSignal,
+						uint32_t optFlags, void **request)
+{
+	(void)context;
+	/* Signal ordering is selected per-comm from OFI_NCCL_GIN_STRONG_SIGNAL, not
+	   from NCCL's per-op isStrongSignal hint (same as v14). */
+	(void)isStrongSignal;
+	return nccl_ofi_gin_iputSignal(rmaCtx, srcOff, srcMhandle, size, dstOff, dstMhandle, rank,
+				       signalOff, signalMhandle, signalValue, signalOp, optFlags,
+				       request);
+}
+
+static ncclResult_t nccl_ofi_rma_iget_v15(void *rmaCtx, int context, uint64_t remoteOff,
+					  void *remoteMhandle, size_t size, uint64_t localOff,
+					  void *localMhandle, uint32_t rank, uint32_t optFlags,
+					  void **request)
+{
+	(void)context;
+	return nccl_ofi_gin_iget(rmaCtx, remoteOff, remoteMhandle, size, localOff, localMhandle,
+				 rank, optFlags, request);
+}
+
+/* RMA v15 op-table. NCCL's GIN proxy binds this in preference to v14 (via rma_v15.cc),
+ * so the aggregate hint is not dropped. */
+NCCL_OFI_EXPORT_SYMBOL ncclRma_v15_t ncclRmaPlugin_v15 = {
+	.name = "Libfabric",
+	.init = nccl_ofi_gin_init,
+	.devices = nccl_ofi_gin_devices,
+	.getProperties = nccl_ofi_gin_getProperties_v13,
+	.listen = nccl_ofi_gin_listen,
+	.connect = nccl_ofi_gin_connect,
+	.createContext = nccl_ofi_rma_createContext_v14,
+	.regMrSym = nccl_ofi_rma_regMrSym_v14,
+	.regMrSymDmaBuf = nccl_ofi_rma_regMrSymDmaBuf_v14,
+	.deregMrSym = nccl_ofi_gin_deregMrSym,
+	.destroyContext = nccl_ofi_gin_destroyContext_v13,
+	.closeColl = nccl_ofi_gin_closeColl,
+	.closeListen = nccl_ofi_gin_closeListen,
+	.iput = nccl_ofi_rma_iput_v15,
+	.iputSignal = nccl_ofi_rma_iputSignal_v15,
+	.iget = nccl_ofi_rma_iget_v15,
 	.iflush = nccl_ofi_gin_iflush_v13,
 	.test = nccl_ofi_gin_test,
 	.rmaProgress = nccl_ofi_gin_ginProgress,

--- a/src/rdma/gin/nccl_ofi_gin_reqs.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_reqs.cpp
@@ -287,11 +287,23 @@ int nccl_net_ofi_gin_metadata_send_req_t::post()
 	nccl_ofi_gin_mr_handle_t *metadata_handle =
 		static_cast<nccl_ofi_gin_mr_handle_t *>(metadata_elem->mr_handle);
 
-	ssize_t rc =
-		fi_send(ep, metadata_elem->ptr, sizeof(nccl_net_ofi_gin_signal_metadata_msg_t),
-			fi_mr_desc(metadata_handle->get_mr(rail_id)), remote_addr, &ctx.ofi_ctx);
+	void *desc = fi_mr_desc(metadata_handle->get_mr(rail_id));
+	struct iovec iov = { .iov_base = metadata_elem->ptr,
+			     .iov_len = sizeof(nccl_net_ofi_gin_signal_metadata_msg_t) };
+	struct fi_msg msg = {};
+	msg.msg_iov = &iov;
+	msg.desc = &desc;
+	msg.iov_count = 1;
+	msg.addr = remote_addr;
+	msg.context = &ctx.ofi_ctx;
+
+	ssize_t rc = fi_sendmsg(ep, &msg, flags);
+
+	/* Drop FI_MORE for retry — must not remain pending in the queue */
+	flags &= ~FI_MORE;
+
 	if (rc != 0 && rc != -FI_EAGAIN) {
-		NCCL_OFI_WARN("fi_send failed with RC %zd", rc);
+		NCCL_OFI_WARN("fi_sendmsg failed with RC %zd", rc);
 	}
 
 	return rc;


### PR DESCRIPTION
*Description of changes:*
`FI_MORE` was added to the plugin proxy path in NCCL: https://github.com/NVIDIA/nccl/pull/2254. We need to add the corresponding plugin changes. This PR adds the v15 API and coalesces doorbells with FI_MORE on the plugin side.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
