### PR TITLE
doc: Add plugin docs for explaining the plugin architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ connection-less reliable interface. This allows NCCL applications to take
 benefit of libfabric's transport layer services like reliable message support
 and operating system bypass.
 
+## Documentation
+
+Developer and architecture documentation lives in the [`doc/`](doc/) directory.
+Start with the [documentation index](doc/README.md), which links the
+architecture docs (overall operation, initialization, libfabric, the RDMA and
+send/recv protocols, the connection manager, completion/progress, topology, GIN,
+and the tuner) as well as the feature and operations guides.
+
 ## Getting Started
 
 The best way to build the plugin is to start with the latest [release

--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,80 @@
+# AWS OFI NCCL — Documentation Index
+
+This is the entry point for the developer/architecture documentation of the
+AWS OFI NCCL plugin — the library that lets NVIDIA NCCL, AMD RCCL, and AWS
+Neuron use [libfabric](https://ofiwg.github.io/libfabric/) (the EFA provider on
+EC2) as their network transport.
+
+If you are new to the codebase, **start with
+[`overall-operation.md`](overall-operation.md)**.
+
+## Architecture docs
+
+These are the "grand picture" documents written for software developers and
+engineers, describing how the plugin is structured internally. Each ends with a
+table of main entry-point files.
+
+| Doc | What it covers | Read it when you need to… |
+|---|---|---|
+| [`overall-operation.md`](overall-operation.md) | The whole plugin: what it is, the `plugin → device → domain → endpoint → communicator` object model, the two transports, and the end-to-end lifecycle. | Get oriented before anything else. |
+| [`plugin-initialization.md`](plugin-initialization.md) | `.so` load → vtable shims → provider discovery → transport selection → devices ready. | Understand startup, protocol selection, or the platform hooks. |
+| [`libfabric.md`](libfabric.md) | libfabric's object model (`fi_info`, fabric/domain/endpoint/AV/CQ/MR), `FI_EP_RDM`, the EFA provider, and how the plugin maps onto it. | Understand the layer beneath the plugin. |
+| [`rdma-protocol.md`](rdma-protocol.md) | RDMA theory (write/read, memory registration, GPUDirect, eager vs rendezvous) **and** the implementation, including the receiver-driven mailbox and memory registration. | Work on the high-performance transport or memory registration. |
+| [`sendrecv-protocol.md`](sendrecv-protocol.md) | The tagged two-sided transport (`fi_tsend`/`fi_trecv`), tags-as-connections, and its tradeoffs vs RDMA. | Work on the simple/fallback transport. |
+| [`tuner.md`](tuner.md) | The separate tuner plugin (`ncclTunerPlugin_vN`): region vs model approaches for choosing collective algorithm/protocol. | Work on collective tuning decisions. |
+| [`connection-manager.md`](connection-manager.md) | The shared `src/cm/` handshake that emulates connections over connection-less RDM. | Understand how `listen`/`connect`/`accept` actually complete. |
+| [`completion-progress.md`](completion-progress.md) | The request/context model, CQ-polling progress engine, `-FI_EAGAIN` retry, and message ordering/dedup. | Understand how async ops become NCCL completions. |
+| [`threading-model.md`](threading-model.md) | How NCCL's proxy threads drive the plugin, the endpoint-per-thread model, and where lock pressure arises (`ep_lock` spinlock, `domain_lock`, `mr_cache_lock`, `req_lock`, …). | Reason about concurrency, thread safety, or lock contention. |
+| [`topology.md`](topology.md) | Intra-node hwloc topology, grouping NICs into rails, the synthetic NCCL topology file, `sort_rails`, and cross-node device identity. | Understand multi-rail devices and GPU–NIC locality. |
+| [`gin.md`](gin.md) | GPU-Initiated Networking: the device-side RMA op-table, symmetric memory, and the proxy vs EFA-GDA/GDAKI backends. | Work on GPU-initiated / GDAKI paths. |
+
+### Suggested reading order
+
+1. [`overall-operation.md`](overall-operation.md) — the map.
+2. [`libfabric.md`](libfabric.md) — the foundation.
+3. [`plugin-initialization.md`](plugin-initialization.md) — how it comes up.
+4. [`connection-manager.md`](connection-manager.md) +
+   [`completion-progress.md`](completion-progress.md) — the shared machinery.
+5. [`threading-model.md`](threading-model.md) — how NCCL's threads drive it all
+   and the resulting lock pressure.
+6. [`rdma-protocol.md`](rdma-protocol.md) and
+   [`sendrecv-protocol.md`](sendrecv-protocol.md) — the transports.
+7. [`topology.md`](topology.md) — multi-rail detail.
+8. [`gin.md`](gin.md) and [`tuner.md`](tuner.md) — the specialized plugins.
+
+## Feature and operations docs
+
+These predate the architecture set above and are more feature- or
+operations-focused. They live alongside the architecture docs in this
+directory.
+
+| Doc | What it covers |
+|---|---|
+| [`gin-getting-started.md`](gin-getting-started.md) | Hands-on setup for GIN, including EFA-GDA requirements and environment variables. Companion to [`gin.md`](gin.md). |
+| [`multi-recv.md`](multi-recv.md) | Deep dive into grouped receives (`maxRecvs > 1`) and eager support in the RDMA protocol. Companion to [`rdma-protocol.md`](rdma-protocol.md). |
+| [`topology-aware.md`](topology-aware.md) | Cluster-level topology-aware **host placement / rank mapping** (Slurm/EKS). A different layer from the intra-node grouping in [`topology.md`](topology.md). |
+| [`tracing.md`](tracing.md) | LTTng tracing of requests and how traces correlate with libfabric operations. |
+| [`efa-env-var.md`](efa-env-var.md) | EFA environment-variable cheatsheet for performance tuning. |
+| [`coding-standards.md`](coding-standards.md) | Coding conventions for contributing to the plugin. |
+
+## Other top-level references
+
+- [`README.md`](../README.md) — project overview and requirements.
+- [`INSTALL.md`](../INSTALL.md) — building and installing from a release tarball.
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution guidelines.
+- [`AGENTS.md`](../AGENTS.md) — build system, testing, and coding-convention notes.
+
+## Areas not yet covered by an architecture doc
+
+For future documentation work, the following subsystems are only described
+inline in code or in passing here:
+
+- Internal building blocks: freelist, id pool, message buffer, SPSC/MPSC rings,
+  scheduler (partially covered in [`rdma-protocol.md`](rdma-protocol.md)
+  and [`completion-progress.md`](completion-progress.md)).
+- The platform layer as its own topic (currently inside
+  [`plugin-initialization.md`](plugin-initialization.md) and
+  [`topology.md`](topology.md)).
+- Observability: stats/histograms and NVTX tracing.
+- GPU/accelerator integration: CUDA/ROCm copy abstractions, the CUDA-flush path.
+- A developer-oriented build/configure and testing guide.

--- a/doc/completion-progress.md
+++ b/doc/completion-progress.md
@@ -1,0 +1,168 @@
+# AWS OFI NCCL — Completion, Progress, and the Request Model
+
+*This document describes the
+cross-cutting machinery that turns asynchronous libfabric operations into NCCL
+request completions: the request/context model, the CQ-polling progress engine,
+retry handling, and message ordering. For the big picture see
+[`overall-operation.md`](overall-operation.md).*
+
+Every non-blocking NCCL operation (`isend`, `irecv`, `iflush`, `iwrite`,
+`iread`) follows the same pattern regardless of transport:
+
+1. NCCL calls the operation.
+2. The plugin submits one or more libfabric operations.
+3. The plugin returns to NCCL an opaque **request** handle.
+4. NCCL polls `test(request, &done, &size)` until `done`.
+5. On completion the plugin frees the request.
+
+The pieces below make that work.
+
+## The request
+
+A **request** (`nccl_net_ofi_req` in [`include/nccl_ofi.h`](../include/nccl_ofi.h))
+is the handle for one outstanding operation. Its only public method is
+`test(int *done, int *size)`. Each transport subclasses it:
+
+- SENDRECV: `nccl_net_ofi_sendrecv_req` — direction (SEND/RECV), size, state.
+- RDMA: `nccl_net_ofi_rdma_req` — a family of subtypes (send, recv, eager-copy,
+  flush, RMA, receive-buffer, close) with virtual
+  `post()` / `handle_completion()` / `free()` / `test()`.
+
+Requests carry a small **state machine**: `CREATED → PENDING → COMPLETED` (or
+`ERROR`). `test()` reports `done` once the request reaches a terminal state, and
+returns the number of bytes actually transferred (important for receives, where
+the size is not known until the message arrives).
+
+### Requests come from freelists
+
+Requests are not `malloc`'d per operation. Each communicator draws them from a
+**freelist** (`src/nccl_ofi_freelist.cpp`), a pre-allocated, growable pool.
+Completing a request returns it to the freelist and decrements an inflight
+counter. Limits (`NCCL_OFI_MAX_REQUESTS`, `NCCL_OFI_MAX_SEND_REQUESTS`) bound
+how many operations can be in flight, providing back-pressure. RDMA sizes all
+request subtypes to a single freelist slot so one pool serves them all.
+
+## The context: linking a libfabric op back to its request
+
+libfabric completions don't hand back C++ object — they hand back a
+pointer given to them. That pointer is a **`struct fi_context2`**, embedded in a
+`nccl_net_ofi_context` (in `include/nccl_ofi.h`):
+
+```cpp
+class nccl_net_ofi_context {
+    virtual int handle_cq_entry(struct fi_cq_entry *cq_entry, uint16_t rail_id) = 0;
+    virtual int handle_error_entry(struct fid_cq *cq,
+                                   struct fi_cq_err_entry *err_entry,
+                                   uint16_t rail_id) = 0;
+    struct fi_context2 ofi_ctx;   // pointer to this is passed to every fi_* op
+};
+```
+
+Every libfabric operation is submitted with `&ctx.ofi_ctx` as its context. When
+the completion (or error) surfaces, the progress engine recovers the enclosing
+`nccl_net_ofi_context` via `cpp_container_of` and calls its virtual callback,
+which knows how to advance the owning request. This is the single mechanism that
+ties the whole asynchronous data path together.
+
+## The progress engine: draining completion queues
+
+Progress is **not** driven by a background thread in the common path — it is
+driven **synchronously** whenever NCCL calls into the plugin (`test`, and also
+the `send`/`recv`/`accept`/`connect`/`flush` hot paths poll opportunistically).
+Each poll drains the relevant completion queue(s) with `fi_cq_read`.
+
+### SENDRECV (single CQ)
+
+`sendrecv_cq_process()` loops `fi_cq_read()` into a batch of tagged completion
+entries (`cq_read_count` at a time; CQ format `FI_CQ_FORMAT_TAGGED`):
+
+- normal completion → `sendrecv_process_completions()` recovers the context and
+  calls `handle_cq_entry()` (records received length, marks `COMPLETED`);
+- `-FI_EAVAIL` → `fi_cq_readerr()` + `handle_error_entry()` (marks `ERROR`);
+- `-FI_EAGAIN` → nothing pending, stop.
+
+### RDMA (per-rail CQs)
+
+Because the RDMA transport spreads traffic across up to `MAX_NUM_RAILS` rails,
+each rail has its own CQ. `ofi_process_cq()` → `ofi_process_cq_rail()` →
+`rdma_process_completions()` iterates the rails. Two completion shapes:
+
+- a **`FI_REMOTE_WRITE`** completion has *no* context — it is an inbound payload
+  landing. The plugin steers it to the right receive request using the **32-bit
+  immediate data** carried by the write (`handle_write_comp`).
+- otherwise the completion carries a context → recover it → `handle_cq_entry()`
+  → dispatch to the owning request's `handle_completion(flags, rail_id)`.
+
+A striped message spans multiple rails, so per-rail completions are **counted
+under a lock**; the request flips `PENDING → COMPLETED` only when the segment
+count matches the total. See [`rdma-protocol.md`](rdma-protocol.md).
+
+## Retry and back-pressure (`-FI_EAGAIN`)
+
+libfabric can refuse a submission when its queues are full, returning
+`-FI_EAGAIN`. The plugin never blocks on this:
+
+- **SENDRECV** returns a `NULL` request from `send()` so NCCL simply retries the
+  call later (after progressing the CQ).
+- **RDMA** queues the request on the endpoint's **pending-requests queue** and
+  re-posts it as completions free up capacity (`post_with_pending_retry`).
+
+This keeps the data path lock-light and non-blocking, which matters because NCCL
+drives it from its proxy threads.
+
+## Message ordering and de-duplication (RDMA)
+
+One-sided RDMA writes can complete out of order and, on a reliable-datagram
+fabric, the protocol must tolerate retransmission. The RDMA transport therefore
+tracks per-message state in a **message buffer** (`nccl_ofi_msgbuff`,
+`src/nccl_ofi_msgbuff.cpp`), keyed by `msg_seq_num`. It records whether each
+sequence number is in-progress, completed, etc., which lets the receiver:
+
+- match an arriving write (or eager message) to the correct request even when
+  no matching receive was posted, and
+- reject duplicates.
+
+The eager path additionally uses a wrap-safe sequence chain to order eager
+messages against later control messages.
+
+## Progress models: `FI_PROGRESS_AUTO` vs `FI_PROGRESS_MANUAL`
+
+libfabric providers advertise how they make progress. The global
+`data_progress_auto` (set during
+[initialization](plugin-initialization.md)) records whether the provider
+progresses on its own. Where progress is manual, the plugin must explicitly poll
+the CQ to move things forward (for example, when a sender is waiting for a
+control-mailbox entry to appear). The connection manager similarly benefits from
+`FI_PROGRESS_AUTO` to complete connection responses promptly.
+
+## Completion flow at a glance
+
+```
+NCCL test(req)                     (or send/recv/flush hot path)
+   │
+   ▼
+transport CQ process  ── fi_cq_read ──▶ completion entries
+   │                                        │
+   │ FI_REMOTE_WRITE (RDMA)                 │ has context
+   ▼                                        ▼
+handle_write_comp                    cpp_container_of → nccl_net_ofi_context
+   │  (steer by immediate data)             │
+   ▼                                        ▼
+recv request                          ctx->handle_cq_entry(rail_id)
+   │                                        │
+   └────────────▶ request state ◀───────────┘  (count rails under lock)
+                       │  PENDING → COMPLETED / ERROR
+                       ▼
+                 test() reports done + size, frees req to freelist
+```
+
+## Main entry-point files
+
+| Concern | Location |
+|---|---|
+| Request & context base classes | `include/nccl_ofi.h` (`nccl_net_ofi_req`, `nccl_net_ofi_context`) |
+| SENDRECV completion | `src/nccl_ofi_sendrecv.cpp` (`sendrecv_cq_process`, `sendrecv_process_completions`, `handle_cq_entry`/`handle_error_entry`) |
+| RDMA completion | `src/nccl_ofi_rdma.cpp` (`ofi_process_cq`, `ofi_process_cq_rail`, `rdma_process_completions`, `handle_write_comp`, `handle_cq_entry`) |
+| Request pooling | `src/nccl_ofi_freelist.cpp`, `include/nccl_ofi_freelist.h` |
+| Message ordering / dedup | `src/nccl_ofi_msgbuff.cpp`, `include/nccl_ofi_msgbuff.h` |
+| Pending-retry queue | `src/nccl_ofi_rdma.cpp` (endpoint pending-requests queue, `post_with_pending_retry`) |

--- a/doc/connection-manager.md
+++ b/doc/connection-manager.md
@@ -1,0 +1,138 @@
+# AWS OFI NCCL — Connection Manager
+
+*This document describes the
+connection manager (`src/cm/`, `include/cm/`), a self-contained subsystem shared
+by both transports. It expands on material previously summarized inside the
+protocol docs. For the big picture see
+[`overall-operation.md`](overall-operation.md).*
+
+## Why a connection manager exists
+
+libfabric's `FI_EP_RDM` endpoints are **connection-less** — there is no
+`connect()`/`accept()` at the fabric level, only addresses. NCCL's transport
+API, however, is **connection-oriented**: one side `listen`s, the other
+`connect`s, and the listener `accept`s. Both the RDMA and SENDRECV transports
+therefore need a small handshake that:
+
+1. carries each side's endpoint address (and any transport-specific setup data)
+   to the other, and
+2. does so **non-blockingly**, because NCCL calls `connect`/`accept` repeatedly
+   until they report a communicator.
+
+Rather than each transport hand-rolling this, the **connection manager (CM)**
+implements it once. The transports supply only an opaque blob of
+transport-specific connection data; the CM handles the messaging, buffering, and
+completion bookkeeping.
+
+## Where it fits in the object model
+
+A transport creates **one `nccl_ofi_connection_manager` per domain**
+(`nccl_net_ofi_domain_t`). The CM maintains its **own** libfabric endpoint —
+separate from the data-path endpoints — bound to the plugin endpoint's
+completion queue that the transport passes in. This keeps connection-setup
+traffic isolated while still being driven by the same CQ-polling loop as data
+traffic (see [`completion-progress.md`](completion-progress.md)).
+
+```
+domain
+  ├─ connection_manager        (its own fid_ep + AV + registered conn-msg buffers)
+  │     ├─ listener            (from listen())
+  │     │     └─ receiver      (from listener->accept(), one per incoming peer)
+  │     └─ send_connector      (from connect())
+  └─ data-path endpoints ...   (the transport's normal traffic)
+```
+
+## The three CM objects
+
+Defined in [`include/cm/nccl_ofi_cm.h`](../include/cm/nccl_ofi_cm.h):
+
+- **`nccl_ofi_cm_listener`** — created by `connection_manager::listen()`. It owns
+  a `nccl_net_ofi_conn_handle` obtained via `get_handle()`; the transport returns
+  that handle to NCCL, which ferries it **out of band** (over its bootstrap
+  channel) to the connecting node. `accept()` returns a `receiver` for each
+  incoming connection (or `nullptr` if none is ready).
+- **`nccl_ofi_cm_send_connector`** — created by
+  `connection_manager::connect(handle, transport_connect_msg, size)`. Represents
+  an in-progress outbound connection. `test_ready()` reports completion; once
+  complete, `get_conn_resp_msg_data()` returns the receiver's response payload.
+- **`nccl_ofi_cm_receiver`** — created by `listener->accept()`. Represents an
+  in-progress inbound connection. The transport reads the sender's payload with
+  `get_conn_msg_data()`, fills the response with `set_conn_resp_msg_data()`, and
+  polls `test_ready()`.
+
+All three are **non-owning references** to shared `cm_resources`; the transport
+owns and deletes the listener/connector/receiver objects it is handed.
+
+## The handshake
+
+The exchange is a two-message, non-blocking round trip:
+
+```
+connect side                                   listen/accept side
+------------                                   ------------------
+connection_manager::connect(handle, msg)
+   │  builds SEND_CONN_MSG
+   │  {conn_ep_name, ids} + transport payload
+   └───────────────  fi_send  ───────────────▶  CM rx buffer completes
+                                                 look up listener by id
+                                                 listener->accept() → receiver
+                                                 transport reads get_conn_msg_data()
+                                                 transport set_conn_resp_msg_data()
+   receiver seen ready       ◀── fi_send ──────  builds SEND_CONN_RESP_MSG
+   (test_ready → COMPLETE)                        + transport response payload
+```
+
+- The wire message is `nccl_ofi_cm_conn_msg` (type, local id, remote id,
+  connecting endpoint name) with the transport's opaque data appended.
+- The CM pre-posts a pool of **registered receive buffers** so incoming
+  connection messages have somewhere to land.
+- Listeners register themselves in a callback map keyed by id; when a connection
+  message arrives, the CM routes it to the right listener and builds a receiver.
+
+## Non-blocking progress
+
+Because NCCL polls, both `send_connector::test_ready()` and
+`receiver::test_ready()` return:
+
+- `CM_CONN_COMPLETE (1)` — the connection is established and usable;
+- `CM_CONN_INCOMPLETE (0)` — not yet; call again later;
+- a negative errno on a network error.
+
+Progress is driven by the transport's normal CQ processing (the CM endpoint
+shares the transport's CQ). Under `FI_PROGRESS_AUTO` providers, a connection
+response can complete immediately on submission, which the CM handles as a
+fast path (relevant to shared communicators and multi-recv).
+
+## What each transport supplies and does with it
+
+The CM is deliberately **transport-agnostic**: it moves an opaque
+`conn_msg_data` / `conn_resp_msg_data` blob of a size the transport declares at
+construction (`conn_msg_data_size`). The transports layer their own meaning on
+top:
+
+- **SENDRECV** puts `nccl_ofi_connection_info_t` (endpoint name + assigned
+  **tag**) in the payload. The acceptor allocates the tag and returns it in the
+  response; the connector adopts it. See
+  [`sendrecv-protocol.md`](sendrecv-protocol.md).
+- **RDMA** puts `nccl_ofi_rdma_connection_info_t` (per-rail endpoint names, comm
+  id, and the **control-mailbox address + per-rail rkeys**) in the payload. This
+  is what bootstraps the receiver-driven RDMA-write rendezvous. See
+  [`rdma-protocol.md`](rdma-protocol.md).
+
+The transport-side state machines that call into the CM are:
+
+- RDMA: `ep::connect` → `cm->connect` → finish on `test_ready`; and the
+  `listen_comm::accept` state machine
+  (`COMM_CREATE_START → CONN_REQ_PENDING → CONN_RESP_REQ_PENDING → CONNECTED`).
+- SENDRECV: `ep_t::connect` and `listen_comm::accept`, structured identically.
+
+## Main entry-point files
+
+| Concern | Location |
+|---|---|
+| Public CM API (manager, listener, connector, receiver) | `include/cm/nccl_ofi_cm.h` |
+| Shared resources (endpoint, AV, buffer pools, callback map) | `include/cm/nccl_ofi_cm_resources.h`, `src/cm/nccl_ofi_cm_resources.cpp` |
+| CM request types (send-conn, send-conn-resp, rx) | `include/cm/nccl_ofi_cm_reqs.h`, `src/cm/nccl_ofi_cm_reqs.cpp` |
+| Wire/type definitions | `include/cm/nccl_ofi_cm_types.h` |
+| Manager implementation | `src/cm/nccl_ofi_cm.cpp` |
+| Transport call sites | `src/nccl_ofi_rdma.cpp` (`ep::connect`, `listen_comm::accept`), `src/nccl_ofi_sendrecv.cpp` |

--- a/doc/gin.md
+++ b/doc/gin.md
@@ -1,0 +1,134 @@
+# AWS OFI NCCL — GPU-Initiated Networking (GIN)
+
+*This document describes the GIN
+subsystem architecturally. For hands-on setup and environment variables, see the
+existing [`gin-getting-started.md`](gin-getting-started.md). For the big
+picture see [`overall-operation.md`](overall-operation.md).*
+
+## What GIN is
+
+Normally NCCL's network transport is driven by the **CPU** (proxy threads issue
+the sends/receives). **GIN (GPU-Initiated Networking)** lets communication be
+initiated from the **GPU side** instead, which suits symmetric-memory collectives
+and device-side one-sided operations (e.g. `ncclBarrierSession`, all-to-all
+kernels).
+
+GIN is exposed to NCCL as a **separate plugin op-table**, distinct from the
+network transport described in these docs. NCCL `dlopen`s the library
+and binds whichever GIN/RMA symbol it finds; the plugin does not switch modes at
+runtime. It is implemented under `include/rdma/gin/` and `src/rdma/gin/`, and it
+is supported **only over the RDMA transport** (`nccl_ofi_gin_init` fails if the
+selected protocol isn't RDMA).
+
+## The device API model
+
+GIN implements NCCL's device-side one-sided RMA API. The abstract contract is in
+[`include/nccl_ofi_gin_base.h`](../include/nccl_ofi_gin_base.h):
+
+- **Symmetric memory registration** (`regMrSym` / `regMrSymDmaBuf`): a
+  *collective* registration across all ranks. It registers a buffer and
+  all-gathers the per-rail keys/addresses so any rank can address the region on
+  any peer purely by `(rank, offset)`. This symmetric addressing is what makes
+  device-side one-sided ops possible.
+- **`iputSignal`**: RDMA-write `size` bytes from a local symmetric buffer into a
+  peer's symmetric buffer, then perform a **signal** (increment/write a value) at
+  a target signal location. The peer GPU spins on that signal to learn the data
+  has arrived. A plain "put" is `iputSignal` with no signal.
+- **`iget`**: RDMA-read from a remote symmetric buffer into a local one.
+- **`iflush`**: fence prior `iget`s so their data is visible to the GPU (a
+  loopback read per rail, mirroring the transport's flush).
+- **Signals / counters**: the completion-notification mechanism. The peer
+  observes a counter rather than polling a CQ.
+- Requests are `nccl_ofi_gin_req_t`, polled via `test()`.
+
+## Two backends
+
+GIN ships two implementations of that contract. Which one NCCL uses depends on
+the symbol it binds and on capability gating (below).
+
+### Proxy mode (always built)
+
+- The **GPU enqueues** network work; **CPU proxy progress threads** issue the
+  actual libfabric operations (`fi_writedata` / `fi_read` / `fi_send`) on the
+  multi-rail EFA endpoints.
+- Signal delivery on the receiver is a CPU-driven read-modify-write via
+  **GDRCopy** (which CPU-maps GPU memory; GDRCopy 2.5+ is required and checked at
+  init). A single process-wide GDRCopy worker coalesces updates to the same
+  signal slot.
+- Works on any EFA provider — this is the portable path.
+
+### EFA-GDA / GDAKI mode (built only with `HAVE_GDAKI`)
+
+- **GDAKI** = GPUDirect Async Kernel-Initiated. The **GPU kernel itself** builds
+  and posts work-queue entries (WQEs) directly to the EFA send queue and polls
+  the completion queue from the kernel — the **CPU is fully bypassed** on the
+  data path.
+- Completions/signals are observed through **EFA hardware completion counters**
+  that the NIC writes directly into GPU HBM (DMA-BUF-backed). The kernel reads
+  the counter value with no host round-trip.
+- Requires mapping the EFA doorbell/SQ MMIO region into the GPU address space
+  (hence the NVIDIA driver's `PeerMappingOverride=1` requirement).
+- Available only on specific instances with the required software stack (see
+  gating below and the getting-started guide).
+
+## How GIN reuses the RDMA transport
+
+GIN does not reimplement the network stack — it layers onto the RDMA transport's
+object model (see [`rdma-protocol.md`](rdma-protocol.md)):
+
+- **Endpoints.** GIN gets a transport endpoint via `device->get_ep(...)` using a
+  *distinct* endpoint key, so its proxy endpoint/lock are separate from ordinary
+  RMA traffic. It then opens its **own per-rail** libfabric endpoints/CQs/AVs on
+  the transport's `nccl_net_ofi_domain_t`, with GIN-specific hints
+  (immediate/CQ-data support).
+- **Rails & scheduler.** Same `MAX_NUM_RAILS` model, round-robin rail selection,
+  and reuse of the threshold scheduler.
+- **Memory registration.** Symmetric MRs register on every rail (one `fid_mr`
+  per rail) using the transport's rkey pool. GIN is global-MR only
+  (`FI_MR_ENDPOINT` is rejected).
+- **GDAKI shares the proxy's domains.** GDAKI reuses the same protection domains
+  as proxy mode, so symmetric-MR keys are valid on the GDAKI endpoints. To expose
+  the EFA GDA device ops, the RDMA transport opens the proxy domain with the
+  libfabric 2.5 ABI when GDAKI is usable.
+- **Bootstrap.** Connection and MR metadata are exchanged with a ring all-gather
+  built on the transport's send/recv communicators.
+
+## Backend selection and gating
+
+There is **no plugin-side runtime toggle** — NCCL binds whichever exported
+symbol matches its build, and the plugin then checks whether the requested
+backend is actually usable.
+
+- **Exported symbols.** Proxy: `ncclGinPlugin_v11` / `ncclGinPlugin_v13` plus
+  `ncclRmaPlugin_v14` / `ncclRmaPlugin_v15` (always). GDAKI:
+  `ncclGinPlugin_v14` (name `Libfabric_GDAKI`), exported only when built with
+  `HAVE_GDAKI`.
+- **Runtime capability.** `nccl_ofi_gin_gdaki_capable()` requires: built with
+  `HAVE_GDAKI`, runtime libfabric ≥ 2.5, DMA-BUF viable, and an EFA provider.
+- **Platform authorization.** `PlatformAWS::config_gdaki_domain()`
+  (`src/platform-aws.cpp`) is consulted per rail-domain; it allows or refuses
+  GDAKI based on the instance's `efa_hw_comp_cntr` flag (overridable via
+  `OFI_NCCL_GDAKI_EFA_HW_COUNTER`). This flag is set for **P5en, P6-B200, and
+  P6-B300**; other EFA instances fall back to proxy.
+- **User selection.** NCCL 2.31 defaults EFA to proxy; `NCCL_GIN_TYPE=5`
+  requests EFA-GDA explicitly (see the getting-started guide).
+- **ABI/layout version.** The GDAKI context validates NCCL's `backendVersion`
+  against `NCCL_OFI_GDAKI_MAX_BACKEND_VERSION` so the plugin builds exactly the
+  queue/counter memory layout the NCCL device kernel expects.
+
+If a requested capability isn't supported (e.g. strong or VA signals on
+EFA-GDA), the application can fall back to proxy mode.
+
+## Main entry-point files
+
+| Concern | Location |
+|---|---|
+| Abstract device contract | `include/nccl_ofi_gin_base.h` |
+| Shared API + exported symbols | `include/rdma/gin/nccl_ofi_gin_api.h`, `src/rdma/gin/nccl_ofi_gin_api.cpp` (`nccl_ofi_gin_init`, listen/connect/regMrSym/deregMrSym/ginProgress/finalize; `ncclGinPlugin_v11`/`v13`, `ncclRmaPlugin_v14`/`v15`) |
+| Proxy backend | `src/rdma/gin/nccl_ofi_gin.cpp` (put comm, signal work, flow control, GDRCopy worker) |
+| GIN resources (per-rail EP/CQ/AV, MR, freelists) | `src/rdma/gin/nccl_ofi_gin_resources.cpp`, `include/rdma/gin/nccl_ofi_gin_resources.h` |
+| Wire types / requests / all-gather | `include/rdma/gin/nccl_ofi_gin_types.h`, `..._reqs.{h,cpp}`, `..._allgather.{h,cpp}` |
+| GDAKI backend (`HAVE_GDAKI`) | `src/rdma/gin/nccl_ofi_gin_gdaki.cpp` (`createContext`, `ncclGinPlugin_v14`), `..._gdaki_resources.{h,cpp}`, `..._gdaki_dev.h`, `include/rdma/gin/nccl_ofi_gin_gdaki.h` |
+| Transport hooks | `include/nccl_ofi_rdma.h` (`get_gin_resources`/`set_gin_resources`), `src/nccl_ofi_rdma.cpp` (2.5-ABI domain selection), `src/platform-aws.cpp` (`config_gdaki_domain`, `efa_hw_comp_cntr`) |
+| Functional tests | `tests/functional/gin_put_gdaki_gpu.cu`, `gin_signal_gdaki_gpu.cu`, `gin_gdaki_misconfig_probe.cpp`, `gin_gdaki_backend_version.cpp`; host/proxy RMA: `rma.cpp`, `rma_multiseg_signal.cpp`, `rma_duplicate_mr.cpp` |
+| Getting started (setup/env) | `gin-getting-started.md` |

--- a/doc/libfabric.md
+++ b/doc/libfabric.md
@@ -1,0 +1,194 @@
+# libfabric and Its Relation to the AWS OFI NCCL Plugin
+
+*This document explains what
+libfabric is, its core object model and provider architecture (especially EFA),
+and how the plugin maps its own objects onto libfabric. For the big picture see
+[`overall-operation.md`](overall-operation.md).*
+
+## What libfabric is
+
+[libfabric](https://ofiwg.github.io/libfabric/) (a.k.a. OFI, OpenFabrics
+Interfaces) is a low-level, vendor-neutral communication API. Applications
+express *what* they need — reliable messaging, tagged matching, one-sided RDMA,
+GPU memory support — and libfabric routes those calls to a **provider** that
+knows how to drive a specific fabric/NIC. On AWS the provider is **EFA**
+(Elastic Fabric Adapter).
+
+The plugin depends on libfabric **>= 1.18** (higher versions unlock DMA-BUF and
+other features). The source tree the plugin is developed against lives at
+`https://github.com/ofiwg/libfabric`.
+
+## libfabric core objects
+
+libfabric objects are opaque `fid_*` handles, each closed with
+`fi_close(&obj->fid)`. They form a strict creation hierarchy:
+
+```
+fi_getinfo()  ─▶  struct fi_info  (a linked list of "here is what I can give you")
+                     │
+   fi_fabric(info)  ─▶  fid_fabric
+                            │
+        fi_domain(fabric, info)  ─▶  fid_domain      (a NIC + protection boundary)
+                                        ├─ fi_endpoint(domain, info) ─▶ fid_ep
+                                        ├─ fi_av_open(domain, …)     ─▶ fid_av   (address vector)
+                                        ├─ fi_cq_open(domain, …)     ─▶ fid_cq   (completion queue)
+                                        └─ fi_mr_regattr(domain, …)  ─▶ fid_mr   (memory region)
+```
+
+An endpoint must be **bound** to a CQ and an AV (`fi_ep_bind`) and then
+**enabled** (`fi_enable`) before use. Key roles:
+
+- **`struct fi_info`** — the negotiation currency. Returned by `fi_getinfo()`,
+  it carries `caps`, `mode`, `addr_format`, and sub-attributes (`fabric_attr`,
+  `domain_attr` with `mr_mode`/threading/progress, `ep_attr` with type/protocol,
+  `tx_attr`/`rx_attr`). Every subsequent create call is parameterized by an
+  `fi_info`.
+- **Fabric / Domain** — a fabric is a network; a domain is (roughly) one NIC
+  plus a **protection domain**. Memory-region keys are only valid within their
+  domain.
+- **Endpoint (EP)** — the communication object with an address. Types:
+  - **`FI_EP_RDM`** — *reliable datagram*: connection-less, reliable, ordered.
+    **This is what the plugin always requests.**
+  - `FI_EP_MSG` — connected reliable (like TCP).
+  - `FI_EP_DGRAM` — unreliable.
+- **Address Vector (AV)** — maps a raw peer-address blob to a compact
+  `fi_addr_t`. Because RDM is connection-less, "connecting" to a peer really
+  means `fi_av_insert`-ing its address.
+- **Completion Queue (CQ)** — asynchronous completions, drained with
+  `fi_cq_read` / `fi_cq_readerr`.
+- **Memory Region (MR)** — a registered (pinned, NIC-mapped) buffer. Produces a
+  local descriptor (`fi_mr_desc`) and a remote key (`fi_mr_key`).
+
+### Capabilities the plugin cares about
+
+Set in `info->caps`:
+
+- `FI_MSG` — untagged two-sided send/recv.
+- `FI_TAGGED` — tag-matched two-sided send/recv (used by the SENDRECV transport).
+- `FI_RMA` — one-sided read/write (used by the RDMA transport).
+- `FI_HMEM` — device (GPU / Neuron) memory support, i.e. GPUDirect RDMA.
+- Modifiers: `FI_READ`/`FI_WRITE`/`FI_SEND`/`FI_RECV`/`FI_REMOTE_*`,
+  `FI_LOCAL_COMM`/`FI_REMOTE_COMM`.
+
+And **MR modes** (`domain_attr->mr_mode`) that describe registration
+requirements: `FI_MR_LOCAL`, `FI_MR_VIRT_ADDR`, `FI_MR_ALLOCATED`,
+`FI_MR_PROV_KEY` (provider assigns keys), `FI_MR_HMEM` (device memory),
+`FI_MR_ENDPOINT` (MR must be bound to an endpoint).
+
+## Provider architecture and where EFA fits
+
+Each provider registers a `struct fi_provider` (`.name`, `.getinfo`, `.fabric`,
+`.cleanup`). The core `fi_getinfo()` (in libfabric `src/fabric.c`) fans the
+request out to all providers and concatenates every matching `fi_info`.
+Providers live under `prov/` (efa, verbs, rxm, tcp, shm, cxi, …).
+
+**EFA** is `prov/efa`, registered in `prov/efa/src/efa_prov.c`. It returns
+several info "flavors" in preference order:
+
+- **efa-direct** — a thin, fast path.
+- **efa-rdm** — a full `FI_EP_RDM` protocol engine (eager / medium / long-CTS /
+  long-read; see `prov/efa/src/rdm/` and `docs/efa_rdm_protocol_v4.md`).
+- **dgram** — unreliable datagram.
+
+Core EFA files: `efa_prov.c`, `efa_user_info.c`, `efa_fabric.c`, `efa_domain.c`,
+`efa_ep.c` / `efa_base_ep.c`, `efa_av.c`, `efa_cq.c`, and `efa_mr.c` (+
+`efa_hmem.c`) for registration, HMEM, and DMA-BUF.
+
+## How the plugin uses libfabric
+
+All libfabric interaction is funneled through a small glue layer so the rest of
+the code stays clean.
+
+### Discovery and provider selection
+
+`src/nccl_ofi_ofiutils.cpp : nccl_ofi_ofiutils_get_providers()`:
+
+1. Calls `fi_getinfo(version, NULL, NULL, 0, hints, &providers)`.
+2. Filters the returned list: keep only the requested provider name (`efa`),
+   drop unwanted TCP interfaces, and **collapse structurally identical entries**
+   so there is one `fi_info` per NIC/rail.
+
+The **hints** differ per transport (this is where each transport declares its
+requirements):
+
+- **SENDRECV** (`sendrecv_get_hints()`): `caps = FI_LOCAL_COMM | FI_REMOTE_COMM
+  | FI_TAGGED | FI_MSG` (+`FI_HMEM`, +`FI_RMA|FI_READ` for GDR flush);
+  `ep_attr->type = FI_EP_RDM`; `mode = FI_CONTEXT | FI_CONTEXT2`;
+  `threading = FI_THREAD_SAFE`.
+- **RDMA** (`get_hints()`): `caps = FI_MSG | FI_RMA | FI_HMEM | FI_LOCAL_COMM |
+  FI_REMOTE_COMM` (**no** tagging — it keys on immediate data instead);
+  `ep_attr->type = FI_EP_RDM`; `threading = FI_THREAD_COMPLETION`;
+  `domain_attr->cq_data_size = 4` (needs 32-bit immediate data for
+  `fi_writedata`).
+
+### Resource creation with RAII
+
+`src/nccl_ofi_ofiutils.cpp` wraps each libfabric create call
+(`fabric_create` → `fi_fabric`, `domain_create` → `fi_domain`,
+`av_create` → `fi_av_open`, `cq_create` → `fi_cq_open`,
+`ep_create` → `fi_endpoint` + binds + `fi_setopt` + platform
+`config_endpoint()` + `fi_enable`, `mr_regattr` → `fi_mr_regattr`).
+
+Lifetime is managed by the RAII wrapper in
+[`include/ofi/resource_wrapper.h`](../include/ofi/resource_wrapper.h). A macro
+generates, for each libfabric type, an `ofi_<t>_ptr` (a `unique_ptr` whose
+deleter calls `fi_close`) and an `ofi_<t>_result` (an error-code + resource pair
+that replaces C-style out-parameters). If construction throws midway, already
+created handles unwind and close automatically. (`fi_info` uses its own
+`ofi_info_ptr` with an `fi_freeinfo` deleter.)
+
+### The object-model mapping
+
+The plugin's classes (in `include/nccl_ofi.h`) map onto libfabric like this:
+
+| Plugin class | libfabric backing | Notes |
+|---|---|---|
+| `nccl_net_ofi_plugin_t` | the `fi_info` provider list + topology | one global instance |
+| `nccl_net_ofi_device_t` | one selected `fi_info` per NIC / rail group | `get_ofi_info(rail_id)` |
+| `nccl_net_ofi_domain_t` | **`fid_domain` + AV + CQ** | protection & threading boundary; owns MR cache + rkey pool |
+| `nccl_net_ofi_ep_t` | **`fid_ep`** (bound to CQ + AV) | per-proxy-thread RDM address |
+| listen/send/recv comm | a logical link over the RDM endpoint + an AV entry | connection-oriented API over connection-less RDM |
+| `nccl_net_ofi_req` / `nccl_net_ofi_context` | one libfabric operation + its completion | embeds `struct fi_context2` |
+| `nccl_net_ofi_mr_handle_t` | **`fid_mr`** + key | `get_mr_key()` returns the rkey |
+
+### Emulating connections on a connection-less fabric
+
+`FI_EP_RDM` has no notion of a connection, but NCCL's API is connection-oriented.
+The plugin bridges this by exchanging a raw endpoint-address blob **out of band**
+inside `nccl_net_ofi_conn_handle_t` (`ep_name[56]` + `comm_id` + saved state),
+which NCCL ferries over its bootstrap channel. Each side `fi_av_insert`s the
+peer's address to obtain an `fi_addr_t`. From there:
+
+- **SENDRECV** distinguishes logical connections by **tag** (a control bit plus
+  a per-communicator ring id).
+- **RDMA** runs a small **connection-manager** handshake (`src/cm/`) and then
+  uses `FI_MSG`/`FI_RMA` with 4-byte immediate CQ data, striping across rails.
+
+### Completions
+
+Every operation carries a `struct fi_context2` embedded in a
+`nccl_net_ofi_context`. On completion the plugin reads the CQ (`fi_cq_read`),
+recovers the owning context via `cpp_container_of`, and calls its
+`handle_cq_entry()` / `handle_error_entry()` callback.
+
+## Main entry-point files
+
+**Plugin side:**
+
+- `src/nccl_ofi_ofiutils.cpp`, `include/nccl_ofi_ofiutils.h` — discovery,
+  create/bind/enable helpers.
+- `include/ofi/resource_wrapper.h` — RAII wrappers over `fid_*`.
+- `include/nccl_ofi.h` — the object model that maps onto libfabric.
+- `src/nccl_ofi_net.cpp` — protocol selection and where hints/providers are
+  chosen.
+- Transports `src/nccl_ofi_rdma.cpp` and `src/nccl_ofi_sendrecv.cpp` build the
+  hints.
+
+**libfabric side:**
+
+- Headers: `include/rdma/{fabric.h, fi_domain.h, fi_endpoint.h, fi_tagged.h,
+  fi_rma.h, fi_cm.h, fi_errno.h}`.
+- Core: `src/fabric.c` (getinfo dispatch + provider registry), `src/hmem*.c`.
+- EFA provider: `prov/efa/src/{efa_prov.c, efa_user_info.c, efa_fabric.c,
+  efa_domain.c, efa_ep.c, efa_av.c, efa_cq.c, efa_mr.c}` and the RDM engine in
+  `prov/efa/src/rdm/`.

--- a/doc/overall-operation.md
+++ b/doc/overall-operation.md
@@ -1,0 +1,159 @@
+# AWS OFI NCCL — Overall Plugin Operation
+
+*This is the
+"grand picture" document. The other `*.md` files drill into individual
+subsystems (initialization, libfabric, tuner, RDMA protocol, send/recv
+protocol).*
+
+## What the plugin is
+
+AWS OFI NCCL is a shared library that lets NVIDIA **NCCL**, AMD **RCCL**, and
+AWS **Neuron** collective-communication runtimes use
+[**libfabric**](https://ofiwg.github.io/libfabric/) as their network transport
+— in practice, the **EFA** (Elastic Fabric Adapter) provider on EC2.
+
+NCCL has a pluggable "network" interface (`ncclNet`). It knows how to run
+collectives (all-reduce, all-gather, …) but delegates the actual point-to-point
+byte movement between nodes to a network plugin. This project **is** that
+plugin. It translates NCCL's **connection-oriented** transport API
+(`listen`/`connect`/`accept`/`isend`/`irecv`) onto libfabric's
+**connection-less, reliable-datagram** interface (`FI_EP_RDM`).
+
+The plugin ships two independent pieces that NCCL loads separately:
+
+1. **A network (transport) plugin** — moves the bytes. Exposed via
+   `ncclNetPlugin_vN` symbols.
+2. **A tuner plugin** — advises NCCL *which* collective algorithm/protocol to
+   use for a given message size and cluster shape. Exposed via
+   `ncclTunerPlugin_vN` symbols. It never touches the wire. See
+   [`tuner.md`](tuner.md).
+
+## The 30-second mental model
+
+```
+   NCCL runtime  ── dlopen ──▶  libnccl-net.so  (this plugin)
+        │                            │
+        │  ncclNet vtable            │  fi_* calls
+        ▼                            ▼
+  collective ops              libfabric  ──▶  EFA provider  ──▶  NIC(s)
+```
+
+- NCCL calls the plugin's vtable functions.
+- The plugin calls libfabric (`fi_getinfo`, `fi_endpoint`, `fi_tsend`,
+  `fi_writedata`, `fi_cq_read`, …).
+- libfabric routes to a **provider** (EFA on AWS), which drives the hardware.
+
+## Core object model
+
+Every part of the plugin is organized around one hierarchy, defined in
+[`include/nccl_ofi.h`](../include/nccl_ofi.h):
+
+```
+plugin  (1 per process; global `plugin` in nccl_ofi_api.cpp)
+  └─ device        (~one NIC / port / multi-rail group; unit of bandwidth sharing)
+       └─ domain   (a libfabric fid_domain + AV + CQ + MR cache + rkey pool;
+       │            also the threading / locking boundary)
+            └─ endpoint  (a libfabric fid_ep with a unique fabric address;
+                          typically one per proxy thread)
+                 └─ communicator  (listen / send / recv — one logical connection)
+```
+
+Ownership flows *downward* with `shared_ptr`: a communicator keeps its endpoint
+alive, an endpoint keeps its domain alive. Devices and domains keep only
+`weak_ptr` caches, so resources are reclaimed automatically when the last
+communicator closes. Domains and endpoints are created **lazily** on the first
+`device->get_ep(...)` call, not up front.
+
+This base model is implemented once and specialized by each **transport**:
+
+| Transport | Files | How it moves data |
+|---|---|---|
+| **SENDRECV** | `src/nccl_ofi_sendrecv.cpp` | libfabric **tagged** two-sided messaging (`fi_tsend`/`fi_trecv`). Simple, single-rail. |
+| **RDMA** | `src/nccl_ofi_rdma.cpp` | one-sided **RDMA write** rendezvous, striped across multiple **rails** (NICs). Higher performance. |
+
+See [`sendrecv-protocol.md`](sendrecv-protocol.md) and
+[`rdma-protocol.md`](rdma-protocol.md).
+
+## Lifecycle at a glance
+
+1. **Load & init.** NCCL `dlopen`s the library and `dlsym`s the highest
+   `ncclNetPlugin_vN` it supports, then calls the vtable's `.init`. That
+   funnels through version-shim wrappers into the version-agnostic
+   `nccl_net_ofi_init()` and `nccl_net_ofi_create_plugin()`, which detect the
+   platform, discover libfabric providers, **select a transport**, and create
+   `device` objects. Full detail in
+   [`plugin-initialization.md`](plugin-initialization.md).
+2. **Discover devices.** NCCL calls `.devices` and `.getProperties` per device.
+3. **Connect.** For each peer link, NCCL calls `listen` on one side and
+   `connect` on the other; the acceptor calls `accept`. Because `FI_EP_RDM` is
+   connection-less, the plugin exchanges raw endpoint addresses out-of-band
+   (through a handle NCCL ferries over its bootstrap channel) and runs a small
+   **connection-manager** handshake (`src/cm/`).
+4. **Transfer.** NCCL issues non-blocking `isend`/`irecv` (and, for the RMA API,
+   `iwrite`/`iread`), each returning a *request* handle. NCCL polls `test`
+   until the request completes. Under the hood the plugin submits libfabric
+   operations and drains completion queues with `fi_cq_read`.
+5. **Flush.** After a GPUDirect receive, `iflush` forces the NIC's DMA writes to
+   be visible to the GPU before NCCL reads the buffer.
+6. **Teardown.** NCCL closes communicators; when the process exits,
+   `nccl_net_ofi_fini()` tears down the plugin.
+
+## Data-path essentials shared by both transports
+
+- **Requests & completions.** Every non-blocking operation allocates a request
+  from a per-communicator freelist and embeds a `struct fi_context2`
+  (`nccl_net_ofi_context` in `include/nccl_ofi.h`). libfabric returns that
+  context on completion; the plugin recovers the owning request and invokes its
+  `handle_cq_entry()` / `handle_error_entry()` callback. Progress is driven from
+  `test()` and from the send/recv hot paths.
+- **Memory registration.** Before a buffer can be sent or received it must be
+  *registered* with libfabric (pins pages, programs the NIC). Registration is
+  expensive, so it is **cached per domain** and keyed by page-aligned address.
+  GPU memory is registered via `FI_HMEM` (GPUDirect RDMA), optionally exported
+  through **dmabuf**. This is central to the RDMA protocol and is covered in
+  depth in [`rdma-protocol.md`](rdma-protocol.md).
+- **Platform awareness.** `src/platform-aws.cpp` maps the EC2 instance type to a
+  topology file, default transport, and a set of libfabric/NCCL environment
+  tweaks, and validates per-endpoint EFA capabilities.
+
+## Where to start reading (main entry-point files)
+
+| Concern | File(s) |
+|---|---|
+| NCCL-facing symbol tables (vtables) | `src/nccl_ofi_interface_nvidia.cpp`, `src/nccl_ofi_interface_neuron.cpp` |
+| Version-agnostic API layer | `src/nccl_ofi_api.cpp`, `include/nccl_ofi_api.h` |
+| Bootstrap, protocol selection, base object model | `src/nccl_ofi_net.cpp`, `include/nccl_ofi.h` |
+| Platform (EC2) integration | `src/platform-aws.cpp`, `include/platform-aws.h` |
+| SENDRECV transport | `src/nccl_ofi_sendrecv.cpp`, `include/nccl_ofi_sendrecv.h` |
+| RDMA transport | `src/nccl_ofi_rdma.cpp`, `include/nccl_ofi_rdma.h`, `src/cm/` |
+| Connection handshake (both transports) | `src/cm/`, `include/cm/` |
+| Completion / progress engine | `src/nccl_ofi_freelist.cpp`, `src/nccl_ofi_msgbuff.cpp` |
+| Topology / multi-rail | `src/nccl_ofi_topo.cpp`, `include/nccl_ofi_topo.h` |
+| GPU-Initiated Networking (GIN) | `src/rdma/gin/`, `include/rdma/gin/`, `include/nccl_ofi_gin_base.h` |
+| Memory registration | `src/nccl_ofi_mr.cpp`, `include/nccl_ofi_mr.h`, `src/nccl_ofi_idpool.cpp` |
+| libfabric glue / RAII | `src/nccl_ofi_ofiutils.cpp`, `include/ofi/resource_wrapper.h` |
+| Tuner (separate plugin) | `src/tuner/` |
+
+## The companion documents
+
+- [`plugin-initialization.md`](plugin-initialization.md) — how the
+  library loads, discovers providers, picks a transport, and reaches "devices
+  ready".
+- [`libfabric.md`](libfabric.md) — what libfabric is, its object model
+  and the EFA provider, and how the plugin maps onto it.
+- [`rdma-protocol.md`](rdma-protocol.md) — RDMA theory (write/read,
+  registration, GPUDirect, eager vs rendezvous) and the actual implementation,
+  including memory registration.
+- [`sendrecv-protocol.md`](sendrecv-protocol.md) — the tagged-messaging
+  transport and its tradeoffs versus RDMA.
+- [`connection-manager.md`](connection-manager.md) — the shared handshake
+  (`src/cm/`) that emulates NCCL's connection-oriented `listen`/`connect`/`accept`
+  over connection-less libfabric endpoints.
+- [`completion-progress.md`](completion-progress.md) — the request/context
+  model, the CQ-polling progress engine, `-FI_EAGAIN` retry/back-pressure, and
+  message ordering/de-duplication.
+- [`topology.md`](topology.md) — intra-node hwloc topology, grouping NICs into
+  rails, the synthetic NCCL topology file, and cross-node device identity.
+- [`tuner.md`](tuner.md) — the algorithm/protocol advisor plugin.
+- [`gin.md`](gin.md) — GPU-Initiated Networking: the device-side RMA op-table,
+  symmetric memory, and the proxy vs EFA-GDA/GDAKI backends.

--- a/doc/plugin-initialization.md
+++ b/doc/plugin-initialization.md
@@ -1,0 +1,170 @@
+# AWS OFI NCCL — Plugin Initialization
+
+*This document explains how the
+library is loaded by NCCL/Neuron, how it discovers hardware, how it chooses a
+transport, and how it reaches the point where NCCL can start using devices. For
+the big picture see [`overall-operation.md`](overall-operation.md).*
+
+## The problem initialization solves
+
+NCCL doesn't know anything about EFA or libfabric. It just `dlopen`s a network
+plugin and calls a fixed set of function pointers. Initialization is where the
+plugin:
+
+1. Presents the right **symbols/vtable** for whatever NCCL version loaded it.
+2. Reads its **configuration** (environment variables).
+3. Detects the **platform** (which EC2 instance, which topology).
+4. Discovers **libfabric providers** and picks one (EFA).
+5. Chooses a **transport** (RDMA vs SENDRECV).
+6. Builds the **device objects** NCCL will enumerate.
+
+All of this happens before the first `listen`/`connect`.
+
+## Entry points
+
+| Role | File(s) |
+|---|---|
+| Exported `ncclNetPlugin_vN` vtables + per-version shims | `src/nccl_ofi_interface_nvidia.cpp`, `src/nccl_ofi_interface_neuron.cpp` |
+| Version-agnostic API (`nccl_net_ofi_init`, holds global `plugin`) | `src/nccl_ofi_api.cpp` |
+| Core bootstrap (`nccl_net_ofi_create_plugin`), protocol selection | `src/nccl_ofi_net.cpp` |
+| Transport init + `complete_init` | `src/nccl_ofi_rdma.cpp`, `src/nccl_ofi_sendrecv.cpp` |
+| Platform detection & endpoint config | `src/platform-aws.cpp`, `src/nccl_ofi_platform.cpp` |
+| Parameter / environment system | `include/nccl_ofi_param.h`, `include/nccl_ofi_param_impl.h` |
+| Object-model base classes | `include/nccl_ofi.h` |
+
+## The vtable / symbol layer
+
+Each interface file declares, inside `extern "C"`, one global variable per NCCL
+API version named exactly `ncclNetPlugin_vN` (NVIDIA: v6–v12; Neuron: v4–v6).
+NCCL `dlsym`s the highest version it supports. Each is a struct of function
+pointers (`.init`, `.devices`, `.getProperties`, `.listen`, `.connect`,
+`.accept`, `.regMr`, `.isend`, `.irecv`, `.iflush`, `.test`, `.close*`,
+`.iwrite`, `.iread`, …).
+
+The pointers target **per-version wrapper functions** (`init_v11`,
+`connect_v10`, `getProperties_v12`, …) whose only job is to absorb signature
+differences between NCCL versions (`int` vs `size_t`, added `trafficClass` /
+profiler / device-comm arguments, renamed structs) and then delegate to a
+**single version-agnostic implementation** in `src/nccl_ofi_api.cpp`.
+Unsupported optional slots are left `NULL`.
+
+This is why the rest of the codebase never has to think about NCCL versions:
+the shims normalize everything at the boundary.
+
+## The init call chain
+
+```
+NCCL dlopen + dlsym ncclNetPlugin_vN
+   → .init  (vtable slot)
+   → init_vN()               [interface_*.cpp: version shim; sets up atexit,
+   │                          ref-counts multi-init, stores per-comm config]
+   → nccl_net_ofi_init()     [api.cpp: guard against double-init, store logger,
+   │                          ofi_nccl_parameters_init(), set abort_on_error]
+   → nccl_net_ofi_create_plugin(&plugin)   [net.cpp: the real work]
+```
+
+Internal functions return plain `int`/errno; the API boundary translates them to
+`ncclResult_t` via `nccl_net_ofi_retval_translate()`.
+
+## Inside `nccl_net_ofi_create_plugin()` (`src/nccl_ofi_net.cpp`)
+
+This is the heart of initialization:
+
+1. **Environment/basics.** Reset the environment manager, log the libfabric
+   version, read the system page size and CQ read batch size, and (on GPU
+   builds) initialize the GPU runtime.
+2. **Topology.** Create the hardware topology object
+   (`nccl_ofi_topo_create()`), owned by a file-scope `unique_ptr` — the sole
+   owner for the process lifetime.
+3. **Platform init.** Register platforms and call
+   `get_platform().init(&provider_filter)` (see below).
+4. **Protocol selection.** Decide RDMA vs SENDRECV (see below). This produces a
+   plugin object but does **not** yet create devices.
+5. **`plugin->complete_init()`.** The chosen transport allocates its `device`
+   objects.
+6. **Probe endpoint.** Create one endpoint
+   (`device->get_ep(0, gettid())`) to lazily bring up a domain + endpoint. This
+   fires the platform `config_endpoint` hook and determines whether **GPUDirect
+   (GDR)** is supported. Then it is torn down.
+7. **Post-checks.** Assert GDR support is known, reconcile duplicate-connection
+   settings with GDR, and if GDR/HMEM is unavailable, force `NCCL_PROTO=simple`.
+   Finally apply the deferred environment changes and publish the plugin.
+
+After this returns, NCCL calls `.devices` and `.getProperties`, and the plugin
+is ready.
+
+## Transport selection
+
+Selection is keyed on the `OFI_NCCL_PROTOCOL` parameter and *where it came
+from* (user environment, platform-set, or default):
+
+- **User set `OFI_NCCL_PROTOCOL`** → honor it directly.
+- **Platform set it** (e.g. `platform-aws.cpp` chose a default for the instance
+  type) → honor that.
+- **Otherwise (default) auto-probe:** call `nccl_net_ofi_rdma_init()` and ask
+  whether it found *multiple rails/NICs*. Use RDMA if it did; otherwise also try
+  `nccl_net_ofi_sendrecv_init()` and fall back to SENDRECV; if only RDMA
+  succeeded, use single-rail RDMA.
+
+Effective priority: **user env > platform default > RDMA-if-multi-NIC >
+SENDRECV > single-rail RDMA**.
+
+Neuron's `init_v4` forces SENDRECV (unless the user overrides), because its
+synchronous `connect()` is incompatible with RDMA's asynchronous
+connection-response handshake.
+
+### Two-phase transport bring-up
+
+Each transport uses the same two-phase pattern:
+
+- **`*_init()`** — build libfabric **hints** (desired capabilities), then call
+  `nccl_ofi_ofiutils_get_providers()` trying descending libfabric API versions
+  (to negotiate DMA-BUF and GDR support), and construct the plugin object. RDMA
+  additionally runs topology population/grouping to form **rails** (validating
+  `max_group_size <= MAX_NUM_RAILS`).
+- **`complete_init()`** — allocate one `device` object per selected `fi_info`
+  entry. RDMA writes an NCCL topology file when rails are grouped. Domains and
+  endpoints are **not** created here — they come up lazily on first use.
+
+## Platform integration (`src/platform-aws.cpp`)
+
+The platform layer is a priority-based singleton (`PlatformManager` in
+`src/nccl_ofi_platform.cpp`). `PlatformAWS` is registered only on AWS builds; a
+no-op `Default` platform is the fallback. `OFI_NCCL_PLATFORM` can override
+detection.
+
+- **`PlatformAWS::init(&provider_filter)`** matches the running EC2 instance
+  type against an ordered `platform_data_map[]`. Each entry carries: a topology
+  XML file, default duplicate-connection count, latency, whether GDR is
+  required, and a **default transport** (SENDRECV for p4d/p4de/p3dn/g5/inf;
+  RDMA for p5/p5e/p5en/p6/trn), plus an environment-variable map. It forces
+  `FI_PROVIDER=efa` unless overridden, queues EFA/NCCL environment tweaks
+  (fork-safety, NVLS/tuner workarounds) for deferred application, and sets
+  `NCCL_TOPO_FILE` if a platform topology exists.
+- **`PlatformAWS::config_endpoint(info, ep)`** is invoked from
+  `nccl_ofi_ofiutils.cpp` on *every* endpoint creation, just before
+  `fi_enable`. It enforces `gdr_required`, validates native (non-emulated) RDMA
+  write support for the RDMA transport, and probes EFA's 128-byte in-order
+  delivery options to decide whether NCCL's LL/LL128 protocols are safe —
+  forcing `NCCL_PROTO=simple` if ordering guarantees are missing.
+
+The **topology** object is created once and passed by non-owning pointer to the
+transports; it informs rail grouping, device GUIDs, and the generated NCCL
+topology file. See [`topology-aware.md`](topology-aware.md) for the
+topology model itself.
+
+## Configuration / parameters
+
+`include/nccl_ofi_param.h` defines the plugin's environment variables (e.g.
+`OFI_NCCL_PROTOCOL`, `OFI_NCCL_PLATFORM`, flush and GDR toggles).
+`ofi_nccl_parameters_init()` parses them early in `nccl_net_ofi_init()`. Each
+parameter records its **source** (default / environment / API), which — as shown
+above — the protocol-selection logic depends on.
+
+## Teardown
+
+`nccl_net_ofi_fini()` (`src/nccl_ofi_api.cpp`) prints histograms, deletes the
+global `plugin`, and clears it. On NVIDIA, `init_v2` registers an `atexit`
+handler so cleanup runs even if NCCL doesn't call `fini` explicitly; the
+ref-counted init path ensures the plugin initializes once and finalizes once
+across multiple NCCL communicators.

--- a/doc/rdma-protocol.md
+++ b/doc/rdma-protocol.md
@@ -1,0 +1,291 @@
+# AWS OFI NCCL — RDMA Protocol
+
+*This document covers both the
+**theory** of RDMA (writes/reads, memory registration, GPUDirect, eager vs
+rendezvous) and how the plugin **actually implements** it, including memory
+registration. For the big picture see
+[`overall-operation.md`](overall-operation.md); for the underlying API
+see [`libfabric.md`](libfabric.md).*
+
+The RDMA transport is the high-performance path, preferred on multi-NIC EC2
+instances (p5/p5e/p5en/p6/trn). Its implementation lives in
+`src/nccl_ofi_rdma.cpp` (+ `include/nccl_ofi_rdma.h`) with the connection
+manager under `src/cm/`.
+
+---
+
+## Part 1 — RDMA theory
+
+### One-sided operations
+
+**RDMA** (Remote Direct Memory Access) lets a NIC read or write a remote host's
+memory **without involving the remote CPU**. The two primitives:
+
+- **RDMA write** — the initiator pushes data into a remote buffer.
+- **RDMA read** — the initiator pulls data from a remote buffer.
+
+Both are *one-sided*: the initiator names a local address, a remote address, and
+a remote key; the target's CPU is not interrupted. This is the key advantage
+over two-sided send/recv (the SENDRECV transport), where the receiver must post
+a matching buffer and the provider does matching work.
+
+For the target buffer to be writable/readable remotely, it must be
+**pre-registered** and its **remote key (rkey)** must be known to the initiator.
+
+### Memory registration, lkey/rkey, protection domains
+
+Before a NIC can DMA to/from a buffer, the OS must **pin** the pages (prevent
+them from being swapped/moved) and the NIC must be programmed with the
+virtual→physical mapping. This is **memory registration**. It yields:
+
+- a **local descriptor / lkey** (`fi_mr_desc`) — presented by the local side to
+  authorize its own NIC to access the buffer;
+- a **remote key / rkey** (`fi_mr_key`) — handed to a peer so that peer's writes
+  or reads targeting this buffer are authorized.
+
+Registrations live in a **protection domain** (a libfabric `fid_domain`); keys
+are only meaningful within that domain. Registration is **expensive** (syscalls,
+page pinning, NIC programming), so real systems **cache** registrations.
+
+### GPUDirect RDMA, dmabuf, GDRCopy
+
+- **GPUDirect RDMA** lets the NIC DMA **directly to/from GPU HBM**, bypassing a
+  bounce through host memory. It requires provider `FI_HMEM` support and the
+  right MR interface (`FI_HMEM_CUDA` / `FI_HMEM_ROCR` / `FI_HMEM_NEURON`) plus
+  the GPU device id.
+- **dmabuf** is a Linux kernel mechanism (>= 5.12) to export a GPU allocation as
+  a file descriptor, giving the NIC driver a clean, driver-agnostic handle to
+  the GPU memory for registration.
+- **GDRCopy** is a *separate* library that CPU-maps GPU memory for low-latency
+  host load/store. The plugin uses it on the **control path** (small metadata),
+  not for bulk data.
+
+### Eager vs rendezvous
+
+Two classic strategies trade round-trips against copies:
+
+- **Eager** (small messages): the sender immediately pushes the payload into a
+  pre-posted buffer on the receiver. One trip, but the receiver must **copy**
+  from that landing buffer to its final destination.
+- **Rendezvous** (large messages): the receiver first advertises its
+  destination buffer (address + rkey); the sender then RDMA-writes the payload
+  **directly** into the final buffer — zero-copy, but one extra round trip for
+  the advertisement.
+
+The RDMA transport uses **both**, choosing per message.
+
+---
+
+## Part 2 — Implementation in the plugin
+
+### Rails and the scheduler
+
+A "device" here is a **multi-rail group** — up to `MAX_NUM_RAILS = 4` physical
+NICs treated as one logical device. There are two rail families:
+
+- **data rails** (`rails[]`, each with its own endpoint + AV + CQ) for bulk
+  writes/reads;
+- **control rails** (`control_rails[]`) for control messages and eager receives.
+
+The **scheduler** (`src/nccl_ofi_scheduler.cpp`,
+`nccl_net_ofi_threshold_scheduler`) decides how to split a message across rails.
+It returns a *schedule* — an array of `{rail_id, offset, msg_size}`. Small
+messages round-robin onto a single rail; large messages are striped across all
+rails in 128-byte-aligned chunks (aligned for NCCL's LL128 protocol). This is
+how the transport aggregates the bandwidth of multiple NICs.
+
+### The control-message "mailbox" — the key design idea
+
+Instead of sending control messages as tagged two-sided messages, the RDMA
+transport implements **receiver-driven rendezvous by RDMA-writing the control
+message into a mailbox in the sender's memory**:
+
+1. The sender allocates a page-aligned **mailbox** and registers it. Its slots
+   number `2 × NCCL_OFI_MAX_REQUESTS` so slots are never overwritten while in
+   flight. The sender ships the mailbox base offset + per-rail rkeys to the
+   receiver during connection setup.
+2. When NCCL calls `recv()`, the receiver builds a control entry describing its
+   destination buffer — `{buff_offset, mr_key[MAX_NUM_RAILS], buff_len, tag,
+   msg_seq_num}` — and **RDMA-writes** it into the sender's mailbox at slot
+   `msg_seq_num % mailbox_size`.
+3. The sender's `send()` polls its mailbox for a matching entry before starting
+   the rendezvous write.
+4. The sender RDMA-writes the payload **directly into the receiver's final
+   buffers**, striped across rails per the schedule, using `fi_writedata` so
+   each write carries **32-bit immediate data**. The immediate data encodes
+   `{segment count, recv index, comm id, msg_seq_num}`, letting the receiver
+   steer each completion to the right request **without a matching receive**.
+
+Relevant structures: `nccl_net_ofi_ctrl_msg_entry_t` (64 B) and
+`nccl_net_ofi_ctrl_msg_t` in `include/nccl_ofi_rdma.h`; immediate-data
+pack/unpack macros near the top of `src/nccl_ofi_rdma.cpp`.
+
+### The eager path
+
+For small messages (payload + header ≤ the eager threshold), the sender skips
+the mailbox round trip. It prepends an 8-byte header
+(`nccl_ofi_eager_msg_header_t`: eager offset, previous batch count, eager
+sequence, tag) and uses `fi_sendmsg` with `FI_REMOTE_CQ_DATA` on one data rail.
+The payload lands in a **pre-posted bounce buffer** on the receiver. The
+receiver then issues a **local `fi_read`** (an "eager copy" request) to move the
+payload — skipping the 8-byte header — from the bounce buffer into the final
+destination. A wrap-safe sequence chain orders eager messages against any later
+control messages.
+
+### Request types
+
+All requests derive from `nccl_net_ofi_rdma_req` with virtual
+`post()` / `handle_completion()` / `free()` / `test()`. The main types:
+
+| Request | Role |
+|---|---|
+| `rdma_send_req` | rendezvous write (`fi_writedata`/`fi_write`) or eager `fi_sendmsg` |
+| `rdma_recv_req` | RDMA-write the control entry into the sender's mailbox |
+| `rdma_recv_segms_req` | track individual write segments of a striped message |
+| `rdma_eager_copy_req` | local `fi_read` from bounce buffer to final destination |
+| `rdma_flush_req` | per-rail `fi_read` to force GPUDirect write visibility |
+| `rdma_rma_op_req` | NCCL RMA API (`iwrite`/`iread`) |
+| `rdma_rx_buff_req` | pre-posted `fi_recv` buffers for control/eager traffic |
+
+All are sized to fit a single freelist slot.
+
+### Data-path entry points (functions in `src/nccl_ofi_rdma.cpp`)
+
+- **`send()`** — guard inflight count; check the mailbox for a matching
+  control entry; decide eager vs rendezvous; copy the remote offset + rkeys;
+  post the write(s) per rail with immediate data. `-FI_EAGAIN` queues the
+  request on the endpoint's pending queue.
+- **`recv()`** — allocate a `rdma_recv_req`, populate a mailbox slot, and
+  `fi_write` it to the sender; if the eager payload already arrived, spawn the
+  eager-copy `fi_read`.
+- **`write()` / `write_inline()` / `read()`** — the NCCL RMA API, implemented
+  with `fi_writemsg` (`FI_INJECT` for inline) and `fi_read` on rail 0, using the
+  caller-supplied destination and rkey.
+- **`flush()`** — a small `fi_read` from the just-written GPU buffer into a
+  per-rail host buffer to force the NIC's DMA writes to be visible before NCCL
+  reads GPU memory (fast path: `cudaDeviceFlushGPUDirectRDMAWrites`).
+
+### Completion handling
+
+Each rail has its own CQ. `ofi_process_cq()` → `ofi_process_cq_rail()` →
+`rdma_process_completions()`:
+
+- A `FI_REMOTE_WRITE` completion (no context) is a payload landing → routed via
+  the immediate data to the target recv request (`handle_write_comp`).
+- Otherwise the op's context is a `fi_context2` inside a `nccl_net_ofi_context`;
+  `cpp_container_of` recovers it and calls `handle_cq_entry()`, which dispatches
+  to the owning request's `handle_completion()`.
+
+Because a striped message spans multiple rails, per-rail completions are counted
+under a lock, and the request flips `PENDING → COMPLETED` only when all segments
+complete. `nccl_ofi_msgbuff` (per recv communicator) tracks `msg_seq_num` status
+for ordering and de-duplication.
+
+### Connection management (`src/cm/`, `include/cm/`)
+
+The connection manager owns its **own** libfabric endpoint (bound to the leader
+NIC's CQ), an AV, and a freelist of registered connection-message buffers. The
+handshake is a two-way exchange:
+
+1. The connecting side `fi_send`s a `SEND_CONN_MSG` carrying its endpoint name
+   plus a transport-specific payload (`nccl_ofi_rdma_connection_info_t`:
+   per-rail endpoint names, comm id, and the **control mailbox address +
+   rkeys**).
+2. The listening side's receive completes, looks up the listener, builds a
+   receiver object, and `fi_send`s a `SEND_CONN_RESP_MSG`.
+
+Because NCCL's `connect`/`accept` are non-blocking, progress is polled via
+`test_ready()` (returning `CM_CONN_INCOMPLETE` until done), driven by the
+transport's CQ processing. In the RDMA transport this is wired through
+`ep::connect` and the `listen_comm::accept` state machine
+(`COMM_CREATE_START → CONN_REQ_PENDING → CONN_RESP_REQ_PENDING → CONNECTED`).
+
+---
+
+## Part 3 — Memory registration in detail
+
+Memory registration is where RDMA theory meets the plugin's real code.
+
+### Registration path
+
+`comm::regMr` → `domain::reg_mr` → **MR cache lookup** → `reg_mr_on_device` on
+a miss. On a miss the plugin:
+
+1. Allocates an rkey from the domain's **rkey pool** (`mr_rkey_pool`) when the
+   provider requires plugin-assigned keys.
+2. Fills an `fi_mr_attr` (`set_mr_req_attr`) with access flags
+   (`FI_SEND|FI_RECV|FI_WRITE|FI_REMOTE_WRITE|FI_READ|FI_REMOTE_READ`), the HMEM
+   interface for the pointer type, and the GPU device id.
+3. Registers **one `fid_mr` per data rail** (`fi_mr_regattr`), storing them in
+   `nccl_net_ofi_rdma_mr_handle_t.mr_data[MAX_NUM_RAILS]`.
+
+If the provider uses `FI_MR_ENDPOINT` (e.g. CXI), separate control-rail MRs are
+bound to the endpoint (`fi_mr_bind` + `fi_mr_enable`); on EFA the control MRs
+simply alias the data MRs. The registered base address is `0` when the provider
+advertises `FI_MR_VIRT_ADDR`, otherwise the buffer's base.
+
+### The MR cache (`src/nccl_ofi_mr.cpp`, `include/nccl_ofi_mr.h`)
+
+Each **domain** owns a cache — a sorted, refcounted vector of registration
+entries keyed by **page-aligned base address + page count**:
+
+- `lookup_entry` rounds to page boundaries and bumps the refcount on a hit;
+- `insert_entry` inserts in sorted order;
+- `del_entry` decrements the refcount and deregisters only when it reaches zero.
+
+Cache keys use `nccl_ofi_mr_ckey`, a union of an `iovec` (virtual-address
+registration) and an `fi_mr_dmabuf` (dmabuf registration), laid out to be
+compatible with `fi_mr_attr`. The virtual-address form is **extended to page
+boundaries** for `fork()` safety (except on Neuron). When `FI_MR_ENDPOINT` is in
+effect, cache entries also match on the endpoint.
+
+### The key pool (`src/nccl_ofi_idpool.cpp`)
+
+`nccl_ofi_idpool_t` is a bit-array allocator (a `vector<uint64_t>` + mutex,
+using `__builtin_ffsll`) that hands out unique ids and returns `FI_KEY_NOTAVAIL`
+when exhausted. It backs both the **rkey pool** (`mr_rkey_pool`) and the pool of
+15-bit **communicator ids** used in the immediate-data encoding. Whether an rkey
+pool is needed (`need_mr_rkey_pool`) is a provider-determined property.
+
+### Freelists (`src/nccl_ofi_freelist.cpp`)
+
+Bounce buffers, control mailboxes, eager headers, requests, and schedule buffers
+all come from **freelists**. "Registered" freelists take register/deregister
+callbacks so each backing block is registered once (page-rounded, with metadata
+at the block end) and grows on demand up to a cap. The RDMA transport supplies a
+callback that registers internal buffers on the domain (and binds them when
+`FI_MR_ENDPOINT` applies).
+
+### dmabuf and GPUDirect glue
+
+- **dmabuf** (`src/nccl_ofi_dmabuf.cpp`): `nccl_ofi_dmabuf_viable` gates use on
+  libfabric >= 1.20, user enablement, GPU dmabuf support, and kernel >= 5.12; the
+  fd is forwarded into `fi_mr_regattr` with `FI_MR_DMABUF`. (On the EFA side this
+  is handled in `prov/efa/src/efa_mr.c`.)
+- **GDRCopy** (`src/nccl_ofi_gdrcopy.cpp`): `libgdrapi.so` is `dlopen`ed as a
+  soft dependency; when present it pins a GPU-page-aligned region and CPU-maps
+  it for low-latency host access on the **control path** only.
+
+---
+
+## Main entry-point reference
+
+| Concern | Location |
+|---|---|
+| Transport, requests, data path | `src/nccl_ofi_rdma.cpp`, `include/nccl_ofi_rdma.h` |
+| CQ processing | `ofi_process_cq`, `rdma_process_completions`, `handle_cq_entry` |
+| Data ops | `send`, `recv`, `write`/`write_inline`, `read`, `flush` |
+| Request posts | `rdma_send_req::post`/`post_eager`, `rdma_recv_req::post`, `rdma_eager_copy_req::post`, `rdma_flush_req::post` |
+| Connection manager | `src/cm/`, `include/cm/` |
+| Multi-rail scheduler | `src/nccl_ofi_scheduler.cpp`, `include/nccl_ofi_scheduler.h` |
+| Memory registration | `src/nccl_ofi_mr.cpp`, `include/nccl_ofi_mr.h` |
+| Key/id pool | `src/nccl_ofi_idpool.cpp` |
+| Freelists | `src/nccl_ofi_freelist.cpp` |
+| dmabuf / GDRCopy | `src/nccl_ofi_dmabuf.cpp`, `src/nccl_ofi_gdrcopy.cpp` |
+
+**In one sentence:** the RDMA transport implements rendezvous by having the
+**receiver RDMA-write its buffer descriptor into a mailbox in the sender's
+memory**, after which the sender RDMA-writes the payload directly into the
+receiver's final (GPU) buffers, striped across rails, using 32-bit immediate
+data to steer each completion — with a bounce-buffer **eager** path for small
+messages.

--- a/doc/sendrecv-protocol.md
+++ b/doc/sendrecv-protocol.md
@@ -1,0 +1,161 @@
+# AWS OFI NCCL — Send/Recv (Tagged) Protocol
+
+*This document describes the
+SENDRECV transport — the simpler of the plugin's two transports — and when it is
+used instead of RDMA. For the big picture see
+[`overall-operation.md`](overall-operation.md); for the alternative see
+[`rdma-protocol.md`](rdma-protocol.md).*
+
+The SENDRECV transport maps NCCL's data movement onto libfabric **tagged,
+two-sided messaging** (`FI_TAGGED` / `FI_MSG`, i.e. `fi_tsend` / `fi_trecv`)
+over a reliable-datagram endpoint (`FI_EP_RDM`). It is far smaller than the RDMA
+transport and is the default on single-NIC instances (p4d/p4de/p3dn/g5/inf) and
+a fallback elsewhere.
+
+Implementation: `src/nccl_ofi_sendrecv.cpp` (+ `include/nccl_ofi_sendrecv.h`),
+reusing the shared connection manager (`src/cm/`), MR cache, freelists, and id
+pool.
+
+## The core idea: tags stand in for connections
+
+`FI_EP_RDM` is connection-less, but NCCL expects distinct logical connections.
+SENDRECV emulates them with **tags**:
+
+- The endpoint's `mem_tag_format` is inspected at device init to count how many
+  high tag bits are free for a "ring id" (`sendrecv_device_prepare_for_connection`).
+  The plugin requires at least `MIN_TAG_BITS_FOR_RING_ID` bits, reserving one
+  bit as a control marker (`OFI_HIGHEST_TAG_BIT`); this also caps
+  `max_communicators`.
+- Each communicator is assigned a unique, monotonically increasing tag when the
+  connection is accepted (`++ep->tag`, bounded by `max_tag`).
+- All sends and receives on that communicator carry its tag, so the provider's
+  tag-matching engine multiplexes many logical connections over one physical
+  RDM endpoint.
+
+## Connection establishment (listen / connect / accept)
+
+The handshake is delegated to the shared **connection manager** rather than
+hand-rolled. The wire payload in both directions is
+`nccl_ofi_connection_info_t { char ep_name[56]; uint64_t ep_namelen; uint64_t
+tag; }` — the raw libfabric endpoint address (`fi_getname`) plus the assigned
+tag.
+
+- **`listen()`** (`ep_t::listen`): get the local endpoint address, insert it
+  into the AV (kept for the local flush read), create the listen communicator,
+  call `cm->listen()`, and return a connection-manager handle in `*handle`
+  (which NCCL passes out-of-band to the peer).
+- **`connect()`** (`ep_t::connect`): a state machine keyed on the handle's
+  stage. On the first call it fills the connection info with its endpoint name
+  and calls `cm->connect(handle, conn_info)`. Subsequent calls progress the CQ
+  and poll `test_ready()`, returning "incomplete" until the peer responds. On
+  completion it reads the response's endpoint name + tag, inserts the remote
+  address into the AV, records the tag, and marks the communicator connected.
+- **`accept()`** (`listen_comm::accept`): a state machine
+  (`COMM_CREATE_START → CONN_REQ_PENDING → CONN_RESP_REQ_PENDING → CONNECTED`).
+  It progresses the CQ, reads the peer's connection message, creates the receive
+  communicator (inserting the peer address into the AV and **allocating a fresh
+  tag**), and sends a response carrying the local endpoint name + tag.
+
+Note the asymmetry: the **acceptor allocates the tag**, and the connector adopts
+it from the response. The tag is the durable output of the handshake.
+
+## Data path: isend / irecv → fi_tsend / fi_trecv
+
+- **`send()`** (`send_comm::send`): `fi_tsend(local_ep, data, size, desc,
+  remote_ep, tag, ctx)`, where `desc` is the local MR descriptor and `tag` is
+  the communicator's tag. On `-FI_EAGAIN` it progresses the CQ and returns a
+  `NULL` request so NCCL retries.
+- **`recv()`** (`recv_comm::recv`): `fi_trecv(local_ep, buf, size, desc,
+  FI_ADDR_UNSPEC, tag, 0 /*ignore bits*/, ctx)`. Matching is by **tag only**,
+  not by source address. The received length comes from the completion entry.
+  Grouped receives are **not** supported (`n == 1` only;
+  `max_group_receives = 1`).
+
+There is **no control mailbox and no manual RDMA write** — the provider's own
+tagged-messaging engine handles matching and (internally) any rendezvous.
+
+## Requests and completion (fi_cq_read)
+
+Each operation allocates a `nccl_net_ofi_sendrecv_req` from a per-communicator
+freelist. The request embeds a context (`nccl_net_ofi_sendrecv_context`
+wrapping `fi_context2`), a direction (SEND/RECV), a size, and a state
+(`CREATED → PENDING → COMPLETED | ERROR`).
+
+Progress is driven by `sendrecv_cq_process()`, which loops `fi_cq_read()` into a
+batch of tagged completion entries (CQ format `FI_CQ_FORMAT_TAGGED`):
+
+- On a normal completion, `sendrecv_process_completions()` recovers the context
+  (`cpp_container_of`) and calls `handle_cq_entry()`, which records the actual
+  received length for receives and marks the request `COMPLETED`.
+- On `-FI_EAVAIL` it reads the error entry (`fi_cq_readerr`) and calls
+  `handle_error_entry()`, marking the request `ERROR`.
+
+`req::test()` (invoked from NCCL's `test`) takes the endpoint lock, drives CQ
+progress if the request is not yet complete, and on completion reports the size,
+frees the request back to the freelist, and decrements the inflight count. CQ
+progress is also driven from the send/recv/accept/connect/flush paths.
+
+## Memory registration
+
+`regMr` goes through `sendrecv_comm_mr_base_reg`, which consults the domain's MR
+cache (keyed by an `nccl_ofi_mr_ckey`) under the cache lock. On a miss,
+`sendrecv_mr_buffers_register` builds an `fi_mr_attr` with access
+`FI_SEND | FI_RECV` (plus `FI_READ`/`FI_REMOTE_READ` for the GDR flush path when
+RMA is supported), the HMEM interface per pointer type
+(`FI_HMEM_SYSTEM/CUDA/ROCR/NEURON`), and the resolved GPU device id; it allocates
+a key from the domain's rkey pool when required and calls `fi_mr_regattr`. If the
+provider uses `FI_MR_ENDPOINT`, the MR is bound to the endpoint
+(`fi_mr_bind` + `fi_mr_enable`). The handle
+(`nccl_net_ofi_sendrecv_mr_handle_t`) holds the `fid_mr` and key; `get_mr_key()`
+returns `fi_mr_key`. Deregistration is refcounted through the cache.
+
+Internal buffers are page-aligned and enlarged to whole pages to avoid `fork()`
+copy-on-write corruption on kernels older than 5.15. See
+[`rdma-protocol.md`](rdma-protocol.md) for the shared registration
+machinery (cache, id pool, dmabuf, GDRCopy), which SENDRECV reuses.
+
+## Flush
+
+`recv_comm::flush()` makes GPUDirect writes visible to the GPU before NCCL
+reads the buffer. It is skipped when flush is disabled or GDR is unsupported,
+and for zero-length receives. If CUDA flush is enabled it calls the GPU flush
+API directly; otherwise it performs a **local loopback `fi_read`** from the
+received GPU buffer into a small pre-registered host bounce buffer
+(`flush_buff`, at most one page, allocated at communicator creation) — the read
+completion guarantees the writes have landed. Only `n == 1` is supported.
+
+## When SENDRECV is used, and its tradeoffs
+
+Selected via `OFI_NCCL_PROTOCOL` or by falling out of the auto-selection logic
+(see [`plugin-initialization.md`](plugin-initialization.md)).
+
+**Characteristics / limitations:**
+
+- **Single rail** (`get_ofi_num_rails() == 1`) — one endpoint/CQ/AV per
+  endpoint; it **cannot stripe across multiple NICs**, which caps throughput on
+  multi-rail EFA instances.
+- **Two-sided** — the receiver must post a buffer and the provider matches by
+  tag; the size is implicit in the completion.
+- **No one-sided RMA** — `write`/`write_inline`/`read` return `-ENOTSUP`
+  (`rma_supported = 0`); `fi_read` is used only for the internal flush.
+- **No grouped receive** (`max_group_receives = 1`).
+- `regIsGlobal = 0`, and a known limitation exists around truncated sends (send
+  larger than the posted receive).
+
+**Why it still exists:** it is simple and robust, has low complexity, works well
+on single-QP / single-rail providers, and serves as a reliable fallback. The
+RDMA transport ([`rdma-protocol.md`](rdma-protocol.md)) exists precisely
+to overcome the single-rail and no-RMA limitations for high-bandwidth
+multi-NIC instances.
+
+## Main entry-point files and functions
+
+| Concern | Location |
+|---|---|
+| Transport implementation | `src/nccl_ofi_sendrecv.cpp`, `include/nccl_ofi_sendrecv.h` |
+| Init / device / domain / endpoint | `nccl_net_ofi_sendrecv_init`, `plugin_t::complete_init`, `sendrecv_device_prepare_for_connection`, `create_domain`, `create_endpoint` |
+| Connection | `ep_t::listen`, `ep_t::connect`, `listen_comm::accept`, `send_comm::create`, `recv_comm::create`, `send_comm::process_conn_resp` |
+| Data path | `send_comm::send` (`fi_tsend`), `recv_comm::recv` (`fi_trecv`), `recv_comm::flush` (`fi_read`) |
+| Completion | `sendrecv_cq_process`, `sendrecv_process_completions`, `handle_cq_entry` / `handle_error_entry`, `req::test` |
+| Memory registration | `sendrecv_comm_mr_base_reg`, `sendrecv_mr_buffers_register`, `sendrecv_comm_mr_base_dereg` |
+| Connection manager (shared) | `src/cm/`, `include/cm/` |

--- a/doc/threading-model.md
+++ b/doc/threading-model.md
@@ -1,0 +1,239 @@
+# AWS OFI NCCL — Threading Model and Lock Pressure
+
+*This document explains which
+threads call the plugin, how the plugin's object model is arranged around those
+threads, and where lock contention can arise. For the big picture see
+[`overall-operation.md`](overall-operation.md); for how completions are polled
+see [`completion-progress.md`](completion-progress.md).*
+
+## How NCCL drives the plugin
+
+The plugin does **not** create its own data-path threads (with one exception,
+GIN proxy mode, below). It is a passive library: NCCL calls its vtable functions
+from NCCL's own threads, and the plugin makes progress synchronously on those
+calls.
+
+The threads that matter are NCCL's **proxy threads**. NCCL runs its collective
+algorithms on the GPU but offloads the *network* portion to the CPU. Two
+long-lived proxy threads are relevant (see NCCL's `src/proxy.cc`):
+
+- A **proxy service thread** handles control/setup RPCs — establishing
+  connections and registering memory. Plugin calls on the **setup path**
+  (`listen`, `connect`, `accept`, `regMr`/`deregMr`) run here (and `init` /
+  `devices` / `getProperties` run on the main thread during bring-up).
+- A **proxy progress thread** (`ncclProxyProgress`, created in
+  `ncclProxyProgressCreate`) spins driving in-flight network operations. The
+  **data path** (`isend`, `irecv`, `iflush`, `test`, and the RMA
+  `iwrite`/`iread`) is called from here — e.g. `src/transport/net.cc` calls
+  `proxyState->ncclNet->isend/irecv/test`.
+
+NCCL creates **one progress thread per
+proxy state**, and a proxy state is per local **CUDA device** — the thread is
+named `"NCCL Progress<dev>"` and pinned to that device
+(`cudaSetDevice(proxyState->cudaDev)`). A process that drives multiple local devices (or
+multiple communicators with their own proxy state) therefore has multiple
+progress threads. NCCL's own **bootstrap** thread also calls `isend`/`irecv`/
+`test` during setup (`src/bootstrap.cc`).
+
+> A **communicator** (`ncclComm`) represents a rank's membership in one group of ranks
+> that run collectives together. A single process holds more than one communicator when
+> it drives several local GPUs, runs multiple independent communication groups, or
+> splits a communicator into sub-groups. A new communicator can get its **own** proxy
+> state (and thus its own progress thread) or **share** it with other communicators. So
+> the exact rule is **one progress thread per group of resource-sharing communicators** —
+> which is also why each such thread naturally lands on its own plugin endpoint (below).
+
+From the plugin's perspective **multiple threads call into the plugin** (progress
+thread(s), the proxy service thread, the bootstrap thread, the main init thread), and
+steady-state data-path traffic for a given device is driven by a **single, device-pinned
+progress thread**.
+
+## The endpoint-per-thread model
+
+The plugin's central concurrency strategy is to give **each calling thread its
+own endpoint**, so that the hot data path is essentially uncontended.
+
+This is visible right at the API boundary. Every `listen`/`connect` obtains an
+endpoint keyed by the calling thread's ID:
+
+```cpp
+// src/nccl_ofi_api.cpp
+ep = device->get_ep(domain_key, nccl_net_ofi_gettid());
+```
+
+`nccl_net_ofi_gettid()` (`src/nccl_ofi_compat.cpp`) returns the OS thread id.
+`device->get_ep(domain_key, endpoint_key)` looks the endpoint up in a per-domain
+cache keyed by that id and creates one on a miss
+(`nccl_net_ofi_domain_t::get_ep`, `src/nccl_ofi_net.cpp`). The endpoint base
+class documents this intent directly (`include/nccl_ofi.h`):
+
+> **Endpoint — A per-Proxy Thread device abstraction.** … allowing for the
+> possibility that the underlying transport uses an endpoint per thread (or per
+> thread calling listen/connect) to drive traffic across multiple Libfabric
+> endpoints and completion queues.
+
+Consequences:
+
+- Two different proxy threads that call `connect`/`listen` land on **different
+  endpoints**, each with its own libfabric endpoint(s) and completion queue(s)
+  (for RDMA, its own set of per-rail endpoints/CQs).
+- A communicator holds a `shared_ptr` to the endpoint it was created on, so all
+  subsequent `isend`/`irecv`/`test` for that communicator run on that same
+  endpoint — i.e. effectively pinned to the endpoint chosen at connect/listen
+  time. (Note the endpoint key is the tid of the thread that ran
+  `connect`/`listen` — often NCCL's proxy *service* thread — while the later
+  data-path calls come from the *progress* thread; the communicator's
+  `shared_ptr` is what lets the progress thread reuse that same endpoint rather
+  than keying a new one on its own tid.)
+- Because each device-driving thread's traffic flows through its own endpoint
+  and CQ, the per-endpoint data-path lock (below) is almost never contended in
+  practice.
+
+The object hierarchy that supports this is
+`plugin → device → domain → endpoint`. A **domain** is explicitly the *thread
+and locking boundary*: resources that share a domain share its locks. Endpoints
+under one domain share that domain's completion-queue/AV plumbing but each has
+its own `ep_lock`.
+
+### The libfabric threading hint matches this
+
+Each transport tells libfabric what threading behavior to expect via
+`domain_attr->threading`:
+
+| Transport | Hint | Meaning |
+|---|---|---|
+| RDMA | `FI_THREAD_COMPLETION` (`src/nccl_ofi_rdma.cpp`) | The app promises to serialize access **per completion domain** (per endpoint/CQ) — exactly what endpoint-per-thread provides — letting the provider use lighter-weight internal locking. |
+| SENDRECV | `FI_THREAD_SAFE` (`src/nccl_ofi_sendrecv.cpp`) | The provider must be fully thread-safe internally. |
+| GIN | `FI_THREAD_COMPLETION` / `FI_THREAD_SAFE` (`src/rdma/gin/…`) | As above, for its own endpoints. |
+
+`FI_THREAD_COMPLETION` is the more performant choice and is safe **only because**
+the plugin guarantees that a given endpoint/CQ is driven under its own lock.
+
+## Locks Used in The Plugin
+
+All locks either use `std::mutex`/`std::lock_guard` or the plugin's pthread
+wrapper (`include/nccl_ofi_pthread.h`, which **aborts** on any lock error). One
+lock is a custom spinlock.
+
+### `ep_lock` — the data-path lock
+
+`ep_lock` is a **`nccl_ofi_spinlock`** (`include/nccl_ofi_spinlock.h`): a
+compare-and-swap spin loop with a CPU `pause` (x86) / `isb` (aarch64) in the
+wait. It is held around essentially **every data-path operation** — `send`,
+`recv`, `test`, `flush`, `write`/`read`, and the connection steps — in both
+transports (many sites in `src/nccl_ofi_rdma.cpp` and
+`src/nccl_ofi_sendrecv.cpp`).
+
+A spinlock is used here precisely *because* of the
+endpoint-per-thread model: the lock is almost always taken by a single thread
+(the one that owns the endpoint), so it is uncontended and a spinlock is far
+cheaper than a mutex. It exists mainly to protect against the cases where more
+than one thread *does* touch an endpoint (for example teardown racing with
+in-flight work, or GIN's proxy worker), and to guard the `ep_active` flag used
+when a communicator is closed with requests still in flight.
+
+### `domain_lock` and `device_lock` — setup-path locks
+
+- **`domain_lock`** (`std::mutex`) guards the domain's endpoint cache
+  (`ep_table`) in `get_ep`, and other per-domain state
+  (`src/nccl_ofi_net.cpp`).
+- **`device_lock`** (`std::mutex`) guards the device's domain cache
+  (`domain_table`) in `get_domain`.
+
+These are taken on the **cold path** — endpoint/domain creation and lookup
+during `connect`/`listen`/`accept` — not on `isend`/`irecv`. They serialize
+communicator setup but do not affect steady-state throughput. Both caches hold
+`weak_ptr`s and are purged lazily on a miss, which keeps them bounded even under
+the GIN pattern of repeated comm create/destroy.
+
+### `mr_cache_lock` — memory registration
+
+Each **domain** owns an MR cache guarded by `mr_cache_lock` (`std::mutex`), taken
+during `regMr`/`deregMr` to look up or insert registrations
+(`src/nccl_ofi_rdma.cpp`, `src/nccl_ofi_sendrecv.cpp`; cache in
+`src/nccl_ofi_mr.cpp`). NCCL registers buffers relatively infrequently and
+caches aggressively, so this is normally low-traffic; it can show up if a
+workload registers/deregisters many distinct buffers. See
+[`rdma-protocol.md`](rdma-protocol.md) for the registration path.
+
+### RDMA-specific data-path locks
+
+- **`req_lock`** (`std::mutex`, per request) — because an RDMA message can be
+  **striped across rails**, each rail completes independently and the per-rail
+  completion counts are updated under `req_lock`
+  (`src/nccl_ofi_rdma.cpp`). It is a very short critical section, per request,
+  and multi-rail by nature (completions can arrive on different CQ-processing
+  contexts).
+- **`rx_buff_mutex`** (per rail) — guards the pool of pre-posted receive/bounce
+  buffers as they are consumed and re-posted.
+- **`pending_reqs_lock`** (per endpoint) — guards the retry queue of requests
+  that got `-FI_EAGAIN` and must be re-posted (see the retry discussion in
+  [`completion-progress.md`](completion-progress.md)).
+
+### Cross-cutting building-block locks
+
+These are generally short and low-contention:
+
+- **id pool lock** (`src/nccl_ofi_idpool.cpp`) — protects the bit-array
+  allocator used for MR rkeys and comm ids.
+- **message-buffer lock** (`src/nccl_ofi_msgbuff.cpp`) — protects per-recv-comm
+  message ordering/dedup state.
+- **connection-manager lock** `cm_mutex` (`src/cm/`) — serializes connection
+  handshake state; cold path.
+- **`ep_addr_list` lock** (`src/nccl_ofi_ep_addr_list.cpp`) — endpoint-address
+  bookkeeping for endpoint reuse.
+
+### Initialization / global locks
+
+Taken once or rarely, never on the data path:
+
+- **`netMutex`** (`src/nccl_ofi_interface_nvidia.cpp`) — ref-counted plugin
+  init/finalize across NCCL communicators.
+- Tuner context lock (`src/tuner/nccl_ofi_tuner.cpp`) and product-name /
+  platform-detection mutexes (`src/nccl_ofi_system.cpp`,
+  `src/platform-aws.cpp`) — one-time detection/caching.
+
+## The GIN exception: plugin-owned progress threads
+
+GIN proxy mode is the one place the plugin runs **its own** threads. NCCL's
+GIN device kernels enqueue work that CPU **proxy progress threads** drain and
+turn into libfabric operations
+(count controlled by `NCCL_GIN_PROXY_NTHREADS`). To keep the
+endpoint-per-thread invariant, GIN keys its endpoint by the progress thread /
+sequence rather than the caller's OS thread id:
+
+```cpp
+// src/rdma/gin/nccl_ofi_gin_api.cpp
+const long endpoint_key = static_cast<long>(context->seq) ...;
+auto ep = device->get_ep(0, endpoint_key);
+```
+
+so each GIN progress thread still gets its own endpoint and `ep_lock`. The
+EFA-GDA/GDAKI backend bypasses the CPU entirely for the data path (the GPU
+posts work), so it does not add CPU-side lock pressure on that path. See
+[`gin.md`](gin.md).
+
+## Main entry-point files
+
+| Concern | Location |
+|---|---|
+| Endpoint lookup keyed by thread id | `src/nccl_ofi_api.cpp` (`get_ep(domain_key, nccl_net_ofi_gettid())`) |
+| Thread-id helper | `src/nccl_ofi_compat.cpp` (`nccl_net_ofi_gettid`) |
+| Endpoint/domain caches + `domain_lock`/`device_lock` | `src/nccl_ofi_net.cpp` (`domain_t::get_ep`, `device_t::get_domain`) |
+| Object model + `ep_lock`, `ep_active` | `include/nccl_ofi.h` |
+| Spinlock primitive | `include/nccl_ofi_spinlock.h` |
+| Mutex wrappers (abort-on-error, RAII) | `include/nccl_ofi_pthread.h` |
+| RDMA data-path locks (`ep_lock`, `req_lock`, `rx_buff_mutex`, `pending_reqs_lock`) + `FI_THREAD_COMPLETION` | `src/nccl_ofi_rdma.cpp` |
+| SENDRECV data-path locks + `FI_THREAD_SAFE` | `src/nccl_ofi_sendrecv.cpp` |
+| MR cache lock | `src/nccl_ofi_mr.cpp` |
+| id pool / msgbuff / CM / ep-addr-list locks | `src/nccl_ofi_idpool.cpp`, `src/nccl_ofi_msgbuff.cpp`, `src/cm/`, `src/nccl_ofi_ep_addr_list.cpp` |
+| GIN proxy progress threads + endpoint keying | `src/rdma/gin/nccl_ofi_gin_api.cpp`, `src/rdma/gin/nccl_ofi_gin.cpp` |
+
+### NCCL side (for reference, in the NCCL source tree)
+
+| Concern | Location |
+|---|---|
+| Proxy progress thread (data path) + service thread | `src/proxy.cc` (`ncclProxyProgress`, `ncclProxyProgressCreate`) |
+| Net transport calling the plugin (`isend`/`irecv`/`test`) | `src/transport/net.cc` |
+| Versioned net-plugin shims | `src/plugin/net/net_v*.cc` |
+| Bootstrap-time `isend`/`irecv`/`test` | `src/bootstrap.cc` |

--- a/doc/topology.md
+++ b/doc/topology.md
@@ -1,0 +1,175 @@
+# AWS OFI NCCL — Topology and Multi-Rail
+
+*This document describes how the
+plugin discovers the intra-node hardware layout, groups NICs into rails, and
+tells NCCL about it. For the big picture see
+[`overall-operation.md`](overall-operation.md); for how rails are used
+on the wire see [`rdma-protocol.md`](rdma-protocol.md).*
+
+> Note: this is the **intra-node hwloc** topology layer. The existing
+> [`topology-aware.md`](topology-aware.md) is about a *different* layer —
+> **host placement** across a cluster (Slurm/EKS).
+
+## The problem: locality and bandwidth aggregation
+
+On AWS accelerator instances each GPU sits behind a PCIe switch alongside one or
+more EFA NICs. Two facts drive everything here:
+
+1. **GPU↔NIC PCIe locality.** GPUDirect RDMA is fastest when a GPU uses the
+   NIC(s) physically closest to it on the PCIe tree. Crossing a switch or NUMA
+   boundary costs bandwidth and latency.
+2. **Multi-rail bandwidth aggregation.** A single EFA NIC cannot saturate a
+   GPU's network bandwidth. Several GPU-local NICs are grouped into a **rail
+   group**, and the RDMA transport stripes each message across all of them,
+   exposing **one logical NCCL device** with the combined bandwidth.
+
+The topology subsystem discovers the layout, decides which NICs belong to which
+GPU, exposes one device per GPU-local NIC group, and hands NCCL a synthetic
+topology file that reflects the real PCIe distances.
+
+## The data model
+
+Defined in [`include/nccl_ofi_topo.h`](../include/nccl_ofi_topo.h):
+
+- **`nccl_ofi_topo_t`** — wraps an hwloc topology, a per-node `data_vec`, and
+  `max_group_size` (the number of rails per device across the machine).
+- **`nccl_ofi_topo_data_t`** — user data attached to each hwloc node: the list
+  of NIC `fi_info` objects on that node (`info_list`, `info_list_len`), a
+  transient `num_groups` used during grouping, and marker flags (is-NIC-subtree,
+  contributed-GPU, closest-NUMA, etc.).
+
+## How the topology is built (hwloc)
+
+`src/nccl_ofi_topo.cpp`:
+
+1. **Create** (`nccl_ofi_topo_create`): initialize hwloc with **I/O discovery**
+   enabled so PCI devices — NICs, GPUs, bridges — appear in the tree.
+2. **Populate** (`nccl_ofi_topo_populate` → `set_user_data`): walk the PCI
+   nodes. GPUs are identified by PCI class/vendor (`is_accelerator_dev`; NVIDIA,
+   AMD; Neuron uses ids that intentionally *don't* match, so Neuron gets no
+   grouping). NICs are matched to hwloc nodes by comparing PCI bus addresses to
+   each libfabric `fi_info`. Each NIC node gets a duplicated `fi_info` attached,
+   and closest-NUMA/package info is recorded for later CPU tagging.
+
+## Grouping NICs into rails
+
+`nccl_ofi_topo_group` runs a few passes (the algorithm is documented as an ASCII
+diagram in the header):
+
+1. Mark the ancestors of every NIC.
+2. Each GPU walks *up* to its nearest NIC-bearing ancestor and increments that
+   ancestor's `num_groups` — this ties one group to each GPU.
+3. NIC `fi_info` lists are lifted up and concatenated at the nearest ancestor
+   that has `num_groups > 0` (orphan NICs with no nearby GPU fall back to one
+   group each).
+4. Each ancestor's combined list is split into `num_groups` roughly equal
+   sublists, each attached to a **leader NIC**. `max_group_size` tracks the
+   largest group.
+
+### Relationship to `MAX_NUM_RAILS` and the device model
+
+`max_group_size` is exactly **rails-per-device**. The RDMA plugin constructor
+asserts `1 <= max_group_size <= MAX_NUM_RAILS` (`= 4`, in
+`include/nccl_ofi_rdma.h`) and aborts otherwise. Then:
+
+- **each grouped `fi_info` list → one NCCL `device`** (`p_devs` is sized to the
+  number of lists);
+- **each NIC in the list → one rail** → one per-rail libfabric endpoint/CQ/AV
+  inside the device;
+- `num_rails` propagates into communicators and connection messages.
+
+SENDRECV always reports a single rail; Neuron gets no grouping (also
+single-rail).
+
+```
+hwloc PCIe tree ── group ──▶  rail group (leader NIC + up to 3 more)
+                                   │
+                                   ▼
+                             nccl_net_ofi_rdma_device_t   (1 logical NCCL device)
+                                   ├─ rail 0 (leader)  → endpoint/CQ/AV
+                                   ├─ rail 1           → endpoint/CQ/AV
+                                   └─ ...
+```
+
+## The synthetic NCCL topology file
+
+NCCL runs its **own** graph search to plan collectives. Left alone, it would see
+N separate NICs, not one fat GPU-local device, and would not exploit the rail
+grouping. So when `max_group_size > 1`, the plugin generates a partial NCCL
+topology XML during `complete_init`:
+
+- `write_topo_file` creates an **anonymous `memfd`**, writes the XML into it, and
+  exports `/proc/self/fd/N` as `NCCL_TOPO_FILE` (unless the user already set
+  one). Using a memfd means no temp file to clean up, and it survives `fork()`.
+- `nccl_ofi_topo_write` emits a `<system>` tree containing only the NIC- and
+  GPU-to-root nodes: `<cpu>` nodes (with NUMA id and host hash, needed for
+  Multi-Node NVLink on newer NCCL), `<pci>` bridge nodes for real PCIe switches,
+  and `<pci>` NIC nodes.
+- **Bandwidth scaling** (`write_nic`): the **leader NIC's** advertised PCIe
+  link speed/width is stepped up until it matches the GPU's PCIe bandwidth, so
+  NCCL treats the whole rail group as a single fat pipe. (EFA links reporting
+  "Unknown" fall back to a Gen4 x8 estimate.)
+
+## Rail ordering: the `sort_rails` platform hook
+
+Before a group's NIC list is split, the platform's `sort_rails` hook reorders it
+so rail ordering is consistent across devices — important because peers must
+pair up matching rails.
+
+- The base `Platform::sort_rails` is a no-op.
+- `PlatformAWS::sort_rails` (`src/platform-aws.cpp`) handles P5/P5e (up to 32 EFA
+  devices). It returns early when there's only one NIC per group (P4d,
+  Trainium). Otherwise it computes each rail's **VF index** and rebuilds the list
+  interleaving by VF index (0,1,0,1,…), which balances traffic across the Nitro
+  cards that back the EFA devices.
+
+  The **VF index** is the SR-IOV **virtual-function** index (`func_idx`) decoded
+  from the EFA device's node GUID (`get_rail_vf_idx` → `get_node_guid_fields`).
+  On EC2, EFA NICs are presented to the guest as SR-IOV virtual functions of a
+  physical Nitro card, and **each pair of EFA devices shares Nitro-card
+  resources**. The VF index identifies which slot of such a pair a NIC occupies
+  (pair-index 0 vs 1). For best performance, rank A's pair-index-0 device should
+  communicate with rank B's pair-index-0 device (and 1↔1), so that traffic lands
+  on correspondingly paired Nitro resources on both hosts. The natural PCIe BDF
+  ordering libfabric produces does **not** reliably line those pairs up (the
+  hypervisor isn't consistent about BDF assignment across the two VFs that share
+  a card), so interleaving by VF index restores the intended 0↔0 / 1↔1 pairing
+  while otherwise preserving BDF order.
+
+  **SR-IOV** (Single Root I/O Virtualization) is a PCIe standard that lets one
+  physical device expose itself as many independent-looking devices: a single
+  **physical function (PF)** owns the silicon, and multiple lightweight **virtual
+  functions (VFs)** are handed out as standalone PCIe devices that a guest can
+  DMA to directly, bypassing the hypervisor for near-native throughput. On EC2
+  the EFA hardware lives on a Nitro card (the PF), and each EFA NIC the instance
+  sees is a VF of that card — which is why several rails can share one card's
+  resources.
+
+## Cross-node device identity: `device_get_guid`
+
+For NCCL to pair the *same* rail between two hosts, each device needs a
+**stable, cross-node identity**. `PlatformAWS::device_get_guid`
+(`src/platform-aws.cpp`) produces one by packing a unique node id with the
+device index (or a per-card PCI domain/bus decoded from the EFA node GUID). This
+is what lets rank A's rail 2 line up with rank B's rail 2.
+
+## Where topology sits in the flow
+
+- The process owns exactly **one `nccl_ofi_topo_t`**, created in
+  `nccl_net_ofi_create_plugin` (`src/nccl_ofi_net.cpp`) as a `unique_ptr`; the
+  plugin base holds a non-owning pointer.
+- The RDMA constructor populates and groups it, then sizes `p_devs` to the
+  number of groups.
+- `complete_init` iterates the groups (`nccl_ofi_topo_next_info_list`),
+  constructing one device per group and writing the topology file if grouped.
+
+## Main entry-point files
+
+| Concern | Location |
+|---|---|
+| Data model + grouping algorithm (documented) | `include/nccl_ofi_topo.h` |
+| Discovery / populate / group / write | `src/nccl_ofi_topo.cpp` — `nccl_ofi_topo_create`, `nccl_ofi_topo_populate`, `nccl_ofi_topo_group`, `nccl_ofi_topo_write`, `nccl_ofi_topo_next_info_list` |
+| Topology creation + ownership | `src/nccl_ofi_net.cpp` (`nccl_net_ofi_create_plugin`) |
+| Rail-count guard + topo-file emission + device construction | `src/nccl_ofi_rdma.cpp` (`write_topo_file`, plugin ctor, `complete_init`) |
+| Rail ordering + cross-node identity | `src/platform-aws.cpp` (`sort_rails`, `device_get_guid`) |
+| `MAX_NUM_RAILS` (= 4) | `include/nccl_ofi_rdma.h` |

--- a/doc/tuner.md
+++ b/doc/tuner.md
@@ -1,0 +1,131 @@
+# AWS OFI NCCL — Tuner
+
+*This document describes the tuner
+plugin, which is **separate** from the network transport plugin. For the big
+picture see [`overall-operation.md`](overall-operation.md).*
+
+## What a NCCL tuner plugin is
+
+NCCL has an internal cost model that, for every collective launch, picks a
+combination of:
+
+- **algorithm** — `NCCL_ALGO_{TREE, RING, NVLS, NVLS_TREE, PAT, COLLNET_*}`
+- **protocol** — `NCCL_PROTO_{LL, LL128, SIMPLE}`
+- **channel count** (and, in newer versions, chunk size)
+
+A **tuner plugin** is an optional, separate plugin interface that lets an
+external library override or bias those choices. NCCL `dlopen`s the shared
+object and looks for versioned symbols named `ncclTunerPlugin_vN`. Crucially,
+the tuner is a pure **decision advisor** — it never touches the network. It
+reads the cluster shape at init and, per collective, is told the collective
+type, message size, and other hints, and returns its recommendation.
+
+This is entirely distinct from the `ncclNetPlugin_vN` transport interface
+(described in the other docs). The two plugins are loaded independently and may
+even live in different `.so` files, so the tuner re-runs its **own** parameter
+init and builds its **own** topology — it shares no state with the net plugin,
+only lightweight helpers (platform detection, parameter parsing, logging).
+
+Implementation: `src/tuner/` with headers in `include/tuner/` and
+`include/internal/tuner/`.
+
+## The exported interface
+
+`src/tuner/nccl_ofi_tuner.cpp` exports **three** tuner API versions
+simultaneously so it works across NCCL releases:
+
+- **`ncclTunerPlugin_v2`** (NCCL 2.21.5+): writes the chosen `algorithm` and
+  `protocol` directly through out-parameters.
+- **`ncclTunerPlugin_v3`** (2.22.3+): a **cost-table** style. NCCL passes a
+  `float collCostTable[numAlgo][numProto]`; the tuner forces its choice by
+  setting the chosen cell to `0.0` (lowest cost). Declining simply leaves the
+  table untouched so NCCL falls back to its own decision.
+- **`ncclTunerPlugin_v6`** (2.30.3+): adds buffer registration and
+  `getChunkSize`.
+
+Each exported struct wires up `.init`, `.getCollInfo`, `.destroy`/`.finalize`,
+and (v6) `.getChunkSize`.
+
+### `getCollInfo`
+
+The central decision function. Inputs: collective type (AllReduce, AllGather,
+ReduceScatter, …), message size in bytes, number of pipeline ops, the cost
+table, and the available algorithm/protocol counts; output includes the chosen
+cell (set to `0.0`) and, optionally, a channel count. It dispatches through
+function pointers in the tuner context to either the **region** or **model**
+implementation. CollNet is always skipped ("no CollNet on AWS today"), and NVLS
+(single-node) is skipped for multi-node jobs.
+
+### `init`
+
+`nccl_ofi_tuner_init` re-initializes the tuner's own parameters and uses a
+process-static `TunerProcessConfig`
+(`include/tuner/nccl_ofi_tuner_process_config.h`) that builds a topology,
+detects the platform via `PlatformManager` + product name, and maps the EC2
+instance type (p5 / p5e / p5en / p6-b200 / p6-b300 / …) to an internal platform
+enum. It **falls back to NCCL's internal tuner** when the platform is non-AWS,
+when `NCCL_OFI_TUNER_TYPE=Internal`, or when a heterogeneous-hardware override
+(`OFI_NCCL_FORCE_NUM_RAILS`) is set. When both approaches are supported it
+prefers **Region** over **Model**.
+
+## The two approaches: Region vs Model
+
+### Region-based (default) — `src/tuner/nccl_ofi_regions.cpp`
+
+For each `(collective type, platform, communicator shape)` the tuner holds a set
+of hand-tuned **2D polygonal regions** in the `(message size, rank count)`
+plane, each labeled with a fixed `{algorithm, protocol}`. Lookup:
+
+- coordinates are transformed to log2 space;
+- a **ray-casting point-in-polygon** test (with a bounding-box pre-screen) finds
+  which region contains the operating point;
+- the first matching region wins (so region order matters).
+
+The regions are derived empirically from benchmark data, keyed by communicator
+shape (e.g. `nRanks == 8*nNodes`, `2*nNodes`, or `nNodes`), and projected out to
+the maximum supported sizes/rank counts. The region path **also** tunes channel
+counts (e.g. for P6 Tree/LL128 and PAT) and, on v6, chunk sizes — modeling EFA
+in-flight saturation versus pipeline fill. It supports P5/P5e, P5en, P6, and
+P6-B300, and falls back to NCCL for very small clusters (≤ 2 nodes) or points no
+region covers.
+
+### Model-based — `src/tuner/nccl_ofi_model.cpp`
+
+An analytic **Hockney-style** cost model:
+`t = latency · pipe_ops + size / bandwidth` (`nccl_ofi_tuner_compute_cost`),
+picking the lowest-cost combination. It uses per-platform parameters (network
+latency, per-rail internode bandwidth, intranode bandwidth, rail count, an
+NVLink latency table). It models AllReduce for Ring/Tree/NVLS_Tree only,
+penalizes LL/LL128 bandwidth, and adds a completion overhead for SIMPLE. It
+supports only P5/P5e and P5en and does **not** set channel counts or chunk size.
+
+### Tradeoff
+
+| | Region (default) | Model |
+|---|---|---|
+| Basis | empirical benchmark polygons | analytic cost formula |
+| Coverage | precise where measured; several platforms | generalizes, but AllReduce + 2 platforms only |
+| Extras | tunes channels + chunk size | decision only |
+
+Region is preferred because it is more accurate where it has data and also tunes
+channels/chunk sizes.
+
+## How it plugs in (separately from the net plugin)
+
+- NCCL `dlopen`s the tuner and `dlsym`s `ncclTunerPlugin_vN` — independently of
+  the `ncclNetPlugin_vN` transport symbols.
+- The tuner therefore runs its own parameter init and builds its own topology;
+  there is no shared runtime state with the transport.
+- It never issues network operations. It reads `nRanks`/`nNodes` at init and,
+  per collective, the `(collType, nBytes, …)` inputs, and writes back algorithm,
+  protocol, channel, and chunk-size hints.
+
+## Main entry-point files and functions
+
+| Concern | Location |
+|---|---|
+| Exported symbols + dispatch | `src/tuner/nccl_ofi_tuner.cpp` — `ncclTunerPlugin_v{2,3,6}`, `nccl_ofi_tuner_init`/`_v2`/`_v6`, `nccl_ofi_tuner_get_coll_info`/`_v2`/`_v6`, `_get_chunk_size`, `_destroy` |
+| Region approach | `src/tuner/nccl_ofi_regions.cpp` — `region_init_internal`, `region_get_coll_info_internal_v3`/`_v6`/`_v2`, `region_get_chunk_size_internal`, `is_inside_region`, `extend_region`, `is_region_supported` |
+| Model approach | `src/tuner/nccl_ofi_model.cpp` — `model_init_internal`, `model_get_coll_info_internal_*`, `nccl_ofi_tuner_compute_cost`, `is_model_supported` |
+| Shared context / types | `include/tuner/nccl_ofi_tuner_common.h`, `nccl_ofi_tuner_region.h`, `nccl_ofi_tuner_model.h`, `nccl_ofi_tuner_process_config.h` |
+| Tests | `tests/unit/region_based_tuner.cpp` |


### PR DESCRIPTION
doc: Add plugin docs for explaining the plugin architecture and main logic

*Description of changes:*

Add markdown documents for explaining the following aspects of the plugin:

- overall operation
- plugin initialization
- operation with libfabric
- rdma protocol
- send/recv protocol
- connection management
- completion progress
- threading model
- topology
- tuner
- gin

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
