### PR TITLE
ci: build a CUDA 11.8 container image

### DIFF
--- a/.github/workflows/update-containers.yaml
+++ b/.github/workflows/update-containers.yaml
@@ -59,6 +59,45 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  # CUDA 11 coverage. Single image, so no matrix: reuses the AL2023 Dockerfile
+  # with an override to pin CUDA 11.8 (the last CUDA 11 release). AL2023 because
+  # its native gcc (11.5) is inside CUDA 11.8 nvcc's supported host-compiler
+  # range (<= 11), and its glibc (2.34) is old enough that CUDA 11.8's device
+  # math headers compile cleanly against it. Unlike the default image this one
+  # installs nvcc, so it is also able to compile the GDAKI .cu tests.
+  build-al2023-cuda11-containers:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push AL2023 CUDA 11 container
+        uses: docker/build-push-action@v6
+        with:
+          context: docker/base
+          file: docker/base/Dockerfile.al2023
+          push: true
+          tags: ghcr.io/${{ github.repository }}/aws-ofi-nccl-al2023-cuda11:cuda-efalattest
+          build-args: |
+            ENABLE_CUDA=true
+            EFA_INSTALLER_VERSION=latest
+            CUDA_REPO_URL=http://developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/cuda-rhel9.repo
+            CUDA_PACKAGES=cuda-cudart-devel-11-8 cuda-nvcc-11-8 cuda-driver-devel-11-8
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
   # for historical reasons, U22 is referenced as "ubuntu" in the container names
   # and the matrix.  We should not do that again.
   build-ubuntu2204-containers:

--- a/docker/base/Dockerfile.al2023
+++ b/docker/base/Dockerfile.al2023
@@ -3,6 +3,13 @@ FROM public.ecr.aws/amazonlinux/amazonlinux:2023
 # Accept build argument
 ARG ENABLE_CUDA=false
 ARG EFA_INSTALLER_VERSION=latest
+# Which CUDA packages to install and which NVIDIA yum repo to pull them from.
+# Overridden by the CUDA 11 image, which pins 11-8 and uses the rhel9 repo
+# because NVIDIA's amzn2023 repo starts at 12-5. Keep CUDA_REPO_URL and
+# CUDA_PACKAGES in sync. Both package sets install a /usr/local/cuda
+# alternatives symlink, which is the path configure is pointed at.
+ARG CUDA_REPO_URL=http://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo
+ARG CUDA_PACKAGES="cuda-cudart-devel-12-6 cuda-crt-12-6"
 
 # Install ALL required base packages and development tools
 RUN yum -y update && \
@@ -24,11 +31,9 @@ RUN yum -y update && \
 
 # Install CUDA if enabled
 RUN if [ "$ENABLE_CUDA" = "true" ]; then \
-        dnf config-manager --add-repo \
-        http://developer.download.nvidia.com/compute/cuda/repos/amzn2023/x86_64/cuda-amzn2023.repo \
-        --save && \
+        dnf config-manager --add-repo "$CUDA_REPO_URL" --save && \
         yum -y clean expire-cache && \
-        yum -y install cuda-cudart-devel-12-6 cuda-crt-12-6 && \
+        yum -y install $CUDA_PACKAGES && \
         yum clean all; \
     fi
 


### PR DESCRIPTION
Add an AL2023-based image with CUDA 11.8, the last CUDA 11 release.
AL2023 because its native gcc (11.5) is inside CUDA 11.8 nvcc's
supported host-compiler range (<= 11), and its glibc (2.34) is old
enough that CUDA 11.8's device math headers compile cleanly against
it. Unlike the default images this one installs nvcc, so it is also
able to compile the GDAKI .cu tests.

CUDA 11.8 is not published in NVIDIA's amzn2023 yum repo, so the image
pulls from the rhel9 repo instead. The packages install cleanly against
AL2023's glibc.

No job consumes the image yet. The build job that uses it follows
separately, so the image is published before anything references it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
