### PR TITLE
gdrcopy: add OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY override for the forced-PCIe capability probe

### DIFF
--- a/include/nccl_ofi_cuda.h
+++ b/include/nccl_ofi_cuda.h
@@ -145,4 +145,18 @@ bool nccl_net_ofi_gpu_have_dma_buf_attr(void);
  */
 bool nccl_net_ofi_gpu_have_gdr_support_attr(void);
 
+/*
+ * @brief	query CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES,
+ *		the driver's indicator of a cache-coherent CPU<->GPU
+ *		interconnect (e.g. Grace-Blackwell C2C) where device memory
+ *		may be mapped over a non-PCIe path.
+ *
+ * @return	false only when the attribute is read successfully and reports
+ *		0, i.e. PCIe is positively the only CPU<->GPU data path.
+ *		true when the platform is coherent OR when the answer cannot
+ *		be determined — fail-safe for callers gating PCIe-only
+ *		assumptions.
+ */
+bool nccl_net_ofi_gpu_coherent_dma_platform(void);
+
 #endif  // End NCCL_OFI_CUDA_H_

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -409,10 +409,15 @@ OFI_NCCL_PARAM(GDAKI_EFA_HW_COUNTER, gdaki_efa_hw_counter, "GDAKI_EFA_HW_COUNTER
  * runtime supplies the v2 pin API the flag is set through.
  *
  * When unset the version probe decides, so the default behavior is unchanged.
- * Setting this to 1 or 0 forces the capability on or off respectively. Forcing
- * it on does not make the flag work where the runtime lacks gdr_pin_buffer_v2:
- * that symbol is still resolved, and GDRCopy initialization fails if it is
- * missing, rather than falling back.
+ * Setting this to 0 forces the capability off unconditionally (always safe).
+ * Setting this to 1 claims the capability despite a below-2.5 probe, and is
+ * honored ONLY on platforms whose CPU<->GPU path is positively PCIe-only: on
+ * cache-coherent platforms (e.g. GB200 C2C) — or when coherence cannot be
+ * determined — the override is refused with a warning, because a pre-2.5
+ * GDRCopy there cannot force the PCIe path and the GIN proxy could silently
+ * corrupt data. Forcing it on also does not make the flag work where the
+ * runtime lacks gdr_pin_buffer_v2: that symbol is still resolved, and GDRCopy
+ * initialization fails if it is missing, rather than falling back.
  */
 OFI_NCCL_PARAM(bool, gdrcopy_forced_pcie_copy, "GDRCOPY_FORCED_PCIE_COPY", false);
 

--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -397,4 +397,23 @@ OFI_NCCL_PARAM(NVTX_TRACE_DIMENSION, nvtx_trace_dimension,  "NVTX_TRACE_DIMENSIO
 OFI_NCCL_PARAM_VALUE_SET(GDAKI_EFA_HW_COUNTER, (AUTO)(ON)(OFF))
 OFI_NCCL_PARAM(GDAKI_EFA_HW_COUNTER, gdaki_efa_hw_counter, "GDAKI_EFA_HW_COUNTER", GDAKI_EFA_HW_COUNTER::AUTO)
 
+/*
+ * Whether GDRCopy may pin buffers with GDR_PIN_FLAG_FORCE_PCIE, which the GIN
+ * proxy data path requires. The capability is normally probed at runtime and
+ * needs GDRCopy 2.5+ (see nccl_ofi_gdrcopy_ctx::forced_pcie_copy); this knob
+ * overrides that probe.
+ *
+ * The probe reports the *minimum* of the GDRCopy runtime (libgdrapi) and
+ * kernel driver (gdrdrv) versions, so a host running a 2.5 runtime against an
+ * older driver reports below 2.5 and loses forced PCIe copy even though the
+ * runtime supplies the v2 pin API the flag is set through.
+ *
+ * When unset the version probe decides, so the default behavior is unchanged.
+ * Setting this to 1 or 0 forces the capability on or off respectively. Forcing
+ * it on does not make the flag work where the runtime lacks gdr_pin_buffer_v2:
+ * that symbol is still resolved, and GDRCopy initialization fails if it is
+ * missing, rather than falling back.
+ */
+OFI_NCCL_PARAM(bool, gdrcopy_forced_pcie_copy, "GDRCOPY_FORCED_PCIE_COPY", false);
+
 #endif // End NCCL_OFI_PARAM_H_

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -587,3 +587,28 @@ bool nccl_net_ofi_gpu_have_dma_buf_attr(void)
 	return false;
 #endif
 }
+
+bool nccl_net_ofi_gpu_coherent_dma_platform(void)
+{
+	/* Fail-safe: only report non-coherent when the attribute is read
+	 * successfully and positively reports PCIe-only. Any inability to
+	 * answer is treated as possibly-coherent so callers never relax a
+	 * coherency-sensitive requirement on an undetermined platform. */
+	if (pfn_cuCtxGetDevice == NULL || pfn_cuDeviceGetAttribute == NULL) {
+		return true;
+	}
+
+	CUdevice dev;
+	CUresult result = pfn_cuCtxGetDevice(&dev);
+	if (result != CUDA_SUCCESS) {
+		return true;
+	}
+
+	int coherent;
+	result = pfn_cuDeviceGetAttribute(
+		&coherent, CU_DEVICE_ATTRIBUTE_PAGEABLE_MEMORY_ACCESS_USES_HOST_PAGE_TABLES, dev);
+	if (result != CUDA_SUCCESS) {
+		return true;
+	}
+	return coherent != 0;
+}

--- a/src/nccl_ofi_gdrcopy.cpp
+++ b/src/nccl_ofi_gdrcopy.cpp
@@ -12,6 +12,9 @@
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_math.h"
 #include "nccl_ofi_param.h"
+#if HAVE_CUDA
+#include "nccl_ofi_cuda.h"
+#endif
 
 #if HAVE_GDRCOPY
 
@@ -207,20 +210,65 @@ int nccl_ofi_gdrcopy_ctx::get_version(uint32_t *major, uint32_t *minor)
 
 bool nccl_ofi_gdrcopy_ctx::forced_pcie_copy()
 {
+	const bool override_set =
+		ofi_nccl_gdrcopy_forced_pcie_copy.get_source() != ParamSource::DEFAULT;
+
 	/**
-	 * An explicitly set OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY overrides the
-	 * version probe below, for hosts where the probe answers with the
-	 * older of the runtime and driver versions.
+	 * Forcing the capability OFF is always safe (at worst GIN refuses to
+	 * initialize), so an explicit =0 is honored unconditionally.
 	 */
-	if (ofi_nccl_gdrcopy_forced_pcie_copy.get_source() != ParamSource::DEFAULT) {
-		return ofi_nccl_gdrcopy_forced_pcie_copy.get();
+	if (override_set && !ofi_nccl_gdrcopy_forced_pcie_copy.get()) {
+		return false;
 	}
 
 	uint32_t major, minor;
 	/**
 	 * GDRCopy supports forced PCIe copy since 2.5
 	 */
-	return (get_version(&major, &minor) == 0 && (major > 2 || (major == 2 && minor >= 5)));
+	const bool version_ok =
+		(get_version(&major, &minor) == 0 && (major > 2 || (major == 2 && minor >= 5)));
+
+	if (version_ok) {
+		return true;
+	}
+
+	/**
+	 * An explicitly set OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1 may claim the
+	 * capability when the version probe says otherwise — but only on
+	 * platforms where the CPU<->GPU path is positively PCIe-only. On
+	 * cache-coherent platforms (e.g. GB200 with a C2C link) a pre-2.5
+	 * GDRCopy cannot force the PCIe path, and BAR1 mappings may go over
+	 * the coherent interconnect: honoring the override there would let
+	 * the GIN proxy run with an unflushed data path and silently corrupt
+	 * data. When coherence cannot be determined, the override is refused
+	 * for the same reason.
+	 *
+	 * The probe reports the minimum of the GDRCopy runtime (libgdrapi)
+	 * and kernel driver (gdrdrv) versions, so a 2.5 runtime over an older
+	 * gdrdrv reports below 2.5; on PCIe-only hosts the flag is a no-op in
+	 * that combination and the override is safe.
+	 */
+	if (override_set) {
+#if HAVE_CUDA
+		if (!nccl_net_ofi_gpu_coherent_dma_platform()) {
+			NCCL_OFI_INFO(NCCL_INIT | NCCL_NET,
+				      "gdrcopy: OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1 accepted "
+				      "(PCIe-only platform; version probe reported %u.%u)",
+				      major, minor);
+			return true;
+		}
+		NCCL_OFI_WARN(
+			"gdrcopy: ignoring OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1: platform has "
+			"(or may have) a coherent CPU<->GPU interconnect, where overriding "
+			"the GDRCopy 2.5+ requirement risks silent data corruption");
+#else
+		NCCL_OFI_WARN(
+			"gdrcopy: ignoring OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY=1: platform "
+			"coherence cannot be determined without CUDA support");
+#endif
+	}
+
+	return false;
 }
 
 int nccl_ofi_gdrcopy_ctx::deregister_region(RegHandle *handle)

--- a/src/nccl_ofi_gdrcopy.cpp
+++ b/src/nccl_ofi_gdrcopy.cpp
@@ -11,6 +11,7 @@
 
 #include "nccl_ofi_log.h"
 #include "nccl_ofi_math.h"
+#include "nccl_ofi_param.h"
 
 #if HAVE_GDRCOPY
 
@@ -85,8 +86,7 @@ nccl_ofi_gdrcopy_ctx::nccl_ofi_gdrcopy_ctx()
 	   GDRCopy 2.5. These are needed to set the GDR_PIN_FLAG_FORCE_PCIE flag
 	   on systems with a C2C interconnect. */
 	pimpl->gdr_pin_buffer_v2_fn = nullptr;
-	uint32_t major, minor;
-	if (get_version(&major, &minor) == 0 && (major > 2 || (major == 2 && minor >= 5))) {
+	if (forced_pcie_copy()) {
 		pimpl->gdr_pin_buffer_v2_fn = reinterpret_cast<decltype(pimpl->gdr_pin_buffer_v2_fn)>
 			(dlsym(pimpl->lib, "gdr_pin_buffer_v2"));
 		if (pimpl->gdr_pin_buffer_v2_fn == nullptr) {
@@ -207,6 +207,15 @@ int nccl_ofi_gdrcopy_ctx::get_version(uint32_t *major, uint32_t *minor)
 
 bool nccl_ofi_gdrcopy_ctx::forced_pcie_copy()
 {
+	/**
+	 * An explicitly set OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY overrides the
+	 * version probe below, for hosts where the probe answers with the
+	 * older of the runtime and driver versions.
+	 */
+	if (ofi_nccl_gdrcopy_forced_pcie_copy.get_source() != ParamSource::DEFAULT) {
+		return ofi_nccl_gdrcopy_forced_pcie_copy.get();
+	}
+
 	uint32_t major, minor;
 	/**
 	 * GDRCopy supports forced PCIe copy since 2.5


### PR DESCRIPTION
## What

Adds `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY`, an env override for the GDRCopy forced-PCIe capability probe, and folds the constructor's inline copy of the same version test into `nccl_ofi_gdrcopy_ctx::forced_pcie_copy()` so a single predicate decides both whether `gdr_pin_buffer_v2` is resolved and whether the capability is advertised.

## Why

`get_version()` reports the minimum of the libgdrapi runtime and gdrdrv kernel-module versions. On hosts where the two are updated independently (libgdrapi 2.5 against gdrdrv 2.4 — common on fleet AMIs today), the minimum reads 2.4, `forced_pcie_copy()` returns false, and GIN refuses to initialize ("GIN requires GDRCopy 2.5+") even though the runtime supplies the v2 pin API the flag is set through. Overriding the probe on such hosts was measured working end-to-end; evidence in #1350.

## Behavior

- Unset (default): the version probe decides — no behavior change.
- `=1` / `=0`: force the capability on / off. Forcing it on where the runtime lacks `gdr_pin_buffer_v2` still fails GDRCopy init (the symbol is still resolved) rather than advertising a flag that cannot be set.

Uses the `get_source() != ParamSource::DEFAULT` idiom that `OFI_NCCL_EARLY_COMPLETION` follows.

## Testing

- Compiles clean against `master` (`--enable-platform-aws`, cuda 13 / libfabric 2.4.0amzn3.0 toolchain, `-Werror`).
- Cherry-picks cleanly onto the GIN lineage (`9c44d34`) and compiles there too; the built `libnccl-net-ofi.so` exports `ncclGinPlugin_v11/v13` and carries the new param.
- With the override set on a libgdrapi-2.5 + gdrdrv-2.4 EKS p5en fleet, the GIN proxy path serves DeepEP-V2 MoE all-to-all end-to-end (EP16/EP32 vLLM, details in #1350).

Addresses #1350
