### PR TITLE
Fix Automake missing .Plo dependency error in efa-dp-direct

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -96,7 +96,7 @@ if HAVE_GDAKI
 noinst_LTLIBRARIES += libefa_cuda_dp.la
 
 libefa_cuda_dp_la_SOURCES = \
-	$(top_srcdir)/3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
+	../3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
 
 libefa_cuda_dp_la_CPPFLAGS = \
 	-I$(abs_top_srcdir)/include \


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
