### PR TITLE
release: Make alpha releases deterministic and provide meta-data in release to make auto ingestion easier by consumers

### DIFF
--- a/.github/workflows/generate-release-draft.yml
+++ b/.github/workflows/generate-release-draft.yml
@@ -13,7 +13,41 @@ permissions:
   packages: read
 
 jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.parse.outputs.tag }}
+      version: ${{ steps.parse.outputs.version }}
+      is_alpha: ${{ steps.parse.outputs.is_alpha }}
+      tarball: ${{ steps.parse.outputs.tarball }}
+      dsc: ${{ steps.parse.outputs.dsc }}
+      debian_tar: ${{ steps.parse.outputs.debian_tar }}
+      srpm: ${{ steps.parse.outputs.srpm }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: contrib/scripts/release_version
+          sparse-checkout-cone-mode: false
+
+      - name: Parse release tag
+        id: parse
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          chmod +x contrib/scripts/release_version
+          eval "$(contrib/scripts/release_version "$RELEASE_TAG")"
+          {
+            echo "tag=${TAG}"
+            echo "version=${VERSION}"
+            echo "is_alpha=${IS_ALPHA}"
+            echo "tarball=${TARBALL}"
+            echo "dsc=${DSC}"
+            echo "debian_tar=${DEBIAN_TAR}"
+            echo "srpm=${SRPM}"
+          } >> "$GITHUB_OUTPUT"
+
   build:
+    needs: metadata
     strategy:
       matrix:
         include:
@@ -27,6 +61,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     name: Build for ${{ matrix.name }}
+    env:
+      PLUGIN_TAG: ${{ needs.metadata.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -35,7 +71,7 @@ jobs:
 
       - name: Configure and build
         run: |
-          git config --global --add safe.directory $GITHUB_WORKSPACE
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           ./autogen.sh
           ./configure --with-mpi=/opt/amazon/openmpi \
                       --with-libfabric=/opt/amazon/efa \
@@ -50,16 +86,36 @@ jobs:
       - name: Generate source packages
         if: matrix.generate_packages
         run: |
-          echo "Attempting to generate packages for tag: ${{ github.ref_name }}"
-          ./contrib/scripts/generate_source_packages.sh "${{ github.ref_name }}"
+          echo "Generating packages for tag: ${{ needs.metadata.outputs.tag }}"
+          ./contrib/scripts/generate_source_packages.sh "${{ needs.metadata.outputs.tag }}"
+
+      - name: Validate expected artifacts
+        if: matrix.generate_packages
+        run: |
+          set -e
+          TARBALL="${{ needs.metadata.outputs.tarball }}"
+          DSC="${{ needs.metadata.outputs.dsc }}"
+          DEBIAN_TAR="${{ needs.metadata.outputs.debian_tar }}"
+          SRPM="${{ needs.metadata.outputs.srpm }}"
+
+          for f in "${TARBALL}" "${DSC}" "${DEBIAN_TAR}" "${SRPM}"; do
+            if [ ! -f "${f}" ]; then
+              echo "ERROR: Expected artifact missing: ${f}" >&2
+              find . -maxdepth 1 -type f \( -name '*.tar*' -o -name '*.dsc' -o -name '*.rpm' \) -print
+              exit 1
+            fi
+          done
+          echo "All four expected artifacts present."
 
       - name: Prepare release notes
         if: matrix.generate_packages
         run: |
-          VERSION=${{ github.ref_name }}
-          awk -v version="$VERSION" '
+          TAG="${{ needs.metadata.outputs.tag }}"
+          TARBALL="${{ needs.metadata.outputs.tarball }}"
+
+          cat > release-notes.awk <<'AWK'
           BEGIN { found=0; printing=0; }
-          $0 ~ "^# " version " \\(" { found=1; printing=1; print; next }
+          index($0, "# " version " (") == 1 { found=1; printing=1; print; next }
           printing==1 && $0 ~ "^# v[0-9]" { printing=0; exit }
           printing==1 { print }
           END {
@@ -67,17 +123,15 @@ jobs:
               print "No specific release notes found for version " version > "/dev/stderr"
               exit 1
             }
-          }' RELEASENOTES.md > RELEASE_NOTES.md
+          }
+          AWK
+          awk -v version="${TAG}" -f release-notes.awk RELEASENOTES.md > RELEASE_NOTES.md
+          rm -f release-notes.awk
 
-          # Extract version without 'v' prefix for tarball name
-          TARBALL_VERSION=$(echo $VERSION | sed 's/^v//')
-          TARBALL_NAME="aws-ofi-nccl-${TARBALL_VERSION}.tar.gz"
-
-          # Calculate SHA512 checksum for the tarball and format it properly
-          CHECKSUM=$(sha512sum ${TARBALL_NAME})
-
-          # Append checksum information to release notes in the exact format of the v1.16.0 release
-          echo -e "\nChecksum (sha512) for the release tarball \`aws-ofi-nccl-${TARBALL_VERSION}.tar.gz\`:\n\n\`\`\`\n${CHECKSUM}\n\`\`\`" >> RELEASE_NOTES.md
+          # Append checksum for the tarball
+          CHECKSUM=$(sha512sum "${TARBALL}")
+          printf "\nChecksum (sha512) for the release tarball \`%s\`:\n\n\`\`\`\n%s\n\`\`\`\n" \
+            "${TARBALL}" "${CHECKSUM}" >> RELEASE_NOTES.md
 
       - name: Upload artifacts
         if: matrix.generate_packages
@@ -85,14 +139,16 @@ jobs:
         with:
           name: packages-${{ matrix.name }}
           path: |
-            *.tar*
-            *.dsc
-            *.rpm
+            ${{ needs.metadata.outputs.tarball }}
+            ${{ needs.metadata.outputs.dsc }}
+            ${{ needs.metadata.outputs.debian_tar }}
+            ${{ needs.metadata.outputs.srpm }}
+            release-manifest.txt
             RELEASE_NOTES.md
           if-no-files-found: error
 
   create-release:
-    needs: build
+    needs: [metadata, build]
     runs-on: ubuntu-latest
     steps:
       - name: Download all artifacts
@@ -100,18 +156,57 @@ jobs:
         with:
           name: packages-ubuntu
 
+      - name: Validate artifacts before release
+        run: |
+          set -e
+          TARBALL="${{ needs.metadata.outputs.tarball }}"
+          DSC="${{ needs.metadata.outputs.dsc }}"
+          DEBIAN_TAR="${{ needs.metadata.outputs.debian_tar }}"
+          SRPM="${{ needs.metadata.outputs.srpm }}"
+
+          for f in "${TARBALL}" "${DSC}" "${DEBIAN_TAR}" "${SRPM}" release-manifest.txt; do
+            if [ ! -f "${f}" ]; then
+              echo "ERROR: Expected file missing: ${f}" >&2
+              ls -la
+              exit 1
+            fi
+          done
+          echo "All release files present."
+
+      - name: Generate release metadata
+        run: |
+          cat > release-metadata.json <<EOF
+          {
+            "tag": "${{ needs.metadata.outputs.tag }}",
+            "version": "${{ needs.metadata.outputs.version }}",
+            "is_alpha": ${{ needs.metadata.outputs.is_alpha }},
+            "commit": "${{ github.sha }}",
+            "workflow_run_id": "${{ github.run_id }}",
+            "artifacts": [
+              "${{ needs.metadata.outputs.tarball }}",
+              "${{ needs.metadata.outputs.dsc }}",
+              "${{ needs.metadata.outputs.debian_tar }}",
+              "${{ needs.metadata.outputs.srpm }}"
+            ]
+          }
+          EOF
+
       - name: Display structure of downloaded files
-        run: ls -R
+        run: ls -la
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
-          name: AWS OFI NCCL ${{ github.ref_name }}
+          name: AWS OFI NCCL ${{ needs.metadata.outputs.tag }}
           draft: true
-          prerelease: false
+          prerelease: ${{ needs.metadata.outputs.is_alpha == 'true' }}
           body_path: RELEASE_NOTES.md
           files: |
-            aws-ofi-nccl*
-            libnccl-ofi-*
+            ${{ needs.metadata.outputs.tarball }}
+            ${{ needs.metadata.outputs.dsc }}
+            ${{ needs.metadata.outputs.debian_tar }}
+            ${{ needs.metadata.outputs.srpm }}
+            release-manifest.txt
+            release-metadata.json
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/tag-makedist.yaml
+++ b/.github/workflows/tag-makedist.yaml
@@ -32,6 +32,8 @@ jobs:
     runs-on: ubuntu-latest
     container: ${{ matrix.container }}
     name: make dist for tag ${{ github.ref_name }}
+    env:
+      PLUGIN_TAG: ${{ startsWith(github.ref, 'refs/tags/') && github.ref_name || '' }}
     steps:
       - run: |
           yum -y update && yum -y install git tar util-linux findutils yum-utils

--- a/contrib/scripts/generate_debian_changelog.sh
+++ b/contrib/scripts/generate_debian_changelog.sh
@@ -1,45 +1,85 @@
 #!/bin/bash
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+# Generate a Debian changelog for source packaging.
+# The first (current) stanza is always derived from the exact requested
+# annotated tag -- never from globally sorting tags.
+#
+# Usage: generate_debian_changelog.sh <tag>
+#   e.g., generate_debian_changelog.sh v1.22.0
+#         generate_debian_changelog.sh v1.22.0a1
+#
 
-fmt=" \
-tagname=%(refname:short) \
-tagger_name=%(taggername:mailmap) \
-tagger_email=%(taggeremail:mailmap) \
-tagger_when=%(taggerdate) \
-committer_name=%(committername:mailmap) \
-committer_email=%(committeremail:mailmap) \
-committer_when=%(committerdate) \
-"
+set -euo pipefail
 
-if [ $# -eq 0 ]; then
-	tag=HEAD
-else
-	tag=$1
-fi
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly RELEASE_VERSION="${SCRIPT_DIR}/release_version"
 
-describe=$(git describe --match="v*" --exclude="v0\.9" --exclude="v0\.9\.[1-2]" --exclude="v1\.[0-4]\.[0-5]" --abbrev=0 "$tag" 2>/dev/null)
-if [ $? -ne 0 ]; then
-	git cat-file blob HEAD:contrib/debian-template/changelog | sed "s/@PLACEHOLDER@/$(git describe --match="v*" --exclude="v0\.9" --exclude="v0\.9\.[1-2]" --exclude="v1\.[0-4]\.[0-5]" --always --abbrev=15)/g"
-	exit 0
-fi
-
-git for-each-ref --shell --sort=-v:refname --format "$fmt" --merged "$tag" | {
-	while read line; do
-		eval $line
-		(echo ${tagname} | grep -qE '^v[0-9]') || continue
-		version=$(echo $tagname | sed 's/^v//g' | sed 's/-aws$//g')
-		when=${committer_when:-${tagger_when}}
-		email=${tagger_email:-${committer_email}}
-		name=${tagger_name:-${committer_name}}
-		# Tue Jan 22 23:07:21 2019 -0800 -> Tue, 22 Jan 2019 23:07:21 -0800
-		when=$(echo $when | awk '{ printf "%s, %s %s %s %s %s", $1, $3, $2, $5, $4, $6 }')
-		cat <<EOF
-aws-ofi-nccl (${version}-1) unstable; urgency=medium
-
-  * New release for tag $tagname
-
- -- $name $email  $when
-EOF
-
-	done
-
+die() {
+	printf 'generate_debian_changelog.sh: error: %s\n' "$*" >&2
+	exit 1
 }
+
+if [[ $# -ne 1 ]]; then
+	die "Usage: generate_debian_changelog.sh <tag>"
+fi
+
+readonly INPUT_TAG="$1"
+
+# Validate the tag format using the central parser
+if ! "${RELEASE_VERSION}" --validate "${INPUT_TAG}"; then
+	die "Tag '${INPUT_TAG}' does not match required format."
+fi
+
+# Parse version metadata
+eval "$("${RELEASE_VERSION}" "${INPUT_TAG}")"
+
+# Verify the tag exists as an annotated tag
+tag_type="$(git cat-file -t "refs/tags/${INPUT_TAG}" 2>/dev/null)" || \
+	die "Tag '${INPUT_TAG}' does not exist in this repository."
+
+if [[ "${tag_type}" != "tag" ]]; then
+	die "Tag '${INPUT_TAG}' is not an annotated tag (type: ${tag_type})."
+fi
+
+# Extract tagger metadata from the exact requested tag
+fmt='%(taggername:mailmap)%0a%(taggeremail:mailmap)%0a%(taggerdate:rfc2822)'
+tag_meta="$(git for-each-ref --format="${fmt}" "refs/tags/${INPUT_TAG}")"
+
+tagger_name="$(echo "${tag_meta}" | sed -n '1p')"
+tagger_email="$(echo "${tag_meta}" | sed -n '2p')"
+tagger_when="$(echo "${tag_meta}" | sed -n '3p')"
+
+# Fall back to committer info if tagger is unavailable (shouldn't happen for annotated tags)
+if [[ -z "${tagger_name}" ]]; then
+	commit_sha="$(git rev-list -n1 "refs/tags/${INPUT_TAG}")"
+	tagger_name="$(git log -1 --format='%cN' "${commit_sha}")"
+	tagger_email="<$(git log -1 --format='%cE' "${commit_sha}")>"
+	tagger_when="$(git log -1 --format='%cD' "${commit_sha}")"
+fi
+
+[[ -n "${tagger_name}" ]] || die "Cannot determine tagger/committer name for '${INPUT_TAG}'."
+[[ -n "${tagger_when}" ]] || die "Cannot determine tagger/committer date for '${INPUT_TAG}'."
+
+formatted_when="${tagger_when}"
+
+# Determine release description
+if [[ "${IS_ALPHA}" == "true" ]]; then
+	release_desc="New upstream prerelease ${VERSION}"
+else
+	release_desc="New upstream release ${VERSION}"
+fi
+
+# Emit the current stanza from the exact requested tag
+cat <<EOF
+aws-ofi-nccl (${DEBIAN_VERSION}) unstable; urgency=medium
+
+  * ${release_desc}
+
+ -- ${tagger_name} ${tagger_email}  ${formatted_when}
+
+EOF

--- a/contrib/scripts/generate_release_tag
+++ b/contrib/scripts/generate_release_tag
@@ -5,101 +5,145 @@
 # See LICENSE.txt for license information
 #
 
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+readonly RELEASE_VERSION="${SCRIPT_DIR}/release_version"
+
 usage() {
-    echo "Usage: $0 --ref <reference> --tag <tag name> [--push <remote>]" 1>&2
-    echo "" 1>&2
-    echo "Options:" 1>&2
-    echo "  --ref <reference>  Target git reference to tag (e.g., HEAD, a commit sha)" 1>&2
-    echo "  --tag <tag name>   Release tag name (e.g., v1.19.0)" 1>&2
-    echo "  --push <remote>    Push the tag to the specified remote after creation" 1>&2
+    cat >&2 <<EOF
+Usage: $0 --ref <reference> --tag <tag name> [--push <remote>] [--dry-run]
+
+Options:
+  --ref <reference>  Target git reference to tag (e.g., HEAD, a commit sha)
+  --tag <tag name>   Release tag name (e.g., v1.22.0 or v1.22.0a1)
+  --push <remote>    Push the tag to the specified remote after creation
+  --dry-run          Validate all preconditions without creating the tag
+EOF
+    exit 1
+}
+
+die() {
+    printf 'Error: %s\n' "$*" >&2
     exit 1
 }
 
 reference=""
 tagname=""
 push_remote=""
+dry_run=false
 
-while [ $# -gt 0 ]; do
+while [[ $# -gt 0 ]]; do
     case "$1" in
         --ref)
-            [ -z "$2" ] && usage
+            [[ -z "${2:-}" ]] && usage
             reference="$2"
             shift 2
             ;;
         --tag)
-            [ -z "$2" ] && usage
+            [[ -z "${2:-}" ]] && usage
             tagname="$2"
             shift 2
             ;;
         --push)
-            [ -z "$2" ] && usage
+            [[ -z "${2:-}" ]] && usage
             push_remote="$2"
             shift 2
             ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
         *)
-            echo "Error: unknown option $1" 1>&2
+            echo "Error: unknown option $1" >&2
             usage
             ;;
     esac
 done
 
-if [ -z "$reference" ] || [ -z "$tagname" ]; then
+if [[ -z "${reference}" ]] || [[ -z "${tagname}" ]]; then
     usage
 fi
 
+# --- Strict tag validation using central parser ---
+if ! "${RELEASE_VERSION}" --validate "${tagname}"; then
+    die "Tag '${tagname}' does not match required format: v<MAJOR>.<MINOR>.<PATCH>[a<N>]"
+fi
+
+# Parse version metadata for informational output
+eval "$("${RELEASE_VERSION}" "${tagname}")"
+
 echo "reference: ${reference}"
 echo "tag: ${tagname}"
+echo "version: ${VERSION}"
+echo "is_alpha: ${IS_ALPHA}"
 
 # Verify the remote exists early, before creating the tag
-if [ -n "${push_remote}" ]; then
+if [[ -n "${push_remote}" ]]; then
     if ! git remote get-url "${push_remote}" > /dev/null 2>&1; then
-        echo "Remote '${push_remote}' does not exist." 1>&2
-        exit 1
+        die "Remote '${push_remote}' does not exist."
     fi
 fi
 
-# verify that tag looks sanely formatted
-if ! [[ "${tagname}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+ ]]; then
-    echo "Tag ${tagname} does not look like a release tag."
-    exit 1
+# Verify that the tag does not already exist
+if git rev-parse "refs/tags/${tagname}" > /dev/null 2>&1; then
+    die "Tag '${tagname}' already exists. Refusing to overwrite."
 fi
 
-# verify that the ref we're tagging is in a branch that looks like a reasonable
+# Verify that the ref we're tagging is in a branch that looks like a reasonable
 # release branch for the tag we're creating
-expected_release_branch=`echo ${tagname} | sed -E 's/(v[0-9]+\.[0-9]+)\..*/\1.x/'`
-branches=`git branch --contains ${reference} --format="    %(refname:short)"`
-if ! echo "${branches}"  | grep -q ${expected_release_branch} ; then
-    echo "None of the branches containing ${reference} look like a release branch for ${tagname}.
-Found branches include:
-$branches" 1>&2
-    exit 1
+expected_release_branch="${RELEASE_BRANCH}"
+branches="$(git branch --contains "${reference}" --format="%(refname:short)" 2>/dev/null)" || \
+    die "Cannot find branches containing '${reference}'. Is the reference valid?"
+
+if ! echo "${branches}" | grep -qx "${expected_release_branch}"; then
+    die "None of the branches containing '${reference}' match expected release branch '${expected_release_branch}'.
+Found branches:
+${branches}"
 fi
 
-# Verify RELEASENOTES.md is sane
-case `git show ${reference}:RELEASENOTES.md | sed 15q` in
-    *"${tagname}"*) : ;;
-    *)
-	echo "RELEASENOTES.md not updated; not tagging." 1>&2
-	exit 1
-	;;
-esac
+# Verify RELEASENOTES.md mentions the tag in the first 15 lines
+release_notes_head="$(git show "${reference}:RELEASENOTES.md" 2>/dev/null | sed 15q)" || \
+    die "Cannot read RELEASENOTES.md from '${reference}'."
 
-# Make the tag
-git tag -s -a -m "Create ${tagname} release tag" "${tagname}" "${reference}"
-if test $? -ne 0 ; then
-    echo "Creating tag ${tagname} on reference ${reference} failed".
-    exit 1
+release_notes_found=false
+while IFS= read -r line; do
+    if [[ "${line}" == "# ${tagname} ("* ]]; then
+        release_notes_found=true
+        break
+    fi
+done <<< "${release_notes_head}"
+
+if [[ "${release_notes_found}" != true ]]; then
+    die "RELEASENOTES.md does not contain a heading for '${tagname}' in the first 15 lines. Not tagging."
+fi
+
+# --- Dry-run exits here ---
+if [[ "${dry_run}" == true ]]; then
+    echo ""
+    echo "=== DRY RUN: All preconditions passed ==="
+    echo "Tag '${tagname}' would be created at '${reference}'"
+    echo "Expected artifacts:"
+    echo "  ${TARBALL}"
+    echo "  ${DSC}"
+    echo "  ${DEBIAN_TAR}"
+    echo "  ${SRPM}"
+    exit 0
+fi
+
+# Make the signed annotated tag
+if ! git tag -s -a -m "Create ${tagname} release tag" "${tagname}" "${reference}"; then
+    die "Creating tag '${tagname}' on reference '${reference}' failed."
 fi
 
 echo "${tagname} tag created at reference ${reference}."
 
 # Push if --push was specified
-if [ -n "${push_remote}" ]; then
+if [[ -n "${push_remote}" ]]; then
     echo "Pushing ${tagname} to ${push_remote}..."
-    git push "${push_remote}" "${tagname}"
-    if test $? -ne 0 ; then
-        echo "Pushing tag ${tagname} to ${push_remote} failed." 1>&2
-        exit 1
+    if ! git push "${push_remote}" "${tagname}"; then
+        die "Pushing tag '${tagname}' to '${push_remote}' failed."
     fi
     echo "${tagname} pushed to ${push_remote}."
 else

--- a/contrib/scripts/generate_source_packages.sh
+++ b/contrib/scripts/generate_source_packages.sh
@@ -1,48 +1,137 @@
 #!/bin/bash
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+# Generate Debian and RPM source packages from a release tarball.
+# Uses the central release_version parser and the exact requested tag.
+#
+# Usage: generate_source_packages.sh <tag>
+#   e.g., generate_source_packages.sh v1.22.0
+#         generate_source_packages.sh v1.22.0a1
+#
 
-set -e
+set -euo pipefail
 
-SCRIPT_LOCATION=$(realpath $(dirname $BASH_SOURCE))
-REPO_ROOT=$(realpath "$SCRIPT_LOCATION/../..")
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly SCRIPT_DIR
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+readonly REPO_ROOT
+readonly RELEASE_VERSION="${SCRIPT_DIR}/release_version"
 
-if [ $# -eq 0 ]; then
-	echo "Usage: $0 <version>"
-	echo "  <version>  Release version (e.g., v1.19.0 or 1.19.0)"
+die() {
+	printf 'generate_source_packages.sh: error: %s\n' "$*" >&2
+	exit 1
+}
+
+if [[ $# -ne 1 ]]; then
+	echo "Usage: $0 <tag>" >&2
+	echo "  <tag>  Release tag (e.g., v1.22.0 or v1.22.0a1)" >&2
 	exit 1
 fi
 
-# Strip leading 'v' if present
-upstream_version=$(echo "$1" | sed 's/^v//')
-tarball="aws-ofi-nccl-${upstream_version}.tar.gz"
+readonly INPUT_TAG="$1"
 
-if [ ! -f "$tarball" ]; then
-	echo "Error: tarball not found: $tarball"
-	exit 1
+# --- Parse and validate the tag ---
+if ! "${RELEASE_VERSION}" --validate "${INPUT_TAG}"; then
+	die "Tag '${INPUT_TAG}' does not match required format."
 fi
 
-tmpdir=$(mktemp -d)
-trap "rm -rf $tmpdir" EXIT
+eval "$("${RELEASE_VERSION}" "${INPUT_TAG}")"
 
-# Extract the make dist tarball
-tar -xzf "$tarball" -C "$tmpdir"
-srcdir="$tmpdir/aws-ofi-nccl-${upstream_version}"
+echo "=== Generating source packages for ${INPUT_TAG} ==="
+echo "VERSION=${VERSION}"
+echo "IS_ALPHA=${IS_ALPHA}"
+echo "Expected artifacts:"
+echo "  ${TARBALL}"
+echo "  ${DSC}"
+echo "  ${DEBIAN_TAR}"
+echo "  ${SRPM}"
+echo ""
 
-# Generate debian changelog from git tags
-changelog=$($SCRIPT_LOCATION/generate_debian_changelog.sh "v${upstream_version}")
+# --- Verify the tarball exists ---
+if [[ ! -f "${TARBALL}" ]]; then
+	die "Required tarball not found: ${TARBALL}"
+fi
 
-# Set up debian directory from repo template (not in make dist tarball)
-cp -r "$REPO_ROOT/contrib/debian-template" "$srcdir/debian"
-echo "$changelog" > "$srcdir/debian/changelog"
+# --- Create temporary working directory ---
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT
 
-# Build debian source package (native format, no orig.tar.gz needed)
-(cd "$srcdir" && dpkg-source --build .)
+# --- Extract the tarball ---
+tar -xzf "${TARBALL}" -C "${tmpdir}"
+srcdir="${tmpdir}/aws-ofi-nccl-${VERSION}"
 
-# Build SRPM
-sed "s/@VERSION@/${upstream_version}/" "$REPO_ROOT/contrib/fedora/aws-ofi-nccl.spec" |
-	sed "s/@TARBALL@/aws-ofi-nccl-${upstream_version}.tar.gz/" \
-		>"$tmpdir/aws-ofi-nccl.spec"
-cp "$tarball" "$tmpdir/"
-(cd "$tmpdir" && rpmbuild --define "_sourcedir $(pwd)" --define "_srcrpmdir $(pwd)" -bs aws-ofi-nccl.spec)
+if [[ ! -d "${srcdir}" ]]; then
+	die "Expected source directory not found after extraction: aws-ofi-nccl-${VERSION}"
+fi
 
-# Move final artifacts to current directory
-mv "$tmpdir"/*.dsc "$tmpdir"/*.tar.xz "$tmpdir"/*.src.rpm .
+# --- Generate debian changelog from the exact tag ---
+changelog="$("${SCRIPT_DIR}/generate_debian_changelog.sh" "${INPUT_TAG}")"
+
+# --- Set up debian directory from repo template ---
+cp -r "${REPO_ROOT}/contrib/debian-template" "${srcdir}/debian"
+echo "${changelog}" > "${srcdir}/debian/changelog"
+
+# --- Build debian source package (native format) ---
+(cd "${srcdir}" && dpkg-source --build .)
+
+# --- Build SRPM ---
+sed "s/@VERSION@/${VERSION}/" "${REPO_ROOT}/contrib/fedora/aws-ofi-nccl.spec" |
+	sed "s/@TARBALL@/${TARBALL}/" \
+		> "${tmpdir}/aws-ofi-nccl.spec"
+cp "${TARBALL}" "${tmpdir}/"
+(cd "${tmpdir}" && rpmbuild --define "_sourcedir $(pwd)" --define "_srcrpmdir $(pwd)" -bs aws-ofi-nccl.spec)
+
+# --- Validate exactly one of each expected output ---
+dsc_count="$(find "${tmpdir}" -maxdepth 1 -name "*.dsc" | wc -l)"
+debian_tar_count="$(find "${tmpdir}" -maxdepth 1 -name "*.tar.xz" | wc -l)"
+srpm_count="$(find "${tmpdir}" -maxdepth 1 -name "*.src.rpm" | wc -l)"
+
+[[ "${dsc_count}" -eq 1 ]] || die "Expected exactly 1 .dsc file, found ${dsc_count}"
+[[ "${debian_tar_count}" -eq 1 ]] || die "Expected exactly 1 .tar.xz file, found ${debian_tar_count}"
+[[ "${srpm_count}" -eq 1 ]] || die "Expected exactly 1 .src.rpm file, found ${srpm_count}"
+
+# --- Move artifacts to current directory ---
+mv "${tmpdir}/${DSC}" . 2>/dev/null || die "Expected DSC '${DSC}' not found in build output"
+mv "${tmpdir}/${DEBIAN_TAR}" . 2>/dev/null || die "Expected Debian tar '${DEBIAN_TAR}' not found in build output"
+
+# SRPM naming may include dist suffix; find the actual file
+actual_srpm="$(find "${tmpdir}" -maxdepth 1 -name "libnccl-ofi-${VERSION}-1*.src.rpm" -print -quit)"
+[[ -n "${actual_srpm}" ]] || die "Expected SRPM matching 'libnccl-ofi-${VERSION}-1*.src.rpm' not found"
+mv "${actual_srpm}" "./${SRPM}"
+
+# --- Validate DSC metadata ---
+if [[ -f "${DSC}" ]]; then
+	# Check that the DSC references the correct Debian tar
+	if ! grep -Fq "${DEBIAN_TAR}" "${DSC}"; then
+		die "DSC '${DSC}' does not reference expected Debian tar '${DEBIAN_TAR}'"
+	fi
+	# Check version in DSC
+	dsc_version="$(grep "^Version:" "${DSC}" | awk '{print $2}')"
+	if [[ "${dsc_version}" != "${DEBIAN_VERSION}" ]]; then
+		die "DSC version '${dsc_version}' does not match expected '${DEBIAN_VERSION}'"
+	fi
+fi
+
+# --- Generate SHA256 manifest ---
+echo "=== Generating release manifest ==="
+manifest_file="release-manifest.txt"
+{
+	echo "# AWS OFI NCCL Release Manifest"
+	echo "# Tag: ${TAG}"
+	echo "# Version: ${VERSION}"
+	echo "# IS_ALPHA: ${IS_ALPHA}"
+	echo "# Generated: $(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+	echo "#"
+	echo "# SHA256 checksums for release artifacts:"
+	sha256sum "${TARBALL}" "${DSC}" "${DEBIAN_TAR}" "${SRPM}"
+} > "${manifest_file}"
+
+echo ""
+echo "=== Release artifacts generated successfully ==="
+cat "${manifest_file}"
+echo ""
+echo "Artifacts:"
+ls -la "${TARBALL}" "${DSC}" "${DEBIAN_TAR}" "${SRPM}" "${manifest_file}"

--- a/contrib/scripts/release_version
+++ b/contrib/scripts/release_version
@@ -1,0 +1,174 @@
+#!/bin/bash
+#
+# Copyright (c) 2026      Amazon.com, Inc. or its affiliates. All rights reserved.
+#
+# See LICENSE.txt for license information
+#
+# Central release version parser for AWS OFI NCCL.
+# Supports only: ^v[0-9]+\.[0-9]+\.[0-9]+(a[1-9][0-9]*)?$
+#
+# Usage:
+#   release_version <tag>
+#   release_version --validate <tag>
+#   release_version --field <field> <tag>
+#
+# Output (default): KEY=VALUE pairs safe for shell eval
+# Fields: TAG, VERSION, BASE_VERSION, ALPHA_SEQUENCE, IS_ALPHA,
+#          TARBALL, DSC, DEBIAN_TAR, SRPM, DEBIAN_VERSION, RELEASE_BRANCH
+#
+# Exit codes:
+#   0 - success
+#   1 - invalid tag or usage error
+
+set -euo pipefail
+
+readonly PROG="${0##*/}"
+readonly TAG_REGEX='^v([0-9]+)\.([0-9]+)\.([0-9]+)(a([1-9][0-9]*))?$'
+
+usage() {
+	cat >&2 <<EOF
+Usage: ${PROG} [--validate|--field <field>] <tag>
+
+Parse a release tag and emit version metadata.
+
+Options:
+  --validate   Exit 0 if tag is valid, 1 otherwise (no output on success)
+  --field <f>  Print only the value of field <f>
+
+Supported tag format: v<MAJOR>.<MINOR>.<PATCH>[a<N>]
+  where N >= 1
+
+Fields: TAG VERSION BASE_VERSION MAJOR MINOR PATCH ALPHA_SEQUENCE IS_ALPHA
+        TARBALL DSC DEBIAN_TAR SRPM DEBIAN_VERSION RELEASE_BRANCH
+EOF
+	exit 1
+}
+
+die() {
+	printf '%s: error: %s\n' "${PROG}" "$*" >&2
+	exit 1
+}
+
+parse_tag() {
+	local tag="$1"
+
+	if ! [[ "${tag}" =~ ${TAG_REGEX} ]]; then
+		die "tag '${tag}' does not match required format: v<MAJOR>.<MINOR>.<PATCH>[a<N>]"
+	fi
+
+	MAJOR="${BASH_REMATCH[1]}"
+	MINOR="${BASH_REMATCH[2]}"
+	PATCH="${BASH_REMATCH[3]}"
+	ALPHA_SUFFIX="${BASH_REMATCH[4]}"
+	ALPHA_SEQUENCE="${BASH_REMATCH[5]}"
+
+	TAG="${tag}"
+	BASE_VERSION="${MAJOR}.${MINOR}.${PATCH}"
+
+	if [[ -n "${ALPHA_SUFFIX}" ]]; then
+		IS_ALPHA=true
+		VERSION="${BASE_VERSION}a${ALPHA_SEQUENCE}"
+	else
+		IS_ALPHA=false
+		VERSION="${BASE_VERSION}"
+		ALPHA_SEQUENCE=""
+	fi
+
+	DEBIAN_VERSION="${VERSION}-1"
+	TARBALL="aws-ofi-nccl-${VERSION}.tar.gz"
+	DSC="aws-ofi-nccl_${DEBIAN_VERSION}.dsc"
+	DEBIAN_TAR="aws-ofi-nccl_${DEBIAN_VERSION}.tar.xz"
+	SRPM="libnccl-ofi-${VERSION}-1.src.rpm"
+	RELEASE_BRANCH="v${MAJOR}.${MINOR}.x"
+}
+
+emit_all() {
+	cat <<EOF
+TAG=${TAG}
+VERSION=${VERSION}
+BASE_VERSION=${BASE_VERSION}
+MAJOR=${MAJOR}
+MINOR=${MINOR}
+PATCH=${PATCH}
+ALPHA_SEQUENCE=${ALPHA_SEQUENCE}
+IS_ALPHA=${IS_ALPHA}
+TARBALL=${TARBALL}
+DSC=${DSC}
+DEBIAN_TAR=${DEBIAN_TAR}
+SRPM=${SRPM}
+DEBIAN_VERSION=${DEBIAN_VERSION}
+RELEASE_BRANCH=${RELEASE_BRANCH}
+EOF
+}
+
+emit_field() {
+	local field="$1"
+	case "${field}" in
+		TAG) echo "${TAG}" ;;
+		VERSION) echo "${VERSION}" ;;
+		BASE_VERSION) echo "${BASE_VERSION}" ;;
+		MAJOR) echo "${MAJOR}" ;;
+		MINOR) echo "${MINOR}" ;;
+		PATCH) echo "${PATCH}" ;;
+		ALPHA_SEQUENCE) echo "${ALPHA_SEQUENCE}" ;;
+		IS_ALPHA) echo "${IS_ALPHA}" ;;
+		TARBALL) echo "${TARBALL}" ;;
+		DSC) echo "${DSC}" ;;
+		DEBIAN_TAR) echo "${DEBIAN_TAR}" ;;
+		SRPM) echo "${SRPM}" ;;
+		DEBIAN_VERSION) echo "${DEBIAN_VERSION}" ;;
+		RELEASE_BRANCH) echo "${RELEASE_BRANCH}" ;;
+		*) die "unknown field '${field}'" ;;
+	esac
+}
+
+# --- Main ---
+
+mode="emit"
+field=""
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+		--validate)
+			mode="validate"
+			shift
+			;;
+		--field)
+			[[ $# -lt 2 ]] && usage
+			mode="field"
+			field="$2"
+			shift 2
+			;;
+		--help|-h)
+			usage
+			;;
+		-*)
+			die "unknown option '$1'"
+			;;
+		*)
+			break
+			;;
+	esac
+done
+
+[[ $# -ne 1 ]] && usage
+input_tag="$1"
+
+case "${mode}" in
+	validate)
+		# Suppress error output for validate mode
+		if [[ "${input_tag}" =~ ${TAG_REGEX} ]]; then
+			exit 0
+		else
+			exit 1
+		fi
+		;;
+	emit)
+		parse_tag "${input_tag}"
+		emit_all
+		;;
+	field)
+		parse_tag "${input_tag}"
+		emit_field "${field}"
+		;;
+esac

--- a/m4/get_version.sh
+++ b/m4/get_version.sh
@@ -5,49 +5,95 @@
 # See LICENSE.txt for license information
 #
 
-# if there is a top-level release version file, then use that as the version.
+# Central version discovery for build-time use.
+# Priority order:
+#   1. .release_version file (in release tarballs)
+#   2. Explicit PLUGIN_TAG environment variable (validated, must point at HEAD)
+#   3. Single git tag at HEAD
+#   4. git-<sha> development version
+#   5. BRAZIL_PACKAGE_CHANGE_ID fallback
+
+# Locate the release_version parser (relative to this script's location in m4/)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RELEASE_VERSION="${SCRIPT_DIR}/../contrib/scripts/release_version"
+
+# 1. If there is a top-level release version file, use that as the version.
 # This allows tarballs to run autogen without ending up in a weird place.
 if test -f .release_version ; then
     cat .release_version
     exit 0
 fi
 
-# pull the version from git
+# 2. Pull the version from git
 if git rev-parse --git-dir > /dev/null 2>&1 ; then
-    # am I on a tag?
-    version=`git tag --points-at HEAD`
+
+    # If PLUGIN_TAG is explicitly set, validate and use it directly.
+    if test -n "${PLUGIN_TAG:-}" ; then
+        # Validate format if the central parser is available
+        if test -x "${RELEASE_VERSION}" ; then
+            if ! "${RELEASE_VERSION}" --validate "${PLUGIN_TAG}" ; then
+                echo "PLUGIN_TAG '${PLUGIN_TAG}' does not match required release tag format." 1>&2
+                exit 1
+            fi
+        fi
+
+        # Verify the tag exists
+        if ! git rev-parse "refs/tags/${PLUGIN_TAG}" > /dev/null 2>&1 ; then
+            echo "PLUGIN_TAG '${PLUGIN_TAG}' does not exist as a git tag." 1>&2
+            exit 1
+        fi
+
+        # Verify the tag points at HEAD
+        tag_commit="$(git rev-list -n1 "refs/tags/${PLUGIN_TAG}" 2>/dev/null)"
+        head_commit="$(git rev-parse HEAD 2>/dev/null)"
+        if test "${tag_commit}" != "${head_commit}" ; then
+            echo "PLUGIN_TAG '${PLUGIN_TAG}' points at ${tag_commit}, but HEAD is ${head_commit}." 1>&2
+            exit 1
+        fi
+
+        # Strip leading 'v' and emit version
+        version="$(echo "${PLUGIN_TAG}" | sed -E 's/^v([0-9]+\.[0-9]+.*)/\1/')"
+        echo "${version}"
+        exit 0
+    fi
+
+    # No explicit PLUGIN_TAG -- discover tags at HEAD
+    version="$(git tag --points-at HEAD)"
     if test ${?} -ne 0 ; then
         echo "Git tag failed, aborting" 1>&2
         exit 1
     fi
-    # handle the case where there are multiple tags at this commit.  Note that
-    # GitHub's handling of push events of tags is to do a checkout that only
-    # includes the pushed tag (even when there are multiple tags pushed at the
-    # same time, GitHub will run 2 jobs in parallel).
-    if (( $(grep -c . <<<"$version") > 1 )); then
-        if test "${PLUGIN_TAG}" = "" ; then
-            echo "More than one tag found:
+
+    # Handle the case where there are multiple tags at this commit.
+    # Without PLUGIN_TAG, multiple tags is ambiguous and must fail.
+    if test -n "${version}" ; then
+        tag_count="$(echo "${version}" | grep -c .)"
+        if test "${tag_count}" -gt 1 ; then
+            echo "More than one tag found at HEAD:
 ${version}
 
-Set PLUGIN_TAG to the correct tag" 1>&2
+Set PLUGIN_TAG to the correct tag." 1>&2
             exit 1
-        elif (( $(grep -c "^${PLUGIN_TAG}\$" <<<"${version}") != 1 )); then
-            echo "PLUGIN_TAG set to \"${PLUGIN_TAG}\", which does not seem to be a valid tag.
-Valid tags are:
-${version}" 1>&2
-            exit 1
+        fi
+
+        # Single tag found -- validate it if parser is available
+        if test -x "${RELEASE_VERSION}" ; then
+            if "${RELEASE_VERSION}" --validate "${version}" ; then
+                version="$(echo "${version}" | sed -E 's/^v([0-9]+\.[0-9]+.*)/\1/')"
+                echo "${version}"
+                exit 0
+            fi
+            # Non-release tag at HEAD: fall through to git-sha
         else
-            version="${PLUGIN_TAG}"
+            # No parser available; use permissive extraction
+            version="$(echo "${version}" | sed -E 's/v([0-9]+\.[0-9]+.*)/\1/')"
+            echo "${version}"
+            exit 0
         fi
     fi
-    if test "${version}" != "" ; then
-        version=`echo ${version} | sed -E 's/v([0-9]+\.[0-9]+.*)/\1/'`
-        echo ${version}
-        exit 0
-    fi
 
-    # no tag, so save the git hash
-    version=`git rev-parse --short HEAD`
+    # No tag at HEAD (or non-release tag); emit git-sha development version
+    version="$(git rev-parse --short HEAD)"
     if test ${?} -ne 0 ; then
         echo "Git rev-parse failed, aborting" 1>&2
         exit 1
@@ -56,10 +102,10 @@ ${version}" 1>&2
     exit 0
 fi
 
-# Try environment variable from AWS internal Brazil Package Builder
+# 3. Try environment variable from AWS internal Brazil Package Builder
 # (Package Builder strips .git/ before build scripts run but provides
 # the commit ID via env var).
-if test "${BRAZIL_PACKAGE_CHANGE_ID}" != "" ; then
+if test -n "${BRAZIL_PACKAGE_CHANGE_ID:-}" ; then
     echo "git-${BRAZIL_PACKAGE_CHANGE_ID:0:7}"
     exit 0
 fi


### PR DESCRIPTION
*Description of changes:*

Release packaging previously derived its version by sorting all tags merged into the requested ref. An alpha tag can sort above a final tag, causing final packages to carry the alpha identity. Wildcard artifact selection can also obscure the exact files attached to a release.

Treat the exact vX.Y.Z[aN] tag as the release identity from tagging through build and source packaging. Reject ambiguous refs and mismatched artifacts so every candidate is immutable and its release artifacts can be identified by name and checksum.

Create alpha and final GitHub releases as drafts, mark only alpha drafts as prereleases, and attach source metadata so each release is auditable. The release-metadata.json file provides structured provenance. A downstream consumer of the plugin can use it to validate the expected four-artifact set or record the exact tag, commit, and workflow run during qualification. The release remains a draft until it is explicitly published.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
