### PR TITLE
ci: add Ubuntu 26.04 PR CI job

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -271,6 +271,94 @@ jobs:
           path: config.log
           if-no-files-found: ignore
 
+  Ubuntu2604:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        cc:
+          - gcc-14
+          - gcc-15
+          - clang-19
+          - clang-20
+        tracing:
+          - lttng
+          - nvtx
+          - lttng-nvtx
+          - none
+        sdk:
+          - cuda
+          - neuron
+        build-type:
+          - release
+          - debug
+        exclude:
+          # NVTX requires CUDA, so skip the nvtx variants on neuron.
+          - tracing: nvtx
+            sdk: neuron
+          - tracing: lttng-nvtx
+            sdk: neuron
+
+    name: U2604/${{ matrix.sdk }}/${{matrix.cc}}/${{matrix.tracing}}/${{ matrix.build-type }}
+    # Host runner is ubuntu-24.04; the 26.04 environment comes from the container.
+    # See comment on u2204 job: nvtx and lttng-nvtx reuse the lttng container.
+    container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2604:${{ matrix.sdk }}-${{ matrix.cc }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+
+      - name: Fix Git Configuration
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
+      - name: Build Plugin
+        run: |
+          set -x
+          cc_family=`echo ${{ matrix.cc }} | awk -F'-' '{print $1}'`
+          cc_version=`echo ${{ matrix.cc }} | awk -F'-' '{print $2}'`
+          if [ "${cc_family}" = "gcc" ]; then
+              export CC="gcc-${cc_version}"
+              export CXX="g++-${cc_version}"
+              export CPP="cpp-${cc_version}"
+          elif [ "${cc_family}" = "clang" ]; then
+              export CC="clang-${cc_version}"
+              export CXX="clang++-${cc_version}"
+              export CPP="clang-cpp-${cc_version}"
+          else
+              echo "unknown compiler family ${cc_family}"
+              exit 1
+          fi
+          ./autogen.sh
+          ./configure --with-mpi=/opt/amazon/openmpi \
+                      --with-libfabric=/opt/amazon/efa \
+                      --enable-tests=yes \
+                      --enable-werror=yes \
+                      --enable-picky-compiler=yes \
+                      --enable-platform-aws \
+                      ${{ matrix.sdk == 'neuron' && '--enable-neuron' || '--with-cuda=/usr/local/cuda' }} \
+                      ${{ matrix.build-type == 'debug' && '--enable-debug --enable-trace'  || '' }} \
+                      ${{ contains(matrix.tracing, 'lttng') && '--with-lttng' || '' }} \
+                      ${{ contains(matrix.tracing, 'nvtx') && '--with-nvtx=/usr/local/cuda' || '' }}
+
+      - name: Call `make`
+        run: make V=1
+
+      - name: Call `make check`
+        run: make check V=1 || (cat tests/unit/test-suite.log && exit 1)
+
+      - name: Call `make install`
+        run: sudo make install V=1
+
+      - name: Call `make distcheck`
+        run: make distcheck V=1
+
+      - name: Upload config.log
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.cc }}-${{ matrix.sdk }}-u2604-config.log
+          path: config.log
+          if-no-files-found: ignore
+
   thread-safety-check:
     runs-on: ubuntu-24.04
     strategy:


### PR DESCRIPTION
*Description of changes:*

Exercise the plugin on the newest Ubuntu LTS in addition to 24.04 by adding an Ubuntu 26.04 build/test job to PR CI. The job mirrors the Ubuntu2404 job and pulls the aws-ofi-nccl-ubuntu2604 images (cc: gcc-14, gcc-15, clang-19, clang-20; nvtx variants reuse the lttng image). The host runner is ubuntu-24.04 and the 26.04 environment is provided by the container, so no 26.04 hosted runner is required.

The change is additive: existing jobs, including the Ubuntu 22.04 build and CodeChecker, are left unchanged, so this only expands coverage rather than altering it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
