### PR TITLE
param: Disable eager messages by default

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -222,9 +222,10 @@ OFI_NCCL_PARAM(float, net_latency, "NET_LATENCY", 0.0);
 
 /*
  * Eager message size limit when using RDMA protocol. Message sizes greater than
- * this limit will always be sent using RDMA write instead of eagerly.
+ * this limit will always be sent using RDMA write instead of eagerly. Setting
+ * this to -1 disables eager messages entirely.
  */
-OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", -1);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
*Description of changes:*

The multi-recv feature uses the eager path for small message transfers. We want to compare multi-recv performance with eager enabled against eager disabled. If disabling eager shows no regression, it will give us a good reason to remove eager support from the multi-recv path. Disabling eager messages by default lets us run that evaluation across the fleet without per-job environment changes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
