### PR TITLE
param: Re-enable eager

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -225,7 +225,7 @@ OFI_NCCL_PARAM(float, net_latency, "NET_LATENCY", 0.0);
  * this limit will always be sent using RDMA write instead of eagerly. Setting
  * this to -1 disables eager messages entirely.
  */
-OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", -1);
+OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", 8192);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.


### PR DESCRIPTION
*Description of changes:*

Restore the default EAGER_MAX_SIZE to 8192, reverting the temporary disable (7df78cd param: Disable eager messages by default). Finish the debugging of multi-recv feature, so eager can be re-enabled by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
