### PR TITLE
rdma: require full ctrl msg arrival before consuming entries

### DIFF
--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -248,9 +248,6 @@ typedef struct nccl_net_ofi_ctrl_msg_entry {
 
 	/* Tag for matching this sub-entry to the corresponding isend */
 	int16_t tag;
-	/* Per-entry sequence number for RDMA atomicity verification.
-	 * In entries[0], this also serves as the ctrl msg ready bit. */
-	uint16_t msg_seq_num;
 	/* The following fields are only meaningful in entries[0] and carry
 	 * metadata that applies to the entire control message. */
 	uint16_t flags;
@@ -260,7 +257,10 @@ typedef struct nccl_net_ofi_ctrl_msg_entry {
 	/* Set by sender when this entry has been consumed by either eager or write */
 	uint8_t entry_used;
 	/* Padding to 64-byte cache line boundary */
-	uint8_t pad[8];
+	uint8_t pad[10];
+	/* Per-entry sequence number for RDMA atomicity verification.
+	 * In all entries, this also serves as the ctrl msg ready bit. */
+	uint16_t msg_seq_num;
 } nccl_net_ofi_ctrl_msg_entry_t;
 static_assert(sizeof(nccl_net_ofi_ctrl_msg_entry_t) == 64,
 		"Wrong size for RDMA Control message entry");

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2134,24 +2134,42 @@ static inline bool has_ctrl_msg(nccl_net_ofi_rdma_send_comm* s_comm, uint16_t se
 {
 	uint16_t slot = seq_num % NCCL_OFI_CTRL_MAILBOX_SIZE;
 	uint16_t expected = (uint16_t)(seq_num & MSG_SEQ_NUM_MASK);
-	if (READ_ONCE(s_comm->ctrl_mailbox[slot].entries[0].msg_seq_num) != expected) {
+	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
+	uint16_t num_recvs;
+
+	/* entries[0] doubles as the ready bit and carries num_recvs, so it has
+	 * to be validated before num_recvs can be trusted as a loop bound. */
+	if (READ_ONCE(ctrl->entries[0].msg_seq_num) != expected) {
 		return false;
 	}
 
-	// create barrier point so that no code which depends on a valid
-	// control message is hoisted above the msg_seq_num check
+	// create barrier point so that num_recvs won't be hoisted
+	// above the msg_seq_num checks
 	std::atomic_thread_fence(std::memory_order_acquire);
 
-	nccl_net_ofi_ctrl_msg_t *ctrl = &s_comm->ctrl_mailbox[slot];
-	/* Grouped receive: verify per-entry seq nums and find matching tag */
-	for (uint16_t i = 0; i < ctrl->entries[0].num_recvs; i++) {
+	num_recvs = READ_ONCE(ctrl->entries[0].num_recvs);
+
+	/* Verify the remaining entries of the grouped receive have arrived */
+	for (uint16_t i = 1; i < num_recvs; i++) {
 		if (READ_ONCE(ctrl->entries[i].msg_seq_num) != expected) {
 			return false;
 		}
+	}
+
+	// create barrier point so that no code which depends on a valid
+	// control message is hoisted above the msg_seq_num checks
+	std::atomic_thread_fence(std::memory_order_acquire);
+
+	if (ignore_tag_match) {
+		return true;
+	}
+
+	/* Find a free entry matching this tag */
+	for (uint16_t i = 0; i < num_recvs; i++) {
 		if (ctrl->entries[i].entry_used == 1) {
 			continue;
 		}
-		if (ignore_tag_match || (ctrl->entries[i].tag == tag)) {
+		if (ctrl->entries[i].tag == tag) {
 			return true;
 		}
 	}
@@ -5545,9 +5563,6 @@ bool nccl_net_ofi_rdma_send_comm::drain_sender_eager_queue()
 		uint16_t seq = this->next_msg_seq_num;
 		if (!has_ctrl_msg(this, seq, 0, true))
 			return false;
-
-		/* Memory fence: we're about to read ctrl msg contents */
-		std::atomic_thread_fence(std::memory_order_acquire);
 
 		uint16_t slot = seq % NCCL_OFI_CTRL_MAILBOX_SIZE;
 		nccl_net_ofi_ctrl_msg_t *ctrl = &this->ctrl_mailbox[slot];


### PR DESCRIPTION
Each ctrl msg entry can arrive at a different time, but has_ctrl_msg()
returned at the first usable entry without checking that the rest had
arrived. That is a bug when ignore_tag_match is set, since the caller then
scans every entry, and an entry that has not arrived yet still holds zeroes
that look like a free entry with tag 0.

Verify all num_recvs entries up front before looking at the ctrl message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

*Testing:* All2All 8B->8GB and eager and ring functional tests on 2 p5en nodes.