### PR TITLE
Fix Automake missing .Plo dependency error in efa-dp-direct fixes #1353

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,7 +96,7 @@ if HAVE_GDAKI
 noinst_LTLIBRARIES += libefa_cuda_dp.la
 
 libefa_cuda_dp_la_SOURCES = \
-	$(top_srcdir)/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
+	../3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
 
 libefa_cuda_dp_la_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \


### PR DESCRIPTION
Use a relative path instead of the $(top_srcdir) variable for libefa_cuda_dp_la_SOURCES in src/Makefile.am.

When HAVE_GDAKI evaluates to false, Automake correctly skips building the libefa_cuda_dp.la library. However, due to a known Automake bug involving subdir-objects combined with $(top_srcdir), config.status fails to generate the dummy empty .deps/*.Plo dependency files for the skipped sources.

Because the generated Makefile still unconditionally includes these .Plo files, the missing file causes `make` to fail with a "No rule to make target 'libefa_cuda_dp_la-efa_cuda_dp.Plo'" error. Switching to a relative path bypasses this Automake bug, allowing config.status to calculate paths properly and generate the dummy dependency files, resolving the build error without breaking out-of-tree (VPATH) builds.

*Issue #, if available:*

#1353 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
