### PR TITLE
tuner: Enable PAT channel optimization on P6-B300

### DIFF
--- a/src/tuner/nccl_ofi_regions.cpp
+++ b/src/tuner/nccl_ofi_regions.cpp
@@ -2144,8 +2144,9 @@ ncclResult_t region_get_coll_info_internal_v3(nccl_ofi_tuner_context_t *ctx,
 		*nChannels = calculateBestNChannelTree(nBytes, region_ctx->log2_nnodes);
 	}
 
-	/* Selecting best nChannels for P6 platform PAT AG/RS 0x7 */
-	if ((region_ctx->platform == NCCL_OFI_TUNER_P6) && (nBytes <= 32 * 1024 * 1024) &&
+	/* Selecting best nChannels for P6 platforms PAT AG/RS 0x7 */
+	if ((region_ctx->platform == NCCL_OFI_TUNER_P6 || region_ctx->platform == NCCL_OFI_TUNER_P6_B300)
+		&& (nBytes <= 32 * 1024 * 1024) &&
 		(algorithm == NCCL_ALGO_PAT) && (protocol == NCCL_PROTO_SIMPLE) &&
 		(region_ctx->dims.num_nodes == region_ctx->dims.num_ranks)) {
 		*nChannels = calculateBestNChannelPat(nBytes, region_ctx->dims.num_nodes);


### PR DESCRIPTION
The PAT AllGather/ReduceScatter 0x7 nChannels selection (`calculateBestNChannelPat`) was gated to P6 (B200) only. P6-B300 shows the same PAT/Simple behavior in the one-rank-per-node (0x7) topology and benefits from the same reduced-channel selection, so extend the platform guard to also match `NCCL_OFI_TUNER_P6_B300`.

The rest of the guard is unchanged: the override applies only when the region tuner selects PAT/SIMPLE, nBytes <= 32 MiB, and `num_nodes == num_ranks` (the 0x7, one-rank-per-node case). RING selections, messages > 32 MiB, and other topologies are unaffected.

&nbsp;
Testing shows AllGather 0x7 on P6-B300 improves across 128 KiB–512 KiB (4-node) and 128 KiB–1 MiB (8-node) when forcing PAT/Simple to run with the reduced channel counts. 

Note that this PR enables that channel selection on P6-B300, but it only takes effect where the region tuner already selects PAT/Simple. A follow-up PR to revise the P6-B300 tuner regions is needed so PAT/Simple is selected if it outperforms RING LL/LL128, fully realizing the improvement.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
