### PR TITLE
gdrcopy: fall back to the v1 pin API when the v2 pin ioctl is unsupported (gdrdrv < 2.5)

### DIFF
--- a/src/nccl_ofi_gdrcopy.cpp
+++ b/src/nccl_ofi_gdrcopy.cpp
@@ -129,6 +129,15 @@ int nccl_ofi_gdrcopy_ctx::register_region(void *device_ptr, size_t size, RegHand
 			ret = pimpl->gdr_pin_buffer_v2_fn(pimpl->gdr, regbgn,
 							  handle->gdr_reglen, flags, &mh);
 		}
+		/* On a host whose gdrdrv kernel module predates 2.5 while
+		 * userspace libgdrapi is 2.5+, the v2 pin ioctl is not
+		 * recognized by the kernel (EINVAL/ENOTTY) even though the
+		 * runtime resolved gdr_pin_buffer_v2. Fall back to the v1 pin
+		 * API, which is identical at the gdr_mh_t output level. */
+		if (ret == EINVAL || ret == ENOTTY) {
+			ret = pimpl->gdr_pin_buffer_fn(pimpl->gdr, regbgn,
+						       handle->gdr_reglen, 0, 0, &mh);
+		}
 	} else {
 		ret = pimpl->gdr_pin_buffer_fn(pimpl->gdr, regbgn, handle->gdr_reglen, 0, 0, &mh);
 	}


### PR DESCRIPTION
*Issue #, if available:* #1350

*Description of changes:*

**Scoped down to avoid overlapping #1351** (which carries the `OFI_NCCL_GDRCOPY_FORCED_PCIE_COPY` env override and the probe unification). This PR is now only the **v1 pin fallback** — the second half of the #1350 fix, composing with #1351:

On a host whose gdrdrv **kernel** module predates 2.5 while userspace `libgdrapi` is 2.5+ (a common pairing on fleet AMIs), `gdr_pin_buffer_v2` resolves fine at init, but the v2 pin **ioctl** is not recognized by the kernel and fails with `EINVAL`/`ENOTTY` at registration time. This change falls back to the v1 pin API in that case instead of failing the registration; the two are identical at the `gdr_mh_t` output level (only the flags input differs).

Why both halves are needed (measured, mixed 2-node p5en fleet — one gdrdrv 2.5, one 2.4, libgdrapi 2.5.2 on both):

| | #1351 override alone | + this fallback |
|---|---|---|
| GIN init gate on the 2.4 node | passes (capability asserted) | passes |
| buffer registration on the 2.4 node | v2 pin ioctl fails → registration error | **v1 pin succeeds** |
| workload | faults | DeepEP dispatch/combine correctness gate PASS, exit 0 both nodes, zero CUDA 719 combine faults |

Inert everywhere the v2 ioctl works: the fallback only fires on `EINVAL`/`ENOTTY` from the v2 pin call.

Draft pending maintainer read on #1350/#1351 — if you'd rather fold this hunk into #1351 as one PR, happy to do that instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
