### PR TITLE
rdma: Disable eager messages by default

### DIFF
--- a/include/nccl_ofi_param.h
+++ b/include/nccl_ofi_param.h
@@ -224,8 +224,9 @@ OFI_NCCL_PARAM(float, net_latency, "NET_LATENCY", 0.0);
  * Eager message size limit when using RDMA protocol. Message sizes greater than
  * this limit will always be sent using RDMA write instead of eagerly. Setting
  * this to -1 disables eager messages entirely.
+ * Default is disabled
  */
-OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", 8192);
+OFI_NCCL_PARAM(int, eager_max_size, "EAGER_MAX_SIZE", -1);
 
 /*
  * Decide whether or not mutexes should default to errorcheck mode.

--- a/tests/functional/eager_multirecv.cpp
+++ b/tests/functional/eager_multirecv.cpp
@@ -1600,6 +1600,19 @@ public:
 
 int main(int argc, char *argv[])
 {
+	/*
+	 * Eager messages are disabled by default (OFI_NCCL_EAGER_MAX_SIZE == -1).
+	 * This suite specifically exercises the eager path, so force-enable eager
+	 * with the historical default size (8192). The test constants (EAGER_SIZE,
+	 * LARGE_SIZE, and the T14 size-boundary check) all assume this value.
+	 *
+	 * This must run before the plugin is loaded and initialized (the TestSuite
+	 * constructor dlopen()s the plugin and ext_net->init() calls
+	 * ofi_nccl_parameters_init(), which reads the environment). overwrite=0 so
+	 * an explicit OFI_NCCL_EAGER_MAX_SIZE from the caller still takes priority.
+	 */
+	setenv("OFI_NCCL_EAGER_MAX_SIZE", "8192", 0);
+
 	TestSuite suite;
 
 	Test5_SingleEagerLate t5;


### PR DESCRIPTION
## Summary
Change the default of `OFI_NCCL_EAGER_MAX_SIZE` from `8192` to `-1`, which disables the eager send path unless a user explicitly opts in. Eager remains available by setting `OFI_NCCL_EAGER_MAX_SIZE` to a positive value.

## Testing
To keep exercising the eager code paths, the `eager_multirecv` functional suite now sets `OFI_NCCL_EAGER_MAX_SIZE=8192` 