### PR TITLE
Fix release tag check on macOS

### DIFF
--- a/contrib/scripts/generate_release_tag
+++ b/contrib/scripts/generate_release_tag
@@ -59,7 +59,7 @@ if [ -n "${push_remote}" ]; then
 fi
 
 # verify that tag looks sanely formatted
-if ! echo ${tagname} | sed -E '/v[0-9]+\.[0-9]+\.[0-9]+.*/!{q1}' > /dev/null; then
+if ! [[ "${tagname}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
     echo "Tag ${tagname} does not look like a release tag."
     exit 1
 fi


### PR DESCRIPTION
*Description of changes:*
The tag format check in generate_release_tag uses the GNU sed extension "q1", which BSD sed rejects with an error. On macOS this makes the check fail for every tag name, including valid ones. Replace the sed invocation with a native bash regex match, which works the same on both GNU and BSD platforms.

The new pattern is anchored, so tag names must start with "vX.Y.Z" rather than merely contain it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
