### PR TITLE
.ci/aws: migrate PR CI test stages to Ubuntu 26.04

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -269,20 +269,20 @@ pipeline {
                     stages["4_p3dn_ubuntu2204"] = get_test_stage_with_lock_container("4_p3dn_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p3dn.24xlarge", p3dn_lock_label, num_instances, p3_p4_addl_args)
 
                     // p4d tests
-                    stages["4_p4d_ubuntu2204"] = get_test_stage_with_lock_container("4_p4d_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
+                    stages["4_p4d_ubuntu2604"] = get_test_stage_with_lock_container("4_p4d_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
 
                     // p5 tests
-                    stages["4_p5_ubuntu2204"] = get_test_stage_with_lock_container("4_p5_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
+                    stages["4_p5_ubuntu2604"] = get_test_stage_with_lock_container("4_p5_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
 
                     // p5en tests
-                    stages["4_p5en_ubuntu2204"] = get_test_stage_with_lock_container("4_p5en_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
+                    stages["4_p5en_ubuntu2604"] = get_test_stage_with_lock_container("4_p5en_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
 
                     // g4dn tests
-                    stages["4_g4dn_ubuntu2204"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
-                    stages["4_g4dn_ubuntu2204_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204_tcp", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
+                    stages["4_g4dn_ubuntu2604"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2604", env.BUILD_TAG, "ubuntu2604", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
+                    stages["4_g4dn_ubuntu2604_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2604_tcp", env.BUILD_TAG, "ubuntu2604", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
 
                     // trn2 tests
-                    stages["4_trn2_ubuntu2204"] = get_test_stage_with_lock_persistent("4_trn2_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "trn2.48xlarge", trn2_lock_label, num_instances, neuron_addl_args)
+                    stages["4_trn2_ubuntu2604"] = get_test_stage_with_lock_persistent("4_trn2_ubuntu2604", env.BUILD_TAG, "ubuntu2604", "trn2.48xlarge", trn2_lock_label, num_instances, neuron_addl_args)
 
                     parallel stages
                 }

--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -270,19 +270,24 @@ pipeline {
 
                     // p4d tests
                     stages["4_p4d_ubuntu2604"] = get_test_stage_with_lock_container("4_p4d_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
+                    stages["4_p4d_alinux2023"] = get_test_stage_with_lock_container("4_p4d_alinux2023", env.BUILD_TAG, base_os, "alinux2023", "p4d.24xlarge", p4d_lock_label, num_instances, p3_p4_addl_args)
 
                     // p5 tests
                     stages["4_p5_ubuntu2604"] = get_test_stage_with_lock_container("4_p5_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
+                    stages["4_p5_alinux2023"] = get_test_stage_with_lock_container("4_p5_alinux2023", env.BUILD_TAG, base_os, "alinux2023", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
 
                     // p5en tests
                     stages["4_p5en_ubuntu2604"] = get_test_stage_with_lock_container("4_p5en_ubuntu2604", env.BUILD_TAG, base_os, "ubuntu2604", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
+                    stages["4_p5en_alinux2023"] = get_test_stage_with_lock_container("4_p5en_alinux2023", env.BUILD_TAG, base_os, "alinux2023", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
 
                     // g4dn tests
                     stages["4_g4dn_ubuntu2604"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2604", env.BUILD_TAG, "ubuntu2604", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
                     stages["4_g4dn_ubuntu2604_tcp"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2604_tcp", env.BUILD_TAG, "ubuntu2604", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_tcp_addl_args)
+                    stages["4_g4dn_alinux2023"] = get_test_stage_with_lock_persistent("4_g4dn_alinux2023", env.BUILD_TAG, "alinux2023", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)
 
                     // trn2 tests
                     stages["4_trn2_ubuntu2604"] = get_test_stage_with_lock_persistent("4_trn2_ubuntu2604", env.BUILD_TAG, "ubuntu2604", "trn2.48xlarge", trn2_lock_label, num_instances, neuron_addl_args)
+                    stages["4_trn2_alinux2023"] = get_test_stage_with_lock_persistent("4_trn2_alinux2023", env.BUILD_TAG, "alinux2023", "trn2.48xlarge", trn2_lock_label, num_instances, neuron_addl_args)
 
                     parallel stages
                 }


### PR DESCRIPTION
*Description of changes:*

Move the AWS PR CI test stages for p4d, p5, p5en, g4dn (incl. tcp) and trn2 from Ubuntu 22.04 to Ubuntu 26.04, reusing the PortaFiducia container-os mechanism. These are migrated in place rather than added alongside 22.04, so the stage count (and CI hardware time) is unchanged while moving coverage to the newer OS/CUDA.

p3dn is intentionally kept on ubuntu2204: it is a V100 (Volta, sm_70) instance, and CUDA 13 shipped with the Ubuntu 26.04 image removes offline compilation and library support for pre-Turing architectures (Maxwell/Pascal/Volta).


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
