### PR TITLE
Improve accelerator libs handling

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -15,7 +15,8 @@ EXTRA_DIST = \
 	NOTICE \
 	README.md \
 	RELEASENOTES.md \
-	m4/get_version.sh
+	m4/get_version.sh \
+	contrib/scripts/check_cuda_usage
 
 
 AM_DISTCHECK_CONFIGURE_FLAGS=$(NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS)
@@ -24,6 +25,14 @@ AM_DISTCHECK_CONFIGURE_FLAGS=$(NCCL_NET_OFI_DISTCHCK_CONFIGURE_FLAGS)
 # Ref: https://www.gnu.org/software/automake/manual/html_node/Basics-of-Distribution.html
 TAR_OPTIONS = --owner=0 --group=0
 export TAR_OPTIONS
+
+# after each build, verify that there are no problematic cuda runtime
+# calls in the build
+all-local:
+	@if test -d "$(top_srcdir)/.git"; then \
+		echo "Checking for CUDA Runtime symbols" ; \
+		$(top_srcdir)/contrib/scripts/check_cuda_usage ; \
+	fi
 
 # create a hook so that autogen.sh works in release tarballs
 # Implement the equivalent of check-news, but for RELEASENOTES.md

--- a/contrib/scripts/check_cuda_usage
+++ b/contrib/scripts/check_cuda_usage
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+# Scan through all object files in the build directory looking for
+# symbols that start with cuda*, indicating that they belong to the
+# CUDA Runtime (which we're not supposed to use in the plugin, beyond
+# the simple RuntimeGetVersion/GetDriverEntryPoint calls we need in
+# the cuda helper file.
+#
+# The tests are allowed to use the CUDA runtime, so they are skipped
+# for this check.  There used to be a submodule in
+# 3rd-party/efa-dp-direct/ which did violate these rules.  Skip that
+# as well, so that we don't fail the build during a git bisect that
+# jumps from the submodule timeframe to the current subtree timeframe.
+#
+# this script will be run from the top of the build tree
+
+files=`find . -path "*/tests" -prune -o -path "*/efa-dp-direct" -prune -o -name "*.o" -print`
+
+for file in $files ; do
+    symbols=`nm -u -f just-symbols $file | grep '^cuda'`
+
+    if test `basename $file` = "nccl_ofi_cuda.o" ; then
+       symbols=`echo "$symbols" | grep -vE '(^cudaRuntimeGetVersion$|^cudaGetDriverEntryPoint)'`
+    fi
+
+    if test -n "$symbols" ; then
+       echo "******************** ERROR ********************"
+       echo ""
+       echo "CUDA Runtime symbols found in $file:"
+       echo "$symbols"
+       echo ""
+       echo "Aborting build!"
+    fi
+done

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -87,7 +87,7 @@ extern enum gdr_support_level_t support_gdr;
 /* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
  * to flush data to the GPU. Note, CUDA flush support is not supported on all
  * platforms and should be disabled by default */
-extern bool cuda_flush;
+extern bool nccl_ofi_use_cuda_flush;
 
 /* number of cq entries to read in a single call to fi_cq_read.
    This variable will be updated during init (hence, can not be

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -5,6 +5,28 @@
 # See LICENSE.txt for license information
 #
 
+# IMPORTANT CUDA LIBRARIES NOTE: The core plugin code should only use
+# the driver interface (ie, cu* functions), with the exception of
+# cudaRuntimeGetVersion(), cudaGetDriverEntryPoint() and its recent
+# cousin cudaGetDriverEntryPointByVersion().  The goal is to be able
+# to ship a plugin binary that works with multiple versions of CUDA,
+# and the CUDA runtime is not versioned to allow use across multiple
+# major versions.  We have two ways of dealing with that:
+#
+#  1. static link against the runtime.  This is the default, but
+#     raises questions about shipping a binary, since the plugin includes
+#     Nvidia code at that point.
+#  2. dlopen libcudart and hope that Nvidia didn't break the ABI for
+#     the two getDriverEntryPoint functions.  This is enabled by
+#     --enable-cudart-dynamic.
+#
+# The core library should not use cuda* functions.  The Automake
+# variable CUDA_RUNTIME_LIB exists so that tests can directly call
+# cuda* functions (being much easier to use thank their cu*
+# equivalents) and should be added to the LIBS of any test that uses
+# cuda directly.  It should not be added to any LIBS for code that
+# will end up in one of the NCCL plugins.
+
 AC_DEFUN([CHECK_PKG_CUDA], [
   check_pkg_found=yes
 

--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -1,6 +1,6 @@
 # -*- autoconf -*-
 #
-# Copyright (c) 2023      Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2023-2026 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
@@ -37,17 +37,17 @@ AC_DEFUN([CHECK_PKG_CUDA], [
         [check_pkg_found=no],
         [cuda_realpath="$(realpath ${with_cuda})"
          cuda_ldpath="${cuda_realpath}/lib64"
-         CUDA_LDFLAGS="-L${cuda_ldpath}"
-         CUDA_CPPFLAGS="-isystem ${cuda_realpath}/include"
+         CPPFLAGS="${CPPFLAGS} -isystem ${cuda_realpath}/include"
+         LDFLAGS="${LDFLAGS} -L${cuda_ldpath}"
          AS_IF([test "x${enable_cudart_dynamic}" = "xyes"],
-               [CUDA_LIBS="-lrt -ldl"
-                CUDA_RUNTIME_LIBS="-l${cudart_lib}"],
-               [CUDA_LIBS="-l${cudart_lib} -lrt -ldl"
+               [CUDA_RUNTIME_LIBS="-l${cudart_lib}"],
+               [LIBS="-l${cudart_lib} ${LIBS} "
                 CUDA_RUNTIME_LIBS=""])
-         LDFLAGS="${CUDA_LDFLAGS} ${LDFLAGS}"
-         LIBS="${CUDA_LIBS} ${LIBS}"
-         CPPFLAGS="${CUDA_CPPFLAGS} ${CPPFLAGS}"
         ])
+
+  dnl cudart calls the shm interface, which is still defined in librt
+  dnl in some Glibc versions, so check if we need it here.
+  AC_SEARCH_LIBS([shm_open], [rt], [], [])
 
   AS_IF([test "${check_pkg_found}" = "yes"],
         [AC_SEARCH_LIBS(
@@ -55,7 +55,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
          [${cudart_lib}],
          [],
          [check_pkg_found=no],
-         [-ldl -lrt])])
+         [])])
 
   check_cuda_gdr_flush_define=0
   AS_IF([test "${check_pkg_found}" = "yes"],
@@ -113,7 +113,10 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   AS_IF([test "${check_pkg_found}" = "yes"],
         [check_pkg_define=1
          $1],
-        [check_pkg_define=0
+        [CPPFLAGS="${check_pkg_CPPFLAGS_save}"
+         LDFLAGS="${check_pkg_LDFLAGS_save}"
+         LIBS="${check_pkg_LIBS_save}"
+         check_pkg_define=0
          $2])
 
   AC_DEFINE_UNQUOTED([HAVE_CUDA], [${check_pkg_define}], [Defined to 1 if CUDA is available])
@@ -123,14 +126,7 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   AC_DEFINE_UNQUOTED([ENABLE_CUDART_DYNAMIC], [${enable_cudart_dynamic_define}], [Defined to 1 if CUDA dynamic runtime linking is enabled])
   AM_CONDITIONAL([HAVE_CUDA], [test "${check_pkg_found}" = "yes"])
 
-  AC_SUBST([CUDA_LDFLAGS])
-  AC_SUBST([CUDA_CPPFLAGS])
-  AC_SUBST([CUDA_LIBS])
   AC_SUBST([CUDA_RUNTIME_LIBS])
-
-  CPPFLAGS="${check_pkg_CPPFLAGS_save}"
-  LDFLAGS="${check_pkg_LDFLAGS_save}"
-  LIBS="${check_pkg_LIBS_save}"
 
   AS_UNSET([check_pkg_found])
   AS_UNSET([check_pkg_define])

--- a/m4/check_pkg_nvtx.m4
+++ b/m4/check_pkg_nvtx.m4
@@ -1,6 +1,6 @@
 # -*- autoconf -*-
 #
-# Copyright (c) 2024      Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2024-2026 Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
@@ -14,10 +14,6 @@ AC_DEFUN([CHECK_PKG_NVTX], [
   dnl if provided a path, add the path to CFLAGS. Otherwise assume it's provided by --with-cuda.
   AS_IF([test "x${with_nvtx}" != "xyes" -a "x${with_nvtx}" != "xno"],
         [CPPFLAGS="-isystem ${with_nvtx}/include ${CPPFLAGS}"])
-
-  dnl Try to use CUDA's incdir flags if cuda is being used and no specific path was provided.
-  AS_IF([test "x${with_nvtx}" = "xyes" -a "x${with_cuda}" != "xyes" -a "x${with_cuda}" != "xno"],
-        [CPPFLAGS="${CUDA_CPPFLAGS} ${CPPFLAGS}"])
 
   dnl don't enable it by default.
   AS_IF([test -z "${with_nvtx}"], [check_pkg_found=no])

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2018-2025, Amazon.com, Inc. or its affiliates. All rights reserved.
+# Copyright (c) 2018-2026, Amazon.com, Inc. or its affiliates. All rights reserved.
 #
 # See LICENSE.txt for license information
 #
@@ -7,7 +7,7 @@
 AM_CPPFLAGS = -I$(abs_top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-AM_CPPFLAGS += $(CUDA_CPPFLAGS) $(ROCM_CPPFLAGS)
+AM_CPPFLAGS += $(CUDA_CPPFLAGS)
 AM_CPPFLAGS += -DXML_DIR=\"${pkgdatadir}/xml\"
 
 sources = \
@@ -80,8 +80,8 @@ endif
 # us writing dlopen() handlers for simple unit tests.
 noinst_LTLIBRARIES = libinternal_plugin.la
 libinternal_plugin_la_SOURCES = $(sources)
-libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS) $(ROCM_LDFLAGS)
-libinternal_plugin_la_LIBADD  = $(CUDA_LIBS) $(ROCM_LIBS)
+libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS)
+libinternal_plugin_la_LIBADD  = $(CUDA_LIBS)
 
 if HAVE_GDAKI
 # TODO: Vendored efa-dp-direct commit 81c4dc7 has a bug that causes a 

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -7,7 +7,6 @@
 AM_CPPFLAGS = -I$(abs_top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-AM_CPPFLAGS += $(CUDA_CPPFLAGS)
 AM_CPPFLAGS += -DXML_DIR=\"${pkgdatadir}/xml\"
 
 sources = \
@@ -80,8 +79,8 @@ endif
 # us writing dlopen() handlers for simple unit tests.
 noinst_LTLIBRARIES = libinternal_plugin.la
 libinternal_plugin_la_SOURCES = $(sources)
-libinternal_plugin_la_LDFLAGS = -static $(CUDA_LDFLAGS)
-libinternal_plugin_la_LIBADD  = $(CUDA_LIBS)
+libinternal_plugin_la_LDFLAGS = -static
+libinternal_plugin_la_LIBADD=
 
 if HAVE_GDAKI
 # TODO: Vendored efa-dp-direct commit 81c4dc7 has a bug that causes a 
@@ -100,7 +99,6 @@ libefa_cuda_dp_la_SOURCES = \
 
 libefa_cuda_dp_la_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \
-	$(CUDA_CPPFLAGS) \
 	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/common \
 	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/host
 

--- a/src/nccl_ofi_cuda.cpp
+++ b/src/nccl_ofi_cuda.cpp
@@ -241,9 +241,9 @@ int nccl_net_ofi_gpu_init(void)
 
 	if (HAVE_CUDA_GDRFLUSH_SUPPORT && nccl_net_ofi_gpu_have_gdr_support_attr() && ofi_nccl_cuda_flush_enable()) {
 		NCCL_OFI_WARN("CUDA flush enabled");
-		cuda_flush = true;
+		nccl_ofi_use_cuda_flush = true;
 	} else {
-		cuda_flush = false;
+		nccl_ofi_use_cuda_flush = false;
 	}
 
 	return 0;

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -70,7 +70,7 @@ enum gdr_support_level_t support_gdr = GDR_UNKNOWN;
 /* Indicates if the cudaDeviceFlushGPUDirectRDMAWrites function should be used
  * to flush data to the GPU. Note, CUDA flush support is not supported on all
  * platforms and should be disabled by default */
-bool cuda_flush = false;
+bool nccl_ofi_use_cuda_flush = false;
 
 /* number of cq entries to read in a single call to fi_cq_read.
    This variable will be updated during init (hence, can not be

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -4441,7 +4441,7 @@ int nccl_net_ofi_rdma_recv_comm::flush(int n, void **buffers,
 		goto exit;
 
 #if HAVE_GPU
-	if (cuda_flush) {
+	if (nccl_ofi_use_cuda_flush) {
 		ret = nccl_net_ofi_gpu_flush_gpudirect_rdma_writes();
 		if (ret != 0) {
 			NCCL_OFI_WARN("Error performing GPU GDR flush");

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -1024,7 +1024,7 @@ int nccl_net_ofi_sendrecv_recv_comm::close()
 		endpoint->sendrecv_endpoint_abort();
 	}
 
-	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !nccl_ofi_use_cuda_flush) {
 		NCCL_OFI_TRACE(NCCL_NET, "De-registering buffer for flush operations");
 		/* Deregister Flush buffer memory region */
 		mr_handle = this->flush_buff.mr_handle;
@@ -1078,7 +1078,7 @@ int nccl_net_ofi_sendrecv_recv_comm::flush(int n, void **buffers,
 		goto exit;
 
 #if HAVE_CUDA
-	if (cuda_flush) {
+	if (nccl_ofi_use_cuda_flush) {
 		ret = nccl_net_ofi_gpu_flush_gpudirect_rdma_writes();
 		if (ret != 0) {
 			NCCL_OFI_WARN("Error performing GPU GDR flush");
@@ -1350,7 +1350,7 @@ nccl_net_ofi_sendrecv_recv_comm *nccl_net_ofi_sendrecv_recv_comm::create(nccl_ne
 	 * Setup flush resources if using GPUDirect RDMA unless user disables
 	 * flush operations
 	 */
-	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !cuda_flush) {
+	if (!ofi_nccl_gdr_flush_disable() && support_gdr == GDR_SUPPORTED && !nccl_ofi_use_cuda_flush) {
 		r_comm->flush_buff.size = NCCL_OFI_FLUSH_SIZE;
 		ret = r_comm->alloc_and_reg_flush_buff(domain, ep_arg,
 						       key_pool);
@@ -2200,7 +2200,7 @@ static void sendrecv_get_hints(struct fi_info *hints, int req_gdr)
 
 	if (req_gdr) {
 		hints->caps |= FI_HMEM;
-		if (!cuda_flush) {
+		if (!nccl_ofi_use_cuda_flush) {
 			hints->caps |= FI_RMA | FI_READ;
 		}
 		/*

--- a/tests/functional/Makefile.am
+++ b/tests/functional/Makefile.am
@@ -9,9 +9,9 @@
 AM_CPPFLAGS = -I$(top_srcdir)/include
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party
 AM_CPPFLAGS += -isystem $(abs_top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include
-AM_CPPFLAGS += $(MPI_CPPFLAGS) $(CUDA_CPPFLAGS)
-AM_LDFLAGS = $(MPI_LDFLAGS) $(CUDA_LDFLAGS)
-LDADD = $(MPI_LIBS) $(CUDA_LIBS) $(CUDA_RUNTIME_LIBS)
+AM_CPPFLAGS += $(MPI_CPPFLAGS)
+AM_LDFLAGS = $(MPI_LDFLAGS)
+LDADD = $(MPI_LIBS) $(CUDA_RUNTIME_LIBS)
 
 # this is a little jenky, but we've always assumed we had wrapper compilers
 # available for MPI.  We don't want to just override CXX to get mpicxx used,
@@ -94,7 +94,7 @@ gin_signal_gdaki_gpu_LDADD = $(LDADD) -lcuda
 		-I$(top_srcdir)/3rd-party/nccl/$(DEVICE_INTERFACE)/include \
 		-isystem $(top_srcdir)/3rd-party/efa-gda/CUDA/common \
 		-isystem $(top_srcdir)/3rd-party/efa-gda/CUDA/device \
-		$(MPI_CPPFLAGS) $(CUDA_CPPFLAGS) \
+		$(MPI_CPPFLAGS) \
 		-c -o $@ $<
 endif # HAVE_NVCC
 endif # HAVE_GDAKI

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -40,9 +40,6 @@ base_sources = unit_test.cpp
 
 
 if !ENABLE_NEURON
-  AM_LDFLAGS = $(CUDA_LDFLAGS)
-  AM_CPPFLAGS += $(CUDA_CPPFLAGS)
-  LDADD += $(CUDA_LIBS)
   noinst_PROGRAMS += gdrcopy
   gdrcopy_SOURCES = $(base_sources) gdrcopy.cpp
   gdrcopy_LDADD = $(LDADD) $(CUDA_RUNTIME_LIBS)


### PR DESCRIPTION
A couple patches to clean up the accelerator libs handling in the build system that were found while trying to understand the recent cudart dlopen issue.  There is also a patch to actively break the build if it contains more than the expected 3 (2 versions of GetDriverEntryPoint) calls in the generated object files.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
