### PR TITLE
Code cleanups around const-ness

### DIFF
--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -288,7 +288,7 @@ public:
 			      int device_index,
 			      struct fi_info *info);
 
-	virtual int get_properties(nccl_ofi_properties_t *props) = 0;
+	virtual int get_properties(nccl_ofi_properties_t *props) const = 0;
 
 	/**
 	 * Retrieve an fi_info object associated with this device to be used for connection
@@ -439,7 +439,7 @@ public:
 	/**
 	 * @brief       Returns number of rails.
 	 */
-	virtual uint16_t get_ofi_num_rails() = 0;
+	virtual uint16_t get_ofi_num_rails() const = 0;
 
 	/* Create a new endpoint
 	 *
@@ -450,7 +450,7 @@ public:
 	/**
 	 * @brief	Returns the base domain's device back-pointer.
 	 */
-	inline nccl_net_ofi_device_t *get_device()
+	inline nccl_net_ofi_device_t *get_device() const
 	{
 		return device;
 	}
@@ -608,7 +608,7 @@ public:
 	 * Get reference to the back-pointed net domain object associated with
 	 * this endpoint
 	 */
-	inline nccl_net_ofi_domain_t &get_domain()
+	inline nccl_net_ofi_domain_t &get_domain() const
 	{
 		return *domain;
 	}

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -266,8 +266,6 @@ typedef struct nccl_ofi_properties {
 	size_t max_p2p_bytes;
 	/** Max transfer size for collective operations **/
 	size_t max_coll_bytes;
-	/** Support eager **/
-	bool eager_support;
 } nccl_ofi_properties_t;
 
 /**

--- a/include/nccl_ofi.h
+++ b/include/nccl_ofi.h
@@ -7,7 +7,6 @@
 
 #include <unordered_map>
 #include <memory>
-#include <optional>
 #include <rdma/fabric.h>
 #include <rdma/fi_errno.h>
 #include <rdma/fi_domain.h>
@@ -468,7 +467,10 @@ public:
 	/*
 	 * Protocol-agnostic MR cache for this device.
 	 */
-	std::optional<nccl_ofi_mr_cache> mr_cache;
+	nccl_ofi_mr_cache mr_cache;
+
+	/* Whether the MR cache is enabled for this domain */
+	const bool mr_cache_enabled;
 
 	/* Lock protecting mr_cache operations */
 	std::mutex mr_cache_lock;

--- a/include/nccl_ofi_mr.h
+++ b/include/nccl_ofi_mr.h
@@ -201,8 +201,8 @@ typedef struct nccl_ofi_reg_entry nccl_ofi_reg_entry_t;
 class nccl_ofi_mr_cache {
 public:
 	/**
-	 * Create a new mr cache. Both the initial number of entries and the
-	 * page size must be greater than zero.
+	 * Create a new mr cache. The page size must be greater than zero.
+	 * An init_num_entries of zero creates an empty cache (disabled).
 	 *
 	 * @param init_num_entries Initial capacity (used for vector::reserve)
 	 * @param page_size Page size for address alignment

--- a/include/nccl_ofi_rdma.h
+++ b/include/nccl_ofi_rdma.h
@@ -536,7 +536,7 @@ public:
     int write(void* src, size_t size, void* src_mhandle, uint64_t dest, uint64_t mr_key, nccl_net_ofi_req **req) override;
     int write_inline(void* src, size_t size, uint64_t dest, uint64_t mr_key, nccl_net_ofi_req **request) override;
 
-    nccl_net_ofi_rdma_ep_t *get_ep();
+    nccl_net_ofi_rdma_ep_t *get_ep() const;
     nccl_net_ofi_rdma_send_comm_rail_t *get_data_rail(uint16_t rail_id);
     bool drain_sender_eager_queue();
 
@@ -757,7 +757,7 @@ public:
     int close() override;
     int read(void* dest, size_t size, void* dest_mhandle, uint64_t src, uint64_t mr_key, nccl_net_ofi_req **req) override;
 
-    nccl_net_ofi_rdma_ep_t *get_ep();
+    nccl_net_ofi_rdma_ep_t *get_ep() const;
     nccl_net_ofi_rdma_recv_comm_rail_t *get_data_rail(uint16_t rail_id);
     nccl_net_ofi_rdma_recv_comm_rail_t *get_control_rail(uint16_t rail_id);
     int allocate_recv_req(nccl_net_ofi_rdma_device_t *device,
@@ -1205,12 +1205,12 @@ public:
 		return domain_rails[rail_id].domain;
 	}
 
-	inline uint16_t get_ofi_num_rails() override
+	inline uint16_t get_ofi_num_rails() const override
 	{
 		return num_rails;
 	}
 
-	inline nccl_net_ofi_rdma_device_t *rdma_domain_get_device();
+	inline nccl_net_ofi_rdma_device_t *rdma_domain_get_device() const;
 
 	inline nccl_net_ofi_rdma_domain_rail_t *rdma_domain_get_rail(uint16_t rail_id)
 	{
@@ -1494,12 +1494,12 @@ public:
 	/* Returns a raw pointer for downcasting to the transport-specific
 	 * domain type. Safe because the ep holds shared_ptr<domain>,
 	 * so the domain is alive as long as the ep exists. */
-	inline nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain()
+	inline nccl_net_ofi_rdma_domain_t *rdma_endpoint_get_domain() const
 	{
 		return static_cast<nccl_net_ofi_rdma_domain_t *>(domain.get());
 	}
 
-	inline nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device()
+	inline nccl_net_ofi_rdma_device_t *rdma_endpoint_get_device() const
 	{
 		return rdma_endpoint_get_domain()->rdma_domain_get_device();
 	}
@@ -1508,7 +1508,7 @@ public:
 	 * Get pointer to the gin resources associated with this endpoint, or
 	 * nullptr if there are no associated GIN resources.
 	 */
-	inline nccl_ofi_gin_resources *get_gin_resources()
+	inline nccl_ofi_gin_resources *get_gin_resources() const
 	{
 		return gin_resources;
 	}
@@ -1876,7 +1876,7 @@ public:
 				   struct fi_info *info_list,
 				   const nccl_ofi_topo_t *topo);
 
-	int get_properties(nccl_ofi_properties_t *props) override;
+	int get_properties(nccl_ofi_properties_t *props) const override;
 
 	inline struct fi_info *get_ofi_info_for_cm() const override
 	{
@@ -2032,7 +2032,7 @@ int nccl_net_ofi_rdma_init(const char *provider_filter,
 			   bool *found_multi_rail,
 			   nccl_ofi_topo_t *topo);
 
-inline nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_domain_t::rdma_domain_get_device()
+inline nccl_net_ofi_rdma_device_t *nccl_net_ofi_rdma_domain_t::rdma_domain_get_device() const
 {
 	return static_cast<nccl_net_ofi_rdma_device_t *>(device);
 }

--- a/include/nccl_ofi_sendrecv.h
+++ b/include/nccl_ofi_sendrecv.h
@@ -187,12 +187,12 @@ public:
 		return domain;
 	}
 
-	inline uint16_t get_ofi_num_rails() override
+	inline uint16_t get_ofi_num_rails() const override
 	{
 		return 1;
 	}
 	
-	inline nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device();
+	inline nccl_net_ofi_sendrecv_device_t *sendrecv_domain_get_device() const;
 
 	/* Caller must hold the device lock */
 	std::shared_ptr<nccl_net_ofi_ep_t> create_endpoint() override;
@@ -236,12 +236,12 @@ public:
 	/* Returns a raw pointer for downcasting to the transport-specific
 	 * domain type. Safe because the ep holds shared_ptr<domain>,
 	 * so the domain is alive as long as the ep exists. */
-	inline nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain()
+	inline nccl_net_ofi_sendrecv_domain_t *sendrecv_endpoint_get_domain() const
 	{
 		return static_cast<nccl_net_ofi_sendrecv_domain_t *>(domain.get());
 	}
 
-	inline nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device()
+	inline nccl_net_ofi_sendrecv_device_t *sendrecv_endpoint_get_device() const
 	{
 		return sendrecv_endpoint_get_domain()->sendrecv_domain_get_device();
 	}
@@ -251,7 +251,7 @@ public:
 	 *
 	 * @return	fid_domain for the device (P-series) or endpoint (Neuron).
 	 */
-	inline ofi_domain_ptr &sendrecv_endpoint_get_ofi_domain()
+	inline ofi_domain_ptr &sendrecv_endpoint_get_ofi_domain() const
 	{
 		return sendrecv_endpoint_get_domain()->domain;
 	}
@@ -363,7 +363,7 @@ public:
 				       int device_id,
 				       struct fi_info *info_arg);
 
-	int get_properties(nccl_ofi_properties_t *props) override;
+	int get_properties(nccl_ofi_properties_t *props) const override;
 
 	inline struct fi_info *get_ofi_info_for_cm() const override
 	{
@@ -464,7 +464,7 @@ int nccl_net_ofi_sendrecv_init(const char *provider_filter,
 			       const nccl_ofi_topo_t *topo);
 
 
-inline nccl_net_ofi_sendrecv_device_t *nccl_net_ofi_sendrecv_domain_t::sendrecv_domain_get_device()
+inline nccl_net_ofi_sendrecv_device_t *nccl_net_ofi_sendrecv_domain_t::sendrecv_domain_get_device() const
 {
 	return static_cast<nccl_net_ofi_sendrecv_device_t *>(device);
 }

--- a/src/nccl_ofi_mr.cpp
+++ b/src/nccl_ofi_mr.cpp
@@ -14,11 +14,6 @@ nccl_ofi_mr_cache::nccl_ofi_mr_cache(size_t init_num_entries,
 				     size_t page_size_arg)
 	: page_size(page_size_arg)
 {
-	if (init_num_entries == 0) {
-		NCCL_OFI_WARN("MR cache: initial number of entries must be positive");
-		throw std::runtime_error("MR cache: initial number of entries must be positive");
-	}
-
 	if (page_size_arg == 0) {
 		NCCL_OFI_WARN("MR cache: page size must be positive");
 		throw std::runtime_error("MR cache: page size must be positive");

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -840,15 +840,13 @@ std::shared_ptr<nccl_net_ofi_ep_t> nccl_net_ofi_domain_t::get_ep(long endpoint_k
 
 nccl_net_ofi_domain_t::nccl_net_ofi_domain_t(nccl_net_ofi_device_t *device_arg,
 					     unsigned int domain_key_arg)
-	: device(device_arg),
+	: mr_cache(ofi_nccl_mr_cache_disable() ? 0 : NCCL_OFI_MR_CACHE_INIT_SIZE,
+		   system_page_size),
+	  mr_cache_enabled(!ofi_nccl_mr_cache_disable()),
+	  device(device_arg),
 	  domain_key(domain_key_arg)
 {
 	assert(this->device != nullptr);
-
-	if (!ofi_nccl_mr_cache_disable()) {
-		this->mr_cache.emplace(NCCL_OFI_MR_CACHE_INIT_SIZE,
-				       system_page_size);
-	}
 
 	if (this->device->need_mr_rkey_pool) {
 		/* The provider may return support for a larger key size. Use

--- a/src/nccl_ofi_net.cpp
+++ b/src/nccl_ofi_net.cpp
@@ -482,9 +482,6 @@ static int set_nic_props_default(int dev_id, struct fi_info *nic_prov,
 
 	props->max_group_receives = NCCL_OFI_MAX_RECVS;
 
-	/* Disable eager by default.  Will be overwritten depending on libfabric feature*/
-	props->eager_support = false;
-
 	if (support_gdr == GDR_SUPPORTED) {
 		props->hmem_support = true;
 	} else {
@@ -565,29 +562,6 @@ int nccl_net_ofi_plugin_t::nccl_net_ofi_info_properties(struct fi_info *nic_prov
 		ret = 0;
 		goto exit;
 	}
-
-#if HAVE_DECL_FI_EFA_FEATURE_OPS
-	{ /* Scope block: C++ forbids goto past auto variable initialization */
-		auto fabric_result = nccl_ofi_ofiutils_fabric_create(nic_prov);
-		if (OFI_UNLIKELY(fabric_result.is_failure())) {
-			NCCL_OFI_WARN("Couldn't open a fabric provider. RC: %d, ERROR: %s",
-				      fabric_result.error_code, fi_strerror(-fabric_result.error_code));
-			ret = fabric_result.error_code;
-			goto error;
-		}
-
-		struct fi_efa_feature_ops *feat_ops = NULL;
-		ret = fi_open_ops(&fabric_result.resource->fid, FI_EFA_FEATURE_OPS, 0,
-				  (void **)&feat_ops, NULL);
-		if (ret != 0) {
-			NCCL_OFI_WARN("fi_open_ops for EFA features failed. RC: %d, ERROR: %s",
-				      ret, fi_strerror(-ret));
-			ret = 0;
-		} else if (feat_ops->query("mixed_hmem_iov")) {
-			props->eager_support = true;
-		}
-	}
-#endif
 
 	/* name is NULL if device is a part of multirail config */
 	/* overriding default name only if value is available from provider */

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -2981,7 +2981,7 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handl
 		return 0;
 	}
 
-	if (this->mr_cache) {
+	if (this->mr_cache_enabled) {
 		std::lock_guard cache_guard(this->mr_cache_lock);
 
 		/*
@@ -2989,7 +2989,7 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr(nccl_net_ofi_rdma_mr_handle_t *mr_handl
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = this->mr_cache->del_entry(mr_handle);
+		int ret = this->mr_cache.del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -3008,13 +3008,13 @@ int nccl_net_ofi_rdma_domain_t::dereg_mr_no_lock(nccl_net_ofi_rdma_mr_handle_t *
 		return 0;
 	}
 
-	if (this->mr_cache) {
+	if (this->mr_cache_enabled) {
 		/*
 		* Depending on the number of references on this handle and the cache
 		* itself, this call would either just decrement the refcnt, or delete
 		* the entry for this handle.
 		*/
-		int ret = this->mr_cache->del_entry(mr_handle);
+		int ret = this->mr_cache.del_entry(mr_handle);
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
 		} else if (ret == 0) {
@@ -3175,7 +3175,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 	nccl_net_ofi_rdma_mr_handle_t *ret_handle = NULL;
 	*mhandle = NULL;
 
-	if (this->mr_cache) {
+	if (this->mr_cache_enabled) {
 		/*
 		 * MR cache is locked between lookup and insert, to be sure we
 		 * insert a missing entry.
@@ -3183,7 +3183,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 		std::lock_guard cache_guard(this->mr_cache_lock);
 
 		ret_handle = static_cast<nccl_net_ofi_rdma_mr_handle_t *>(
-			this->mr_cache->lookup_entry(ckey, endpoint_mr));
+			this->mr_cache.lookup_entry(ckey, endpoint_mr));
 		if (ret_handle) {
 			/* Cache hit */
 			*mhandle = ret_handle;
@@ -3196,7 +3196,7 @@ int nccl_net_ofi_rdma_domain_t::reg_mr(nccl_ofi_mr_ckey_ref ckey,
 			return ret;
 		}
 
-		ret = this->mr_cache->insert_entry(ckey,
+		ret = this->mr_cache.insert_entry(ckey,
 						     endpoint_mr,
 						     ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -14,6 +14,11 @@
 #include <unistd.h>
 #include <pthread.h>
 #include <stdlib.h>
+#ifdef HAVE_RDMA_FI_EXT_EFA_H
+#ifdef HAVE_RDMA_FI_EXT_EFA_H
+#include <rdma/fi_ext_efa.h>
+#endif
+#endif
 
 #include "nccl_ofi.h"
 #include "nccl_ofi_log.h"
@@ -418,7 +423,6 @@ int nccl_net_ofi_rdma_device_t::get_properties(nccl_ofi_properties_t *props)
 		static_assert(NCCL_OFI_MAX_RECVS <= (1 << NCCL_OFI_RDMA_RECV_IDX_BITS),
 					  "NCCL_OFI_MAX_RECVS must fit in RECV_IDX_BITS");
 		props->max_communicators = NCCL_OFI_RDMA_MAX_COMMS;
-		this->eager_support = props->eager_support;
 	} else {
 		return ret;
 	}
@@ -7075,6 +7079,22 @@ nccl_net_ofi_rdma_device_t::nccl_net_ofi_rdma_device_t(nccl_net_ofi_plugin_t *pl
 			      strerror(-ret));
 		throw std::runtime_error("RDMA device constructor: connection prep failed");
 	}
+
+	/* Verify support for eager messages */
+#if HAVE_DECL_FI_EFA_FEATURE_OPS
+	{ /* Scope block: C++ forbids goto past auto variable initialization */
+		struct fi_efa_feature_ops *feat_ops = NULL;
+		ret = fi_open_ops(&this->device_rails[0].fabric->fid, FI_EFA_FEATURE_OPS, 0,
+				  (void **)&feat_ops, NULL);
+		if (ret != 0) {
+			NCCL_OFI_WARN("fi_open_ops for EFA features failed. RC: %d, ERROR: %s",
+				      ret, fi_strerror(-ret));
+			ret = 0;
+		} else if (feat_ops->query("mixed_hmem_iov")) {
+			this->eager_support = true;
+		}
+	}
+#endif
 
 	/* NVTX domain */
 #if HAVE_NVTX_TRACING

--- a/src/nccl_ofi_rdma.cpp
+++ b/src/nccl_ofi_rdma.cpp
@@ -181,7 +181,7 @@ static nccl_net_ofi_rdma_close_msg_t *rdma_send_close_get_msg
 }
 
 
-nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_send_comm::get_ep()
+nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_send_comm::get_ep() const
 {
 	return (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 }
@@ -195,7 +195,7 @@ nccl_net_ofi_rdma_recv_comm_rail_t *nccl_net_ofi_rdma_recv_comm::get_control_rai
 	return &this->control_rails[rail_id];
 }
 
-nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_recv_comm::get_ep()
+nccl_net_ofi_rdma_ep_t *nccl_net_ofi_rdma_recv_comm::get_ep() const
 {
 	return (nccl_net_ofi_rdma_ep_t *)this->ep.get();
 }
@@ -400,7 +400,7 @@ static inline size_t ofi_info_list_length(struct fi_info *info_list)
 }
 
 
-int nccl_net_ofi_rdma_device_t::get_properties(nccl_ofi_properties_t *props)
+int nccl_net_ofi_rdma_device_t::get_properties(nccl_ofi_properties_t *props) const
 {
 	int ret;
 	const nccl_net_ofi_rdma_plugin_t *plugin_ptr = this->rdma_device_get_plugin();

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -714,7 +714,7 @@ static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_ha
 		return;
 	}
 
-	if (domain && domain->mr_cache) {
+	if (domain && domain->mr_cache_enabled) {
 		/*
 		 * Depending on the number of references on this handle and the
 		 * cache itself, this call would either just decrement the
@@ -722,7 +722,7 @@ static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_ha
 		 */
 		{
 			std::lock_guard guard(domain->mr_cache_lock);
-			ret = domain->mr_cache->del_entry((void *)mr_handle);
+			ret = domain->mr_cache.del_entry((void *)mr_handle);
 		}
 		if (OFI_UNLIKELY(ret < 0)) {
 			NCCL_OFI_WARN("Failed to delete MR cache entry");
@@ -771,7 +771,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 
 	int ret = 0;
 	nccl_net_ofi_sendrecv_mr_handle_t *ret_handle = nullptr;
-	bool has_cache = domain->mr_cache.has_value();
+	bool has_cache = domain->mr_cache_enabled;
 
 	if (has_cache) {
 		/*
@@ -781,7 +781,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 		std::lock_guard cache_guard(domain->mr_cache_lock);
 
 		ret_handle = static_cast<nccl_net_ofi_sendrecv_mr_handle_t *>(
-			domain->mr_cache->lookup_entry(ckey, endpoint_mr));
+			domain->mr_cache.lookup_entry(ckey, endpoint_mr));
 
 		if (ret_handle) {
 			/* Cache hit */
@@ -798,7 +798,7 @@ static int sendrecv_comm_mr_base_reg(nccl_net_ofi_comm *base_comm,
 			return ret;
 		}
 
-		ret = domain->mr_cache->insert_entry(ckey, endpoint_mr, ret_handle);
+		ret = domain->mr_cache.insert_entry(ckey, endpoint_mr, ret_handle);
 		if (OFI_UNLIKELY(ret != 0)) {
 			/* MR cache insert failed. Deregister memory region without
 			 * trying to delete MR cache entry.

--- a/src/nccl_ofi_sendrecv.cpp
+++ b/src/nccl_ofi_sendrecv.cpp
@@ -74,7 +74,7 @@ static void sendrecv_comm_mr_base_dereg(nccl_net_ofi_sendrecv_mr_handle_t *mr_ha
 				       nccl_net_ofi_domain_t *domain);
 
 
-int nccl_net_ofi_sendrecv_device_t::get_properties(nccl_ofi_properties_t *props)
+int nccl_net_ofi_sendrecv_device_t::get_properties(nccl_ofi_properties_t *props) const
 {
 	assert(this->plugin != nullptr);
 	


### PR DESCRIPTION
Short patch series to try and make all the read-only fields in the core that are really read only `const`, so that we get compiler support for enforcing read-only and also a clear cue to ourselves of the read-only (and therefore generally thread safe) nature of the fields.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
