### PR TITLE
Vendor efa-dp-direct at 3rd-party/efa-gda and deregister the submodule at 3rd-party/efa-dp-direct

### DIFF
--- a/.github/workflows/distcheck.yaml
+++ b/.github/workflows/distcheck.yaml
@@ -51,8 +51,6 @@ jobs:
     name: al2023/${{ matrix.sdk }}/efa@${{ matrix.efainstaller }}/${{ matrix.build-type }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -127,8 +125,6 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.cc-variant }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/build-plugin
         with:
@@ -170,8 +166,6 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/build-plugin
         with:
@@ -214,8 +208,6 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2604:${{ matrix.sdk }}-${{ matrix.cc }}-${{ (contains(matrix.tracing, 'nvtx') && 'lttng') || matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - uses: ./.github/actions/build-plugin
         with:
@@ -243,8 +235,6 @@ jobs:
     container: ghcr.io/${{ github.repository }}/aws-ofi-nccl-ubuntu2404:${{ matrix.sdk }}-${{ matrix.cc }}-${{ matrix.tracing }}-efalattest
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
@@ -297,8 +287,6 @@ jobs:
     name: CodeChecker - ${{ matrix.sdk }}
     steps:
       - uses: actions/checkout@v6
-        with:
-          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -32,7 +32,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.ref }}
-          submodules: recursive
 
       - name: Configure and build
         run: |

--- a/.github/workflows/tag-makedist.yaml
+++ b/.github/workflows/tag-makedist.yaml
@@ -36,8 +36,6 @@ jobs:
       - run: |
           yum -y update && yum -y install git tar util-linux findutils yum-utils
       - uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Fix Git Configuration
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "3rd-party/efa-dp-direct"]
-	path = 3rd-party/efa-dp-direct
-	url = https://github.com/amzn/efa-dp-direct.git

--- a/3rd-party/Makefile.am
+++ b/3rd-party/Makefile.am
@@ -6,5 +6,5 @@
 
 EXTRA_DIST = \
 	boost \
-	efa-dp-direct \
+	efa-gda \
 	nccl

--- a/3rd-party/efa-gda/CODE_OF_CONDUCT.md
+++ b/3rd-party/efa-gda/CODE_OF_CONDUCT.md
@@ -1,0 +1,4 @@
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.

--- a/3rd-party/efa-gda/CONTRIBUTING.md
+++ b/3rd-party/efa-gda/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing Guidelines
+
+Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
+documentation, we greatly value feedback and contributions from our community.
+
+Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
+information to effectively respond to your bug report or contribution.
+
+
+## Reporting Bugs/Feature Requests
+
+We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+
+When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
+reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+
+* A reproducible test case or series of steps
+* The version of our code being used
+* Any modifications you've made relevant to the bug
+* Anything unusual about your environment or deployment
+
+
+## Contributing via Pull Requests
+Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+1. You are working against the latest source on the *main* branch.
+2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+
+To send us a pull request, please:
+
+1. Fork the repository.
+2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+3. Ensure local tests pass.
+4. Commit to your fork using clear commit messages.
+5. Send us a pull request, answering any default questions in the pull request interface.
+6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+
+GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
+[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+
+
+## Finding contributions to work on
+Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
+
+
+## Code of Conduct
+This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
+For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
+opensource-codeofconduct@amazon.com with any additional questions or comments.
+
+
+## Security issue notifications
+If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
+
+
+## Licensing
+
+See the [LICENSE](LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.

--- a/3rd-party/efa-gda/CUDA/Makefile
+++ b/3rd-party/efa-gda/CUDA/Makefile
@@ -1,0 +1,20 @@
+NVCC=nvcc
+NVCC_FLAGS=-G -rdc=true
+CUDA_FLAGS=-Xcompiler -fPIC
+INCLUDES=-Ihost -Idevice -Icommon
+
+BUILDDIR=build
+
+all: $(BUILDDIR)/libefacudadp.so
+
+$(BUILDDIR):
+	mkdir -p $(BUILDDIR)
+
+$(BUILDDIR)/libefacudadp.so: $(BUILDDIR)/efa_cuda_dp.o | $(BUILDDIR)
+	$(NVCC) $(NVCC_FLAGS) -shared -o $@ $^ -lcudart
+
+$(BUILDDIR)/efa_cuda_dp.o: host/efa_cuda_dp.cpp host/efa_cuda_dp.h common/efa_cuda_dp_types.h | $(BUILDDIR)
+	$(NVCC) $(NVCC_FLAGS) $(INCLUDES) -c $< $(CUDA_FLAGS) -o $@
+
+clean:
+	rm -rf $(BUILDDIR)

--- a/3rd-party/efa-gda/CUDA/README.md
+++ b/3rd-party/efa-gda/CUDA/README.md
@@ -1,0 +1,372 @@
+# EFA CUDA Datapath Implementation
+
+A high-performance CUDA implementation for direct EFA datapath operations, enabling GPU kernels to directly post work requests and poll for completions without CPU involvement. Optimized for machine learning training, inference, and GPU-accelerated computing workloads.
+
+## Overview
+
+This implementation provides CUDA device functions that allow GPU kernels to directly interact with EFA queue pairs and completion queues. By bypassing the CPU for datapath operations, it achieves improved performance for GPU-to-GPU communication over EFA, particularly beneficial for distributed machine learning training, inference workloads, and HPC applications requiring high-bandwidth inter-GPU communication.
+
+## Package Structure
+
+```
+CUDA/
+├── common/
+│   └── efa_cuda_dp_types.h       # QP/CQ/WQ struct definitions (shared by host & device)
+├── device/
+│   ├── efa_cuda_dp.cuh           # Datapath enums and __device__ function declarations
+│   ├── efa_cuda_dp_impl.cuh      # __device__ function implementations (include in kernels)
+│   └── efa_io_defs.h             # EFA I/O HW structure definitions (internal)
+├── host/
+│   ├── efa_cuda_dp.h             # C API header: attribute structs, init signatures, version
+│   └── efa_cuda_dp.cpp           # Host-side create/destroy implementations
+├── Makefile
+└── README.md
+```
+
+## API Reference
+
+### Host-Side C API (`host/efa_cuda_dp.h`)
+
+#### Queue Management
+```c
+struct efa_cuda_cq *efa_cuda_create_cq(struct efa_cuda_cq_attrs *attrs, uint32_t inlen);
+void efa_cuda_destroy_cq(struct efa_cuda_cq *d_cq);
+
+struct efa_cuda_qp *efa_cuda_create_qp(struct efa_cuda_qp_attrs *attrs, uint32_t inlen);
+void efa_cuda_destroy_qp(struct efa_cuda_qp *d_qp);
+int efa_cuda_get_version(int *major, int *minor, int *subminor);
+
+// Attribute structures - always zero-initialize for compatibility
+struct efa_cuda_cq_attrs {
+    uint64_t comp_mask;     // Reserved for future use
+    uint64_t flags;         // Reserved for future use
+    uint8_t *buffer;        // Device buffer for CQ entries
+    uint32_t num_entries;   // Number of entries (must be power of 2)
+    uint32_t entry_size;    // Size of each CQ entry in bytes
+};
+
+struct efa_cuda_qp_attrs {
+    uint64_t comp_mask;     // Reserved for future use
+    uint64_t flags;         // Reserved for future use
+    uint8_t *sq_buffer;     // Device buffer for send queue
+    uint8_t *rq_buffer;     // Device buffer for receive queue
+    uint32_t *sq_doorbell;  // Send queue doorbell pointer
+    uint32_t *rq_doorbell;  // Receive queue doorbell pointer
+    uint32_t sq_num_entries;// Send queue entries (must be power of 2)
+    uint32_t sq_entry_size; // Send queue entry size
+    uint32_t sq_max_batch;  // Maximum batch size for send operations
+    uint32_t rq_num_entries;// Receive queue entries (must be power of 2)
+    uint32_t rq_entry_size; // Receive queue entry size
+    uint32_t reserved;      // Must be zero
+};
+```
+
+**Note**: The `inlen` parameter enables compatibility checking - use `sizeof(attrs)` to allow the library to validate extended fields are zero.
+
+### Device-Side CUDA API (`device/efa_cuda_dp.cuh`)
+
+#### Completion Queue Operations
+```cuda
+__device__ void *efa_cuda_cq_poll(efa_cuda_cq *cq, int position);
+__device__ int efa_cuda_cq_pop(efa_cuda_cq *cq, int amount);
+```
+
+#### Work Completion Info Getters
+```cuda
+__device__ enum efa_cuda_wc_opcode efa_cuda_wc_read_opcode(void *wc_buf);
+__device__ bool efa_cuda_wc_is_unsolicited(void *wc_buf);
+__device__ uint16_t efa_cuda_wc_read_req_id(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_vendor_err(void *wc_buf);
+__device__ bool efa_cuda_wc_has_imm(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_imm_data(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_byte_len(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_qp_num(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_src_qp(void *wc_buf);
+__device__ uint32_t efa_cuda_wc_read_slid(void *wc_buf);
+```
+
+#### Work Request Initialization and Configuration
+```cuda
+__device__ int efa_cuda_init_send_wr(void *wr_buf, uint16_t wr_id);
+__device__ int efa_cuda_init_send_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t imm_data);
+__device__ int efa_cuda_init_rdma_read_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr);
+__device__ int efa_cuda_init_rdma_write_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr);
+__device__ int efa_cuda_init_rdma_write_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr, uint32_t imm_data);
+
+__device__ void efa_cuda_wr_set_remote(void *wr_buf, uint16_t ah, uint32_t remote_qpn, uint32_t remote_qkey);
+__device__ int efa_cuda_wr_set_inline_data(void *wr_buf, void *addr, size_t length);
+__device__ int efa_cuda_wr_set_sge(void *wr_buf, uint32_t lkey, uint64_t addr, uint32_t length);
+__device__ void efa_cuda_wr_set_processing_hints(void *wr_buf, uint32_t hints);
+```
+
+#### Work Queue Operations
+```cuda
+__device__ int efa_cuda_start_sq_batch(efa_cuda_qp *qp, int batch_size);
+__device__ int efa_cuda_sq_batch_place_wr(efa_cuda_qp *qp, int index_in_batch, void *wr_buf);
+__device__ void efa_cuda_flush_sq_wrs(efa_cuda_qp *qp);
+__device__ int efa_cuda_post_recv_wr(efa_cuda_qp *qp, uint16_t req_id, uint64_t addr, uint32_t length, uint32_t lkey);
+__device__ void efa_cuda_flush_rq_wrs(efa_cuda_qp *qp);
+```
+
+#### Compatibility Checks
+```cuda
+__device__ bool efa_cuda_is_cq_compatible(efa_cuda_cq *cq);
+__device__ bool efa_cuda_is_qp_compatible(efa_cuda_qp *qp);
+```
+
+## Version Checking and Compatibility
+
+To ensure compatibility between dynamically linked libraries and directly included CUDA implementations, the library provides two mechanisms:
+
+### 1. Library Version Checking (Host Code)
+
+Use `efa_cuda_get_version()` to verify the dynamically linked library version:
+
+```c
+int major, minor, subminor;
+int ret = efa_cuda_get_version(&major, &minor, &subminor);
+if (ret == 0) {
+    printf("EFA CUDA DP Library Version: %d.%d.%d\n", major, minor, subminor);
+
+    // Check compatibility with expected version
+    if (major != EFA_CUDA_DP_VERSION_MAJOR || minor != EFA_CUDA_DP_VERSION_MINOR) {
+        fprintf(stderr, "Incompatible library version\n");
+        return -1;
+    }
+}
+```
+
+### 2. Struct Compatibility Checking (CUDA Device Code)
+
+Use compatibility functions to verify that structs created by the library are compatible with your CUDA code:
+
+```cuda
+__global__ void check_compatibility_kernel(efa_cuda_cq *cq, efa_cuda_qp *qp) {
+    // Check CQ compatibility
+    if (!efa_cuda_is_cq_compatible(cq)) {
+        printf("CQ struct is not compatible with this implementation\n");
+        return;
+    }
+
+    // Check QP compatibility
+    if (!efa_cuda_is_qp_compatible(qp)) {
+        printf("QP struct is not compatible with this implementation\n");
+        return;
+    }
+
+    // Proceed with operations...
+}
+```
+
+## Usage Examples
+
+### Basic Send Operation
+```cuda
+__global__ void send_kernel(efa_cuda_qp *qp, efa_cuda_cq *cq, void *data, size_t len) {
+    // Initialize send work request
+    efa_io_tx_wqe wr_buf;
+    efa_cuda_init_send_wr(&wr_buf, 1); // req_id = 1
+
+    // Set scatter-gather element
+    efa_cuda_wr_set_sge(&wr_buf, lkey, (uint64_t)data, len);
+
+    // Set remote info
+    efa_cuda_wr_set_remote(&wr_buf, ah, remote_qpn, qkey);
+
+    // Post work request
+    efa_cuda_start_sq_batch(qp, 1);
+    efa_cuda_sq_batch_place_wr(qp, 0, &wr_buf);
+    efa_cuda_flush_sq_wrs(qp);
+
+    // Poll for completion
+    void *wc_buf;
+    while (!(wc_buf = efa_cuda_cq_poll(cq, 0))) {
+        // Wait for completion
+    }
+
+    // Check completion status
+    if (!efa_cuda_wc_read_vendor_err(wc_buf)) {
+        // Send completed successfully
+    }
+
+    // Pop the completion
+    efa_cuda_cq_pop(cq, 1);
+}
+```
+
+### RDMA Write with Immediate
+```cuda
+__global__ void rdma_write_imm_kernel(efa_cuda_qp *qp, void *local_data,
+                                       uint64_t remote_addr, uint32_t rkey,
+                                       uint32_t imm_data, size_t len) {
+    efa_io_tx_wqe wr_buf;
+
+    // Initialize RDMA write with immediate
+    efa_cuda_init_rdma_write_imm_wr(&wr_buf, 2, rkey, remote_addr, imm_data);
+
+    // Set local data
+    efa_cuda_wr_set_sge(&wr_buf, local_lkey, (uint64_t)local_data, len);
+
+    // Post and flush
+    efa_cuda_start_sq_batch(qp, 1);
+    efa_cuda_sq_batch_place_wr(qp, 0, &wr_buf);
+    efa_cuda_flush_sq_wrs(qp);
+}
+```
+
+### Receive Operation
+```cuda
+__global__ void recv_kernel(efa_cuda_qp *qp, efa_cuda_cq *cq, void *recv_buf, size_t len) {
+    // Post receive work request
+    efa_cuda_post_recv_wr(qp, 0, (uint64_t)recv_buf, len, recv_lkey);
+    efa_cuda_flush_rq_wrs(qp);
+
+    // Poll for receive completion
+    void *wc_buf;
+    while (!(wc_buf = efa_cuda_cq_poll(cq, 0))) {
+        // Wait for receive
+    }
+
+    if (efa_cuda_wc_read_opcode(wc_buf) & EFA_CUDA_WC_RECV) {
+        uint32_t received_bytes = efa_cuda_wc_read_byte_len(wc_buf);
+        if (efa_cuda_wc_has_imm(wc_buf)) {
+            uint32_t imm_data = efa_cuda_wc_read_imm_data(wc_buf);
+        }
+    }
+
+    // Pop the completion
+    efa_cuda_cq_pop(cq, 1);
+}
+```
+
+## Parallel Operations Support
+
+The library supports parallel operations for both work request posting and completion polling, allowing multiple threads to work concurrently.
+
+### Parallel Work Request Posting Example
+```cuda
+__global__ void parallel_send_kernel(efa_cuda_qp *qp, void **data_ptrs, size_t *lengths, int num_requests) {
+    int tid = threadIdx.x;
+
+    if (tid == 0) {
+        // Start batch for all threads
+        efa_cuda_start_sq_batch(qp, num_requests);
+    }
+    __syncthreads();
+
+    if (tid < num_requests) {
+        // Each thread prepares its own work request
+        efa_io_tx_wqe wr_buf;
+        efa_cuda_init_send_wr(&wr_buf, tid);
+        efa_cuda_wr_set_sge(&wr_buf, lkey, (uint64_t)data_ptrs[tid], lengths[tid]);
+        efa_cuda_wr_set_remote(&wr_buf, ah, remote_qpn, qkey);
+
+        // Place work request at thread's position in batch
+        efa_cuda_sq_batch_place_wr(qp, tid, &wr_buf);
+    }
+
+    __syncthreads();
+
+    if (tid == 0) {
+        // Flush all work requests
+        efa_cuda_flush_sq_wrs(qp);
+    }
+}
+```
+
+### Parallel Polling Example
+```cuda
+__global__ void parallel_poll_kernel(efa_cuda_cq *cq) {
+    int tid = threadIdx.x;
+
+    // Each thread polls a different position
+    void *wc_buf = efa_cuda_cq_poll(cq, tid);
+    if (wc_buf) {
+        // Process completion at position tid
+        uint16_t req_id = efa_cuda_wc_read_req_id(wc_buf);
+        // ... handle completion
+    }
+
+    __syncthreads();
+
+    // Pop all processed completions (only one thread should do this)
+    if (tid == 0) {
+        int completed_count = /* count of successful polls */;
+        efa_cuda_cq_pop(cq, completed_count);
+    }
+}
+```
+
+### Key Points
+- **Work Requests**: Multiple threads can prepare work requests in parallel using `efa_cuda_sq_batch_place_wr` with different indexes
+- **Work Requests**: Batch operations must be coordinated with `efa_cuda_start_sq_batch` and `efa_cuda_flush_sq_wrs`
+- **Polling**: `efa_cuda_cq_poll(cq, position)` returns a pointer to the completion buffer if available, NULL otherwise
+- **Polling**: Multiple threads can poll different positions concurrently
+- **Polling**: `efa_cuda_cq_pop(cq, amount)` advances the CQ consumer pointer and must be called after processing completions
+- All work completion read functions take a `void *wc_buf` parameter and act directly on a work completion
+
+## Build Instructions
+
+### Prerequisites
+- NVIDIA CUDA Toolkit
+- EFA kernel driver
+- Compatible GPU with CUDA support
+
+### Building
+```bash
+make clean
+make
+```
+
+This produces:
+- `build/libefacudadp.so` - Shared library
+
+### Linking with Applications
+```bash
+# Host-side code (links against libefacudadp for create/destroy)
+g++ -o myapp_host myapp_host.cpp -ICUDA/host -ICUDA/common -Lbuild -lefacudadp -lcudart
+
+# CUDA kernel code (includes device headers directly)
+nvcc -o myapp_kernel myapp_kernel.cu -ICUDA/device -ICUDA/common
+```
+
+For direct inline usage in CUDA kernels, include `efa_cuda_dp_impl.cuh` directly.
+
+## Assumptions and Limitations
+
+### Threading and Concurrency
+
+#### Object Lifecycle Operations
+- **Single-threaded only**: Queue creation/destruction (`efa_cuda_create_cq`, `efa_cuda_destroy_cq`, `efa_cuda_create_qp`, `efa_cuda_destroy_qp`) must not be called concurrently with any other operations
+
+#### Queue State Operations
+- **Single-threaded only**: Operations that modify queue state (`efa_cuda_cq_pop`, `efa_cuda_start_sq_batch`, `efa_cuda_flush_sq_wrs`, `efa_cuda_post_recv_wr`, `efa_cuda_flush_rq_wrs`) must be serialized per queue
+
+#### Work Request and Completion Operations
+- **Parallel safe**: Multiple threads can access different WR positions (`efa_cuda_sq_batch_place_wr` with different indexes)
+- **Parallel safe**: Multiple threads can poll different CQ positions (`efa_cuda_cq_poll` with different position values)
+- **Parallel safe**: WR initialization and WC read functions are stateless and thread-safe
+
+### Memory Requirements
+- **Memory allocation**: Completion queue and Receive queue buffers must be allocated in GPU-accessible memory, Send queues need to be registered for GPU access
+- **Buffer alignment**: Queue buffers must be properly aligned for hardware access
+- **Power-of-2 sizing**: Queue sizes must be power of 2
+
+### Hardware Constraints
+- **Batch size limits**: Send queue batches limited by `sq_max_batch` parameter that is an EFA device property
+- **Inline data limit**: Maximum 32 bytes inline data per work request
+- **SGE limits**: Limited number of scatter-gather elements per work request
+- **Completion queue sizing**: CQ must accommodate all outstanding work requests
+
+### API Behavior
+- **Work request lifecycle**: Work requests must be properly initialized before use
+- **Flush requirements**: Explicit flush calls required to submit work requests to hardware
+- **Completion ordering**: Completions may not arrive in submission order
+- **Queue overflow**: No validation prevents overfilling send or receive queues - applications must track outstanding work requests
+
+## Performance Notes
+
+- Use batched operations when possible to amortize submission overhead
+- Pre-allocate work request buffers to avoid runtime allocation
+- Consider using inline data for small messages to reduce memory bandwidth
+- Poll completions efficiently to minimize latency

--- a/3rd-party/efa-gda/CUDA/common/efa_cuda_dp_types.h
+++ b/3rd-party/efa-gda/CUDA/common/efa_cuda_dp_types.h
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#ifndef EFA_CUDA_DP_TYPES_H
+#define EFA_CUDA_DP_TYPES_H
+
+#include <stdint.h>
+
+#define EFA_CUDA_DP_VERSION_MAJOR 0
+#define EFA_CUDA_DP_VERSION_MINOR 0
+#define EFA_CUDA_DP_VERSION_SUBMINOR 1
+
+struct efa_cuda_cq {
+	uint64_t comp_mask;
+	uint32_t entry_size;
+	uint32_t num_entries;
+	uint32_t queue_mask;
+	uint32_t queue_size_shift;
+	uint32_t cc;
+	int phase;
+	uint8_t *buf;
+	uint32_t *db;
+};
+
+struct efa_cuda_wq {
+	uint32_t max_sge;
+	uint32_t max_wqes;
+	uint32_t queue_mask;
+	uint32_t queue_size_shift;
+	uint32_t max_batch;
+	uint32_t wqes_pending;
+	uint32_t wqes_posted;
+	uint32_t wqes_completed;
+	uint32_t pc;
+	int phase;
+	uint8_t *buf;
+	uint32_t *db;
+};
+
+struct efa_cuda_rq {
+	struct efa_cuda_wq wq;
+};
+
+struct efa_cuda_sq {
+	struct efa_cuda_wq wq;
+	uint32_t max_inline_data;
+	uint32_t max_rdma_sges;
+};
+
+struct efa_cuda_qp {
+	uint64_t comp_mask;
+	struct efa_cuda_sq sq;
+	struct efa_cuda_rq rq;
+};
+
+#endif

--- a/3rd-party/efa-gda/CUDA/device/efa_cuda_dp.cuh
+++ b/3rd-party/efa-gda/CUDA/device/efa_cuda_dp.cuh
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#ifndef EFA_CUDA_DP_CUH
+#define EFA_CUDA_DP_CUH
+
+#include <cstddef>
+#include <stdint.h>
+#include <cuda_runtime.h>
+
+#include "efa_cuda_dp_types.h"
+#include "efa_io_defs.h"
+
+enum efa_cuda_wc_opcode {
+	EFA_CUDA_WC_SEND,
+	EFA_CUDA_WC_RDMA_WRITE,
+	EFA_CUDA_WC_RDMA_READ,
+/*
+ * Set value of EFA_CUDA_WC_RECV so consumers can test if a completion is a
+ * receive by testing (opcode & EFA_CUDA_WC_RECV).
+ */
+	EFA_CUDA_WC_RECV                  = 1 << 7,
+	EFA_CUDA_WC_RECV_RDMA_WITH_IMM,
+};
+
+enum efa_cuda_processing_hint {
+	EFA_CUDA_PROCESSING_HINT_BURST_PPS_SENSITIVE = 1 << 0,
+};
+
+__device__ void *efa_cuda_cq_poll(efa_cuda_cq *cq, uint32_t position);
+
+__device__ int efa_cuda_cq_pop(efa_cuda_cq *cq, uint32_t amount);
+
+__device__ enum efa_cuda_wc_opcode efa_cuda_wc_read_opcode(void *wc_buf);
+
+__device__ bool efa_cuda_wc_is_unsolicited(void *wc_buf);
+
+__device__ uint16_t efa_cuda_wc_read_req_id(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_vendor_err(void *wc_buf);
+
+__device__ bool efa_cuda_wc_has_imm(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_imm_data(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_byte_len(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_qp_num(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_src_qp(void *wc_buf);
+
+__device__ uint32_t efa_cuda_wc_read_slid(void *wc_buf);
+
+__device__ int efa_cuda_init_send_wr(void *wr_buf, uint16_t wr_id);
+
+__device__ int efa_cuda_init_send_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t imm_data);
+
+__device__ int efa_cuda_init_rdma_read_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr);
+
+__device__ int efa_cuda_init_rdma_write_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr);
+
+__device__ int efa_cuda_init_rdma_write_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr, uint32_t imm_data);
+
+__device__ void efa_cuda_wr_set_remote(void *wr_buf, uint16_t ah, uint32_t remote_qpn, uint32_t remote_qkey);
+
+__device__ int efa_cuda_wr_set_inline_data(void *wr_buf, void *addr, size_t length);
+
+__device__ int efa_cuda_wr_set_sge(void *wr_buf, uint32_t lkey, uint64_t addr, uint32_t length);
+
+__device__ void efa_cuda_wr_set_processing_hints(void *wr_buf, uint32_t hints);
+
+__device__ void efa_cuda_flush_sq_wrs(efa_cuda_qp *qp);
+
+__device__ int efa_cuda_start_sq_batch(efa_cuda_qp *qp, int batch_size);
+
+__device__ int efa_cuda_sq_batch_place_wr(efa_cuda_qp *qp, int index_in_batch, void *wr_buf);
+
+__device__ int efa_cuda_post_recv_wr(efa_cuda_qp *qp, uint16_t req_id, uint64_t addr, uint32_t length, uint32_t lkey);
+
+__device__ void efa_cuda_flush_rq_wrs(efa_cuda_qp *qp);
+
+__device__ bool efa_cuda_is_cq_compatible(efa_cuda_cq *cq);
+
+__device__ bool efa_cuda_is_qp_compatible(efa_cuda_qp *qp);
+
+#endif

--- a/3rd-party/efa-gda/CUDA/device/efa_cuda_dp_impl.cuh
+++ b/3rd-party/efa-gda/CUDA/device/efa_cuda_dp_impl.cuh
@@ -1,0 +1,454 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#ifndef EFA_CUDA_DP_IMPL_CUH
+#define EFA_CUDA_DP_IMPL_CUH
+
+#include <stdio.h>
+#include <cstring>
+#include <errno.h>
+#include <stdint.h>
+
+#include "efa_cuda_dp.cuh"
+
+#define BIT(nr)		(1UL << (nr))
+
+#define __bf_shf(x)	(__builtin_ffsll(x) - 1)
+
+#define EFA_FIELD_GET(_mask, _reg)						\
+	({									\
+		(typeof(_mask))(((_reg) & (_mask)) >> __bf_shf(_mask));		\
+	})
+
+#define EFA_FIELD_PREP(_mask, _val)						\
+	({									\
+		((typeof(_mask))(_val) << __bf_shf(_mask)) & (_mask);		\
+	})
+
+#define BITS_PER_LONG	(8 * sizeof(long))
+
+#define GENMASK(h, l)								\
+	(((~0UL) - (1UL << (l)) + 1) & (~0UL >> (BITS_PER_LONG - 1 - (h))))
+
+#define EFA_GET(ptr, mask)							\
+	EFA_FIELD_GET(mask##_MASK, *(typeof(*ptr) volatile *)(ptr))
+
+#define EFA_SET(ptr, mask, value)						\
+	({									\
+		typeof(ptr) _ptr = ptr;				        	\
+		*_ptr = (*_ptr & ~(mask##_MASK)) |				\
+			EFA_FIELD_PREP(mask##_MASK, value);		        \
+	})
+
+#define efa_container_of(ptr, type, field)					\
+	((type *) ((char *)ptr - offsetof(type, field)))
+
+
+__device__ inline int efa_cuda_cqe_is_pending(const efa_io_cdesc_common *cqe_common, int phase)
+{
+	return EFA_GET(&cqe_common->flags, EFA_IO_CDESC_COMMON_PHASE) == phase;
+}
+
+__device__ inline efa_io_cdesc_common *efa_cuda_get_cqe(efa_cuda_cq *cq, uint32_t position)
+{
+	uint32_t index = (cq->cc + position) & cq->queue_mask;
+	return (efa_io_cdesc_common *)(cq->buf + (index * cq->entry_size));
+}
+
+__device__ inline int efa_cuda_get_cqe_phase(efa_cuda_cq *cq, uint32_t position)
+{
+	return cq->phase ^ (((cq->cc & cq->queue_mask) + position) >> cq->queue_size_shift);
+}
+
+__device__ void *efa_cuda_cq_poll(efa_cuda_cq *cq, uint32_t position)
+{
+	efa_io_cdesc_common *cqe = efa_cuda_get_cqe(cq, position);
+	int cqe_phase = efa_cuda_get_cqe_phase(cq, position);
+
+	if (efa_cuda_cqe_is_pending(cqe, cqe_phase)) {
+		__threadfence_block();
+
+		return cqe;
+	}
+	return nullptr;
+}
+__device__ int efa_cuda_cq_pop(efa_cuda_cq *cq, uint32_t amount)
+{
+	cq->phase = efa_cuda_get_cqe_phase(cq, amount);
+	cq->cc += amount;
+
+	return 0;
+}
+
+__device__ enum efa_cuda_wc_opcode efa_cuda_wc_read_opcode(void *wc_buf)
+{
+	enum efa_io_send_op_type op_type;
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	op_type = (enum efa_io_send_op_type)EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_OP_TYPE);
+
+	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) == EFA_IO_SEND_QUEUE) {
+		if (op_type == EFA_IO_RDMA_WRITE)
+			return EFA_CUDA_WC_RDMA_WRITE;
+
+		if (op_type == EFA_IO_RDMA_READ)
+			return EFA_CUDA_WC_RDMA_READ;
+
+		return EFA_CUDA_WC_SEND;
+	}
+
+	if (op_type == EFA_IO_RDMA_WRITE)
+		return EFA_CUDA_WC_RECV_RDMA_WITH_IMM;
+
+	return EFA_CUDA_WC_RECV;
+}
+
+__device__ bool efa_cuda_wc_is_unsolicited(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	return EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_UNSOLICITED);
+}
+
+__device__ uint16_t efa_cuda_wc_read_req_id(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	return cqe->req_id;
+}
+
+__device__ uint32_t efa_cuda_wc_read_vendor_err(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	return cqe->status;
+}
+
+__device__ bool efa_cuda_wc_has_imm(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	return EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_HAS_IMM);
+}
+
+__device__ uint32_t efa_cuda_wc_read_imm_data(void *wc_buf)
+{
+	struct efa_io_rx_cdesc *rcqe;
+
+	rcqe = efa_container_of(wc_buf, struct efa_io_rx_cdesc, common);
+
+	return rcqe->imm;
+}
+
+__device__ uint32_t efa_cuda_wc_read_byte_len(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+	struct efa_io_rx_cdesc_ex *rcqe;
+	uint32_t length;
+
+	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_Q_TYPE) != EFA_IO_RECV_QUEUE)
+		return 0;
+
+	rcqe = efa_container_of(cqe, struct efa_io_rx_cdesc_ex, base.common);
+
+	length = rcqe->base.length;
+	if (EFA_GET(&cqe->flags, EFA_IO_CDESC_COMMON_OP_TYPE) == EFA_IO_RDMA_WRITE)
+		length |= ((uint32_t)rcqe->u.rdma_write.length_hi << 16);
+
+	return length;
+}
+
+__device__ uint32_t efa_cuda_wc_read_qp_num(void *wc_buf)
+{
+	struct efa_io_cdesc_common *cqe = (struct efa_io_cdesc_common *)wc_buf;
+
+	return cqe->qp_num;
+}
+
+__device__ uint32_t efa_cuda_wc_read_src_qp(void *wc_buf)
+{
+	struct efa_io_rx_cdesc *rcqe;
+
+	rcqe = efa_container_of(wc_buf, struct efa_io_rx_cdesc, common);
+
+	return rcqe->src_qp_num;
+}
+
+__device__ uint32_t efa_cuda_wc_read_slid(void *wc_buf)
+{
+	struct efa_io_rx_cdesc *rcqe;
+
+	rcqe = efa_container_of(wc_buf, struct efa_io_rx_cdesc, common);
+
+	return rcqe->ah;
+}
+
+__device__ int efa_cuda_sq_init_wr(void *wr_buf, enum efa_io_send_op_type op_type, uint16_t wr_id)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+
+	memset(wqe, 0, sizeof(*wqe));
+	EFA_SET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_META_DESC, 1);
+	EFA_SET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_OP_TYPE, op_type);
+	EFA_SET(&wqe->meta.ctrl2, EFA_IO_TX_META_DESC_FIRST, 1);
+	EFA_SET(&wqe->meta.ctrl2, EFA_IO_TX_META_DESC_LAST, 1);
+	EFA_SET(&wqe->meta.ctrl2, EFA_IO_TX_META_DESC_COMP_REQ, 1);
+
+	wqe->meta.req_id = wr_id;
+
+	return 0;
+}
+
+__device__ void efa_cuda_set_wqe_imm_data(void *wr_buf, uint32_t imm_data)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+
+	wqe->meta.immediate_data = imm_data;
+	EFA_SET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_HAS_IMM, 1);
+}
+
+__device__ void efa_cuda_set_remote_mem(struct efa_io_remote_mem_addr *remote_mem, uint32_t rkey, uint64_t remote_addr)
+{
+	remote_mem->rkey = rkey;
+	remote_mem->buf_addr_lo = remote_addr & 0xFFFFFFFF;
+	remote_mem->buf_addr_hi = remote_addr >> 32;
+}
+
+__device__ void efa_cuda_set_tx_buf(struct efa_io_tx_buf_desc *tx_buf, uint64_t addr, uint32_t lkey, uint32_t length)
+{
+	tx_buf->length = length;
+	EFA_SET(&tx_buf->lkey, EFA_IO_TX_BUF_DESC_LKEY, lkey);
+	tx_buf->buf_addr_lo = addr & 0xffffffff;
+	tx_buf->buf_addr_hi = addr >> 32;
+}
+
+__device__ int efa_cuda_init_send_wr(void *wr_buf, uint16_t wr_id)
+{
+	return efa_cuda_sq_init_wr(wr_buf, EFA_IO_SEND, wr_id);
+}
+
+__device__ int efa_cuda_init_send_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t imm_data)
+{
+	int ret;
+
+	ret = efa_cuda_sq_init_wr(wr_buf, EFA_IO_SEND, wr_id);
+	if (ret)
+		return ret;
+
+	efa_cuda_set_wqe_imm_data(wr_buf, imm_data);
+
+	return 0;
+}
+
+__device__ int efa_cuda_init_rdma_read_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	int ret;
+
+	ret = efa_cuda_sq_init_wr(wr_buf, EFA_IO_RDMA_READ, wr_id);
+	if (ret)
+		return ret;
+
+	efa_cuda_set_remote_mem(&wqe->data.rdma_req.remote_mem, rkey, remote_addr);
+
+	return 0;
+}
+
+__device__ int efa_cuda_init_rdma_write_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	int ret;
+
+	ret = efa_cuda_sq_init_wr(wr_buf, EFA_IO_RDMA_WRITE, wr_id);
+	if (ret)
+		return ret;
+
+	efa_cuda_set_remote_mem(&wqe->data.rdma_req.remote_mem, rkey, remote_addr);
+
+	return 0;
+}
+
+__device__ int efa_cuda_init_rdma_write_imm_wr(void *wr_buf, uint16_t wr_id, uint32_t rkey, uint64_t remote_addr, uint32_t imm_data)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	int ret;
+
+	ret = efa_cuda_sq_init_wr(wr_buf, EFA_IO_RDMA_WRITE, wr_id);
+	if (ret)
+		return ret;
+
+	efa_cuda_set_remote_mem(&wqe->data.rdma_req.remote_mem, rkey, remote_addr);
+	efa_cuda_set_wqe_imm_data(wr_buf, imm_data);
+
+	return 0;
+}
+
+__device__ void efa_cuda_wr_set_remote(void *wr_buf, uint16_t ah, uint32_t remote_qpn, uint32_t remote_qkey)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+
+	wqe->meta.ah = ah;
+	wqe->meta.dest_qp_num = remote_qpn;
+	wqe->meta.qkey = remote_qkey;
+}
+
+__device__ int efa_cuda_wr_set_inline_data(void *wr_buf, void *addr, size_t length)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	uint8_t op_type;
+
+	if (length > sizeof(wqe->data.inline_data))
+		return -EINVAL;
+
+	op_type = EFA_GET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_OP_TYPE);
+	if (op_type != EFA_IO_SEND)
+		return -EINVAL;
+
+	EFA_SET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_INLINE_MSG, 1);
+	memcpy(wqe->data.inline_data, addr, length);
+	wqe->meta.length = length;
+
+	return 0;
+}
+
+__device__ int efa_cuda_wr_set_sge(void *wr_buf, uint32_t lkey, uint64_t addr, uint32_t length)
+{
+	struct efa_io_tx_buf_desc *buf;
+	struct efa_io_tx_wqe *wqe;
+	uint8_t op_type;
+
+	wqe = (struct efa_io_tx_wqe *)wr_buf;
+	wqe->meta.length = 1;
+
+	op_type = EFA_GET(&wqe->meta.ctrl1, EFA_IO_TX_META_DESC_OP_TYPE);
+	switch (op_type) {
+	case EFA_IO_SEND:
+		buf = &wqe->data.sgl[0];
+		break;
+	case EFA_IO_RDMA_READ:
+	case EFA_IO_RDMA_WRITE:
+		wqe->data.rdma_req.remote_mem.length = length;
+		buf = &wqe->data.rdma_req.local_mem[0];
+		break;
+	default:
+		return -EINVAL;
+	}
+
+	efa_cuda_set_tx_buf(buf, addr, lkey, length);
+	return 0;
+}
+
+__device__ void efa_cuda_wr_set_processing_hints(void *wr_buf, uint32_t hints)
+{
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	uint32_t io_hints = 0;
+
+	if (hints & EFA_CUDA_PROCESSING_HINT_BURST_PPS_SENSITIVE)
+		io_hints |= EFA_IO_PROCESSING_HINT_BURST_PPS_SENSITIVE;
+
+	EFA_SET(&wqe->meta.ctrl3, EFA_IO_TX_META_DESC_PROCESSING_HINTS, io_hints);
+}
+
+__device__ inline int efa_cuda_get_wqe_phase(efa_cuda_wq *wq, uint32_t index_in_batch)
+{
+	return wq->phase ^ (((wq->pc & wq->queue_mask) + index_in_batch) >> wq->queue_size_shift);
+}
+
+__device__ void efa_cuda_flush_sq_wrs(efa_cuda_qp *qp)
+{
+	if (!qp->sq.wq.wqes_pending)
+		return;
+
+	qp->sq.wq.phase = efa_cuda_get_wqe_phase(&qp->sq.wq, qp->sq.wq.wqes_pending);
+	qp->sq.wq.pc += qp->sq.wq.wqes_pending;
+	qp->sq.wq.wqes_pending = 0;
+
+	__threadfence_system();
+	*qp->sq.wq.db = qp->sq.wq.pc;
+	__threadfence_system();
+}
+
+__device__ int efa_cuda_start_sq_batch(efa_cuda_qp *qp, int batch_size)
+{
+	// TODO: check free space
+
+	if (qp->sq.wq.wqes_pending + batch_size > qp->sq.wq.max_batch)
+		efa_cuda_flush_sq_wrs(qp);
+
+	qp->sq.wq.wqes_pending += batch_size;
+	return 0;
+}
+
+__device__ int efa_cuda_sq_batch_place_wr(efa_cuda_qp *qp, int index_in_batch, void *wr_buf)
+{
+	int wqe_phase = efa_cuda_get_wqe_phase(&qp->sq.wq, index_in_batch);
+	struct efa_io_tx_wqe *wqe = (struct efa_io_tx_wqe *)wr_buf;
+	uint32_t sq_desc_offset;
+	uint64_t *src;
+	uint64_t *dst;
+
+	EFA_SET(&wqe->meta.ctrl2, EFA_IO_TX_META_DESC_PHASE, wqe_phase);
+
+	src = (uint64_t *)wqe;
+	sq_desc_offset = ((qp->sq.wq.pc + index_in_batch) & qp->sq.wq.queue_mask) * sizeof(struct efa_io_tx_wqe);
+	dst = (uint64_t *)(qp->sq.wq.buf + sq_desc_offset);
+	for (int i = 0 ; i < 8 ; i++)
+		dst[i] = src[i];
+
+	return 0;
+}
+
+__device__ int efa_cuda_post_recv_wr(efa_cuda_qp *qp, uint16_t req_id, uint64_t addr, uint32_t length, uint32_t lkey)
+{
+	struct efa_io_rx_desc wqe = {0};
+	uint32_t rq_desc_offset;
+
+	EFA_SET(&wqe.lkey_ctrl, EFA_IO_RX_DESC_FIRST, 1);
+	EFA_SET(&wqe.lkey_ctrl, EFA_IO_RX_DESC_LAST, 1);
+
+	EFA_SET(&wqe.lkey_ctrl, EFA_IO_RX_DESC_LKEY, lkey);
+	wqe.buf_addr_lo = addr;
+	wqe.buf_addr_hi = addr >> 32;
+	wqe.length = length;
+	wqe.req_id = req_id;
+
+	/* Copy descriptor to RX ring */
+	rq_desc_offset = (qp->rq.wq.pc & qp->rq.wq.queue_mask) * sizeof(wqe);
+	memcpy(qp->rq.wq.buf + rq_desc_offset, &wqe, sizeof(wqe));
+
+	qp->rq.wq.pc++;
+	if (!(qp->rq.wq.pc & qp->rq.wq.queue_mask))
+		qp->rq.wq.phase++;
+
+	qp->rq.wq.wqes_pending++;
+	if (qp->rq.wq.wqes_pending == qp->rq.wq.max_batch) {
+		__threadfence_system();
+		*qp->rq.wq.db = qp->rq.wq.pc;
+
+		qp->rq.wq.wqes_pending = 0;
+	}
+
+	return 0;
+}
+
+__device__ void efa_cuda_flush_rq_wrs(efa_cuda_qp *qp)
+{
+	if (!qp->rq.wq.wqes_pending)
+		return;
+
+	__threadfence_system();
+	*qp->rq.wq.db = qp->rq.wq.pc;
+	qp->rq.wq.wqes_pending = 0;
+}
+
+__device__ bool efa_cuda_is_cq_compatible(efa_cuda_cq *cq)
+{
+	return cq->comp_mask == 0;
+}
+
+__device__ bool efa_cuda_is_qp_compatible(efa_cuda_qp *qp)
+{
+	return qp->comp_mask == 0;
+}
+
+#endif

--- a/3rd-party/efa-gda/CUDA/device/efa_io_defs.h
+++ b/3rd-party/efa-gda/CUDA/device/efa_io_defs.h
@@ -1,0 +1,405 @@
+/* SPDX-License-Identifier: GPL-2.0 OR BSD-2-Clause */
+/*
+ * Copyright 2018-2024 Amazon.com, Inc. or its affiliates. All rights reserved.
+ */
+
+#ifndef _EFA_IO_H_
+#define _EFA_IO_H_
+
+#define EFA_IO_TX_DESC_NUM_BUFS              2
+#define EFA_IO_TX_DESC_NUM_RDMA_BUFS         1
+#define EFA_IO_TX_DESC_INLINE_MAX_SIZE       32
+#define EFA_IO_TX_DESC_IMM_DATA_SIZE         4
+#define EFA_IO_TX_DESC_INLINE_PBL_SIZE       1
+
+enum efa_io_queue_type {
+	/* send queue (of a QP) */
+	EFA_IO_SEND_QUEUE                           = 1,
+	/* recv queue (of a QP) */
+	EFA_IO_RECV_QUEUE                           = 2,
+};
+
+enum efa_io_send_op_type {
+	/* send message */
+	EFA_IO_SEND                                 = 0,
+	/* RDMA read */
+	EFA_IO_RDMA_READ                            = 1,
+	/* RDMA write */
+	EFA_IO_RDMA_WRITE                           = 2,
+	/* Fast MR registration */
+	EFA_IO_FAST_REG                             = 3,
+	/* Fast MR invalidation */
+	EFA_IO_FAST_INV                             = 4,
+};
+
+enum efa_io_comp_status {
+	/* Successful completion */
+	EFA_IO_COMP_STATUS_OK                       = 0,
+	/* Flushed during QP destroy */
+	EFA_IO_COMP_STATUS_FLUSHED                  = 1,
+	/* Internal QP error */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_QP_INTERNAL_ERROR = 2,
+	/* Unsupported operation */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_UNSUPPORTED_OP = 3,
+	/* Bad AH */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_INVALID_AH   = 4,
+	/* LKEY not registered or does not match IOVA */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_INVALID_LKEY = 5,
+	/* Message too long */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_BAD_LENGTH   = 6,
+	/* RKEY not registered or does not match remote IOVA */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_ADDRESS = 7,
+	/* Connection was reset by remote side */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_ABORT       = 8,
+	/* Bad dest QP number (QP does not exist or is in error state) */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_DEST_QPN = 9,
+	/* Destination resource not ready (no WQEs posted on RQ) */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_RNR         = 10,
+	/* Receiver SGL too short */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_LENGTH  = 11,
+	/* Unexpected status returned by responder */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_BAD_STATUS  = 12,
+	/* Unresponsive remote - was previously responsive */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_UNRESP_REMOTE = 13,
+	/* No valid AH at remote side (required for RDMA operations) */
+	EFA_IO_COMP_STATUS_REMOTE_ERROR_UNKNOWN_PEER = 14,
+	/* Unreachable remote - never received a response */
+	EFA_IO_COMP_STATUS_LOCAL_ERROR_UNREACH_REMOTE = 15,
+};
+
+enum efa_io_frwr_pbl_mode {
+	EFA_IO_FRWR_INLINE_PBL                      = 0,
+	EFA_IO_FRWR_DIRECT_PBL                      = 1,
+};
+
+enum efa_io_processing_hint {
+	/* Optimize for throughput */
+	EFA_IO_PROCESSING_HINT_BURST_PPS_SENSITIVE  = 1 << 0,
+};
+
+struct efa_io_tx_meta_desc {
+	/* Verbs-generated Request ID */
+	uint16_t req_id;
+
+	/*
+	 * control flags
+	 * 3:0 : op_type - enum efa_io_send_op_type
+	 * 4 : has_imm - immediate_data field carries valid
+	 *    data.
+	 * 5 : inline_msg - inline mode - inline message data
+	 *    follows this descriptor (no buffer descriptors).
+	 *    Note that it is different from immediate data
+	 * 6 : meta_extension - Extended metadata. MBZ
+	 * 7 : meta_desc - Indicates metadata descriptor.
+	 *    Must be set.
+	 */
+	uint8_t ctrl1;
+
+	/*
+	 * control flags
+	 * 0 : phase
+	 * 1 : reserved25 - MBZ
+	 * 2 : first - Indicates first descriptor in
+	 *    transaction. Must be set.
+	 * 3 : last - Indicates last descriptor in
+	 *    transaction. Must be set.
+	 * 4 : comp_req - Indicates whether completion should
+	 *    be posted, after packet is transmitted. Valid only
+	 *    for the first descriptor
+	 * 7:5 : reserved29 - MBZ
+	 */
+	uint8_t ctrl2;
+
+	uint16_t dest_qp_num;
+
+	/*
+	 * If inline_msg bit is set, length of inline message in bytes,
+	 * otherwise length of SGL (number of buffers).
+	 */
+	uint16_t length;
+
+	/*
+	 * immediate data: if has_imm is set, then this field is included within
+	 * Tx message and reported in remote Rx completion.
+	 */
+	uint32_t immediate_data;
+
+	uint16_t ah;
+
+	/*
+	 * control flags
+	 * 1:0 : processing_hints - Bitmask of enum
+	 *    efa_io_processing_hint
+	 * 7:2 : reserved - MBZ
+	 */
+	uint8_t ctrl3;
+
+	uint8_t reserved;
+
+	/* Queue key */
+	uint32_t qkey;
+
+	uint8_t reserved2[12];
+};
+
+/*
+ * Tx queue buffer descriptor, for any transport type. Preceded by metadata
+ * descriptor.
+ */
+struct efa_io_tx_buf_desc {
+	/* length in bytes */
+	uint32_t length;
+
+	/*
+	 * 23:0 : lkey - local memory translation key
+	 * 31:24 : reserved - MBZ
+	 */
+	uint32_t lkey;
+
+	/* Buffer address bits[31:0] */
+	uint32_t buf_addr_lo;
+
+	/* Buffer address bits[63:32] */
+	uint32_t buf_addr_hi;
+};
+
+struct efa_io_remote_mem_addr {
+	/* length in bytes */
+	uint32_t length;
+
+	/* remote memory translation key */
+	uint32_t rkey;
+
+	/* Buffer address bits[31:0] */
+	uint32_t buf_addr_lo;
+
+	/* Buffer address bits[63:32] */
+	uint32_t buf_addr_hi;
+};
+
+struct efa_io_rdma_req {
+	/* Remote memory address */
+	struct efa_io_remote_mem_addr remote_mem;
+
+	/* Local memory address */
+	struct efa_io_tx_buf_desc local_mem[1];
+};
+
+struct efa_io_fast_mr_reg_req {
+	/* Updated local key of the MR after lkey/rkey increment */
+	uint32_t lkey;
+
+	/*
+	 * permissions
+	 * 0 : local_write_enable - Local write permissions:
+	 *    must be set for RQ buffers and buffers posted for
+	 *    RDMA Read requests
+	 * 1 : remote_write_enable - Remote write
+	 *    permissions: must be set to enable RDMA write to
+	 *    the region
+	 * 2 : remote_read_enable - Remote read permissions:
+	 *    must be set to enable RDMA read from the region
+	 * 7:3 : reserved2 - MBZ
+	 */
+	uint8_t permissions;
+
+	/*
+	 * control flags
+	 * 4:0 : phys_page_size_shift - page size is (1 <<
+	 *    phys_page_size_shift)
+	 * 6:5 : pbl_mode - enum efa_io_frwr_pbl_mode
+	 * 7 : reserved - MBZ
+	 */
+	uint8_t flags;
+
+	/* MBZ */
+	uint8_t reserved[2];
+
+	/* IO Virtual Address associated with this MR */
+	uint64_t iova;
+
+	/* Memory region length, in bytes */
+	uint64_t mr_length;
+
+	/* Physical Buffer List, each element is page-aligned. */
+	union {
+		/*
+		 * Inline array of physical page addresses (optimization
+		 * for short region activation).
+		 */
+		uint64_t inline_array[1];
+
+		/* points to PBL (Currently only direct) */
+		uint64_t dma_addr;
+	} pbl;
+};
+
+struct efa_io_fast_mr_inv_req {
+	/* Local key of the MR to invalidate */
+	uint32_t lkey;
+
+	/* MBZ */
+	uint8_t reserved[28];
+};
+
+/*
+ * Tx WQE, composed of tx meta descriptors followed by either tx buffer
+ * descriptors or inline data
+ */
+struct efa_io_tx_wqe {
+	/* TX meta */
+	struct efa_io_tx_meta_desc meta;
+
+	union {
+		/* Send buffer descriptors */
+		struct efa_io_tx_buf_desc sgl[2];
+
+		uint8_t inline_data[32];
+
+		/* RDMA local and remote memory addresses */
+		struct efa_io_rdma_req rdma_req;
+
+		/* Fast registration */
+		struct efa_io_fast_mr_reg_req reg_mr_req;
+
+		/* Fast invalidation */
+		struct efa_io_fast_mr_inv_req inv_mr_req;
+	} data;
+};
+
+/*
+ * Rx buffer descriptor; RX WQE is composed of one or more RX buffer
+ * descriptors.
+ */
+struct efa_io_rx_desc {
+	/* Buffer address bits[31:0] */
+	uint32_t buf_addr_lo;
+
+	/* Buffer Pointer[63:32] */
+	uint32_t buf_addr_hi;
+
+	/* Verbs-generated request id. */
+	uint16_t req_id;
+
+	/* Length in bytes. */
+	uint16_t length;
+
+	/*
+	 * LKey and control flags
+	 * 23:0 : lkey
+	 * 29:24 : reserved - MBZ
+	 * 30 : first - Indicates first descriptor in WQE
+	 * 31 : last - Indicates last descriptor in WQE
+	 */
+	uint32_t lkey_ctrl;
+};
+
+/* Common IO completion descriptor */
+struct efa_io_cdesc_common {
+	/*
+	 * verbs-generated request ID, as provided in the completed tx or rx
+	 * descriptor.
+	 */
+	uint16_t req_id;
+
+	uint8_t status;
+
+	/*
+	 * flags
+	 * 0 : phase - Phase bit
+	 * 2:1 : q_type - enum efa_io_queue_type: send/recv
+	 * 3 : has_imm - indicates that immediate data is
+	 *    present - for RX completions only
+	 * 6:4 : op_type - enum efa_io_send_op_type
+	 * 7 : unsolicited - indicates that there is no
+	 *    matching request - for RDMA with imm. RX only
+	 */
+	uint8_t flags;
+
+	/* local QP number */
+	uint16_t qp_num;
+};
+
+/* Tx completion descriptor */
+struct efa_io_tx_cdesc {
+	/* Common completion info */
+	struct efa_io_cdesc_common common;
+
+	/* MBZ */
+	uint16_t reserved16;
+};
+
+/* Rx Completion Descriptor */
+struct efa_io_rx_cdesc {
+	/* Common completion info */
+	struct efa_io_cdesc_common common;
+
+	/* Transferred length bits[15:0] */
+	uint16_t length;
+
+	/* Remote Address Handle FW index, 0xFFFF indicates invalid ah */
+	uint16_t ah;
+
+	uint16_t src_qp_num;
+
+	/* Immediate data */
+	uint32_t imm;
+};
+
+/* Rx Completion Descriptor RDMA write info */
+struct efa_io_rx_cdesc_rdma_write {
+	/* Transferred length bits[31:16] */
+	uint16_t length_hi;
+};
+
+/* Extended Rx Completion Descriptor */
+struct efa_io_rx_cdesc_ex {
+	/* Base RX completion info */
+	struct efa_io_rx_cdesc base;
+
+	union {
+		struct efa_io_rx_cdesc_rdma_write rdma_write;
+
+		/*
+		 * Valid only in case of unknown AH (0xFFFF) and CQ
+		 * set_src_addr is enabled.
+		 */
+		uint8_t src_addr[16];
+	} u;
+};
+
+/* tx_meta_desc */
+#define EFA_IO_TX_META_DESC_OP_TYPE_MASK                    GENMASK(3, 0)
+#define EFA_IO_TX_META_DESC_HAS_IMM_MASK                    BIT(4)
+#define EFA_IO_TX_META_DESC_INLINE_MSG_MASK                 BIT(5)
+#define EFA_IO_TX_META_DESC_META_EXTENSION_MASK             BIT(6)
+#define EFA_IO_TX_META_DESC_META_DESC_MASK                  BIT(7)
+#define EFA_IO_TX_META_DESC_PHASE_MASK                      BIT(0)
+#define EFA_IO_TX_META_DESC_FIRST_MASK                      BIT(2)
+#define EFA_IO_TX_META_DESC_LAST_MASK                       BIT(3)
+#define EFA_IO_TX_META_DESC_COMP_REQ_MASK                   BIT(4)
+#define EFA_IO_TX_META_DESC_PROCESSING_HINTS_MASK           GENMASK(1, 0)
+
+/* tx_buf_desc */
+#define EFA_IO_TX_BUF_DESC_LKEY_MASK                        GENMASK(23, 0)
+
+/* fast_mr_reg_req */
+#define EFA_IO_FAST_MR_REG_REQ_LOCAL_WRITE_ENABLE_MASK      BIT(0)
+#define EFA_IO_FAST_MR_REG_REQ_REMOTE_WRITE_ENABLE_MASK     BIT(1)
+#define EFA_IO_FAST_MR_REG_REQ_REMOTE_READ_ENABLE_MASK      BIT(2)
+#define EFA_IO_FAST_MR_REG_REQ_PHYS_PAGE_SIZE_SHIFT_MASK    GENMASK(4, 0)
+#define EFA_IO_FAST_MR_REG_REQ_PBL_MODE_MASK                GENMASK(6, 5)
+
+/* rx_desc */
+#define EFA_IO_RX_DESC_LKEY_MASK                            GENMASK(23, 0)
+#define EFA_IO_RX_DESC_FIRST_MASK                           BIT(30)
+#define EFA_IO_RX_DESC_LAST_MASK                            BIT(31)
+
+/* cdesc_common */
+#define EFA_IO_CDESC_COMMON_PHASE_MASK                      BIT(0)
+#define EFA_IO_CDESC_COMMON_Q_TYPE_MASK                     GENMASK(2, 1)
+#define EFA_IO_CDESC_COMMON_HAS_IMM_MASK                    BIT(3)
+#define EFA_IO_CDESC_COMMON_OP_TYPE_MASK                    GENMASK(6, 4)
+#define EFA_IO_CDESC_COMMON_UNSOLICITED_MASK                BIT(7)
+
+#endif /* _EFA_IO_H_ */

--- a/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
+++ b/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#include <stdio.h>
+#include <errno.h>
+#include <stdint.h>
+#include <cuda_runtime.h>
+
+#include "efa_cuda_dp.h"
+#include "efa_cuda_dp_types.h"
+
+static bool is_buf_cleared(void *buf, size_t len)
+{
+	int i;
+
+	for (i = 0; i < len; i++) {
+		if (((uint8_t *)buf)[i])
+			return false;
+	}
+
+	return true;
+}
+
+#define is_ext_cleared(ptr, inlen) \
+	is_buf_cleared((uint8_t *)ptr + sizeof(*ptr), inlen - sizeof(*ptr))
+
+struct efa_cuda_cq *efa_cuda_create_cq(struct efa_cuda_cq_attrs *attrs, uint32_t inlen)
+{
+	cudaError_t cuda_err;
+
+	if (inlen > sizeof(*attrs) && !is_ext_cleared(attrs, inlen)) {
+		printf("Incompatible attributes struct\n");
+		return nullptr;
+	}
+
+	if (__builtin_popcount(attrs->num_entries) != 1) {
+		printf("CQ size must be positive power of 2\n");
+		return nullptr;
+	}
+
+	efa_cuda_cq *d_cq;
+	cuda_err = cudaMalloc(&d_cq, sizeof(efa_cuda_cq));
+	if (cuda_err != cudaSuccess) {
+		printf("Failed to allocate device memory for cq: %s\n",
+		       cudaGetErrorString(cuda_err));
+		return nullptr;
+	}
+
+	efa_cuda_cq h_cq = {};
+	h_cq.buf = attrs->buffer;
+	h_cq.entry_size = attrs->entry_size;
+	h_cq.num_entries = attrs->num_entries;
+	h_cq.queue_mask = attrs->num_entries - 1;
+	h_cq.queue_size_shift = __builtin_ctz(attrs->num_entries);
+	h_cq.cc = 0;
+	h_cq.phase = 1;
+
+	cuda_err = cudaMemcpy(d_cq, &h_cq, sizeof(efa_cuda_cq), cudaMemcpyHostToDevice);
+	if (cuda_err != cudaSuccess) {
+		cudaFree(d_cq);
+		printf("Failed to copy cq to device: %s\n",
+		       cudaGetErrorString(cuda_err));
+		return nullptr;
+	}
+
+	return d_cq;
+}
+
+void efa_cuda_destroy_cq(efa_cuda_cq *d_cq)
+{
+	cudaFree(d_cq);
+}
+
+struct efa_cuda_qp *efa_cuda_create_qp(struct efa_cuda_qp_attrs *attrs, uint32_t inlen)
+{
+	cudaError_t cuda_err;
+
+	if ((inlen > sizeof(*attrs) && !is_ext_cleared(attrs, inlen)) ||
+	    attrs->reserved) {
+		printf("Incompatible attributes struct\n");
+		return nullptr;
+	}
+
+	if (__builtin_popcount(attrs->sq_num_entries) != 1 ||
+	    __builtin_popcount(attrs->rq_num_entries) != 1) {
+		printf("SQ and RQ sizes must be positive powers of 2\n");
+		return nullptr;
+	}
+
+	efa_cuda_qp *d_qp;
+	cuda_err = cudaMalloc(&d_qp, sizeof(efa_cuda_qp));
+	if (cuda_err != cudaSuccess) {
+		printf("Failed to allocate device memory for qp: %s\n",
+		       cudaGetErrorString(cuda_err));
+		return nullptr;
+	}
+
+	efa_cuda_qp h_qp = {};
+
+	h_qp.sq.wq.buf = attrs->sq_buffer;
+	h_qp.sq.wq.db = attrs->sq_doorbell;
+	h_qp.sq.wq.max_wqes = attrs->sq_num_entries;
+	h_qp.sq.wq.max_batch = attrs->sq_max_batch;
+	h_qp.sq.wq.queue_mask = attrs->sq_num_entries - 1;
+	h_qp.sq.wq.queue_size_shift = __builtin_ctz(attrs->sq_num_entries);
+	h_qp.sq.wq.wqes_pending = 0;
+	h_qp.sq.wq.wqes_posted = 0;
+	h_qp.sq.wq.wqes_completed = 0;
+	h_qp.sq.wq.pc = 0;
+	h_qp.sq.wq.phase = 0;
+	// TODO: get from args or delete:
+	h_qp.sq.max_inline_data = 32;
+	h_qp.sq.max_rdma_sges = 2;
+
+	h_qp.rq.wq.buf = attrs->rq_buffer;
+	h_qp.rq.wq.db = attrs->rq_doorbell;
+	h_qp.rq.wq.max_wqes = attrs->rq_num_entries;
+	h_qp.rq.wq.max_batch = attrs->rq_num_entries;
+	h_qp.rq.wq.queue_mask = attrs->rq_num_entries - 1;
+	h_qp.rq.wq.queue_size_shift = __builtin_ctz(attrs->rq_num_entries);
+	h_qp.rq.wq.wqes_pending = 0;
+	h_qp.rq.wq.wqes_posted = 0;
+	h_qp.rq.wq.wqes_completed = 0;
+	h_qp.rq.wq.pc = 0;
+	h_qp.rq.wq.phase = 1;
+
+	cuda_err = cudaMemcpy(d_qp, &h_qp, sizeof(efa_cuda_qp), cudaMemcpyHostToDevice);
+	if (cuda_err != cudaSuccess) {
+		cudaFree(d_qp);
+		printf("Failed to copy qp to device: %s\n",
+		       cudaGetErrorString(cuda_err));
+		return nullptr;
+	}
+
+	return d_qp;
+}
+
+void efa_cuda_destroy_qp(struct efa_cuda_qp *d_qp)
+{
+	if (d_qp)
+		cudaFree(d_qp);
+}
+
+int efa_cuda_get_version(int *major, int *minor, int *subminor)
+{
+	if (!major || !minor || !subminor)
+		return -EINVAL;
+
+	*major = EFA_CUDA_DP_VERSION_MAJOR;
+	*minor = EFA_CUDA_DP_VERSION_MINOR;
+	*subminor = EFA_CUDA_DP_VERSION_SUBMINOR;
+
+	return 0;
+}

--- a/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.h
+++ b/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.h
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+
+#ifndef EFA_CUDA_DP_H
+#define EFA_CUDA_DP_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct efa_cuda_cq_attrs {
+	uint64_t comp_mask;
+	uint64_t flags;
+	uint8_t *buffer;
+	uint32_t num_entries;
+	uint32_t entry_size;
+};
+
+struct efa_cuda_qp_attrs {
+	uint64_t comp_mask;
+	uint64_t flags;
+	uint8_t *sq_buffer;
+	uint8_t *rq_buffer;
+	uint32_t *sq_doorbell;
+	uint32_t *rq_doorbell;
+	uint32_t sq_num_entries;
+	uint32_t sq_entry_size;
+	uint32_t sq_max_batch;
+	uint32_t rq_num_entries;
+	uint32_t rq_entry_size;
+	uint32_t reserved;
+};
+
+struct efa_cuda_cq;
+struct efa_cuda_qp;
+
+struct efa_cuda_cq *efa_cuda_create_cq(struct efa_cuda_cq_attrs *attrs, uint32_t inlen);
+void efa_cuda_destroy_cq(struct efa_cuda_cq *d_cq);
+struct efa_cuda_qp *efa_cuda_create_qp(struct efa_cuda_qp_attrs *attrs, uint32_t inlen);
+void efa_cuda_destroy_qp(struct efa_cuda_qp *d_qp);
+int efa_cuda_get_version(int *major, int *minor, int *subminor);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/3rd-party/efa-gda/LICENSE
+++ b/3rd-party/efa-gda/LICENSE
@@ -1,0 +1,175 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.

--- a/3rd-party/efa-gda/NOTICE
+++ b/3rd-party/efa-gda/NOTICE
@@ -1,0 +1,1 @@
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/3rd-party/efa-gda/README.md
+++ b/3rd-party/efa-gda/README.md
@@ -1,0 +1,99 @@
+# EFA Datapath Direct
+
+This repository contains direct datapath implementations for Amazon's Elastic Fabric Adapter (EFA), enabling high-performance network operations with minimal CPU overhead.
+
+## Elastic Fabric Adapter (EFA) Overview
+
+### What is EFA?
+Elastic Fabric Adapter (EFA) is Amazon's custom network interface designed for machine learning (ML) training, inference, and High Performance Computing (HPC) workloads on AWS. EFA provides:
+
+- **High bandwidth networking**: Up to 400 Gbps network performance on latest instances
+- **Low-latency communication**: Optimized for distributed ML training and inference
+- **Bypass kernel networking**: Direct hardware access for improved performance
+- **AWS integration**: Native support in AWS Nitro System architecture
+- **ML framework optimization**: Optimized for PyTorch, TensorFlow, and other ML frameworks
+
+### Scalable Reliable Datagram (SRD)
+EFA uses SRD as its primary transport protocol, which provides:
+
+- **Reliable delivery**: Guaranteed packet delivery with hardware-level acknowledgments
+- **Multi-path load balancing**: Efficiently distributes traffic across multiple network paths
+- **Fast failure recovery**: Quickly recovers from packet drops or link failures
+- **High-throughput optimization**: Designed for bandwidth-intensive workloads
+- **Hardware-accelerated congestion control**: Built-in flow control mechanisms
+
+## EFA Datapath Implementations
+
+### Traditional Implementations
+1. **Kernel Driver**
+   - Full kernel-space implementation
+   - Standard verbs interface
+   - Complete feature set with all EFA capabilities
+
+2. **Userspace Libraries**
+   - **libfabric provider**: Standard OFI (OpenFabrics Interface) implementation
+   - **libibverbs provider**: RDMA verbs compatibility layer
+   - **MPI libraries**: Direct integration with popular MPI implementations
+
+### Direct Datapath Implementations
+This repository focuses on **direct datapath** implementations that bypass traditional software stacks:
+
+#### Current Implementation
+- **[CUDA Datapath](./CUDA/)**: GPU-native EFA operations for CUDA applications
+  - Direct posting of work requests from GPU kernels
+  - GPU-side completion polling
+  - No CPU involvement in data path operations
+  - Optimized for GPU-to-GPU communication over EFA
+
+#### Planned/Future Implementations
+- **CPU Direct Path**: Userspace CPU implementation with direct hardware access
+- **Additional accelerator support**: Support for other compute accelerators
+
+## Use Cases
+
+### Machine Learning and AI
+- **Distributed ML training**: Large-scale model training across multiple GPUs and nodes
+- **ML inference**: High-throughput inference serving with minimal latency
+- **GPU-to-GPU communication**: Direct GPU communication for parameter synchronization
+- **Model parallelism**: Efficient distribution of large models across multiple devices
+
+### High-Performance Computing (HPC)
+- **GPU-accelerated simulations**: Direct GPU-to-GPU communication
+- **Scientific computing**: Large-scale parallel computations
+- **Computational fluid dynamics**: High-bandwidth data exchange between compute nodes
+
+### Performance-Critical Applications
+- **Real-time analytics**: Low-latency data processing pipelines
+- **Financial modeling**: High-frequency trading and risk calculations
+- **Media processing**: Real-time video/audio processing workflows
+
+## Getting Started
+
+Each implementation directory contains its own detailed documentation:
+
+- **[CUDA Implementation](./CUDA/README.md)**: Complete guide for GPU-based EFA operations
+- Additional implementations will be documented as they are added
+
+## Requirements
+
+### Hardware
+- EFA-enabled EC2 instances
+
+### Software
+- EFA kernel driver installed and configured
+- Libibverbs (rdma-core) and EFA verbs provider
+- Implementation-specific requirements (see individual directories)
+
+## Security
+
+See [CONTRIBUTING](CONTRIBUTING.md#security-issue-notifications) for more information.
+
+## License
+
+This project is licensed under the Apache-2.0 License.
+
+## Related Resources
+
+- [Amazon EFA Documentation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html)
+- [EFA Kernel Driver](https://github.com/amzn/amzn-drivers/tree/master/kernel/linux/efa)
+- [Verbs EFA Provider](https://github.com/linux-rdma/rdma-core/tree/master/providers/efa)

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -4,17 +4,6 @@ We strongly recommend starting with a release tarball available on the
 [GitHub Release Page](https://github.com/aws/aws-ofi-nccl/releases) when
 building from source for production uses.
 
-#### Git checkout
-
-Before running `./configure` from a Git checkout, initialize the required
-`3rd-party/efa-dp-direct` source dependency:
-
-```
-git submodule update --init --recursive 3rd-party/efa-dp-direct
-```
-
-Release tarballs already include this dependency.
-
 #### Libfabric
 
 `aws-ofi-nccl` requires a working installation of Libfabric (v1.18.0 or newer). You can

--- a/autogen.sh
+++ b/autogen.sh
@@ -7,25 +7,4 @@
 
 set -eu
 
-submodule=3rd-party/efa-dp-direct
-
-# In a Git checkout, only initialize the efa-dp-direct submodule only when its 
-# directory is empty.
-# Do not update a populated checkout, which may contain local development changes.
-# Release tarballs must already include the pinned efa-dp-direct source version
-# associated with the release.
-if test -d "$submodule" &&
-   test -n "$(find "$submodule" -maxdepth 0 -empty -print)" &&
-   { test -d .git || test -f .git; }; then
-  if ! git submodule update --init --recursive "$submodule"; then
-    cat >&2 <<EOF
-error: unable to initialize required submodule: $submodule
-
-Check Git access, network connectivity, and credentials, then retry:
-  git submodule update --init --recursive $submodule
-EOF
-    exit 1
-  fi
-fi
-
 autoreconf -ivf

--- a/configure.ac
+++ b/configure.ac
@@ -16,16 +16,15 @@ AC_PREREQ([2.69])
 AC_CONFIG_SRCDIR([src/nccl_ofi_net.cpp])
 
 AC_MSG_CHECKING([for required efa-dp-direct CUDA sources])
-AS_IF([test -f "$srcdir/3rd-party/efa-dp-direct/CUDA/README.md"],
+AS_IF([test -f "$srcdir/3rd-party/efa-gda/CUDA/README.md"],
       [AC_MSG_RESULT([yes])],
       [AC_MSG_RESULT([no])
        AC_MSG_ERROR([Missing required file:
-  3rd-party/efa-dp-direct/CUDA/README.md
+  3rd-party/efa-gda/CUDA/README.md
 
-If this is a Git checkout, initialize the dependency with:
-  git submodule update --init --recursive 3rd-party/efa-dp-direct
-
-Release tarballs must include this file.])])
+3rd-party/efa-gda is vendored directly in this repository and is not a Git
+submodule. A missing file here means the source tree is incomplete. Re-checkout
+the repository or build from a release tarball.])])
 
 AC_CONFIG_AUX_DIR([build-aux])
 AC_CONFIG_HEADERS([include/config.h])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -84,7 +84,7 @@ libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS) $(ROCM_LDFLAGS)
 libinternal_plugin_la_LIBADD  = $(CUDA_LIBS) $(ROCM_LIBS)
 
 if HAVE_GDAKI
-# TODO: Pinned efa-dp-direct submodule commit 81c4dc7 has a bug that causes a 
+# TODO: Vendored efa-dp-direct commit 81c4dc7 has a bug that causes a 
 # "sign-compare" error. To avoid relaxing the sign-compare compilation check
 # when building the entire OFI NCCL plugin library, we separately build a
 # libefa_cuda_dp.la library with "-Wno-error=sign-compare" set. Once we 
@@ -96,12 +96,12 @@ if HAVE_GDAKI
 noinst_LTLIBRARIES += libefa_cuda_dp.la
 
 libefa_cuda_dp_la_SOURCES = \
-	$(top_srcdir)/3rd-party/efa-dp-direct/CUDA/host/efa_cuda_dp.cpp
+	$(top_srcdir)/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
 
 libefa_cuda_dp_la_CPPFLAGS = \
 	$(CUDA_CPPFLAGS) \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/host
+	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/common \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/host
 
 # The pinned host source compares its `int` loop index with a `size_t` length.
 # Scope this temporary warning-as-error exception to third-party code so
@@ -110,8 +110,8 @@ libefa_cuda_dp_la_CXXFLAGS = \
 	-Wno-error=sign-compare
 
 AM_CPPFLAGS += \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-dp-direct/CUDA/host
+	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/common \
+	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/host
 
 # Make the private host implementation available to the internal plugin for
 # later GDAKI integration. It uses CUDA Runtime APIs, so add CUDART only for

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -62,7 +62,7 @@ gin_gdaki_backend_version_SOURCES = $(base_sources) gin_gdaki_backend_version.cp
 # The backendVersion probe includes nccl_ofi_gin_gdaki_dev.h, which pulls in
 # efa-dp-direct's efa_cuda_dp_types.h; add that include path for this target.
 gin_gdaki_backend_version_CPPFLAGS = $(AM_CPPFLAGS) $(CPPFLAGS) \
-	-isystem $(top_srcdir)/3rd-party/efa-dp-direct/CUDA/common
+	-isystem $(top_srcdir)/3rd-party/efa-gda/CUDA/common
 
 # GDAKI GPU smoke test. .cu compiles via the .cu.o suffix rule below,
 # .cpp via the existing CXXCOMPILE; the binary links via CXXLINK
@@ -92,8 +92,8 @@ gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 		-I$(top_srcdir)/include \
 		-I$(top_srcdir)/3rd-party \
 		-I$(top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include \
-		-isystem $(top_srcdir)/3rd-party/efa-dp-direct/CUDA/common \
-		-isystem $(top_srcdir)/3rd-party/efa-dp-direct/CUDA/device \
+		-isystem $(top_srcdir)/3rd-party/efa-gda/CUDA/common \
+		-isystem $(top_srcdir)/3rd-party/efa-gda/CUDA/device \
 		$(MPI_CPPFLAGS) $(CUDA_CPPFLAGS) \
 		-c -o $@ $<
 endif # HAVE_NVCC


### PR DESCRIPTION
**Issue**
A submodule stores only a pointer: the parent repo keeps a gitlink (a commit SHA) plus a .gitmodules entry, and the real files live in a separate repository, so materializing them needs both .git metadata and network access to run git submodule update --init. Brazil's Package Builder doesn't clone the repo: it exports the source tree to S3 and builds from that snapshot, so 3rd-party/efa-dp-direct is an empty directory at build time. Therefore we switch to use git subtree as subtree stores the content itself as ordinary committed files.

**Description of changes:**
Vendor `3rd-party/efa-dp-direct` into the repository as a git subtree at the same commit the submodule was pinned to (`81c4dc7`), and remove the submodule machinery. 
The change includes two commits: deregister the submodule and the cleanup of the submodule-init paths, along with the `git subtree add --squash` (squashed-content commit).

**Updating the vendored copy**
Future pin bumps use `git subtree pull` in place of the old `git submodule update --remote`:

```sh
git subtree pull --prefix=3rd-party/efa-dp-direct \
                 https://github.com/amzn/efa-dp-direct.git <new-commit> \
                 --squash
```
This adds one squashed-content commit plus a merge, the same shape as the initial import.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
