### PR TITLE
gin: Fix regMrSym hang caused by duplicate detection

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin.h
+++ b/include/rdma/gin/nccl_ofi_gin.h
@@ -505,9 +505,21 @@ public:
 	 * insertion, and the per-rank key all-gather. Leaves gdr_handle == nullptr;
 	 * GDRCopy (proxy only) is layered on top by the caller. Caller holds ep_lock. */
 	int regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
-				 nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out);
+				 nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
+		REQUIRES(get_ep_lock());
 
-	int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) override;
+	/* Local part of symmetric memory registration: allocate the handle,
+	 * register data_ptr with the endpoint, and fill in this rank's entry of
+	 * the handle's per-rank metadata table. Caller must hold ep_lock. */
+	int regMrSymLocal(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size, int type,
+			  nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
+		REQUIRES(get_ep_lock());
+
+	int deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_handle) EXCLUDES(get_ep_lock()) override;
+
+	/* Body of deregMrSym, with ep_lock held by the caller. */
+	int deregMrSymLocked(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle)
+		REQUIRES(get_ep_lock());
 
 	void increment_outstanding_ack_counter()
 	{

--- a/src/rdma/gin/nccl_ofi_gin.cpp
+++ b/src/rdma/gin/nccl_ofi_gin.cpp
@@ -317,8 +317,7 @@ int nccl_ofi_rdma_gin_put_comm::send_ack(nccl_ofi_rdma_gin_put_comm &gin_comm, u
 int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
 				      int type, uint64_t mrFlags, nccl_ofi_gin_symm_mr_handle_t **mr_handle_out)
 {
-	auto &gin_ep = resources.get_ep();
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+	std::lock_guard<std::mutex> scoped_ep_lock(get_ep_lock());
 
 	/* Shared core: dedup/refcount, local EFA registration, MR-map insert,
 	   per-rank key all-gather. */
@@ -347,26 +346,10 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBuf(nccl_ofi_mr_ckey_ref ckey, void *
 	return 0;
 }
 
-int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
+int nccl_ofi_rdma_gin_put_comm::regMrSymLocal(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
 				      int type, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
 {
 	auto &gin_ep = resources.get_ep();
-
-	/* Check for duplicate registration */
-	auto it = mr_handle_map.find(data_ptr);
-	if (it != mr_handle_map.end()) {
-		if (it->second.handle->size >= size) {
-			/* Existing MR covers the requested region */
-			it->second.refcnt++;
-			*mr_handle_out = it->second.handle;
-			return 0;
-		}
-		/* Existing MR is too small. We do not support upgrading
-		   an existing registration to a larger size. */
-		NCCL_OFI_WARN("regMrSym for ptr %p with size %zu but existing registration "
-			      "has size %zu", data_ptr, size, it->second.handle->size);
-		return -EINVAL;
-	}
 
 	auto *mr_handle = new nccl_ofi_rdma_gin_symm_mr_handle {};
 
@@ -410,13 +393,50 @@ int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, 
 		}
 	}
 
-	mr_handle_map.insert(std::make_pair(data_ptr, nccl_ofi_rdma_gin_mr_map_entry{mr_handle, 1}));
+	*mr_handle_out = mr_handle;
+	return 0;
+}
 
-	/* Exchange MR metadata with all ranks using AG ring */
+int nccl_ofi_rdma_gin_put_comm::regMrSymDmaBufCommon(nccl_ofi_mr_ckey_ref ckey, void *data_ptr, size_t size,
+				      int type, nccl_ofi_rdma_gin_symm_mr_handle **mr_handle_out)
+{
+	nccl_ofi_rdma_gin_symm_mr_handle *mr_handle = nullptr;
+	int ret = 0;
+
+	/* Check for duplicate registration */
+	auto it = mr_handle_map.find(data_ptr);
+	if (it != mr_handle_map.end()) {
+		if (it->second.handle->size < size) {
+			/* Existing MR is too small. We do not support upgrading
+			   an existing registration to a larger size. */
+			NCCL_OFI_WARN("regMrSym for ptr %p with size %zu but existing registration "
+				      "has size %zu", data_ptr, size, it->second.handle->size);
+			return -EINVAL;
+		}
+		/* Existing MR covers the requested region */
+		it->second.refcnt++;
+		mr_handle = it->second.handle;
+	} else {
+		ret = regMrSymLocal(ckey, data_ptr, size, type, &mr_handle);
+		if (ret != 0) {
+			return ret;
+		}
+		mr_handle_map.insert(std::make_pair(data_ptr,
+						   nccl_ofi_rdma_gin_mr_map_entry{mr_handle, 1}));
+	}
+
+	/* Exchange MR metadata with all ranks using AG ring.
+	 *
+	 * Symmetric registration is collective, so every rank must reach this
+	 * all-gather
+	 */
 	ret = ag_comm.all_gather(mr_handle->remote_mr.data(), sizeof(gin_remote_mr));
 	if (ret != 0) {
-		mr_handle_map.erase(data_ptr);
-		delete mr_handle;
+		int dereg_ret = deregMrSymLocked(mr_handle);
+		if (dereg_ret != 0) {
+			NCCL_OFI_WARN("Failed to release symmetric registration for ptr %p after "
+				      "a failed all-gather: %d", data_ptr, dereg_ret);
+		}
 		return ret;
 	}
 
@@ -429,9 +449,13 @@ int nccl_ofi_rdma_gin_put_comm::deregMrSym(nccl_ofi_gin_symm_mr_handle_t *mr_han
 	auto *mr_handle = static_cast<nccl_ofi_rdma_gin_symm_mr_handle *>(mr_handle_base);
 	NCCL_OFI_TRACE(NCCL_NET, "deregMrSym handle %p", mr_handle);
 
-	auto &gin_ep = resources.get_ep();
-	std::lock_guard scoped_ep_lock(gin_ep.ep_lock);
+	std::lock_guard<std::mutex> scoped_ep_lock(get_ep_lock());
 
+	return deregMrSymLocked(mr_handle);
+}
+
+int nccl_ofi_rdma_gin_put_comm::deregMrSymLocked(nccl_ofi_rdma_gin_symm_mr_handle *mr_handle)
+{
 	auto it = mr_handle_map.find(mr_handle->input_address);
 	if (it == mr_handle_map.end()) {
 		return -ENOENT;

--- a/tests/functional/rma_duplicate_mr.cpp
+++ b/tests/functional/rma_duplicate_mr.cpp
@@ -18,6 +18,10 @@
  * 2. Registering the same buffer with a smaller size is covered by the existing MR
  * 3. Deregistering with outstanding refs keeps the MR alive
  * 4. Data transfers work correctly after duplicate registration
+ * 5. A collective re-registration still completes when one rank has
+ *    deregistered locally in the meantime (refcounts differ across ranks)
+ * 6. That re-registration refreshes the deregistering rank's keys, so RMA
+ *    targeting it still lands
  */
 
 static inline ncclResult_t
@@ -230,6 +234,98 @@ int main(int argc, char *argv[])
 
 	/* Deregister the third (smaller size) registration */
 	OFINCCLCHECK(extRma->deregMrSym(collComm, mhandle3));
+
+	/*
+	 * Test 5: collective re-registration after an asymmetric, rank-local
+	 * deregistration. Regression test for a hang in regMrSym.
+	 *
+	 * NCCL documents ncclCommWindowDeregister as rank-local, so ranks may
+	 * legitimately hold different refcounts for the same buffer. regMrSym
+	 * is still collective, so its per-rank key all-gather has to run on
+	 * every rank -- including ranks whose call only bumps a refcount.
+	 * Previously the dedup fast path returned before the all-gather, so
+	 * rank 0 (a cache miss, having dropped its registration) entered a ring
+	 * all-gather that no peer joined and the job deadlocked here.
+	 *
+	 * A regression manifests as a hang rather than a failed assertion, so
+	 * this case relies on the harness timeout to fail the test.
+	 */
+	void *mhandle_sym1 = nullptr;
+	OFINCCLCHECK(extRma->regMrSym(collComm, buff, SEND_SIZE, buffer_type, mrFlags,
+				      &mhandle_sym1));
+	assert(mhandle_sym1 != nullptr);
+
+	/* Rank 0 alone drops its registration. */
+	if (rank == 0) {
+		OFINCCLCHECK(extRma->deregMrSym(collComm, mhandle_sym1));
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	/* Collective again: a cache miss on rank 0, a refcount bump elsewhere. */
+	void *mhandle_sym2 = nullptr;
+	OFINCCLCHECK(extRma->regMrSym(collComm, buff, SEND_SIZE, buffer_type, mrFlags,
+				      &mhandle_sym2));
+	assert(mhandle_sym2 != nullptr);
+
+	if (rank != 0 && mhandle_sym2 != mhandle_sym1) {
+		NCCL_OFI_WARN("Test 5 FAILED: rank %d still holds a registration, so regMrSym "
+			      "should have returned the same handle. Got %p and %p", rank,
+			      mhandle_sym1, mhandle_sym2);
+		return 1;
+	}
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 5 PASSED — re-registration completed after a "
+		      "rank-local deregister", rank);
+
+	/*
+	 * Test 6: the peers were holding rank 0's pre-deregistration keys. The
+	 * all-gather in Test 5 must have replaced them with the keys from rank
+	 * 0's fresh registration, so an RMA write targeting rank 0 has to land.
+	 */
+	const int send_val2 = 77;
+	if (rank == 1) {
+		OFINCCLCHECK(initialize_buff(buff, SEND_SIZE, buffer_type, send_val2));
+	} else if (rank == 0) {
+		OFINCCLCHECK(initialize_buff(buff, SEND_SIZE, buffer_type, 0));
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank == 1) {
+		std::deque<void *> request_deque;
+		void *request = nullptr;
+		OFINCCLCHECK(extRma->iput(rmaCtx, 0, 0, mhandle_sym2, SEND_SIZE, 0, mhandle_sym2,
+					  0, 0, &request));
+		assert(request != nullptr);
+		request_deque.push_back(request);
+
+		while (!request_deque.empty()) {
+			OFINCCLCHECK(poll_request_completion(extRma, request_deque, collComm,
+							    rmaCtx));
+		}
+	}
+
+	MPI_Barrier(MPI_COMM_WORLD);
+
+	if (rank == 0) {
+		uint8_t verif_buf[SEND_SIZE];
+		CUDACHECK(cudaMemcpy(verif_buf, buff, SEND_SIZE, cudaMemcpyDefault));
+		for (int i = 0; i < SEND_SIZE; ++i) {
+			if (verif_buf[i] != send_val2) {
+				NCCL_OFI_WARN("Test 6 FAILED: index %d expected %d got %d", i,
+					      send_val2, verif_buf[i]);
+				return 1;
+			}
+		}
+	}
+	NCCL_OFI_INFO(NCCL_NET, "Rank %d: Test 6 PASSED — iput to the deregistered rank landed",
+		      rank);
+
+	/* Release: rank 0 holds one registration, every other rank holds two. */
+	OFINCCLCHECK(extRma->deregMrSym(collComm, mhandle_sym2));
+	if (rank != 0) {
+		OFINCCLCHECK(extRma->deregMrSym(collComm, mhandle_sym1));
+	}
 
 	/* Cleanup */
 	OFINCCLCHECK(extRma->destroyContext(rmaCtx));


### PR DESCRIPTION
The plugin maintains a refcounted, address-keyed dedup cache for symmetric registrations.  In case of a duplicate registration, the previous code used the existing registration and exited without participating in the all_gather, causing a hang if some ranks went through the normal registration process. (This is possible in particular if some -- but not all -- ranks deregistered the region before reregistering it.)

Fix: all ranks will now go through the all_gather after local registration, even if it is a duplicate registration. Also added a functional test for this case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
