### PR TITLE
gin: remove GIN_STRONG_SIGNAL env variable and weak-signal mode

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -397,22 +397,4 @@ OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSIO
 OFI_NCCL_PARAM_VALUE_SET(GDAKI_EFA_HW_COUNTER, (AUTO)(ON)(OFF))
 OFI_NCCL_PARAM(GDAKI_EFA_HW_COUNTER, gdaki_efa_hw_counter, "GDAKI_EFA_HW_COUNTER", GDAKI_EFA_HW_COUNTER::AUTO)
 
-/*
- * Enable strong-signal semantics for the GIN plugin.
- *
- * When true, completed requests are delivered to the application in
- * sequence-number order: the plugin waits for any earlier in-flight
- * request to complete before propagating a later one up. A signal
- * completion therefore implies all prior puts on the same (comm, peer)
- * stream have been delivered to the application.
- *
- * When false, completed requests are propagated up as soon as they are
- * fully received, without waiting for earlier requests. Per-token data
- * can become visible to the application out of order. ACK emission to
- * the sender is still ordered (seq-num stream + bundled range ACKs).
- *
- * Default: true (preserves current behavior).
- */
-OFI_NCCL_PARAM(bool, gin_strong_signal, "GIN_STRONG_SIGNAL", true);
-
 #endif // End NCCL_OFI_PARAM_H_

--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -655,41 +655,6 @@ private:
        int gdrcopy_cuda_dev = -1; /* CUDA device the worker binds to */
 
 	/* --- TIER 2: Receiver side — every CQ completion --- */
-	/* Controls signal delivery ordering on this communicator
-	   (env: OFI_NCCL_GIN_STRONG_SIGNAL, default true).
-	 *
-	 * true  (strong-signal mode, default):
-	 *   Completed requests are released up the stack in sequence-number
-	 *   order on a per-(comm, peer) basis. A signal visible to the
-	 *   application therefore implies that:
-	 *     - this signal's own data has landed at the target, and
-	 *     - all prior puts and signals on the same (comm, peer) stream
-	 *       have also landed and been delivered.
-	 *   Out-of-order arrivals are buffered and held until earlier
-	 *   seq_nums complete (see iput_signal_deliver_all and
-	 *   next_delivered_signal_seq_num). This is the contract most NCCL
-	 *   kernels rely on: a single terminal signal proves a whole batch
-	 *   of prior writes is visible, with no per-write verification.
-	 *
-	 * false (weak-signal mode, opt-in):
-	 *   Each signal is delivered as soon as its own segments (metadata +
-	 *   data write) have arrived — no waiting for earlier seq_nums.
-	 *   Per-item payloads may become visible out of order, so the
-	 *   application must verify each item independently (e.g. a per-token
-	 *   SignalInc in MoE low-latency dispatch). Reduces head-of-line
-	 *   blocking when the kernel already handles its own ordering.
-	 *
-	 * Notes:
-	 *   - ACK emission back to the sender stays ordered in both modes
-	 *     (seq-num stream + bundled range ACKs); only the app-visible
-	 *     completion order changes.
-	 *   - The proxy thread supports both modes; this flag is a per-comm
-	 *     selector captured at construction from ofi_nccl_gin_strong_signal(),
-	 *     not a dynamic capability bit.
-	 *   - See handle_signal_metadata_completion / handle_signal_write_completion
-	 *     for the weak-mode early-deliver paths. */
-	bool strong_signal_ordering_enabled;
-
 	/* For each rail, direct-indexed table of fi_addr => peer comm rank.
 	 * Requires FI_AV_TABLE so that fi_addr_t values are dense 0-based
 	 * indices. Unused slots are set to UINT32_MAX as a sentinel. */
@@ -787,7 +752,7 @@ private:
 	 * result into this comm's own SPSC done queue, which only this comm's
 	 * proxy drains. The done queue stays single-producer (the one worker) /
 	 * single-consumer (this proxy), so SPSC FIFO still preserves per-peer
-	 * seq order under strong_signal_ordering. */
+	 * seq order. */
 	nccl_ofi_spsc_ring<gin_signal_done_entry> gdrcopy_done_queue;
 	/* Protects mr_handle->signal_segs: the gdrcopy worker appends on first
 	   touch (ensure_signal_seg) and deregMrSym tears it down. */

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -41,7 +41,6 @@ nccl_ofi_rdma_gin_put_comm::nccl_ofi_rdma_gin_put_comm(nccl_ofi_gin_resources &r
 				     nccl_net_ofi_recv_comm *r_comm_)
     : resources(resources_arg), resource_releaser { resources },
       metadata_fl(nullptr, &freelist_deleter), dev(s_comm_->dev_id),
-      strong_signal_ordering_enabled(ofi_nccl_gin_strong_signal()),
       rank(rank_), nranks(nranks_),
       ag_comm(s_comm_, r_comm_, rank_, nranks_)
 {
@@ -1499,7 +1498,7 @@ int nccl_ofi_rdma_gin_put_comm::iput_signal_recv_req_completion(uint32_t peer_ra
 	NCCL_OFI_TRACE(NCCL_NET, "Completed iputSignal seq num %hu on target",
 		       req->metadata.header.seq_num);
 
-	if (req->metadata_received && strong_signal_ordering_enabled) {
+	if (req->metadata_received) {
 		ret = do_gin_signal_and_trace(peer_rank, req);
 		if (ret != 0) {
 			return ret;
@@ -1578,18 +1577,14 @@ int nccl_ofi_rdma_gin_put_comm::retire_completed_peer_iput_ops(uint32_t peer_ran
 			return ret;
 		}
 
-		/* Fall back to the original per-req completion path when there is
-		   nothing to fold:
-		     - weak ordering: the signal was already posted (and maybe
-		       applied) at CQ-completion time, so retire only advances; or
-		     - the req has no metadata yet (a write-only completion can mark
-		       a req segment-complete before its metadata message arrives,
-		       so signal_base_address is not populated) — the per-req path
-		       correctly skips the gdrcopy in that case.
-		   Producer-side folding only applies under strong ordering with
-		   metadata in hand, which is also the only case build_signal_work
-		   can resolve the slot. */
-		if (!strong_signal_ordering_enabled || !req->metadata_received) {
+		/* Fall back to the original per-req completion path when the
+		   req has no metadata yet (a write-only completion can mark
+		   a req segment-complete before its metadata message arrives,
+		   so signal_base_address is not populated) — the per-req path
+		   correctly skips the gdrcopy in that case.
+		   Folding only applies with metadata in hand, which is also the
+		   only case build_signal_work can resolve the slot. */
+		if (!req->metadata_received) {
 			ack_requested = ack_requested || req->is_ack_requested;
 			rank_comm.rx_consumed = gin_cursor_inc(rank_comm.rx_consumed);
 			rank_comm.next_delivered_signal_seq_num =
@@ -1747,20 +1742,8 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_metadata_completion(
 		req->is_ack_requested = req->is_ack_requested || meta_ack_req;
 	}
 
-	/* Weak-signal mode: once all segments of this signal (metadata +
-	   writes at this same seq, if any) have arrived, deliver it
-	   immediately. This covers metadata-first and writes-first orderings. */
 	if (req->num_seg_completions == req->total_segments) {
-		if (!strong_signal_ordering_enabled) {
-			ret = do_gin_signal_and_trace(peer_rank, req);
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_METADATA_COMPLETION_FUNC_END(
-				dev, this, rail_id, peer_rank, msg_seq_num, ret);
-				return ret;
-			}
-		}
-
-		// If this packet is not full there is no reasong to try and retire packets.
+		// If this packet is not full there is no reason to try and retire packets.
 		ret = retire_completed_peer_iput_ops(peer_rank);
 	}
 
@@ -1843,24 +1826,7 @@ int nccl_ofi_rdma_gin_put_comm::handle_signal_write_completion(struct fi_cq_data
 		req->metadata.header.seq_seg_cnt = req->total_segments;
 		req->metadata.header.msg_type = GIN_MSG_TYPE_METADATA;
 
-		/* Weak-signal mode: from GIN's perspective, iput+signal is a
-		 * single logical operation sharing one sequence number.
-		 * However, from libfabric's perspective these are two separate
-		 * packets — an RDMA write-with-immediate and an fi_send — that
-		 * can complete in either order on the receiver. We therefore
-		 * need to check for signal delivery here (when the last write
-		 * completes after metadata) in addition to
-		 * handle_signal_metadata_completion() (when metadata completes
-		 * after writes). */
-		if (!strong_signal_ordering_enabled && req->metadata_received) {
-			ret = do_gin_signal_and_trace(peer_rank, req);
-			if (OFI_UNLIKELY(ret != 0)) {
-				NCCL_OFI_TRACE_GIN_HANDLE_SIGNAL_WRITE_COMPLETION_FUNC_END(
-					dev, this, rail_id, peer_rank, msg_seq_num, ret);
-				return ret;
-			}
-		}
-		// If this packet is not full there is no reasong to try and retire packets.
+		// If this packet is not full there is no reason to try and retire packets.
 		ret = retire_completed_peer_iput_ops(peer_rank);
 	}
 


### PR DESCRIPTION
Strong-signal ordering (delivering completions in sequence-number order) is the only mode used in practice. Remove the OFI_NCCL_GIN_STRONG_SIGNAL environment variable and the weak-signal early-deliver code paths, making strong ordering unconditional.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
