### PR TITLE
ci: add Ubuntu 26.04 container image and build job

### DIFF
--- a/.github/matrix-config.json
+++ b/.github/matrix-config.json
@@ -27,6 +27,11 @@
       "tracing": ["lttng", "none"],
       "sdk": ["cuda", "neuron"]
     },
+    "ubuntu2604": {
+      "cc": ["gcc-14", "gcc-15", "clang-19", "clang-20"],
+      "tracing": ["lttng", "none"],
+      "sdk": ["cuda", "neuron"]
+    },
     "codechecker": {
       "sdk": ["cuda", "neuron"]
     }

--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -13,6 +13,7 @@ jobs:
       amazonlinux: ${{ steps.set-matrix.outputs.amazonlinux }}
       ubuntu: ${{ steps.set-matrix.outputs.ubuntu }}
       ubuntu2404: ${{ steps.set-matrix.outputs.ubuntu2404 }}
+      ubuntu2604: ${{ steps.set-matrix.outputs.ubuntu2604 }}
       codechecker: ${{ steps.set-matrix.outputs.codechecker }}
     steps:
       - uses: actions/checkout@v6
@@ -21,6 +22,7 @@ jobs:
           echo "amazonlinux=$(jq -c '.matrix_config.amazonlinux' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "ubuntu=$(jq -c '.matrix_config.ubuntu' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "ubuntu2404=$(jq -c '.matrix_config.ubuntu2404' .github/matrix-config.json)" >> $GITHUB_OUTPUT
+          echo "ubuntu2604=$(jq -c '.matrix_config.ubuntu2604' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "codechecker=$(jq -c '.matrix_config.codechecker' .github/matrix-config.json)" >> $GITHUB_OUTPUT
 
   build-amazonlinux-containers:
@@ -125,6 +127,42 @@ jobs:
           file: docker/base/Dockerfile.ubuntu2404
           push: true
           tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
+          build-args: |
+            CC_TYPE=${{ matrix.cc }}
+            ENABLE_TRACING=${{ matrix.tracing == 'lttng' }}
+            ENABLE_CUDA=${{ matrix.sdk == 'cuda' }}
+            EFA_INSTALLER_VERSION=latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-ubuntu2604-containers:
+    needs: get-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.get-matrix.outputs.ubuntu2604)}}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Ubuntu 26.04 containers
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.ubuntu2604
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2604:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
           build-args: |
             CC_TYPE=${{ matrix.cc }}
             ENABLE_TRACING=${{ matrix.tracing == 'lttng' }}

--- a/docker/base/Dockerfile.ubuntu2604
+++ b/docker/base/Dockerfile.ubuntu2604
@@ -1,0 +1,69 @@
+# docker/base/Dockerfile.ubuntu2604
+FROM ubuntu:26.04
+
+# Accept build arguments
+ARG CC_TYPE=gcc-14
+ARG ENABLE_TRACING=false
+ARG ENABLE_CUDA=false
+ARG EFA_INSTALLER_VERSION=latest
+
+# Install updates and base packages
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get upgrade -y && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y \
+      curl wget git build-essential \
+      libhwloc-dev make sudo lsb-release pciutils \
+      libevent-core-2.1-7 libevent-pthreads-2.1-7 \
+      udev dmidecode ethtool iproute2
+
+# Install EFA
+RUN curl -O https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz && \
+    tar -xf aws-efa-installer-*.tar.gz && \
+    cd aws-efa-installer && \
+    ./efa_installer.sh -y --skip-kmod && \
+    cd .. && \
+    rm -rf aws-efa-installer*
+
+# Install compiler based on arguments
+RUN cc_family=`echo ${CC_TYPE} | awk -F'-' '{print $1}'` && \
+    cc_version=`echo ${CC_TYPE} | awk -F'-' '{print $2}'` && \
+    if [ "$cc_family" = "clang" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y \
+	    libc++-${cc_version}-dev clang-${cc_version} lldb-${cc_version} lld-${cc_version} ; \
+    elif [ "$cc_family" = "gcc" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y gcc-${cc_version} g++-${cc_version} ; \
+    else \
+        echo "$cc_family unkonwn.  Aborting." ; exit 1 ; \
+    fi
+
+# Install CUDA if enabled.
+#
+# The CUDA version is pinned explicitly (13.3) for reproducible builds -- it does
+# NOT auto-track the repo, so a weekly image rebuild can't silently change CUDA
+# under us. 13.3 was the latest in the NVIDIA ubuntu2604 repo when this was
+# added; bump this pin deliberately to adopt a newer CUDA. It is intentionally
+# ahead of the ubuntu2404 image, which stays on CUDA 12.6 (u24.04 unchanged),
+# giving forward coverage of a newer CUDA on the newer OS.
+RUN if [ "$ENABLE_CUDA" = "true" ]; then \
+        repo="ubuntu$(lsb_release -r | cut -d':' -f2 | xargs | sed 's/[.]//g')" && \
+        wget https://developer.download.nvidia.com/compute/cuda/repos/${repo}/$(uname -m)/cuda-keyring_1.1-1_all.deb && \
+        dpkg -i cuda-keyring_1.1-1_all.deb && \
+        apt-get update && \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-cudart-dev-13-3 cuda-crt-13-3 ; \
+    fi
+
+# Install tracing packages if enabled.  lttng is always installed
+# when tracing is on; cuda-nvtx is added for CUDA-enabled images so
+# the plugin can be configured with both --with-lttng and
+# --with-nvtx=... and exercise both tracing backends together.
+RUN if [ "$ENABLE_TRACING" = "true" ]; then \
+        DEBIAN_FRONTEND=noninteractive apt-get install -y liblttng-ust-dev ; \
+        if [ "$ENABLE_CUDA" = "true" ]; then \
+            DEBIAN_FRONTEND=noninteractive apt-get install -y cuda-nvtx-13-3 ; \
+        fi ; \
+    fi
+
+RUN rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace


### PR DESCRIPTION
*Description of changes:*

Phase 1 of replacing Ubuntu 22.04 in PR CI with Ubuntu 26.04: publish the new u26.04 build/test container so a later change can point PR CI at it.

- docker/base/Dockerfile.ubuntu2604: FROM ubuntu:26.04, modeled on the 24.04 image. Installs the latest CUDA available in the NVIDIA ubuntu2604 repo (13.3); the ubuntu2404 image intentionally stays on CUDA 12.6.
- update-containers.yaml: add build-ubuntu2604-containers job and the ubuntu2604 get-matrix output.
- matrix-config.json: add ubuntu2604 block (gcc-14, gcc-15, clang-19, clang-20).

Verified locally: all four compiler images build, and the plugin compiles with --enable-werror --enable-picky-compiler against CUDA 13.3 for each.

u22 removal and the PR CI flip are deferred to Phase 2; codechecker stays on its current base for now (Python 3.14 on 26.04 requires a CodeChecker bump).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
