### PR TITLE
Fix/efa gda distcheck artifacts

### DIFF
--- a/3rd-party/Makefile.am
+++ b/3rd-party/Makefile.am
@@ -6,5 +6,36 @@
 
 EXTRA_DIST = \
 	boost \
-	efa-gda \
+	efa-gda/CODE_OF_CONDUCT.md \
+	efa-gda/CONTRIBUTING.md \
+	efa-gda/CUDA/Makefile \
+	efa-gda/CUDA/README.md \
+	efa-gda/LICENSE \
+	efa-gda/NOTICE \
+	efa-gda/README.md \
 	nccl
+
+noinst_HEADERS = \
+	efa-gda/CUDA/common/efa_cuda_dp_types.h \
+	efa-gda/CUDA/device/efa_cuda_dp.cuh \
+	efa-gda/CUDA/device/efa_cuda_dp_impl.cuh \
+	efa-gda/CUDA/device/efa_io_defs.h \
+	efa-gda/CUDA/host/efa_cuda_dp.h
+
+if HAVE_GDAKI
+AM_CPPFLAGS = \
+	-I$(abs_top_srcdir)/include \
+	-isystem $(abs_srcdir)/efa-gda/CUDA/common \
+	-isystem $(abs_srcdir)/efa-gda/CUDA/host
+
+noinst_LTLIBRARIES = libefa_cuda_dp.la
+
+libefa_cuda_dp_la_SOURCES = \
+	efa-gda/CUDA/host/efa_cuda_dp.cpp
+
+# Vendored efa-dp-direct commit 81c4dc7 has a bug that causes a
+# "sign-compare" error. Keep this warning exception scoped to the third-party
+# helper library until the vendored source uses compatible types.
+libefa_cuda_dp_la_CXXFLAGS = \
+	-Wno-error=sign-compare
+endif

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -83,37 +83,12 @@ libinternal_plugin_la_LDFLAGS = -static
 libinternal_plugin_la_LIBADD=
 
 if HAVE_GDAKI
-# TODO: Vendored efa-dp-direct commit 81c4dc7 has a bug that causes a 
-# "sign-compare" error. To avoid relaxing the sign-compare compilation check
-# when building the entire OFI NCCL plugin library, we separately build a
-# libefa_cuda_dp.la library with "-Wno-error=sign-compare" set. Once we 
-# digest an efa-dp-direct version with the sign-compare error bug fixed, we 
-# should stop building a separate libefa_cuda_dp.la library and instead just
-# ingest the efa-dp-direct files directly as sources for the libinternal_plugin.la
-# library.
-
-noinst_LTLIBRARIES += libefa_cuda_dp.la
-
-libefa_cuda_dp_la_SOURCES = \
-	../3rd-party/efa-gda/CUDA/host/efa_cuda_dp.cpp
-
-libefa_cuda_dp_la_CPPFLAGS = \
-	-I$(abs_top_srcdir)/include \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/common \
-	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/host
-
-# The pinned host source compares its `int` loop index with a `size_t` length.
-# Scope this temporary warning-as-error exception to third-party code so
-# plugin-owned sources remain subject to the project warning policy.
-libefa_cuda_dp_la_CXXFLAGS = \
-	-Wno-error=sign-compare
-
 AM_CPPFLAGS += \
 	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/common \
 	-isystem $(abs_top_srcdir)/3rd-party/efa-gda/CUDA/host
 
 libinternal_plugin_la_LIBADD += \
-	libefa_cuda_dp.la
+	$(top_builddir)/3rd-party/libefa_cuda_dp.la
 endif
 
 lib_LTLIBRARIES =


### PR DESCRIPTION
The newer EFA installer provides the hardware-counter ABI required to enable GDAKI, so builds now exercise a path that older installer images skipped. This surfaced a latent distcheck failure in the efa CUDA host source build.

With subdir-objects, compiling efa_cuda_dp.cpp from its relative vendor path creates libtool and dependency artifacts under efa-gda/CUDA/host in the active build tree. Because EXTRA_DIST names efa-gda as a directory, Automake copies it recursively and can merge those generated files into the staged distribution. The nested distcheck build can then mistake a copied .lo for its own output and have libtool reject it.

Strip generated artifact classes from only the staged CUDA host directory so source archives build correctly regardless of the producer tree's build state or layout.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
