### PR TITLE
ci: add SLES 15 container image and build job

### DIFF
--- a/.github/matrix-config.json
+++ b/.github/matrix-config.json
@@ -32,6 +32,10 @@
       "tracing": ["lttng", "none"],
       "sdk": ["cuda", "neuron"]
     },
+    "sles15": {
+      "cc": ["gcc-14"],
+      "sdk": ["cuda"]
+    },
     "codechecker": {
       "sdk": ["cuda", "neuron"]
     }

--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -14,6 +14,7 @@ jobs:
       ubuntu: ${{ steps.set-matrix.outputs.ubuntu }}
       ubuntu2404: ${{ steps.set-matrix.outputs.ubuntu2404 }}
       ubuntu2604: ${{ steps.set-matrix.outputs.ubuntu2604 }}
+      sles15: ${{ steps.set-matrix.outputs.sles15 }}
       codechecker: ${{ steps.set-matrix.outputs.codechecker }}
     steps:
       - uses: actions/checkout@v6
@@ -23,6 +24,7 @@ jobs:
           echo "ubuntu=$(jq -c '.matrix_config.ubuntu' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "ubuntu2404=$(jq -c '.matrix_config.ubuntu2404' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "ubuntu2604=$(jq -c '.matrix_config.ubuntu2604' .github/matrix-config.json)" >> $GITHUB_OUTPUT
+          echo "sles15=$(jq -c '.matrix_config.sles15' .github/matrix-config.json)" >> $GITHUB_OUTPUT
           echo "codechecker=$(jq -c '.matrix_config.codechecker' .github/matrix-config.json)" >> $GITHUB_OUTPUT
 
   build-amazonlinux-containers:
@@ -56,6 +58,41 @@ jobs:
           build-args: |
             ENABLE_CUDA=${{ matrix.sdk == 'cuda' }}
             EFA_INSTALLER_VERSION=${{ matrix.efainstaller }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  build-sles15-containers:
+    needs: get-matrix
+    runs-on: ubuntu-latest
+    strategy:
+      matrix: ${{fromJson(needs.get-matrix.outputs.sles15)}}
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push SLES 15 containers
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.sles15
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-sles15:${{ matrix.sdk }}-${{ matrix.cc }}
+          build-args: |
+            CC_TYPE=${{ matrix.cc }}
+            CUDA_VERSION=12-6
+            EFA_INSTALLER_VERSION=latest
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/docker/base/Dockerfile.sles15
+++ b/docker/base/Dockerfile.sles15
@@ -1,0 +1,80 @@
+FROM registry.suse.com/bci/bci-base:15.7
+
+ARG CC_TYPE=gcc-14
+ARG CUDA_VERSION=12-6
+ARG EFA_INSTALLER_VERSION=latest
+ARG HWLOC_VERSION=2.11.2
+ARG HWLOC_SHA256=866ac8ef07b350a6a2ba0c6826c37d78e8994dcbcd443bdd2b436350de19d540
+
+# SLES ships GCC only under versioned names, so split CC_TYPE (e.g. gcc-14)
+# into family and version like the Ubuntu images.
+#
+# libfabric-devel is pinned to 2.0.0: this is the proxy-only libfabric (no
+# GDAKI), and pinning keeps that coverage reproducible so a future SLES update
+# cannot silently introduce GDAKI and collapse the proxy path. Bump this
+# deliberately if the proxy baseline should move.
+RUN cc_version="${CC_TYPE##*-}" && \
+    zypper --non-interactive addrepo \
+        https://developer.download.nvidia.com/compute/cuda/repos/sles15/x86_64/ cuda && \
+    zypper --gpg-auto-import-keys --non-interactive refresh && \
+    zypper --non-interactive install --no-recommends \
+        autoconf automake libtool \
+        gcc${cc_version} gcc${cc_version}-c++ \
+        make git curl tar gzip bzip2 xz m4 gawk diffutils findutils which \
+        pkg-config libxml2-devel libpciaccess-devel libnl3-devel \
+        rdma-core-devel libfabric-devel=2.0.0 openmpi4-devel \
+        cuda-cudart-devel-${CUDA_VERSION} cuda-crt-${CUDA_VERSION} && \
+    zypper clean --all
+
+# hwloc development files are not in the free SLE_BCI repository (only the
+# runtime library), and the SLE HPC module that ships hwloc-devel requires a
+# paid registration that is not available in CI. Build the pinned release.
+RUN cc_version="${CC_TYPE##*-}" && \
+    curl -fsSL \
+        "https://download.open-mpi.org/release/hwloc/v2.11/hwloc-${HWLOC_VERSION}.tar.gz" \
+        -o /tmp/hwloc.tar.gz && \
+    echo "${HWLOC_SHA256}  /tmp/hwloc.tar.gz" | sha256sum --check --strict && \
+    mkdir /tmp/hwloc && \
+    tar -xzf /tmp/hwloc.tar.gz -C /tmp/hwloc --strip-components=1 && \
+    cd /tmp/hwloc && \
+    CC=gcc-${cc_version} CXX=g++-${cc_version} \
+        ./configure --prefix=/opt/hwloc \
+        --disable-cairo --disable-opencl --disable-nvml && \
+    make -j"$(nproc)" && \
+    make install && \
+    rm -rf /tmp/hwloc /tmp/hwloc.tar.gz
+
+# Container-mode EFA install for the GDAKI-capable libfabric under
+# /opt/amazon/efa. Use --enable-ngc because the installer's SUSE efa-config RPM
+# runs an unconditional "systemctl enable/start efa-config" in its %post, which
+# fails inside a container (no running systemd) and aborts the install.
+# --enable-ngc is the installer's container mode and skips that host setup
+# (implies --skip-kmod --skip-limit-conf --no-verify --yes). The Debian package
+# does not hit this because its postinst defers to debhelper's container-aware
+# systemd handling rather than calling systemctl directly. --skip-mpi avoids
+# pulling the installer's Open MPI (whose hwloc dependency is unsatisfiable
+# here) and keeps the SLES Open MPI for the proxy-only path.
+RUN curl -fsSL \
+        "https://efa-installer.amazonaws.com/aws-efa-installer-${EFA_INSTALLER_VERSION}.tar.gz" \
+        -o /tmp/efa-installer.tar.gz && \
+    mkdir /tmp/efa-installer && \
+    tar -xzf /tmp/efa-installer.tar.gz \
+        -C /tmp/efa-installer --strip-components=1 && \
+    cd /tmp/efa-installer && \
+    ./efa_installer.sh --enable-ngc --skip-mpi && \
+    cd / && \
+    rm -rf /tmp/efa-installer /tmp/efa-installer.tar.gz && \
+    zypper clean --all
+
+# Point the unversioned compiler names at the requested GCC, after the EFA
+# install so the GCC 7 that EFA pulls in through dkms cannot win. Open MPI's
+# wrappers invoke a bare "gcc"/"g++", so this lets them resolve to the intended
+# compiler without per-consumer OMPI_CC/OMPI_CXX overrides.
+RUN cc_version="${CC_TYPE##*-}" && \
+    ln -sf gcc-${cc_version} /usr/bin/gcc && \
+    ln -sf g++-${cc_version} /usr/bin/g++ && \
+    ln -sf cpp-${cc_version} /usr/bin/cpp && \
+    ln -sf gcc-${cc_version} /usr/bin/cc && \
+    ln -sf g++-${cc_version} /usr/bin/c++
+
+WORKDIR /workspace


### PR DESCRIPTION
*Issue #, if available:*
#1365.

*Description of changes:*

SLES 15 is a widely used enterprise distribution, but PR CI does not
exercise the older Autotools shipped by the distribution. That gap allowed
the Automake 1.15.1 failure reported in https://github.com/aws/aws-ofi-nccl/issues/1353 to escape build testing.

Publish a SLES 15 SP7 build container as the first phase of adding that
coverage. The distribution's Autoconf 2.69 and Automake 1.15.1 come from
the base image, alongside GCC 14, CUDA 12.6, Open MPI 4, and hwloc for the
plugin build.

Keep SLES libfabric 2.0 as the default to exercise the proxy-only path.
Use the rolling EFA installer in container mode (--enable-ngc) for the
GDAKI-capable stack under /opt/amazon/efa, with its MPI and plugin packages
disabled so the image retains the SLES Open MPI. Letting the installer
update rdma-core and libfabric together avoids repository changes for every
supported version bump and follows the maintenance model of the Ubuntu
images.

Drive the compiler from CC_TYPE via the matrix, like the Ubuntu images.
SLES ships GCC only under versioned names and the EFA installer pulls in the
distribution default GCC 7 through its dkms dependency, so symlink the
unversioned compiler names to the requested GCC after the EFA install; this
lets Open MPI's wrappers resolve to the intended compiler without per-consumer
overrides.

Build hwloc from a pinned release because hwloc-devel lives in the SLE HPC
module, which requires a paid registration unavailable in CI.

Add the image to the shared matrix and publication workflow so upstream
GHCR can host it before any PR job depends on it. The PR CI jobs remain
deferred to the second phase to avoid that bootstrap dependency.

Part of #1365.




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
