### PR TITLE
gin/gdaki: bind the data endpoint counter for reads as well as writes

### DIFF
--- a/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
+++ b/include/rdma/gin/nccl_ofi_gin_gdaki_resources.h
@@ -501,14 +501,14 @@ public:
 /**
  * Host-side state for the data (main) endpoint.
  *
- * Composes a gdaki_endpoint plus a FI_WRITE hardware counter for
- * tracking local completion of outgoing data-only writes. The kernel
- * spins on this counter (instead of polling the CQ) to determine when
- * Put has completed locally; same model as gdaki_sc_endpoint, just
- * without the FI_REMOTE_WRITE counter (the data EP isn't a signal
- * target).
+ * Composes a gdaki_endpoint plus a hardware counter for tracking local
+ * completion of the operations this endpoint posts; open() takes the
+ * operations to count. The kernel spins on this counter (instead of
+ * polling the CQ) to determine when Put or Get has completed locally;
+ * same model as gdaki_sc_endpoint, just without the FI_REMOTE_WRITE
+ * counter (the data EP isn't a signal target).
  *
- * Member declaration order is critical: write_cntr MUST be declared
+ * Member declaration order is critical: local_cntr MUST be declared
  * BEFORE base so the inner libfabric endpoint closes before the
  * counter bound to it (closing a counter while it is still bound to
  * an open endpoint returns EBUSY in libfabric).
@@ -523,15 +523,17 @@ public:
 	gdaki_data_endpoint(const gdaki_data_endpoint &) = delete;
 	gdaki_data_endpoint &operator=(const gdaki_data_endpoint &) = delete;
 
-	gdaki_hw_counter write_cntr;        /* FI_WRITE (local completion) */
+	gdaki_hw_counter local_cntr;         /* local completion; ops per open() */
 	gdaki_endpoint   base;          /* AFTER counter → EP closes first */
 
 	/**
-	 * Open the inner endpoint, create the FI_WRITE counter, and bind
-	 * the counter before enabling.
+	 * Open the inner endpoint, create the local-completion counter, and bind
+	 * it before enabling. cntr_flags names the operations the counter counts:
+	 * FI_WRITE for an endpoint that only writes, FI_WRITE | FI_READ for one
+	 * that also issues reads.
 	 */
 	void open(struct fid_domain *domain, struct fi_info *ref_info,
-		  struct fi_efa_ops_gda *gda_ops);
+		  struct fi_efa_ops_gda *gda_ops, uint64_t cntr_flags);
 
 	/**
 	 * Populate the inner endpoint's GPU descriptors (QP/CQ attrs,

--- a/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki.cpp
@@ -452,7 +452,7 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 	h.data.target_remote_qpns     = ctx->data[ctx_id]->base.targets.qpns.dev;
 	h.data.target_qkey            = ctx->data[ctx_id]->base.targets.qkeys.dev;
 	h.data.sq_lock = 0;
-	h.data.local_cntr_value = ctx->data[ctx_id]->write_cntr.gpu_ptr();
+	h.data.local_cntr_value = ctx->data[ctx_id]->local_cntr.gpu_ptr();
 	h.data.submitted_count = 0;
 	h.data.sq_size = ctx->data[ctx_id]->base.sq_size;
 
@@ -464,7 +464,7 @@ static void populate_dev_handle(nccl_ofi_gin_gdaki_dev_handle &h,
 	h.pvdata.target_remote_qpns     = ctx->pvdata[ctx_id]->base.targets.qpns.dev;
 	h.pvdata.target_qkey            = ctx->pvdata[ctx_id]->base.targets.qkeys.dev;
 	h.pvdata.sq_lock = 0;
-	h.pvdata.local_cntr_value = ctx->pvdata[ctx_id]->write_cntr.gpu_ptr();
+	h.pvdata.local_cntr_value = ctx->pvdata[ctx_id]->local_cntr.gpu_ptr();
 	h.pvdata.submitted_count = 0;
 	h.pvdata.sq_size = ctx->pvdata[ctx_id]->base.sq_size;
 	h.pvdata.putvalue_slice_base = ctx->pvdata[ctx_id]->putvalue_slice_base;
@@ -753,7 +753,8 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 			 * domain (ofi_domain / proxy_info / gda_ops selected above by
 			 * rail_id = ctx_id % num_rails).
 			 */
-			ctx->data[ctx_id]->open(ofi_domain, proxy_info, gda_ops);
+			/* The data endpoint issues both Put and Get, so it counts reads too. */
+			ctx->data[ctx_id]->open(ofi_domain, proxy_info, gda_ops, FI_WRITE | FI_READ);
 			if (local_n_sc > 0) {
 				ctx->sc_endpoints[ctx_id].reserve(local_n_sc);
 			}
@@ -762,7 +763,8 @@ static ncclResult_t nccl_ofi_gin_gdaki_createContext(void *collComm, ncclGinConf
 				ctx->sc_endpoints[ctx_id][i]->open(ofi_domain, proxy_info, gda_ops);
 			}
 			/* Dedicated PutValue poster endpoint. */
-			ctx->pvdata[ctx_id]->open(ofi_domain, proxy_info, gda_ops);
+			/* PutValue only writes. */
+			ctx->pvdata[ctx_id]->open(ofi_domain, proxy_info, gda_ops, FI_WRITE);
 
 			/*
 			 * Step 5: Exchange ALL of this ctx's endpoint addresses in a

--- a/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
+++ b/src/rdma/gin/nccl_ofi_gin_gdaki_resources.cpp
@@ -350,16 +350,16 @@ void gdaki_endpoint::populate(struct fi_efa_ops_gda *gda_ops,
 }
 
 void gdaki_data_endpoint::open(struct fid_domain *domain, struct fi_info *ref_info,
-			       struct fi_efa_ops_gda *gda_ops)
+			       struct fi_efa_ops_gda *gda_ops, uint64_t cntr_flags)
 {
-	/* Create the FI_WRITE counter first; it will be bound to the inner
-	 * endpoint between open() and enable(). */
-	write_cntr.create(gda_ops, domain);
+	/* Create the counter first; it will be bound to the inner endpoint
+	 * between open() and enable(). */
+	local_cntr.create(gda_ops, domain);
 
 	/* Open the inner endpoint without enable. */
 	base.endpoint.open(domain, ref_info, ofi_nccl_cq_size());
 
-	base.endpoint.bind(&write_cntr.get()->fid, FI_WRITE);
+	base.endpoint.bind(&local_cntr.get()->fid, cntr_flags);
 
 	base.endpoint.enable();
 }


### PR DESCRIPTION
*Description of changes:*

The data endpoint's hardware counter is the device's per-QP local completion source, read by the SQ ring-reuse backpressure and by the blocking Flush. It was bound FI_WRITE only, so an RDMA read completed on the CQ without ever ticking it: a Get left submitted_count permanently ahead of the counter, hanging Flush and never freeing its SQ slot.

Bind the counter FI_WRITE | FI_READ on the data endpoint, because both Put and Get post on that endpoint. The EFA provider routes a completion to cntrs[CNTR_WR] or cntrs[CNTR_RD] by direction, and the bind sets both slots to this one counter, so a Put completion and a Get completion each tick it exactly once. Rename it read_write_cntr to match.

The sc endpoints are not updated: Get supports neither signals nor counters, so it never posts on them and their FI_WRITE-only counter stays correct.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
