### PR TITLE
cuda: Remove -lcudart when using dynamic cudart

### DIFF
--- a/m4/check_pkg_cuda.m4
+++ b/m4/check_pkg_cuda.m4
@@ -71,13 +71,11 @@ AC_DEFUN([CHECK_PKG_CUDA], [
   dnl in some Glibc versions, so check if we need it here.
   AC_SEARCH_LIBS([shm_open], [rt], [], [])
 
+  dnl Use AC_CHECK_LIB instead of AC_SEARCH_LIBS to avoid adding
+  dnl ${cudart_lib} to LIBS, which is also why we have an (essentially
+  dnl dummy) action-if-found specified.
   AS_IF([test "${check_pkg_found}" = "yes"],
-        [AC_SEARCH_LIBS(
-         [cudaGetDriverEntryPoint],
-         [${cudart_lib}],
-         [],
-         [check_pkg_found=no],
-         [])])
+        [AC_CHECK_LIB([${cudart_lib}], [cudaGetDriverEntryPoint], [check_pkg_found=yes], [check_pkg_found=no])])
 
   check_cuda_gdr_flush_define=0
   AS_IF([test "${check_pkg_found}" = "yes"],


### PR DESCRIPTION
Commit e31de68e simplified the flags threading out of check_pkg_cuda, but introduced a regression that resulted in -lcudart being included in the link line when compiled with --enable-cudart-dynamic, because AC_SEARCH_LIBS always added the cudart lib to LIBS.  Switch to AC_CHECK_LIB, which does not add the library to LIBS if an action-if-found is specified.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
