### PR TITLE
ci: run GPU PR CI stages on Ubuntu 24.04 hosts

### DIFF
--- a/.ci/aws/Jenkinsfile
+++ b/.ci/aws/Jenkinsfile
@@ -257,6 +257,7 @@ pipeline {
                     def neuron_test_list = "--test-list test_nccom_test"
 
                     def base_os = "alinux2"
+                    def p5en_base_os = "ubuntu2204"
 
                     def p3_p4_addl_args = "${base_args} ${container_addl_args} ${nvidia_test_list}"
                     def p5_addl_args = "${base_args} ${container_addl_args}  ${nvidia_test_list}"
@@ -275,7 +276,7 @@ pipeline {
                     stages["4_p5_ubuntu2204"] = get_test_stage_with_lock_container("4_p5_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p5.48xlarge", p5_lock_label, num_instances, p5_addl_args)
 
                     // p5en tests
-                    stages["4_p5en_ubuntu2204"] = get_test_stage_with_lock_container("4_p5en_ubuntu2204", env.BUILD_TAG, base_os, "ubuntu2204", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
+                    stages["4_p5en_ubuntu2204"] = get_test_stage_with_lock_container("4_p5en_ubuntu2204", env.BUILD_TAG, p5en_base_os, "ubuntu2204", "p5en.48xlarge", p5en_lock_label, num_instances, p5en_addl_args)
 
                     // g4dn tests
                     stages["4_g4dn_ubuntu2204"] = get_test_stage_with_lock_persistent("4_g4dn_ubuntu2204", env.BUILD_TAG, "ubuntu2204", "g4dn.12xlarge", g4dn_lock_label, num_instances, g4dn_addl_args)


### PR DESCRIPTION
*Description of changes:*

The GDAKI functional tests need DMA-BUF, which requires a host kernel >= 5.12, the AL2 host AMI is on kernel 5.10. Move p5en stage host OS to ubuntu2204.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
